### PR TITLE
Document new impl and object syntaxes

### DIFF
--- a/docs/notes/language-benefits.md
+++ b/docs/notes/language-benefits.md
@@ -5,16 +5,16 @@
 ```
 obj Robot
 
-obj ArmRobot extends Robot {
+obj ArmRobot: Robot {
   vise: Vise
 }
 
-obj HumanoidRobot extends Robot {
+obj HumanoidRobot: Robot {
   vise: Vise
   legs: Legs
 }
 
-obj DogRobot extends Robot {
+obj DogRobot: Robot {
   legs: Legs
 }
 
@@ -30,7 +30,7 @@ trait Moveable
   fn move_to(self, location: Location) async -> void
 
 // Provides implementation for ArmRobot and HumanoidRobot
-impl Gripper for Robot & { vise: Vise }
+impl Gripper for: Robot & { vise: Vise }
   fn grip(self) async -> void
     await! self.vise.close()
 
@@ -38,7 +38,7 @@ impl Gripper for Robot & { vise: Vise }
     await! self.vise.open()
 
 // Provides implementation for DogRobot and HumanoidRobot, but not Human as its not a Robot
-impl Moveable for Robot & { legs: Legs }
+impl Moveable for: Robot & { legs: Legs }
   fn grip(self) async -> void
     await! self.vise.close()
 

--- a/docs/structural-subtyping.md
+++ b/docs/structural-subtyping.md
@@ -13,7 +13,7 @@ fn sum(b: A & { y: i32 }) -> i32
   // Field y cannot be directly accessed because we do not know the supertype of b that defines y field
   b.y
 
-obj B extends A {
+obj B: A {
   y: i32
 }
 

--- a/reference/control-flow.md
+++ b/reference/control-flow.md
@@ -15,9 +15,9 @@ Example:
 ```voyd
 obj Optional
 
-obj None extends Optional
+obj None: Optional
 
-obj Some extends Optional {
+obj Some: Optional {
   value: i32
 }
 

--- a/reference/functions.md
+++ b/reference/functions.md
@@ -257,8 +257,8 @@ Object types overlap if one is an extension of the other:
 
 ```voyd
 obj Animal {}
-obj Dog extends Animal {}
-obj Cat extends Animal {}
+obj Dog: Animal {}
+obj Cat: Animal {}
 
 fn walk(animal: Animal)
 fn walk(dog: Dog) // Ambiguous collision with walk(animal: Animal)

--- a/reference/types/intersections.md
+++ b/reference/types/intersections.md
@@ -62,7 +62,7 @@ let newt: Cat = Animal { name: "Whiskers" } & { lives: 3 }
 let newt = AnimalWithLives { name: "Whiskers", lives: 3 }
 
 // We can define a new compatible nominal object
-obj Cat extends Animal {
+obj Cat: Animal {
   lives: i32
 }
 
@@ -80,11 +80,11 @@ obj Animal {
   name: String
 }
 
-obj Cat extends Animal {
+obj Cat: Animal {
   lives_remaining: i32
 }
 
-obj Dog extends Animal {
+obj Dog: Animal {
   likes_belly_rubs: bool
 }
 
@@ -125,11 +125,11 @@ obj Shape {
   y: i32
 }
 
-impl Image for Shape
+impl Image for: Shape
   fn draw(self) -> Array<Rgb>
     self.image
 
-impl Movable for Shape
+impl Movable for: Shape
   fn move(&self, x: i32, y: i32) -> void
     self.x += x
     self.y += y

--- a/reference/types/objects.md
+++ b/reference/types/objects.md
@@ -123,11 +123,11 @@ obj Animal {
   name: String
 }
 
-obj Cat extends Animal {
+obj Cat: Animal {
   lives_remaining: i32
 }
 
-obj Dog extends Animal {
+obj Dog: Animal {
   likes_belly_rubs: bool
 }
 
@@ -244,7 +244,7 @@ even if a subtype is passed. For example:
 
 ```voyd
 obj Animal {}
-obj Dog extends Animal {}
+obj Dog: Animal {}
 
 impl Animal
   pub fn talk()
@@ -274,9 +274,9 @@ using the methods of a subtype.
 ```voyd
 obj Optional
 
-obj None extends Optional
+obj None: Optional
 
-obj Some extends Optional {
+obj Some: Optional {
   value: i32
 }
 
@@ -305,7 +305,7 @@ final obj Animal {
 }
 
 // Error - Animal is final
-obj Cat extends Animal {
+obj Cat: Animal {
   lives_remaining: i32
 }
 ```

--- a/reference/types/traits.md
+++ b/reference/types/traits.md
@@ -13,7 +13,7 @@ obj Car {
   speed: i32
 }
 
-impl Run for Car
+impl Run for: Car
   fn run(self) -> String
     "Vroom!"
 
@@ -84,9 +84,9 @@ obj Dog {}
 trait Speak
   fn speak() -> void
 
-impl Speak for Animal
+impl Speak for: Animal
   fn speak()
     log "Glub glub"
 
-impl Speak for Dog // ERROR: Speak is already implemented for Dog via parent type Animal
+impl Speak for: Dog // ERROR: Speak is already implemented for Dog via parent type Animal
 ```


### PR DESCRIPTION
Removes `extends` in favor of `:` and introduces a `with:` to `impls` for applying premade implementations.