### PR TITLE
feat: verify index file exists in resolveSrc

### DIFF
--- a/src/lib/__tests__/resolve-src.test.ts
+++ b/src/lib/__tests__/resolve-src.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { resolveSrc } from "../resolve-src.js";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+describe("resolveSrc", () => {
+  it("throws when directory lacks index.voyd", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "voyd-test-"));
+    try {
+      await expect(resolveSrc(dir)).rejects.toThrow(/index\.voyd/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves index file in directory", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "voyd-test-"));
+    const indexFile = path.join(dir, "index.voyd");
+    await writeFile(indexFile, "");
+    try {
+      const info = await resolveSrc(dir);
+      expect(info).toStrictEqual({
+        indexPath: indexFile,
+        srcRootPath: dir,
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/resolve-src.ts
+++ b/src/lib/resolve-src.ts
@@ -25,8 +25,18 @@ export async function resolveSrc(index: string): Promise<SrcInfo> {
   }
 
   if (indexStats.isDirectory()) {
+    const indexFile = path.join(indexPath, "index.voyd");
+    try {
+      const indexFileStats = await stat(indexFile);
+      if (!indexFileStats.isFile()) {
+        throw new Error();
+      }
+    } catch {
+      throw new Error(`Missing index file at ${indexFile}`);
+    }
+
     return {
-      indexPath: path.join(indexPath, "index.voyd"),
+      indexPath: indexFile,
       srcRootPath: indexPath,
     };
   }


### PR DESCRIPTION
## Summary
- validate that directories supplied to `resolveSrc` contain an `index.voyd` file
- add unit tests for `resolveSrc`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688f0caaab1c832aac11ce8e1c325550