### PR TITLE
fix: correct array type builder parameter name

### DIFF
--- a/src/lib/binaryen-gc/types.ts
+++ b/src/lib/binaryen-gc/types.ts
@@ -68,7 +68,7 @@ export type AugmentedBinaryen = typeof binaryen & {
     builder: TypeBuilderRef,
     index: Index,
     elementType: TypeRef,
-    elementPackedTyype: PackedType,
+    elementPackedType: PackedType,
     elementMutable: bool
   ): void;
   _TypeBuilderSetSubType(


### PR DESCRIPTION
## Summary
- fix `_TypeBuilderSetArrayType` parameter typo

## Testing
- `npx vitest run`
- `npm run build` *(fails: Argument of type 'Uint8Array<ArrayBufferLike>' is not assignable to parameter of type 'BufferSource'.)*

------
https://chatgpt.com/codex/tasks/task_e_688fbd92f3c0832abe43b082932cbc99