### PR TITLE
cache flattened unions for compatibility

### DIFF
--- a/src/semantics/resolution/__tests__/types-are-compatible.test.ts
+++ b/src/semantics/resolution/__tests__/types-are-compatible.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+import { ObjectType, UnionType } from "../../../syntax-objects/index.js";
+import { typesAreCompatible } from "../types-are-compatible.js";
+
+describe("typesAreCompatible - unions", () => {
+  test("handles large unions", () => {
+    const objsA: ObjectType[] = [];
+    const objsB: ObjectType[] = [];
+
+    for (let i = 0; i < 100; i++) {
+      const obj = new ObjectType({ name: `Obj${i}`, value: [] });
+      objsA.push(obj);
+      objsB.push(obj);
+    }
+    // Add an extra type to B so that B is a superset of A
+    objsB.push(new ObjectType({ name: "Extra", value: [] }));
+
+    const unionA = new UnionType({ name: "UnionA", childTypeExprs: [] });
+    unionA.types = objsA;
+
+    const unionB = new UnionType({ name: "UnionB", childTypeExprs: [] });
+    unionB.types = objsB;
+
+    expect(typesAreCompatible(unionA, unionB)).toBe(true);
+    expect(typesAreCompatible(unionB, unionA)).toBe(false);
+  });
+
+  test("handles cyclic unions", () => {
+    const a = new ObjectType({ name: "A", value: [] });
+    const b = new ObjectType({ name: "B", value: [] });
+
+    const u1 = new UnionType({ name: "U1", childTypeExprs: [] });
+    const u2 = new UnionType({ name: "U2", childTypeExprs: [] });
+
+    u1.types = [a, u2];
+    u2.types = [b, u1];
+
+    expect(typesAreCompatible(u1, u2)).toBe(true);
+  });
+
+  test("handles deeply nested unions", () => {
+    const depth = 200;
+    let current = new UnionType({ name: `U${depth}`, childTypeExprs: [] });
+    current.types = [new ObjectType({ name: `Obj${depth}`, value: [] })];
+    for (let i = depth - 1; i >= 0; i--) {
+      const next = new UnionType({ name: `U${i}`, childTypeExprs: [] });
+      const obj = new ObjectType({ name: `Obj${i}`, value: [] });
+      next.types = [obj, current];
+      current = next;
+    }
+
+    expect(typesAreCompatible(current, current)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- cache flattened unions with WeakMap to avoid redundant work
- reuse memoized map of union members instead of reconstructing every call

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68980cbd5bd8832abf0606ac15abefef