### PR TITLE
refactor assembler into per-expression modules

### DIFF
--- a/src/__tests__/compiler.test.ts
+++ b/src/__tests__/compiler.test.ts
@@ -10,6 +10,7 @@ import assert from "node:assert";
 import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
 import * as rCallUtil from "../assembler/return-call.js";
 import { readString } from "../lib/read-string.js";
+import { compilers } from "../assembler.js";
 
 describe("E2E Compiler Pipeline", () => {
   test("Compiler can compile and run a basic voyd program", async (t) => {
@@ -77,6 +78,24 @@ describe("E2E Compiler Pipeline", () => {
       7, // Recursive heap object type match Some
       -1, // Recursive heap object type match None
     ]);
+
+    const expectedSyntaxTypes = [
+      "call",
+      "block",
+      "match",
+      "int",
+      "string-literal",
+      "float",
+      "identifier",
+      "fn",
+      "variable",
+      "module",
+      "object-literal",
+      "type",
+    ];
+    t.expect(Object.keys(compilers)).toEqual(
+      t.expect.arrayContaining(expectedSyntaxTypes)
+    );
   });
 
   test("Compiler can do tco", async (t) => {

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -1,9 +1,5 @@
 import binaryen from "binaryen";
-import { Call } from "./syntax-objects/call.js";
 import { Expr } from "./syntax-objects/expr.js";
-import { Fn } from "./syntax-objects/fn.js";
-import { Identifier } from "./syntax-objects/identifier.js";
-import { Int } from "./syntax-objects/int.js";
 import {
   Type,
   Primitive,
@@ -13,11 +9,6 @@ import {
   UnionType,
   IntersectionType,
 } from "./syntax-objects/types.js";
-import { Variable } from "./syntax-objects/variable.js";
-import { Block } from "./syntax-objects/block.js";
-import { Declaration } from "./syntax-objects/declaration.js";
-import { VoydModule } from "./syntax-objects/module.js";
-import { ObjectLiteral } from "./syntax-objects/object-literal.js";
 import {
   binaryenTypeToHeapType,
   typeBuilderCreate,
@@ -27,19 +18,31 @@ import {
   typeBuilderSetOpen,
   typeBuilderBuildAndDispose,
   annotateStructNames,
-  initStruct,
-  refCast,
-  structGetFieldValue,
 } from "./lib/binaryen-gc/index.js";
 import * as gc from "./lib/binaryen-gc/index.js";
 import { TypeRef } from "./lib/binaryen-gc/types.js";
-import { getExprType } from "./semantics/resolution/get-expr-type.js";
-import { Match, MatchCase } from "./syntax-objects/match.js";
 import { initExtensionHelpers } from "./assembler/rtt/extension.js";
-import { returnCall } from "./assembler/return-call.js";
-import { Float } from "./syntax-objects/float.js";
 import { initFieldLookupHelpers } from "./assembler/index.js";
-import { StringLiteral } from "./syntax-objects/string-literal.js";
+
+import { compile as compileCall } from "./assembler/compile-call.js";
+import { compile as compileBlock } from "./assembler/compile-block.js";
+import { compile as compileMatch } from "./assembler/compile-match.js";
+import { compile as compileInt } from "./assembler/compile-int.js";
+import { compile as compileStringLiteral } from "./assembler/compile-string-literal.js";
+import { compile as compileFloat } from "./assembler/compile-float.js";
+import { compile as compileIdentifier } from "./assembler/compile-identifier.js";
+import { compile as compileFunction } from "./assembler/compile-function.js";
+import { compile as compileVariable } from "./assembler/compile-variable.js";
+import { compile as compileDeclaration } from "./assembler/compile-declaration.js";
+import { compile as compileModule } from "./assembler/compile-module.js";
+import { compile as compileObjectLiteral } from "./assembler/compile-object-literal.js";
+import { compile as compileType } from "./assembler/compile-type.js";
+import { compile as compileBool } from "./assembler/compile-bool.js";
+import { compile as compileImpl } from "./assembler/compile-impl.js";
+import { compile as compileUse } from "./assembler/compile-use.js";
+import { compile as compileTrait } from "./assembler/compile-trait.js";
+import { compile as compileMacro } from "./assembler/compile-macro.js";
+import { compile as compileMacroVariable } from "./assembler/compile-macro-variable.js";
 
 const buildingTypePlaceholders = new Map<ObjectType, TypeRef>();
 
@@ -62,517 +65,45 @@ export interface CompileExprOpts<T = Expr> {
   loopBreakId?: string;
 }
 
-export const compileExpression = (opts: CompileExprOpts): number => {
-  const { expr, mod, isReturnExpr } = opts;
-  opts.isReturnExpr = false;
-  // These can take isReturnExpr
-  if (expr.isCall()) return compileCall({ ...opts, expr, isReturnExpr });
-  if (expr.isBlock()) return compileBlock({ ...opts, expr, isReturnExpr });
-  if (expr.isMatch()) return compileMatch({ ...opts, expr, isReturnExpr });
-  if (expr.isInt()) return compileInt({ ...opts, expr });
-  if (expr.isStringLiteral()) return compileStringLiteral({ ...opts, expr });
-  if (expr.isFloat()) return compileFloat({ ...opts, expr });
-  if (expr.isIdentifier()) return compileIdentifier({ ...opts, expr });
-  if (expr.isFn()) return compileFunction({ ...opts, expr });
-  if (expr.isVariable()) return compileVariable({ ...opts, expr });
-  if (expr.isDeclaration()) return compileDeclaration({ ...opts, expr });
-  if (expr.isModule()) return compileModule({ ...opts, expr });
-  if (expr.isObjectLiteral()) return compileObjectLiteral({ ...opts, expr });
-  if (expr.isType()) return compileType({ ...opts, expr });
-  if (expr.isImpl()) return mod.nop();
-  if (expr.isUse()) return mod.nop();
-  if (expr.isMacro()) return mod.nop();
-  if (expr.isMacroVariable()) return mod.nop();
-  if (expr.isTrait()) return mod.nop();
+type CompilerFn = (opts: CompileExprOpts<any>) => number;
 
-  if (expr.isBool()) {
-    return expr.value ? mod.i32.const(1) : mod.i32.const(0);
+export const compilers: Record<string, CompilerFn> = {
+  call: compileCall,
+  block: compileBlock,
+  match: compileMatch,
+  int: compileInt,
+  "string-literal": compileStringLiteral,
+  float: compileFloat,
+  identifier: compileIdentifier,
+  fn: compileFunction,
+  variable: compileVariable,
+  declaration: compileDeclaration,
+  module: compileModule,
+  "object-literal": compileObjectLiteral,
+  type: compileType,
+  bool: compileBool,
+  implementation: compileImpl,
+  use: compileUse,
+  trait: compileTrait,
+  macro: compileMacro,
+  "macro-variable": compileMacroVariable,
+};
+
+export const compileExpression = (opts: CompileExprOpts): number => {
+  const compiler = compilers[opts.expr.syntaxType];
+  if (compiler) {
+    const isReturnExpr = opts.isReturnExpr;
+    opts.isReturnExpr = false;
+    return compiler({ ...opts, isReturnExpr } as any);
   }
 
   throw new Error(
-    `Unrecognized expression ${expr.syntaxType} ${expr.location}`
+    `Unrecognized expression ${opts.expr.syntaxType} ${opts.expr.location}`
   );
 };
-
-const compileStringLiteral = (opts: CompileExprOpts<StringLiteral>) => {
-  const { expr, mod } = opts;
-  return gc.arrayNewFixed(
-    mod,
-    binaryenTypeToHeapType(getI32ArrayType(opts.mod)),
-    expr.value.split("").map((char) => mod.i32.const(char.charCodeAt(0)))
-  );
-};
-
-const compileInt = (opts: CompileExprOpts<Int>) => {
-  const val = opts.expr.value;
-  if (typeof val === "number") {
-    return opts.mod.i32.const(val);
-  }
-
-  const i64Int = val.value;
-  const low = Number(i64Int & BigInt(0xffffffff)); // Extract lower 32 bits
-  const high = Number((i64Int >> BigInt(32)) & BigInt(0xffffffff)); // Extract higher 32 bits
-  return opts.mod.i64.const(low, high);
-};
-
-const compileFloat = (opts: CompileExprOpts<Float>) => {
-  const val = opts.expr.value;
-  if (typeof val === "number") {
-    return opts.mod.f32.const(val);
-  }
-
-  return opts.mod.f64.const(val.value);
-};
-
-const compileType = (opts: CompileExprOpts<Type>) => {
-  const type = opts.expr;
-
-  if (type.isObjectType()) {
-    buildObjectType(opts, type);
-    return opts.mod.nop();
-  }
-
-  if (type.isUnionType()) {
-    buildUnionType(opts, type);
-    return opts.mod.nop();
-  }
-
-  if (type.isIntersectionType()) {
-    buildIntersectionType(opts, type);
-    return opts.mod.nop();
-  }
-
-  return opts.mod.nop();
-};
-
-const compileModule = (opts: CompileExprOpts<VoydModule>) => {
-  const result = opts.mod.block(
-    opts.expr.id,
-    opts.expr.value.map((expr) => compileExpression({ ...opts, expr }))
-  );
-
-  if (opts.expr.isIndex) {
-    opts.expr.getAllExports().forEach((entity) => {
-      if (entity.isFn()) {
-        opts.mod.addFunctionExport(entity.id, entity.name.value);
-      }
-    });
-  }
-
-  return result;
-};
-
-const compileBlock = (opts: CompileExprOpts<Block>) => {
-  return opts.mod.block(
-    null,
-    opts.expr.body.map((expr, index, array) => {
-      if (index === array.length - 1 && opts.isReturnExpr) {
-        return compileExpression({ ...opts, expr, isReturnExpr: true });
-      }
-
-      return compileExpression({ ...opts, expr, isReturnExpr: false });
-    })
-  );
-};
-
-const compileMatch = (opts: CompileExprOpts<Match>) => {
-  const { expr } = opts;
-
-  const constructIfChain = (cases: MatchCase[]): number => {
-    const nextCase = cases.shift();
-    if (!nextCase) return opts.mod.unreachable();
-
-    if (!cases.length) {
-      return compileExpression({ ...opts, expr: nextCase.expr });
-    }
-
-    return opts.mod.if(
-      opts.mod.call(
-        "__extends",
-        [
-          opts.mod.i32.const(nextCase.matchType!.syntaxId),
-          structGetFieldValue({
-            mod: opts.mod,
-            fieldType: opts.extensionHelpers.i32Array,
-            fieldIndex: 0,
-            exprRef: compileIdentifier({ ...opts, expr: expr.bindIdentifier }),
-          }),
-        ],
-        binaryen.i32
-      ),
-      compileExpression({ ...opts, expr: nextCase.expr }),
-      constructIfChain(cases)
-    );
-  };
-
-  const ifChain = constructIfChain(
-    expr.defaultCase ? [...expr.cases, expr.defaultCase] : expr.cases
-  );
-
-  if (expr.bindVariable) {
-    return opts.mod.block(null, [
-      compileVariable({
-        ...opts,
-        isReturnExpr: false,
-        expr: expr.bindVariable,
-      }),
-      ifChain,
-    ]);
-  }
-
-  return ifChain;
-};
-
-const compileIdentifier = (opts: CompileExprOpts<Identifier>) => {
-  const { expr, mod } = opts;
-
-  if (expr.is("break")) return mod.br(opts.loopBreakId!);
-
-  const entity = expr.resolve();
-  if (!entity) {
-    throw new Error(`Unrecognized symbol ${expr.value}`);
-  }
-
-  if (entity.isVariable() || entity.isParameter()) {
-    const type = mapBinaryenType(opts, entity.originalType ?? entity.type!);
-    const get = mod.local.get(entity.getIndex(), type);
-    if (entity.requiresCast) {
-      return refCast(mod, get, mapBinaryenType(opts, entity.type!));
-    }
-    return get;
-  }
-
-  throw new Error(`Cannot compile identifier ${expr}`);
-};
-
-const compileCall = (opts: CompileExprOpts<Call>): number => {
-  const { expr, mod, isReturnExpr } = opts;
-  if (expr.calls("quote")) return (expr.argAt(0) as { value: number }).value; // TODO: This is an ugly hack to get constants that the compiler needs to know at compile time for ex bnr calls;
-  if (expr.calls("=")) return compileAssign(opts);
-  if (expr.calls("if")) return compileIf(opts);
-  if (expr.calls("export")) return compileExport(opts);
-  if (expr.calls("mod")) return mod.nop();
-  if (expr.calls("member-access")) return compileObjMemberAccess(opts);
-  if (expr.calls("while")) return compileWhile(opts);
-  if (expr.calls("break")) return mod.br(opts.loopBreakId!);
-  if (expr.calls("FixedArray")) return compileFixedArray(opts);
-  if (expr.calls("binaryen")) {
-    return compileBnrCall(opts);
-  }
-
-  if (!expr.fn) {
-    throw new Error(`No function found for call ${expr.location}`);
-  }
-
-  if (expr.fn.isObjectType()) {
-    return compileObjectInit(opts);
-  }
-
-  const args = expr.args
-    .toArray()
-    .map((expr) => compileExpression({ ...opts, expr, isReturnExpr: false }));
-
-  const id = expr.fn!.id;
-  const returnType = mapBinaryenType(opts, expr.fn!.returnType!);
-
-  if (isReturnExpr) {
-    return returnCall(mod, id, args, returnType);
-  }
-
-  return mod.call(id, args, returnType);
-};
-
-const compileFixedArray = (opts: CompileExprOpts<Call>) => {
-  const type = opts.expr.type as FixedArrayType;
-  return gc.arrayNewFixed(
-    opts.mod,
-    gc.binaryenTypeToHeapType(mapBinaryenType(opts, type)),
-    opts.expr.argArrayMap((expr) => compileExpression({ ...opts, expr }))
-  );
-};
-
-const compileWhile = (opts: CompileExprOpts<Call>) => {
-  const { expr, mod } = opts;
-  const loopId = expr.syntaxId.toString();
-  const breakId = `__break_${loopId}`;
-  return mod.loop(
-    loopId,
-    mod.block(breakId, [
-      mod.br_if(
-        breakId,
-        mod.i32.ne(
-          compileExpression({
-            ...opts,
-            expr: expr.exprArgAt(0),
-            isReturnExpr: false,
-          }),
-          mod.i32.const(1)
-        )
-      ),
-      compileExpression({
-        ...opts,
-        expr: expr.labeledArg("do"),
-        loopBreakId: breakId,
-        isReturnExpr: false,
-      }),
-      mod.br(loopId),
-    ])
-  );
-};
-
-const compileObjectInit = (opts: CompileExprOpts<Call>) => {
-  const { expr, mod } = opts;
-
-  const objectType = getExprType(expr) as ObjectType;
-  const objectBinType = mapBinaryenType(opts, objectType);
-  const obj = expr.argAt(0) as ObjectLiteral;
-
-  return initStruct(mod, objectBinType, [
-    mod.global.get(
-      `__ancestors_table_${objectType.id}`,
-      opts.extensionHelpers.i32Array
-    ),
-    mod.global.get(
-      `__field_index_table_${objectType.id}`,
-      opts.fieldLookupHelpers.lookupTableType
-    ),
-    ...obj.fields.map((field) =>
-      compileExpression({
-        ...opts,
-        expr: field.initializer,
-        isReturnExpr: false,
-      })
-    ),
-  ]);
-};
-
-const compileExport = (opts: CompileExprOpts<Call>) => {
-  const expr = opts.expr.exprArgAt(0);
-  const result = compileExpression({ ...opts, expr });
-  return result;
-};
-
-const compileAssign = (opts: CompileExprOpts<Call>): number => {
-  const { expr, mod } = opts;
-  const identifier = expr.argAt(0);
-
-  if (identifier?.isCall()) {
-    return compileFieldAssign(opts);
-  }
-
-  if (!identifier?.isIdentifier()) {
-    throw new Error(`Invalid assignment target ${identifier}`);
-  }
-
-  const value = compileExpression({
-    ...opts,
-    expr: expr.argAt(1)!,
-    isReturnExpr: false,
-  });
-  const entity = identifier.resolve();
-  if (!entity) {
-    throw new Error(`${identifier} not found in scope`);
-  }
-
-  if (entity.isVariable()) {
-    return mod.local.set(entity.getIndex(), value);
-  }
-
-  throw new Error(`${identifier} cannot be re-assigned`);
-};
-
-const compileFieldAssign = (opts: CompileExprOpts<Call>) => {
-  const { expr, mod } = opts;
-  const access = expr.callArgAt(0);
-  const member = access.identifierArgAt(1);
-  const target = access.exprArgAt(0);
-  const type = getExprType(target) as ObjectType | IntersectionType;
-
-  if (type.isIntersectionType() || type.isStructural) {
-    return opts.fieldLookupHelpers.setFieldValueByAccessor(opts);
-  }
-
-  const value = compileExpression({
-    ...opts,
-    expr: expr.argAt(1)!,
-    isReturnExpr: false,
-  });
-
-  const index = type.getFieldIndex(member);
-  if (index === -1) {
-    throw new Error(`Field ${member} not found in ${type.id}`);
-  }
-  const memberIndex = type.getFieldIndex(member) + OBJECT_FIELDS_OFFSET;
-
-  return gc.structSetFieldValue({
-    mod,
-    ref: compileExpression({ ...opts, expr: target }),
-    fieldIndex: memberIndex,
-    value,
-  });
-};
-
-const compileBnrCall = (opts: CompileExprOpts<Call>): number => {
-  const { expr } = opts;
-  const funcIdExpr = expr.labeledArg("func");
-  const namespaceExpr = expr.labeledArg("namespace");
-  const argsExpr = expr.labeledArg("args");
-
-  if (!funcIdExpr?.isIdentifier())
-    throw new Error("binaryen call missing 'func:' identifier");
-  if (!namespaceExpr?.isIdentifier())
-    throw new Error("binaryen call missing 'namespace:' identifier");
-  if (!argsExpr?.isCall())
-    throw new Error("binaryen call missing 'args:' list");
-
-  const funcId = funcIdExpr as Identifier;
-  const namespace = namespaceExpr.value;
-  const args = argsExpr as Call;
-
-  const func =
-    namespace === "gc"
-      ? (...args: unknown[]) => (gc as any)[funcId.value](opts.mod, ...args)
-      : (opts.mod as any)[namespace][funcId.value];
-
-  return func(
-    ...(args.argArrayMap((expr: Expr) => {
-      if (expr?.isCall() && expr.calls("BnrType")) {
-        const type = getExprType(expr.typeArgs?.at(0));
-        if (!type) return opts.mod.nop();
-        return mapBinaryenType(opts, type);
-      }
-
-      if (expr?.isCall() && expr.calls("BnrConst")) {
-        const arg = expr.argAt(0);
-        if (!arg) return opts.mod.nop();
-        if ("value" in arg) return arg.value;
-      }
-
-      return compileExpression({ ...opts, expr });
-    }) ?? [])
-  );
-};
-
-const compileVariable = (opts: CompileExprOpts<Variable>): number => {
-  const { expr, mod } = opts;
-  return mod.local.set(
-    expr.getIndex(),
-    expr.initializer
-      ? compileExpression({ ...opts, expr: expr.initializer })
-      : mod.nop()
-  );
-};
-
-const compileFunction = (opts: CompileExprOpts<Fn>): number => {
-  const { expr: fn, mod } = opts;
-  if (fn.genericInstances) {
-    fn.genericInstances.forEach((instance) =>
-      compileFunction({ ...opts, expr: instance })
-    );
-    return mod.nop();
-  }
-
-  if (fn.typeParameters) {
-    return mod.nop();
-  }
-
-  const parameterTypes = getFunctionParameterTypes(opts, fn);
-  const returnType = mapBinaryenType(opts, fn.getReturnType());
-
-  const body = compileExpression({
-    ...opts,
-    expr: fn.body!,
-    isReturnExpr: true,
-  });
-
-  const variableTypes = getFunctionVarTypes(opts, fn);
-
-  mod.addFunction(fn.id, parameterTypes, returnType, variableTypes, body);
-
-  return mod.nop();
-};
-
-const compileDeclaration = (opts: CompileExprOpts<Declaration>) => {
-  const { expr: decl, mod } = opts;
-
-  decl.fns.forEach((expr) =>
-    compileExternFn({ ...opts, expr, namespace: decl.namespace })
-  );
-
-  return mod.nop();
-};
-
-const compileExternFn = (opts: CompileExprOpts<Fn> & { namespace: string }) => {
-  const { expr: fn, mod, namespace } = opts;
-  const parameterTypes = getFunctionParameterTypes(opts, fn);
-
-  mod.addFunctionImport(
-    fn.id,
-    namespace,
-    fn.getNameStr(),
-    parameterTypes,
-    mapBinaryenType(opts, fn.getReturnType())
-  );
-
-  return mod.nop();
-};
-
-const compileObjectLiteral = (opts: CompileExprOpts<ObjectLiteral>) => {
-  const { expr: obj, mod } = opts;
-
-  const objectType = getExprType(obj) as ObjectType;
-  const literalBinType = mapBinaryenType(
-    { ...opts, useOriginalType: true },
-    objectType
-  );
-
-  return initStruct(mod, literalBinType, [
-    mod.global.get(
-      `__ancestors_table_${objectType.id}`,
-      opts.extensionHelpers.i32Array
-    ),
-    mod.global.get(
-      `__field_index_table_${objectType.id}`,
-      opts.fieldLookupHelpers.lookupTableType
-    ),
-    ...obj.fields.map((field) =>
-      compileExpression({ ...opts, expr: field.initializer })
-    ),
-  ]);
-};
-
-const compileIf = (opts: CompileExprOpts<Call>) => {
-  const { expr, mod } = opts;
-  const conditionNode = expr.exprArgAt(0);
-  const ifTrueNode = expr.labeledArg("then");
-  const ifFalseNode = expr.optionalLabeledArg("else");
-  const condition = compileExpression({
-    ...opts,
-    expr: conditionNode,
-    isReturnExpr: false,
-  });
-  const ifTrue = compileExpression({ ...opts, expr: ifTrueNode });
-  const ifFalse =
-    ifFalseNode !== undefined
-      ? compileExpression({ ...opts, expr: ifFalseNode })
-      : undefined;
-
-  return mod.if(condition, ifTrue, ifFalse);
-};
-
-const getFunctionParameterTypes = (opts: CompileExprOpts, fn: Fn) => {
-  const types = fn.parameters.map((param) =>
-    mapBinaryenType(opts, param.type!)
-  );
-
-  return binaryen.createType(types);
-};
-
-const getFunctionVarTypes = (opts: CompileExprOpts, fn: Fn) =>
-  fn.variables.map((v) => mapBinaryenType(opts, v.type!));
 
 type MapBinTypeOpts = CompileExprOpts & {
-  useOriginalType?: boolean; // Use the original type of the object literal, i.e. to initialize an object literal, who normally returns the base object type
+  useOriginalType?: boolean; // Use the original type of the object literal
 };
 
 export const mapBinaryenType = (
@@ -610,7 +141,10 @@ const buildFixedArrayType = (opts: CompileExprOpts, type: FixedArrayType) => {
   return type.binaryenType;
 };
 
-const buildUnionType = (opts: MapBinTypeOpts, union: UnionType): TypeRef => {
+export const buildUnionType = (
+  opts: MapBinTypeOpts,
+  union: UnionType
+): TypeRef => {
   if (union.hasAttribute("binaryenType")) {
     return union.getAttribute("binaryenType") as TypeRef;
   }
@@ -620,7 +154,7 @@ const buildUnionType = (opts: MapBinTypeOpts, union: UnionType): TypeRef => {
   return typeRef;
 };
 
-const buildIntersectionType = (
+export const buildIntersectionType = (
   opts: MapBinTypeOpts,
   inter: IntersectionType
 ): TypeRef => {
@@ -634,11 +168,10 @@ const buildIntersectionType = (
   return typeRef;
 };
 
-// Marks the start of the fields in an object after RTT info fields
-const OBJECT_FIELDS_OFFSET = 2;
-
-/** TODO: Skip building types for object literals that are part of an initializer of an obj */
-const buildObjectType = (opts: MapBinTypeOpts, obj: ObjectType): TypeRef => {
+export const buildObjectType = (
+  opts: MapBinTypeOpts,
+  obj: ObjectType
+): TypeRef => {
   if (opts.useOriginalType && obj.getAttribute("originalType")) {
     return obj.getAttribute("originalType") as TypeRef;
   }
@@ -653,7 +186,10 @@ const buildObjectType = (opts: MapBinTypeOpts, obj: ObjectType): TypeRef => {
 
   const fields = [
     { type: opts.extensionHelpers.i32Array, name: "__ancestors_table" },
-    { type: opts.fieldLookupHelpers.lookupTableType, name: "__field_index_table" },
+    {
+      type: opts.fieldLookupHelpers.lookupTableType,
+      name: "__field_index_table",
+    },
     ...obj.fields.map((field) => ({
       type: mapBinaryenType(opts, field.type!),
       name: field.name,
@@ -675,7 +211,6 @@ const buildObjectType = (opts: MapBinTypeOpts, obj: ObjectType): TypeRef => {
 
   obj.binaryenType = gc.binaryenTypeFromHeapType(heapType, true);
 
-  // Set RTT Ancestors Table (So we don't have to re-calculate it every time)
   mod.addGlobal(
     `__ancestors_table_${obj.id}`,
     opts.extensionHelpers.i32Array,
@@ -683,8 +218,6 @@ const buildObjectType = (opts: MapBinTypeOpts, obj: ObjectType): TypeRef => {
     opts.extensionHelpers.initExtensionArray(obj.getAncestorIds())
   );
 
-  // Set Field Index Table
-  // Set RTT Table (So we don't have to re-calculate it every time)
   mod.addGlobal(
     `__field_index_table_${obj.id}`,
     opts.fieldLookupHelpers.lookupTableType,
@@ -708,30 +241,10 @@ const buildObjectType = (opts: MapBinTypeOpts, obj: ObjectType): TypeRef => {
   return obj.binaryenType;
 };
 
-const compileObjMemberAccess = (opts: CompileExprOpts<Call>) => {
-  const { expr, mod } = opts;
-  const obj = expr.exprArgAt(0);
-  const member = expr.identifierArgAt(1);
-  const objValue = compileExpression({ ...opts, expr: obj });
-  const type = getExprType(obj) as ObjectType | IntersectionType;
-
-  if (type.isIntersectionType() || type.isStructural) {
-    return opts.fieldLookupHelpers.getFieldValueByAccessor(opts);
-  }
-
-  const memberIndex = type.getFieldIndex(member) + OBJECT_FIELDS_OFFSET;
-  const field = type.getField(member)!;
-  return structGetFieldValue({
-    mod,
-    fieldIndex: memberIndex,
-    fieldType: mapBinaryenType(opts, field.type!),
-    exprRef: objValue,
-  });
-};
-
 let i32ArrayType: TypeRef | undefined = undefined;
-const getI32ArrayType = (mod: binaryen.Module) => {
+export const getI32ArrayType = (mod: binaryen.Module) => {
   if (i32ArrayType) return i32ArrayType;
   i32ArrayType = gc.defineArrayType(mod, binaryen.i32, true);
   return i32ArrayType;
 };
+

--- a/src/assembler/compile-block.ts
+++ b/src/assembler/compile-block.ts
@@ -1,0 +1,16 @@
+import { CompileExprOpts, compileExpression } from "../assembler.js";
+import { Block } from "../syntax-objects/block.js";
+
+export const compile = (opts: CompileExprOpts<Block>) => {
+  return opts.mod.block(
+    null,
+    opts.expr.body.map((expr, index, array) => {
+      if (index === array.length - 1 && opts.isReturnExpr) {
+        return compileExpression({ ...opts, expr, isReturnExpr: true });
+      }
+
+      return compileExpression({ ...opts, expr, isReturnExpr: false });
+    })
+  );
+};
+

--- a/src/assembler/compile-bool.ts
+++ b/src/assembler/compile-bool.ts
@@ -1,0 +1,7 @@
+import { CompileExprOpts } from "../assembler.js";
+import { Bool } from "../syntax-objects/bool.js";
+
+export const compile = (opts: CompileExprOpts<Bool>) => {
+  return opts.expr.value ? opts.mod.i32.const(1) : opts.mod.i32.const(0);
+};
+

--- a/src/assembler/compile-call.ts
+++ b/src/assembler/compile-call.ts
@@ -1,0 +1,265 @@
+import { CompileExprOpts, compileExpression, mapBinaryenType } from "../assembler.js";
+import { Call } from "../syntax-objects/call.js";
+import { ObjectLiteral } from "../syntax-objects/object-literal.js";
+import {
+  ObjectType,
+  IntersectionType,
+  FixedArrayType,
+} from "../syntax-objects/types.js";
+import { Identifier } from "../syntax-objects/identifier.js";
+import { Expr } from "../syntax-objects/expr.js";
+import { getExprType } from "../semantics/resolution/get-expr-type.js";
+import { returnCall } from "./return-call.js";
+import * as gc from "../lib/binaryen-gc/index.js";
+
+const OBJECT_FIELDS_OFFSET = 2;
+
+export const compile = (opts: CompileExprOpts<Call>): number => {
+  const { expr, mod, isReturnExpr } = opts;
+  if (expr.calls("quote"))
+    return (expr.argAt(0) as { value: number }).value;
+  if (expr.calls("=")) return compileAssign(opts);
+  if (expr.calls("if")) return compileIf(opts);
+  if (expr.calls("export")) return compileExport(opts);
+  if (expr.calls("mod")) return mod.nop();
+  if (expr.calls("member-access")) return compileObjMemberAccess(opts);
+  if (expr.calls("while")) return compileWhile(opts);
+  if (expr.calls("break")) return mod.br(opts.loopBreakId!);
+  if (expr.calls("FixedArray")) return compileFixedArray(opts);
+  if (expr.calls("binaryen")) {
+    return compileBnrCall(opts);
+  }
+
+  if (!expr.fn) {
+    throw new Error(`No function found for call ${expr.location}`);
+  }
+
+  if (expr.fn.isObjectType()) {
+    return compileObjectInit(opts);
+  }
+
+  const args = expr.args
+    .toArray()
+    .map((expr) => compileExpression({ ...opts, expr, isReturnExpr: false }));
+
+  const id = expr.fn!.id;
+  const returnType = mapBinaryenType(opts, expr.fn!.returnType!);
+
+  if (isReturnExpr) {
+    return returnCall(mod, id, args, returnType);
+  }
+
+  return mod.call(id, args, returnType);
+};
+
+const compileFixedArray = (opts: CompileExprOpts<Call>) => {
+  const type = opts.expr.type as FixedArrayType;
+  return gc.arrayNewFixed(
+    opts.mod,
+    gc.binaryenTypeToHeapType(mapBinaryenType(opts, type)),
+    opts.expr.argArrayMap((expr) => compileExpression({ ...opts, expr }))
+  );
+};
+
+const compileWhile = (opts: CompileExprOpts<Call>) => {
+  const { expr, mod } = opts;
+  const loopId = expr.syntaxId.toString();
+  const breakId = `__break_${loopId}`;
+  return mod.loop(
+    loopId,
+    mod.block(breakId, [
+      mod.br_if(
+        breakId,
+        mod.i32.ne(
+          compileExpression({
+            ...opts,
+            expr: expr.exprArgAt(0),
+            isReturnExpr: false,
+          }),
+          mod.i32.const(1)
+        )
+      ),
+      compileExpression({
+        ...opts,
+        expr: expr.labeledArg("do"),
+        loopBreakId: breakId,
+        isReturnExpr: false,
+      }),
+      mod.br(loopId),
+    ])
+  );
+};
+
+const compileObjectInit = (opts: CompileExprOpts<Call>) => {
+  const { expr, mod } = opts;
+
+  const objectType = getExprType(expr) as ObjectType;
+  const objectBinType = mapBinaryenType(opts, objectType);
+  const obj = expr.argAt(0) as ObjectLiteral;
+
+  return gc.initStruct(mod, objectBinType, [
+    mod.global.get(
+      `__ancestors_table_${objectType.id}`,
+      opts.extensionHelpers.i32Array
+    ),
+    mod.global.get(
+      `__field_index_table_${objectType.id}`,
+      opts.fieldLookupHelpers.lookupTableType
+    ),
+    ...obj.fields.map((field) =>
+      compileExpression({
+        ...opts,
+        expr: field.initializer,
+        isReturnExpr: false,
+      })
+    ),
+  ]);
+};
+
+const compileExport = (opts: CompileExprOpts<Call>) => {
+  const expr = opts.expr.exprArgAt(0);
+  const result = compileExpression({ ...opts, expr });
+  return result;
+};
+
+const compileAssign = (opts: CompileExprOpts<Call>): number => {
+  const { expr, mod } = opts;
+  const identifier = expr.argAt(0);
+
+  if (identifier?.isCall()) {
+    return compileFieldAssign(opts);
+  }
+
+  if (!identifier?.isIdentifier()) {
+    throw new Error(`Invalid assignment target ${identifier}`);
+  }
+
+  const value = compileExpression({
+    ...opts,
+    expr: expr.argAt(1)!,
+    isReturnExpr: false,
+  });
+  const entity = identifier.resolve();
+  if (!entity) {
+    throw new Error(`${identifier} not found in scope`);
+  }
+
+  if (entity.isVariable()) {
+    return mod.local.set(entity.getIndex(), value);
+  }
+
+  throw new Error(`${identifier} cannot be re-assigned`);
+};
+
+const compileFieldAssign = (opts: CompileExprOpts<Call>) => {
+  const { expr, mod } = opts;
+  const access = expr.callArgAt(0);
+  const member = access.identifierArgAt(1);
+  const target = access.exprArgAt(0);
+  const type = getExprType(target) as ObjectType | IntersectionType;
+
+  if (type.isIntersectionType() || type.isStructural) {
+    return opts.fieldLookupHelpers.setFieldValueByAccessor(opts);
+  }
+
+  const value = compileExpression({
+    ...opts,
+    expr: expr.argAt(1)!,
+    isReturnExpr: false,
+  });
+
+  const index = type.getFieldIndex(member);
+  if (index === -1) {
+    throw new Error(`Field ${member} not found in ${type.id}`);
+  }
+  const memberIndex = index + OBJECT_FIELDS_OFFSET;
+
+  return gc.structSetFieldValue({
+    mod,
+    ref: compileExpression({ ...opts, expr: target }),
+    fieldIndex: memberIndex,
+    value,
+  });
+};
+
+const compileBnrCall = (opts: CompileExprOpts<Call>): number => {
+  const { expr } = opts;
+  const funcIdExpr = expr.labeledArg("func");
+  const namespaceExpr = expr.labeledArg("namespace");
+  const argsExpr = expr.labeledArg("args");
+
+  if (!funcIdExpr?.isIdentifier())
+    throw new Error("binaryen call missing 'func:' identifier");
+  if (!namespaceExpr?.isIdentifier())
+    throw new Error("binaryen call missing 'namespace:' identifier");
+  if (!argsExpr?.isCall())
+    throw new Error("binaryen call missing 'args:' list");
+
+  const funcId = funcIdExpr as Identifier;
+  const namespace = namespaceExpr.value;
+  const args = argsExpr as Call;
+
+  const func =
+    namespace === "gc"
+      ? (...args: unknown[]) => (gc as any)[funcId.value](opts.mod, ...args)
+      : (opts.mod as any)[namespace][funcId.value];
+
+  return func(
+    ...(args.argArrayMap((expr: Expr) => {
+      if (expr?.isCall() && expr.calls("BnrType")) {
+        const type = getExprType(expr.typeArgs?.at(0));
+        if (!type) return opts.mod.nop();
+        return mapBinaryenType(opts, type);
+      }
+
+      if (expr?.isCall() && expr.calls("BnrConst")) {
+        const arg = expr.argAt(0);
+        if (!arg) return opts.mod.nop();
+        if ("value" in arg) return (arg as any).value;
+      }
+
+      return compileExpression({ ...opts, expr });
+    }) ?? [])
+  );
+};
+
+const compileIf = (opts: CompileExprOpts<Call>) => {
+  const { expr, mod } = opts;
+  const conditionNode = expr.exprArgAt(0);
+  const ifTrueNode = expr.labeledArg("then");
+  const ifFalseNode = expr.optionalLabeledArg("else");
+  const condition = compileExpression({
+    ...opts,
+    expr: conditionNode,
+    isReturnExpr: false,
+  });
+  const ifTrue = compileExpression({ ...opts, expr: ifTrueNode });
+  const ifFalse =
+    ifFalseNode !== undefined
+      ? compileExpression({ ...opts, expr: ifFalseNode })
+      : undefined;
+
+  return mod.if(condition, ifTrue, ifFalse);
+};
+
+const compileObjMemberAccess = (opts: CompileExprOpts<Call>) => {
+  const { expr, mod } = opts;
+  const obj = expr.exprArgAt(0);
+  const member = expr.identifierArgAt(1);
+  const objValue = compileExpression({ ...opts, expr: obj });
+  const type = getExprType(obj) as ObjectType | IntersectionType;
+
+  if (type.isIntersectionType() || type.isStructural) {
+    return opts.fieldLookupHelpers.getFieldValueByAccessor(opts);
+  }
+
+  const memberIndex = type.getFieldIndex(member) + OBJECT_FIELDS_OFFSET;
+  const field = type.getField(member)!;
+  return gc.structGetFieldValue({
+    mod,
+    fieldIndex: memberIndex,
+    fieldType: mapBinaryenType(opts, field.type!),
+    exprRef: objValue,
+  });
+};
+

--- a/src/assembler/compile-declaration.ts
+++ b/src/assembler/compile-declaration.ts
@@ -1,0 +1,30 @@
+import { CompileExprOpts, mapBinaryenType } from "../assembler.js";
+import { Declaration } from "../syntax-objects/declaration.js";
+import { Fn } from "../syntax-objects/fn.js";
+import { getFunctionParameterTypes } from "./compile-function.js";
+
+export const compile = (opts: CompileExprOpts<Declaration>) => {
+  const { expr: decl, mod } = opts;
+
+  decl.fns.forEach((expr) =>
+    compileExternFn({ ...opts, expr, namespace: decl.namespace })
+  );
+
+  return mod.nop();
+};
+
+const compileExternFn = (opts: CompileExprOpts<Fn> & { namespace: string }) => {
+  const { expr: fn, mod, namespace } = opts;
+  const parameterTypes = getFunctionParameterTypes(opts, fn);
+
+  mod.addFunctionImport(
+    fn.id,
+    namespace,
+    fn.getNameStr(),
+    parameterTypes,
+    mapBinaryenType(opts, fn.getReturnType())
+  );
+
+  return mod.nop();
+};
+

--- a/src/assembler/compile-float.ts
+++ b/src/assembler/compile-float.ts
@@ -1,0 +1,11 @@
+import { CompileExprOpts } from "../assembler.js";
+import { Float } from "../syntax-objects/float.js";
+
+export const compile = (opts: CompileExprOpts<Float>) => {
+  const val = opts.expr.value;
+  if (typeof val === "number") {
+    return opts.mod.f32.const(val);
+  }
+  return opts.mod.f64.const(val.value);
+};
+

--- a/src/assembler/compile-function.ts
+++ b/src/assembler/compile-function.ts
@@ -1,0 +1,44 @@
+import { CompileExprOpts, mapBinaryenType, compileExpression } from "../assembler.js";
+import { Fn } from "../syntax-objects/fn.js";
+import binaryen from "binaryen";
+
+export const compile = (opts: CompileExprOpts<Fn>): number => {
+  const { expr: fn, mod } = opts;
+  if (fn.genericInstances) {
+    fn.genericInstances.forEach((instance) =>
+      compile({ ...opts, expr: instance })
+    );
+    return mod.nop();
+  }
+
+  if (fn.typeParameters) {
+    return mod.nop();
+  }
+
+  const parameterTypes = getFunctionParameterTypes(opts, fn);
+  const returnType = mapBinaryenType(opts, fn.getReturnType());
+
+  const body = compileExpression({
+    ...opts,
+    expr: fn.body!,
+    isReturnExpr: true,
+  });
+
+  const variableTypes = getFunctionVarTypes(opts, fn);
+
+  mod.addFunction(fn.id, parameterTypes, returnType, variableTypes, body);
+
+  return mod.nop();
+};
+
+export const getFunctionParameterTypes = (opts: CompileExprOpts, fn: Fn) => {
+  const types = fn.parameters.map((param) =>
+    mapBinaryenType(opts, param.type!)
+  );
+
+  return binaryen.createType(types);
+};
+
+export const getFunctionVarTypes = (opts: CompileExprOpts, fn: Fn) =>
+  fn.variables.map((v) => mapBinaryenType(opts, v.type!));
+

--- a/src/assembler/compile-identifier.ts
+++ b/src/assembler/compile-identifier.ts
@@ -1,0 +1,26 @@
+import { CompileExprOpts, mapBinaryenType } from "../assembler.js";
+import { Identifier } from "../syntax-objects/identifier.js";
+import { refCast } from "../lib/binaryen-gc/index.js";
+
+export const compile = (opts: CompileExprOpts<Identifier>) => {
+  const { expr, mod } = opts;
+
+  if (expr.is("break")) return mod.br(opts.loopBreakId!);
+
+  const entity = expr.resolve();
+  if (!entity) {
+    throw new Error(`Unrecognized symbol ${expr.value}`);
+  }
+
+  if (entity.isVariable() || entity.isParameter()) {
+    const type = mapBinaryenType(opts, entity.originalType ?? entity.type!);
+    const get = mod.local.get(entity.getIndex(), type);
+    if (entity.requiresCast) {
+      return refCast(mod, get, mapBinaryenType(opts, entity.type!));
+    }
+    return get;
+  }
+
+  throw new Error(`Cannot compile identifier ${expr}`);
+};
+

--- a/src/assembler/compile-impl.ts
+++ b/src/assembler/compile-impl.ts
@@ -1,0 +1,5 @@
+import { CompileExprOpts } from "../assembler.js";
+import { Implementation } from "../syntax-objects/implementation.js";
+
+export const compile = (_: CompileExprOpts<Implementation>) => _.mod.nop();
+

--- a/src/assembler/compile-int.ts
+++ b/src/assembler/compile-int.ts
@@ -1,0 +1,15 @@
+import { CompileExprOpts } from "../assembler.js";
+import { Int } from "../syntax-objects/int.js";
+
+export const compile = (opts: CompileExprOpts<Int>) => {
+  const val = opts.expr.value;
+  if (typeof val === "number") {
+    return opts.mod.i32.const(val);
+  }
+
+  const i64Int = val.value;
+  const low = Number(i64Int & BigInt(0xffffffff));
+  const high = Number((i64Int >> BigInt(32)) & BigInt(0xffffffff));
+  return opts.mod.i64.const(low, high);
+};
+

--- a/src/assembler/compile-macro-variable.ts
+++ b/src/assembler/compile-macro-variable.ts
@@ -1,0 +1,5 @@
+import { CompileExprOpts } from "../assembler.js";
+import { MacroVariable } from "../syntax-objects/macro-variable.js";
+
+export const compile = (_: CompileExprOpts<MacroVariable>) => _.mod.nop();
+

--- a/src/assembler/compile-macro.ts
+++ b/src/assembler/compile-macro.ts
@@ -1,0 +1,5 @@
+import { CompileExprOpts } from "../assembler.js";
+import { Macro } from "../syntax-objects/macros.js";
+
+export const compile = (_: CompileExprOpts<Macro>) => _.mod.nop();
+

--- a/src/assembler/compile-match.ts
+++ b/src/assembler/compile-match.ts
@@ -1,0 +1,55 @@
+import binaryen from "binaryen";
+import { CompileExprOpts, compileExpression } from "../assembler.js";
+import { Match, MatchCase } from "../syntax-objects/match.js";
+import { compile as compileVariable } from "./compile-variable.js";
+import { compile as compileIdentifier } from "./compile-identifier.js";
+import { structGetFieldValue } from "../lib/binaryen-gc/index.js";
+
+export const compile = (opts: CompileExprOpts<Match>) => {
+  const { expr } = opts;
+
+  const constructIfChain = (cases: MatchCase[]): number => {
+    const nextCase = cases.shift();
+    if (!nextCase) return opts.mod.unreachable();
+
+    if (!cases.length) {
+      return compileExpression({ ...opts, expr: nextCase.expr });
+    }
+
+    return opts.mod.if(
+      opts.mod.call(
+        "__extends",
+        [
+          opts.mod.i32.const(nextCase.matchType!.syntaxId),
+          structGetFieldValue({
+            mod: opts.mod,
+            fieldType: opts.extensionHelpers.i32Array,
+            fieldIndex: 0,
+            exprRef: compileIdentifier({ ...opts, expr: expr.bindIdentifier }),
+          }),
+        ],
+        binaryen.i32
+      ),
+      compileExpression({ ...opts, expr: nextCase.expr }),
+      constructIfChain(cases)
+    );
+  };
+
+  const ifChain = constructIfChain(
+    expr.defaultCase ? [...expr.cases, expr.defaultCase] : expr.cases
+  );
+
+  if (expr.bindVariable) {
+    return opts.mod.block(null, [
+      compileVariable({
+        ...opts,
+        isReturnExpr: false,
+        expr: expr.bindVariable,
+      }),
+      ifChain,
+    ]);
+  }
+
+  return ifChain;
+};
+

--- a/src/assembler/compile-module.ts
+++ b/src/assembler/compile-module.ts
@@ -1,0 +1,20 @@
+import { CompileExprOpts, compileExpression } from "../assembler.js";
+import { VoydModule } from "../syntax-objects/module.js";
+
+export const compile = (opts: CompileExprOpts<VoydModule>) => {
+  const result = opts.mod.block(
+    opts.expr.id,
+    opts.expr.value.map((expr) => compileExpression({ ...opts, expr }))
+  );
+
+  if (opts.expr.isIndex) {
+    opts.expr.getAllExports().forEach((entity) => {
+      if (entity.isFn()) {
+        opts.mod.addFunctionExport(entity.id, entity.name.value);
+      }
+    });
+  }
+
+  return result;
+};
+

--- a/src/assembler/compile-object-literal.ts
+++ b/src/assembler/compile-object-literal.ts
@@ -1,0 +1,30 @@
+import { CompileExprOpts, mapBinaryenType, compileExpression } from "../assembler.js";
+import { ObjectLiteral } from "../syntax-objects/object-literal.js";
+import { ObjectType } from "../syntax-objects/types.js";
+import { getExprType } from "../semantics/resolution/get-expr-type.js";
+import { initStruct } from "../lib/binaryen-gc/index.js";
+
+export const compile = (opts: CompileExprOpts<ObjectLiteral>) => {
+  const { expr: obj, mod } = opts;
+
+  const objectType = getExprType(obj) as ObjectType;
+  const literalBinType = mapBinaryenType(
+    { ...opts, useOriginalType: true },
+    objectType
+  );
+
+  return initStruct(mod, literalBinType, [
+    mod.global.get(
+      `__ancestors_table_${objectType.id}`,
+      opts.extensionHelpers.i32Array
+    ),
+    mod.global.get(
+      `__field_index_table_${objectType.id}`,
+      opts.fieldLookupHelpers.lookupTableType
+    ),
+    ...obj.fields.map((field) =>
+      compileExpression({ ...opts, expr: field.initializer })
+    ),
+  ]);
+};
+

--- a/src/assembler/compile-string-literal.ts
+++ b/src/assembler/compile-string-literal.ts
@@ -1,0 +1,13 @@
+import { CompileExprOpts, getI32ArrayType } from "../assembler.js";
+import { StringLiteral } from "../syntax-objects/string-literal.js";
+import { arrayNewFixed, binaryenTypeToHeapType } from "../lib/binaryen-gc/index.js";
+
+export const compile = (opts: CompileExprOpts<StringLiteral>) => {
+  const { expr, mod } = opts;
+  return arrayNewFixed(
+    mod,
+    binaryenTypeToHeapType(getI32ArrayType(mod)),
+    expr.value.split("").map((char) => mod.i32.const(char.charCodeAt(0)))
+  );
+};
+

--- a/src/assembler/compile-trait.ts
+++ b/src/assembler/compile-trait.ts
@@ -1,0 +1,5 @@
+import { CompileExprOpts } from "../assembler.js";
+import { Trait } from "../syntax-objects/trait.js";
+
+export const compile = (_: CompileExprOpts<Trait>) => _.mod.nop();
+

--- a/src/assembler/compile-type.ts
+++ b/src/assembler/compile-type.ts
@@ -1,0 +1,29 @@
+import {
+  CompileExprOpts,
+  buildObjectType,
+  buildUnionType,
+  buildIntersectionType,
+} from "../assembler.js";
+import { Type } from "../syntax-objects/types.js";
+
+export const compile = (opts: CompileExprOpts<Type>) => {
+  const type = opts.expr;
+
+  if (type.isObjectType()) {
+    buildObjectType(opts, type);
+    return opts.mod.nop();
+  }
+
+  if (type.isUnionType()) {
+    buildUnionType(opts, type);
+    return opts.mod.nop();
+  }
+
+  if (type.isIntersectionType()) {
+    buildIntersectionType(opts, type);
+    return opts.mod.nop();
+  }
+
+  return opts.mod.nop();
+};
+

--- a/src/assembler/compile-use.ts
+++ b/src/assembler/compile-use.ts
@@ -1,0 +1,5 @@
+import { CompileExprOpts } from "../assembler.js";
+import { Use } from "../syntax-objects/use.js";
+
+export const compile = (_: CompileExprOpts<Use>) => _.mod.nop();
+

--- a/src/assembler/compile-variable.ts
+++ b/src/assembler/compile-variable.ts
@@ -1,0 +1,13 @@
+import { CompileExprOpts, compileExpression } from "../assembler.js";
+import { Variable } from "../syntax-objects/variable.js";
+
+export const compile = (opts: CompileExprOpts<Variable>) => {
+  const { expr, mod } = opts;
+  return mod.local.set(
+    expr.getIndex(),
+    expr.initializer
+      ? compileExpression({ ...opts, expr: expr.initializer })
+      : mod.nop()
+  );
+};
+


### PR DESCRIPTION
## Summary
- split expression compilation into dedicated modules
- replace conditional chain with map-based dispatch
- assert dispatch map covers expected syntax types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68980c8e8dbc832aa88521ba28c450b6