### PR TITLE
feat: infer object type parameters

### DIFF
--- a/src/__tests__/compiler.test.ts
+++ b/src/__tests__/compiler.test.ts
@@ -77,6 +77,7 @@ describe("E2E Compiler Pipeline", () => {
       8, // trait impls
       7, // Recursive heap object type match Some
       -1, // Recursive heap object type match None
+      5, // Inferred generic object type parameter
     ]);
 
     const expectedSyntaxTypes = [

--- a/src/__tests__/fixtures/e2e-file.ts
+++ b/src/__tests__/fixtures/e2e-file.ts
@@ -325,6 +325,15 @@ pub fn test27() -> i32
   root.right.match(n)
     Some<Node<i32>>: n.value.val
     None: -1
+
+// Simple generic object to test type inference
+obj NodeSimple<T> {
+  val: T
+}
+
+pub fn test28() -> i32
+  let node = NodeSimple { val: 5 }
+  node.val
 `;
 
 export const tcoText = `

--- a/src/semantics/resolution/resolve-object-type.ts
+++ b/src/semantics/resolution/resolve-object-type.ts
@@ -3,6 +3,7 @@ import { nop } from "../../syntax-objects/lib/helpers.js";
 import { List } from "../../syntax-objects/list.js";
 import {
   ObjectType,
+  Type,
   TypeAlias,
   voydBaseObject,
 } from "../../syntax-objects/types.js";
@@ -39,10 +40,52 @@ const resolveGenericObjVersion = (
   type: ObjectType,
   call?: Call
 ): ObjectType | undefined => {
-  if (!call?.typeArgs) return;
+  if (!call) return;
+
+  // If no explicit type args are supplied, try to infer them from the
+  // supplied object literal.
+  if (!call.typeArgs) {
+    call.typeArgs = inferObjectInitTypeArgs(type, call);
+  }
+
+  if (!call.typeArgs) return;
+
   const existing = type.genericInstances?.find((c) => typeArgsMatch(call, c));
   if (existing) return existing;
   return resolveGenericsWithTypeArgs(type, call.typeArgs);
+};
+
+/** Attempt to infer type arguments for a generic object type from the
+ *  initialization call's object literal. */
+const inferObjectInitTypeArgs = (type: ObjectType, call: Call): List | undefined => {
+  const typeParams = type.typeParameters;
+  if (!typeParams?.length) return;
+
+  const objLiteral = call.argAt(0);
+  if (!objLiteral || !objLiteral.isObjectLiteral()) return;
+
+  const inferred: Type[] = [];
+
+  for (const tp of typeParams) {
+    let inferredType: Type | undefined;
+    // Find a field in the object type that references this type parameter
+    for (const field of type.fields) {
+      if (field.typeExpr.isIdentifier() && field.typeExpr.is(tp)) {
+        const initField = objLiteral.fields.find((f) => f.name === field.name);
+        inferredType = initField?.type;
+        break;
+      }
+    }
+
+    if (!inferredType) {
+      // Unable to infer all type parameters
+      return undefined;
+    }
+
+    inferred.push(inferredType);
+  }
+
+  return new List({ value: inferred });
 };
 
 const resolveGenericsWithTypeArgs = (


### PR DESCRIPTION
## Summary
- infer generic object type arguments from initialization literals
- test generic object inference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689848d10dfc832aac7f9948940fdab2