### PR TITLE
feat: compile closures

### DIFF
--- a/src/__tests__/compiler.test.ts
+++ b/src/__tests__/compiler.test.ts
@@ -29,6 +29,17 @@ describe("E2E Compiler Pipeline", () => {
     t.expect(fn(), "Main function returns correct value").toEqual(55n);
   });
 
+  test("Compiler can compile closures", async (t) => {
+    const text = `use std::all
+pub fn main() -> i32
+  let x = 1
+  let f = () => x
+  0
+`;
+    const mod = await compile(text);
+    t.expect(mod.validate(), "Module is valid");
+  });
+
   test("Compiler kitchen sink", async (t) => {
     const mod = await compile(kitchenSink);
     const instance = getWasmInstance(mod);

--- a/src/assembler/compile-call.ts
+++ b/src/assembler/compile-call.ts
@@ -4,12 +4,14 @@ import {
   mapBinaryenType,
 } from "../assembler.js";
 import { refCast } from "../lib/binaryen-gc/index.js";
+import binaryen from "binaryen";
 import { Call } from "../syntax-objects/call.js";
 import { ObjectLiteral } from "../syntax-objects/object-literal.js";
 import {
   ObjectType,
   IntersectionType,
   FixedArrayType,
+  FnType,
 } from "../syntax-objects/types.js";
 import { Identifier } from "../syntax-objects/identifier.js";
 import { Expr } from "../syntax-objects/expr.js";
@@ -35,6 +37,14 @@ export const compile = (opts: CompileExprOpts<Call>): number => {
   }
 
   if (!expr.fn) {
+    const ent = expr.fnName.resolve();
+    if (
+      ent &&
+      (ent.isVariable() || ent.isParameter()) &&
+      ent.type?.isFnType()
+    ) {
+      return compileClosureCall(opts, ent.type as FnType);
+    }
     throw new Error(`No function found for call ${expr.location}`);
   }
 
@@ -67,6 +77,46 @@ export const compile = (opts: CompileExprOpts<Call>): number => {
   }
 
   return mod.call(id, args, returnType);
+};
+
+const compileClosureCall = (
+  opts: CompileExprOpts<Call>,
+  fnType: FnType
+): number => {
+  const { expr, mod, isReturnExpr } = opts;
+  const closureRef = compileExpression({
+    ...opts,
+    expr: expr.fnName,
+    isReturnExpr: false,
+  });
+  const fnRef = gc.structGetFieldValue({
+    mod,
+    fieldIndex: 0,
+    fieldType: binaryen.funcref,
+    exprRef: closureRef,
+  });
+  const envRef = gc.structGetFieldValue({
+    mod,
+    fieldIndex: 1,
+    fieldType: binaryen.eqref,
+    exprRef: closureRef,
+  });
+  const args = expr.args.toArray().map((arg, i) => {
+    const compiled = compileExpression({
+      ...opts,
+      expr: arg,
+      isReturnExpr: false,
+    });
+    const param = fnType.parameters[i];
+    const argType = getExprType(arg);
+    if (param?.type?.isObjectType() && argType?.isTraitType()) {
+      return refCast(mod, compiled, mapBinaryenType(opts, param.type));
+    }
+    return compiled;
+  });
+  const allArgs = [envRef, ...args];
+  const returnType = mapBinaryenType(opts, fnType.returnType);
+  return gc.callRef(mod, fnRef, allArgs, returnType, isReturnExpr);
 };
 
 const compileFixedArray = (opts: CompileExprOpts<Call>) => {

--- a/src/assembler/compile-closure.ts
+++ b/src/assembler/compile-closure.ts
@@ -1,0 +1,114 @@
+import { CompileExprOpts, compileExpression, mapBinaryenType, getClosureBinaryenType } from "../assembler.js";
+import { Closure, Expr, Variable, Parameter } from "../syntax-objects/index.js";
+import * as gc from "../lib/binaryen-gc/index.js";
+import binaryen from "binaryen";
+
+const gatherCaptures = (
+  expr: Expr | undefined,
+  closure: Closure,
+  captures: Map<string, Variable | Parameter>
+) => {
+  if (!expr) return;
+  if (expr.isIdentifier()) {
+    const entity = expr.resolve();
+    if (
+      entity &&
+      (entity.isVariable() || entity.isParameter()) &&
+      entity.parentFn !== closure
+    ) {
+      captures.set(entity.id, entity);
+    }
+    return;
+  }
+  if (expr.isClosure() || expr.isFn()) return;
+  if (expr.isBlock()) {
+    expr.body.forEach((e) => gatherCaptures(e, closure, captures));
+    return;
+  }
+  if (expr.isCall()) {
+    expr.args.each((a) => gatherCaptures(a, closure, captures));
+    if (expr.typeArgs) expr.typeArgs.each((a) => gatherCaptures(a, closure, captures));
+    return;
+  }
+  if (expr.isVariable()) {
+    gatherCaptures(expr.initializer, closure, captures);
+    if (expr.typeExpr) gatherCaptures(expr.typeExpr, closure, captures);
+    return;
+  }
+  if (expr.isObjectLiteral()) {
+    expr.fields.forEach((f) => gatherCaptures(f.initializer, closure, captures));
+    return;
+  }
+  if (expr.isArrayLiteral()) {
+    expr.elements.forEach((e) => gatherCaptures(e, closure, captures));
+    return;
+  }
+  if (expr.isMatch()) {
+    gatherCaptures(expr.operand, closure, captures);
+    expr.cases.forEach((c) => gatherCaptures(c.expr, closure, captures));
+    if (expr.defaultCase) gatherCaptures(expr.defaultCase.expr, closure, captures);
+    return;
+  }
+};
+
+export const compile = (opts: CompileExprOpts<Closure>): number => {
+  const { expr: closure, mod } = opts;
+
+  // Gather captures
+  const captureMap = new Map<string, Variable | Parameter>();
+  gatherCaptures(closure.body, closure, captureMap);
+  const captures = Array.from(captureMap.values());
+  const captureIndexMap = new Map<string, number>();
+  captures.forEach((c, i) => captureIndexMap.set(c.id, i));
+
+  // Environment struct type
+  const envType = gc.defineStructType(mod, {
+    name: `__closure_env_${closure.syntaxId}`,
+    fields: captures.map((c) => ({
+      type: mapBinaryenType(opts, c.type!),
+      name: c.name.value,
+    })),
+    final: true,
+  });
+
+  // Compile body with closure context
+  const body = compileExpression({
+    ...opts,
+    expr: closure.body,
+    isReturnExpr: true,
+    currentClosure: { envType, captureMap: captureIndexMap },
+  });
+
+  const params = [
+    binaryen.eqref,
+    ...closure.parameters.map((p) => mapBinaryenType(opts, p.type!)),
+  ];
+  const returnType = mapBinaryenType(opts, closure.getReturnType());
+  const locals = closure.variables.map((v) => mapBinaryenType(opts, v.type!));
+  const fnName = `__closure_${closure.syntaxId}`;
+
+  mod.addFunction(
+    fnName,
+    binaryen.createType(params),
+    returnType,
+    locals,
+    body
+  );
+
+  // Build environment struct instance
+  const envValues = captures.map((c) => {
+    const type = mapBinaryenType(opts, c.type!);
+    if (c.isVariable()) return mod.local.get(c.getIndex(), type);
+    if (c.isParameter()) return mod.local.get(c.getIndex(), type);
+    return mod.nop();
+  });
+  const envStruct = gc.initStruct(mod, envType, envValues);
+
+  const closureType = getClosureBinaryenType(mod);
+  return gc.initStruct(mod, closureType, [
+    gc.refFunc(mod, fnName, binaryen.funcref),
+    envStruct,
+  ]);
+};
+
+export default { compile };


### PR DESCRIPTION
## Summary
- add Binaryen GC based closure objects with captured environment and function pointers
- enable calling closures via `call_ref`
- compile captured variables from closure environment
- add test ensuring modules with closures validate

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ac738c870832aa8a4cc8633f67f19