### PR TITLE
feat: add closure compilation

### DIFF
--- a/src/__tests__/compiler.test.ts
+++ b/src/__tests__/compiler.test.ts
@@ -3,6 +3,8 @@ import {
   kitchenSink,
   goodTypeInferenceText,
   tcoText,
+  closureNoParamText,
+  closureParamText,
 } from "./fixtures/e2e-file.js";
 import { compile } from "../compiler.js";
 import { describe, test, vi } from "vitest";
@@ -98,6 +100,22 @@ describe("E2E Compiler Pipeline", () => {
     t.expect(Object.keys(compilers)).toEqual(
       t.expect.arrayContaining(expectedSyntaxTypes)
     );
+  });
+
+  test("Compiler can call closures", async (t) => {
+    const mod = await compile(closureNoParamText);
+    const instance = getWasmInstance(mod);
+    const fn = getWasmFn("main", instance);
+    assert(fn, "Function exists");
+    t.expect(fn()).toEqual(5);
+  });
+
+  test("Compiler can call closures with parameters", async (t) => {
+    const mod = await compile(closureParamText);
+    const instance = getWasmInstance(mod);
+    const fn = getWasmFn("main", instance);
+    assert(fn, "Function exists");
+    t.expect(fn()).toEqual(7);
   });
 
   test("Compiler can do tco", async (t) => {

--- a/src/__tests__/fixtures/e2e-file.ts
+++ b/src/__tests__/fixtures/e2e-file.ts
@@ -380,3 +380,15 @@ fn fib_alias(n: i32, a: i64, b: i64) -> i64
 pub fn main() -> i64
   fib(10, 0i64, 1i64)
 `;
+
+export const closureNoParamText = `
+pub fn main()
+  let x = () => 5
+  x()
+`;
+
+export const closureParamText = `
+pub fn main()
+  let x = (v: i32) => v + 5
+  x(2)
+`;

--- a/src/assembler/compile-closure.ts
+++ b/src/assembler/compile-closure.ts
@@ -1,0 +1,112 @@
+import binaryen from "binaryen";
+import { CompileExprOpts, compileExpression, mapBinaryenType } from "../assembler.js";
+import { Closure } from "../syntax-objects/closure.js";
+import { Expr } from "../syntax-objects/expr.js";
+import { Identifier } from "../syntax-objects/identifier.js";
+import { NamedEntity } from "../syntax-objects/named-entity.js";
+import { refFunc, initStruct } from "../lib/binaryen-gc/index.js";
+import * as gc from "../lib/binaryen-gc/index.js";
+import { AugmentedBinaryen } from "../lib/binaryen-gc/types.js";
+import { Parameter } from "../syntax-objects/parameter.js";
+import { Variable } from "../syntax-objects/variable.js";
+
+const bin = binaryen as unknown as AugmentedBinaryen;
+
+const collectCaptured = (
+  expr: Expr,
+  closure: Closure,
+  captured: Map<NamedEntity, number>
+) => {
+  if (expr.isIdentifier()) {
+    const entity = (expr as Identifier).resolve();
+    if (
+      entity &&
+      (entity.isVariable() || entity.isParameter()) &&
+      entity.parentFn !== closure
+    ) {
+      if (!captured.has(entity)) {
+        captured.set(entity, captured.size);
+      }
+    }
+  }
+  const children = (expr as any).children as Expr[] | undefined;
+  if (children) {
+    children.forEach((child) => collectCaptured(child, closure, captured));
+  }
+};
+
+export const compile = (opts: CompileExprOpts<Closure>): number => {
+  const { expr: closure, mod } = opts;
+
+  const captured = new Map<NamedEntity, number>();
+  collectCaptured(closure.body, closure, captured);
+
+  const fields = [
+    { name: "__fn", type: bin.funcref, mutable: false },
+    ...Array.from(captured.keys()).map((entity) => ({
+      name: entity.name.value,
+      type: mapBinaryenType(opts, (entity as any).type!),
+      mutable: false,
+    })),
+  ];
+
+  const envType = gc.defineStructType(mod, {
+    name: `closure_env_${closure.syntaxId}`,
+    fields,
+  });
+
+  const capturedFieldMap = new Map<NamedEntity, number>();
+  Array.from(captured.entries()).forEach(([entity, index]) => {
+    capturedFieldMap.set(entity, index + 1); // offset for fn field
+  });
+
+  const body = compileExpression({
+    ...opts,
+    expr: closure.body,
+    isReturnExpr: true,
+    closureContext: {
+      envType,
+      capturedFieldIndices: capturedFieldMap,
+    },
+  });
+
+  const paramTypes = [
+    envType,
+    ...closure.parameters.map((p: Parameter) => mapBinaryenType(opts, p.type!)),
+  ];
+  const returnType = mapBinaryenType(opts, closure.getReturnType());
+  const localTypes = closure.variables.map((v: Variable) =>
+    mapBinaryenType(opts, v.type!)
+  );
+
+  const fnName = `__closure_fn_${closure.syntaxId}`;
+  const fnRef = mod.addFunction(
+    fnName,
+    binaryen.createType(paramTypes),
+    returnType,
+    localTypes,
+    body
+  );
+
+  // Obtain function type for ref.func
+  const fnHeap = bin._BinaryenFunctionGetType(fnRef);
+  const fnType = bin._BinaryenTypeFromHeapType(fnHeap, false);
+
+  const capturedValues = Array.from(captured.keys()).map((entity) => {
+    const type = mapBinaryenType(opts, (entity as any).type!);
+    return mod.local.get((entity as any).getIndex(), type);
+  });
+
+  const closureValue = initStruct(mod, envType, [
+    refFunc(mod, fnName, fnType),
+    ...capturedValues,
+  ]);
+
+  // store types on closure type for later use
+  const fnTypeObj = closure.getType();
+  fnTypeObj.setAttribute("binaryenType", envType);
+  fnTypeObj.setAttribute("binaryenFnRefType", fnType);
+
+  return closureValue;
+};
+

--- a/src/semantics/init-entities.ts
+++ b/src/semantics/init-entities.ts
@@ -141,15 +141,20 @@ const initClosure = (expr: List): Closure => {
   let parameters: Parameter[] = [];
 
   if (paramsExpr?.isList()) {
-    parameters = paramsExpr.sliceAsArray().flatMap((p) => {
-      if (p.isIdentifier()) {
-        return new Parameter({ name: p, typeExpr: undefined });
-      }
-      if (!p.isList()) {
-        throw new Error("Invalid parameter");
-      }
-      return listToParameter(p);
-    });
+    if (paramsExpr.calls(":")) {
+      const param = listToParameter(paramsExpr);
+      parameters = Array.isArray(param) ? param : [param];
+    } else {
+      parameters = paramsExpr.sliceAsArray().flatMap((p) => {
+        if (p.isIdentifier()) {
+          return new Parameter({ name: p, typeExpr: undefined });
+        }
+        if (!p.isList()) {
+          throw new Error("Invalid parameter");
+        }
+        return listToParameter(p);
+      });
+    }
   } else if (paramsExpr?.isIdentifier()) {
     parameters = [new Parameter({ name: paramsExpr, typeExpr: undefined })];
   }

--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -27,10 +27,11 @@ export const resolveCall = (call: Call): Call => {
   const memberAccessCall = getMemberAccessCall(call);
   if (memberAccessCall) return memberAccessCall;
 
+  const calleeType = getIdentifierType(call.fnName);
+
   // Constructor fn. TODO:
-  const type = getIdentifierType(call.fnName);
-  if (type?.isObjectType()) {
-    return resolveObjectInit(call, type);
+  if (calleeType?.isObjectType()) {
+    return resolveObjectInit(call, calleeType);
   }
 
   if (call.typeArgs) {
@@ -39,6 +40,11 @@ export const resolveCall = (call: Call): Call => {
 
   call.fn = getCallFn(call);
   call.type = call.fn?.returnType;
+  if (call.fn) return call;
+
+  if (calleeType?.isFnType()) {
+    call.type = calleeType.returnType;
+  }
   return call;
 };
 

--- a/src/semantics/resolution/resolve-closure.ts
+++ b/src/semantics/resolution/resolve-closure.ts
@@ -3,6 +3,18 @@ import { Parameter } from "../../syntax-objects/parameter.js";
 import { getExprType } from "./get-expr-type.js";
 import { resolveEntities } from "./resolve-entities.js";
 import { resolveTypeExpr } from "./resolve-type-expr.js";
+import {
+  Primitive,
+  Type,
+  i32,
+  f32,
+  i64,
+  f64,
+  bool,
+  dVoid,
+  dVoyd,
+  voydString,
+} from "../../syntax-objects/types.js";
 
 export const resolveClosure = (closure: Closure): Closure => {
   if (closure.typesResolved) {
@@ -38,7 +50,25 @@ const resolveParameters = (params: Parameter[]) => {
       throw new Error(`Unable to determine type for ${p}`);
     }
 
+    if (p.typeExpr.isIdentifier()) {
+      const primMap: Record<string, Type> = {
+        i32,
+        f32,
+        i64,
+        f64,
+        bool,
+        void: dVoid,
+        voyd: dVoyd,
+        string: voydString,
+      };
+      const prim = primMap[p.typeExpr.value];
+      if (prim) {
+        p.type = prim;
+        return;
+      }
+    }
     p.typeExpr = resolveTypeExpr(p.typeExpr);
+    p.typeExpr = resolveEntities(p.typeExpr);
     p.type = getExprType(p.typeExpr);
   });
 };


### PR DESCRIPTION
## Summary
- compile closures into environment structs with captured values and function pointer
- support invoking closures and reading captured variables from their environment
- map function types to binaryen types and include closure compiler
- resolve calls to closure variables and type-check their arguments
- allow closures to declare typed parameters that are registered in scope
- cache closure function types and correct parameter indexing and function ref typing
- add tests for invoking closures with and without parameters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ac738c870832aa8a4cc8633f67f19