### PR TITLE
feat: support labeled parameters

### DIFF
--- a/src/__tests__/fixtures/labeled-params.ts
+++ b/src/__tests__/fixtures/labeled-params.ts
@@ -1,0 +1,15 @@
+export const labeledParamsVoyd = `
+use std::all
+
+fn normal(a: i32, { b: i32 }) -> i32
+  a + b
+
+fn mixed(a: i32, { b: i32, with c: i32 }) -> i32
+  a + b + c
+
+pub fn normal_labels() -> i32
+  normal(1, b: 2)
+
+pub fn mixed_labels() -> i32
+  mixed(1, b: 2, with: 4)
+`;

--- a/src/__tests__/labeled-params.e2e.test.ts
+++ b/src/__tests__/labeled-params.e2e.test.ts
@@ -1,0 +1,26 @@
+import { labeledParamsVoyd } from "./fixtures/labeled-params.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E labeled parameters", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(labeledParamsVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("function with normal labels runs", (t) => {
+    const fn = getWasmFn("normal_labels", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "normal_labels returns correct value").toEqual(3);
+  });
+
+  test("function mixing normal and external labels runs", (t) => {
+    const fn = getWasmFn("mixed_labels", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "mixed_labels returns correct value").toEqual(7);
+  });
+});

--- a/src/assembler/compile-call.ts
+++ b/src/assembler/compile-call.ts
@@ -34,6 +34,14 @@ export const compile = (opts: CompileExprOpts<Call>): number => {
     return compileBnrCall(opts);
   }
 
+  if (expr.calls(":")) {
+    return compileExpression({
+      ...opts,
+      expr: expr.argAt(1)!,
+      isReturnExpr,
+    });
+  }
+
   if (!expr.fn) {
     throw new Error(`No function found for call ${expr.location}`);
   }

--- a/src/semantics/__tests__/labeled-params.test.ts
+++ b/src/semantics/__tests__/labeled-params.test.ts
@@ -1,0 +1,42 @@
+import { test } from "vitest";
+import { initEntities } from "../init-entities.js";
+import { List } from "../../syntax-objects/list.js";
+import { Identifier } from "../../syntax-objects/identifier.js";
+import { Fn } from "../../syntax-objects/fn.js";
+
+const param = (name: string, type: string) =>
+  new List([":", Identifier.from(name), Identifier.from(type)]);
+
+const fnTemplate = (params: List) =>
+  new List([
+    "define_function",
+    Identifier.from("add"),
+    new List(["parameters", ...params.toArray()]),
+    new List(["return_type"]),
+    new List(["block"]),
+  ]);
+
+test("initEntities assigns label for wrapped parameter", (t) => {
+  const params = new List([
+    param("a", "i32"),
+    new List(["object", new List([":", Identifier.from("to"), Identifier.from("i32")])]),
+  ]);
+  const fn = initEntities(fnTemplate(params)) as Fn;
+  t.expect(fn.parameters.map((p) => p.label?.value)).toEqual([undefined, "to"]);
+});
+
+test("initEntities supports explicit external labels", (t) => {
+  const params = new List([
+    param("a", "i32"),
+    new List([
+      "object",
+      new List([
+        Identifier.from("to"),
+        param("b", "i32"),
+      ]),
+    ]),
+  ]);
+  const fn = initEntities(fnTemplate(params)) as Fn;
+  t.expect(fn.parameters[1].name.value).toBe("b");
+  t.expect(fn.parameters[1].label?.value).toBe("to");
+});

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -105,7 +105,7 @@ const parametersMatch = (candidate: Fn, call: Call) =>
     const argType = getExprType(arg);
     if (!argType) return false;
     const argLabel = getExprLabel(arg);
-    const labelsMatch = p.label === argLabel;
+    const labelsMatch = p.label?.value === argLabel;
     return typesAreCompatible(argType, p.type!) && labelsMatch;
   });
 


### PR DESCRIPTION
## Summary
- handle parameter labels and overrides in `init-entities`
- fix call resolution and codegen for labeled arguments
- add tests for labeled parameters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ad63c6adc832aa4030c08ed5f1916