### PR TITLE
Allow object args to satisfy labeled parameters

### DIFF
--- a/src/__tests__/fixtures/labeled-params.ts
+++ b/src/__tests__/fixtures/labeled-params.ts
@@ -7,9 +7,16 @@ fn normal(a: i32, { b: i32 }) -> i32
 fn mixed(a: i32, { b: i32, with c: i32 }) -> i32
   a + b + c
 
+fn move({ x: i32, y: i32, z: i32 }) -> i32
+  x + y + z
+
 pub fn normal_labels() -> i32
   normal(1, b: 2)
 
 pub fn mixed_labels() -> i32
   mixed(1, b: 2, with: 4)
+
+pub fn move_vec() -> i32
+  let vec = { x: 1, y: 2, z: 3 }
+  move(vec)
 `;

--- a/src/__tests__/labeled-params.e2e.test.ts
+++ b/src/__tests__/labeled-params.e2e.test.ts
@@ -23,4 +23,10 @@ describe("E2E labeled parameters", () => {
     assert(fn, "Function exists");
     t.expect(fn(), "mixed_labels returns correct value").toEqual(7);
   });
+
+  test("object argument expands into labeled params", (t) => {
+    const fn = getWasmFn("move_vec", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "move_vec returns correct value").toEqual(6);
+  });
 });

--- a/src/assembler/compile-call.ts
+++ b/src/assembler/compile-call.ts
@@ -34,6 +34,10 @@ export const compile = (opts: CompileExprOpts<Call>): number => {
     return compileBnrCall(opts);
   }
 
+  // Labeled arguments (": label expr") are wrappers added during call
+  // transformation. Compile the inner expression directly so that, when
+  // labeled parameters are supplied via an object, only the field expressions
+  // are emitted and the object itself is never constructed or passed.
   if (expr.calls(":")) {
     return compileExpression({
       ...opts,

--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -38,6 +38,44 @@ export const resolveCall = (call: Call): Call => {
   }
 
   call.fn = getCallFn(call);
+
+  // Expand a single object argument into labeled field accesses when possible
+  if (call.fn && call.args.length === 1) {
+    const objArg = call.argAt(0)!;
+    const objType = getExprType(objArg);
+    if (objType?.isObjectType()) {
+      const params = call.fn.parameters;
+      const labeledParams = params.filter((p) => p.label);
+      if (
+        labeledParams.length === params.length &&
+        labeledParams.every((p) => objType.hasField(p.label!.value))
+      ) {
+        const newArgs = labeledParams.map((p) => {
+          const fieldName = p.label!.value;
+          const fieldType = objType.getField(fieldName)?.type;
+          const access = new Call({
+            ...call.metadata,
+            fnName: Identifier.from("member-access"),
+            args: new List({
+              value: [objArg.clone(), Identifier.from(fieldName)],
+            }),
+            type: fieldType,
+          });
+          return new Call({
+            ...call.metadata,
+            fnName: Identifier.from(":"),
+            args: new List({
+              value: [Identifier.from(fieldName), access],
+            }),
+            type: fieldType,
+          });
+        });
+        call.args = new List({ value: newArgs });
+        call.args.parent = call;
+      }
+    }
+  }
+
   call.type = call.fn?.returnType;
   return call;
 };


### PR DESCRIPTION
## Summary
- treat single object argument as matching all labeled parameters
- expand object argument into field accesses before compilation
- document and test passing an object variable to a function with labeled parameters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ae3083128832a9a0443885d7677b1