### PR TITLE
refactor: isolate lexer state

### DIFF
--- a/src/parser/__tests__/lexer.test.ts
+++ b/src/parser/__tests__/lexer.test.ts
@@ -1,0 +1,25 @@
+import { Lexer } from "../lexer.js";
+import { CharStream } from "../char-stream.js";
+import { test } from "vitest";
+
+const tokenize = (input: string) => {
+  const chars = new CharStream(input, "test");
+  const tokens: string[] = [];
+  const lexer = new Lexer();
+  while (chars.hasCharacters) {
+    const token = lexer.tokenize(chars);
+    if (!token.isWhitespace) {
+      tokens.push(token.value);
+    }
+  }
+  return tokens;
+};
+
+test("handles nested generics", ({ expect }) => {
+  expect(tokenize("Map<List<int>>"))
+    .toEqual(["Map", "<", "List", "<", "int", ">", ">"]);
+});
+
+test("tokenizes >> as operator outside generics", ({ expect }) => {
+  expect(tokenize("a >> b")).toEqual(["a", ">>", "b"]);
+});

--- a/src/parser/reader-macros/html/html.ts
+++ b/src/parser/reader-macros/html/html.ts
@@ -1,5 +1,5 @@
 import { List } from "../../../syntax-objects/list.js";
-import { lexer } from "../../lexer.js";
+import { Lexer } from "../../lexer.js";
 import { ReaderMacro } from "../types.js";
 import { HTMLParser } from "./html-parser.js";
 
@@ -19,7 +19,7 @@ export const htmlMacro: ReaderMacro = {
         return reader(file, "}");
       },
     });
-    const start = lexer(file);
+    const start = new Lexer().tokenize(file);
     const html = parser.parse(start.value);
     return new List({ value: ["html", html], location: token.location });
   },


### PR DESCRIPTION
## Summary
- encapsulate angle-bracket depth in a `Lexer` instance
- thread lexer state through `parseChars` and reader macros
- update tests to construct fresh lexer instances

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b947be4d4832ab351ef7b702e2f23