### PR TITLE
Expose expression types for assembler

### DIFF
--- a/src/assembler/compile-call.ts
+++ b/src/assembler/compile-call.ts
@@ -5,7 +5,6 @@ import {
 } from "../assembler.js";
 import { refCast } from "../lib/binaryen-gc/index.js";
 import { Call } from "../syntax-objects/call.js";
-import { getExprType } from "../semantics/resolution/get-expr-type.js";
 import { returnCall } from "./return-call.js";
 import { builtinCallCompilers } from "./builtin-call-registry.js";
 import { compileObjectInit } from "./compile-object-init.js";
@@ -35,7 +34,7 @@ export const compile = (opts: CompileExprOpts<Call>): number => {
 
     if (!expr.fn?.isFn()) return compiled;
     const param = expr.fn?.parameters[i];
-    const argType = getExprType(arg);
+    const argType = arg.getType();
     if (param?.type?.isObjectType() && argType?.isTraitType()) {
       return refCast(mod, compiled, mapBinaryenType(opts, param.type));
     }

--- a/src/assembler/compile-object-literal.ts
+++ b/src/assembler/compile-object-literal.ts
@@ -1,13 +1,12 @@
 import { CompileExprOpts, mapBinaryenType, compileExpression } from "../assembler.js";
 import { ObjectLiteral } from "../syntax-objects/object-literal.js";
 import { ObjectType } from "../syntax-objects/types.js";
-import { getExprType } from "../semantics/resolution/get-expr-type.js";
 import { initStruct } from "../lib/binaryen-gc/index.js";
 
 export const compile = (opts: CompileExprOpts<ObjectLiteral>) => {
   const { expr: obj, mod } = opts;
 
-  const objectType = getExprType(obj) as ObjectType;
+  const objectType = obj.getType() as ObjectType;
   const literalBinType = mapBinaryenType(
     { ...opts, useOriginalType: true },
     objectType

--- a/src/assembler/rtt/field-accessor.ts
+++ b/src/assembler/rtt/field-accessor.ts
@@ -26,7 +26,6 @@ import {
   mapBinaryenType,
 } from "../../assembler.js";
 import { Call } from "../../syntax-objects/call.js";
-import { getExprType } from "../../semantics/resolution/get-expr-type.js";
 
 const bin = binaryen as unknown as AugmentedBinaryen;
 
@@ -191,7 +190,7 @@ export const initFieldLookupHelpers = (mod: binaryen.Module) => {
     const { expr, mod } = opts;
     const obj = expr.exprArgAt(0);
     const member = expr.identifierArgAt(1);
-    const objType = getExprType(obj) as ObjectType | IntersectionType;
+    const objType = obj.getType() as ObjectType | IntersectionType;
 
     const field = objType.isIntersectionType()
       ? objType.nominalType?.getField(member) ??
@@ -235,7 +234,7 @@ export const initFieldLookupHelpers = (mod: binaryen.Module) => {
       expr: expr.argAt(1)!,
       isReturnExpr: false,
     });
-    const objType = getExprType(target) as ObjectType | IntersectionType;
+    const objType = target.getType() as ObjectType | IntersectionType;
 
     const field = objType.isIntersectionType()
       ? objType.nominalType?.getField(member) ??

--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -96,11 +96,12 @@ const expandObjectArg = (call: Call) => {
   const newArgs = labeledParams.map((p) => {
     const fieldName = p.label!.value;
     const fieldType = structType.getField(fieldName)?.type;
+    const objClone = resolveEntities(objArg.clone());
     const access = new Call({
       ...call.metadata,
       fnName: Identifier.from("member-access"),
       args: new List({
-        value: [objArg.clone(), Identifier.from(fieldName)],
+        value: [objClone, Identifier.from(fieldName)],
       }),
       type: fieldType,
     });

--- a/src/semantics/resolution/resolve-entities.ts
+++ b/src/semantics/resolution/resolve-entities.ts
@@ -56,10 +56,14 @@ export const resolveEntities = (expr: Expr | undefined): Expr => {
 };
 
 const captureIdentifier = (id: Identifier) => {
+  // Populate the identifier's type for downstream consumers
+  id.type = getExprType(id);
+
   const parentFn = id.parentFn;
   if (!parentFn?.isClosure()) return;
   const entity = id.resolve();
   if (!entity) return;
+
   if (
     (entity.isVariable() || entity.isParameter()) &&
     entity.parentFn !== parentFn &&

--- a/src/syntax-objects/call.ts
+++ b/src/syntax-objects/call.ts
@@ -55,6 +55,10 @@ export class Call extends Syntax {
     return this.#type;
   }
 
+  getType(): Type | undefined {
+    return this.type;
+  }
+
   eachArg(fn: (expr: Expr) => void) {
     this.args.each(fn);
     return this;

--- a/src/syntax-objects/identifier.ts
+++ b/src/syntax-objects/identifier.ts
@@ -1,6 +1,7 @@
 import { Expr } from "./expr.js";
 import { NamedEntity } from "./named-entity.js";
 import { Syntax, SyntaxMetadata } from "./syntax.js";
+import { Type } from "./types.js";
 
 export type Id = string | Identifier;
 
@@ -15,6 +16,8 @@ export class Identifier extends Syntax {
   readonly isQuoted?: boolean;
   /** The given name of the identifier */
   value: string;
+  /** Resolved type for this identifier, populated during semantic analysis */
+  type?: Type;
 
   constructor(opts: string | IdentifierOpts) {
     if (typeof opts === "string") {
@@ -71,6 +74,10 @@ export class Identifier extends Syntax {
 
   toJSON() {
     return this.value;
+  }
+
+  getType(): Type | undefined {
+    return this.type;
   }
 }
 

--- a/src/syntax-objects/object-literal.ts
+++ b/src/syntax-objects/object-literal.ts
@@ -30,6 +30,10 @@ export class ObjectLiteral extends Syntax {
       this.fields.map((f) => [f.name, f.initializer.toJSON()]),
     ];
   }
+
+  getType(): Type | undefined {
+    return this.type;
+  }
 }
 
 export type ObjectLiteralField = {

--- a/src/syntax-objects/syntax.ts
+++ b/src/syntax-objects/syntax.ts
@@ -140,6 +140,15 @@ export abstract class Syntax {
     };
   }
 
+  /**
+   * Returns the static type resolved for this expression, if available.
+   * Subclasses that carry type information should override this method
+   * and/or populate a `type` property during semantic analysis.
+   */
+  getType(): Type | undefined {
+    return undefined;
+  }
+
   /** Clone this object (Implementations should not carry over resolved type expression) */
   abstract clone(parent?: Expr): Expr;
 


### PR DESCRIPTION
## Summary
- add `getType()` hooks and `type` fields on core expression objects
- populate identifier types during semantic resolution
- read expression types directly in assembler instead of calling `getExprType`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b9f411814832aa12513dada0eb43d