### PR TITLE
feat: add tuple literal support

### DIFF
--- a/src/__tests__/compiler.test.ts
+++ b/src/__tests__/compiler.test.ts
@@ -79,6 +79,7 @@ describe("E2E Compiler Pipeline", () => {
       -1, // Recursive heap object type match None
       5, // Inferred generic object type parameter
       1, // Trait parameter type
+      2, // Tuple literal
     ]);
 
     const expectedSyntaxTypes = [

--- a/src/__tests__/fixtures/e2e-file.ts
+++ b/src/__tests__/fixtures/e2e-file.ts
@@ -351,6 +351,11 @@ fn takes_worker(w: DoWork) -> i32
 pub fn test29() -> i32
   let w = Worker {}
   takes_worker(w)
+
+// Tuple literal and numeric member access
+pub fn test30() -> i32
+  let tup = (1, 2, 3)
+  tup.1
 `;
 
 export const tcoText = `


### PR DESCRIPTION
## Summary
- treat tuple literals as structural object literals with numeric fields
- allow numeric member access and tuple types during entity initialization
- add tuple e2e test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bb42945c0832a9bfe2f24849929c5