### PR TITLE
feat: support object literal shorthand

### DIFF
--- a/src/__tests__/fixtures/object-literal-shorthand.ts
+++ b/src/__tests__/fixtures/object-literal-shorthand.ts
@@ -1,0 +1,13 @@
+export const objectShorthandVoyd = `
+use std::all
+
+fn sum_vec({ a: i32, b: i32, c: i32 }) -> i32
+  a + b + c
+
+pub fn run() -> i32
+  let a = 1
+  let b = 2
+  let vec = { a, b, c: 3 }
+  sum_vec(vec)
+`;
+

--- a/src/__tests__/object-literal-shorthand.e2e.test.ts
+++ b/src/__tests__/object-literal-shorthand.e2e.test.ts
@@ -1,0 +1,21 @@
+import { objectShorthandVoyd } from "./fixtures/object-literal-shorthand.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E object literal shorthand", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(objectShorthandVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("object literal shorthand expands correctly", (t) => {
+    const fn = getWasmFn("run", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "run returns correct value").toEqual(6);
+  });
+});
+

--- a/src/semantics/init-entities.ts
+++ b/src/semantics/init-entities.ts
@@ -233,17 +233,24 @@ const initObjectLiteral = (obj: List) => {
   return new ObjectLiteral({
     ...obj.metadata,
     fields: obj.sliceAsArray(1).map((f) => {
-      if (!f.isList()) {
-        throw new Error("Invalid object field");
-      }
-      const name = f.identifierAt(1);
-      const initializer = f.at(2);
-
-      if (!name || !initializer) {
-        throw new Error("Invalid object field");
+      // Support object literal field shorthand: `{ a }` becomes
+      // `{ a: a }`
+      if (f.isIdentifier()) {
+        return { name: f.value, initializer: initEntities(f) };
       }
 
-      return { name: name.value, initializer: initEntities(initializer) };
+      if (f.isList()) {
+        const name = f.identifierAt(1);
+        const initializer = f.at(2);
+
+        if (!name || !initializer) {
+          throw new Error("Invalid object field");
+        }
+
+        return { name: name.value, initializer: initEntities(initializer) };
+      }
+
+      throw new Error("Invalid object field");
     }),
   });
 };


### PR DESCRIPTION
## Summary
- allow object literals to use shorthand fields, e.g. `{ a, b, c: 3 }`
- add e2e test covering shorthand behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e0fa7c860832a947728ce44fd5dd7