### PR TITLE
feat: introduce DOM binding interface

### DIFF
--- a/docs/star.voyd.md
+++ b/docs/star.voyd.md
@@ -12,6 +12,40 @@
 - **jsdom binding**: parallel implementation using `jsdom` to enable server-side rendering during compilation or tests.
 - Both bindings expose a common interface so components compile once and run in both environments.
 
+## DOM Binding Interface
+
+To keep rendering portable, both the browser and `jsdom` implementations provide the same set of DOM primitives:
+
+```ts
+export interface VNode {}
+export interface VElement extends VNode {}
+export interface VText extends VNode {}
+
+export interface DomBinding {
+  /** Create an element with the given tag name */
+  createElement(tag: string): VElement;
+  /** Create a text node */
+  createTextNode(text: string): VText;
+  /** Set an attribute on an element */
+  setAttribute(el: VElement, name: string, value: string): void;
+  /** Remove an attribute from an element */
+  removeAttribute(el: VElement, name: string): void;
+  /** Append a child to a parent node */
+  appendChild(parent: VNode, child: VNode): void;
+  /** Remove a child from a parent node */
+  removeChild(parent: VNode, child: VNode): void;
+  /** Insert a child before a reference node */
+  insertBefore(parent: VNode, child: VNode, ref: VNode | null): void;
+  /** Set the text content of a node */
+  setText(node: VNode, text: string): void;
+}
+
+export function setDomBinding(binding: DomBinding): void;
+export function getDomBinding(): DomBinding;
+```
+
+The `VNode` family of types is intentionally opaque: a binding may use native DOM objects, numeric handles, or even string IDs. The active binding is registered at runtime via `setDomBinding` and retrieved with `getDomBinding`. This indirection lets components compile once and run in different environments without embedding environment-specific logic.
+
 ## Virtual DOM Expectations
 
 - Maintain a minimal virtual representation of the DOM.

--- a/src/star/dom-binding.ts
+++ b/src/star/dom-binding.ts
@@ -1,0 +1,35 @@
+export interface VNode {}
+export interface VElement extends VNode {}
+export interface VText extends VNode {}
+
+export interface DomBinding {
+  /** Create an element with the given tag name */
+  createElement(tag: string): VElement;
+  /** Create a text node */
+  createTextNode(text: string): VText;
+  /** Set an attribute on an element */
+  setAttribute(el: VElement, name: string, value: string): void;
+  /** Remove an attribute from an element */
+  removeAttribute(el: VElement, name: string): void;
+  /** Append a child to a parent node */
+  appendChild(parent: VNode, child: VNode): void;
+  /** Remove a child from a parent node */
+  removeChild(parent: VNode, child: VNode): void;
+  /** Insert a child before a reference node */
+  insertBefore(parent: VNode, child: VNode, ref: VNode | null): void;
+  /** Set the text content of a node */
+  setText(node: VNode, text: string): void;
+}
+
+let currentBinding: DomBinding | undefined;
+
+export function setDomBinding(binding: DomBinding): void {
+  currentBinding = binding;
+}
+
+export function getDomBinding(): DomBinding {
+  if (!currentBinding) {
+    throw new Error("DOM binding has not been set");
+  }
+  return currentBinding;
+}


### PR DESCRIPTION
## Summary
- define DomBinding interface to abstract DOM operations
- add runtime setDomBinding/getDomBinding
- document DOM binding interface and rationale for star.voyd

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e26550328832aa50759c97aca948f