### PR TITLE
feat(star): add browser DOM binding

### DIFF
--- a/docs/star.voyd.md
+++ b/docs/star.voyd.md
@@ -64,3 +64,7 @@ The `VNode` family of types is intentionally opaque: a binding may use native DO
 - Strategy for hydration when rendering initially on the server.
 - Defining the exact shape and lifetime of the virtual DOM nodes.
 - Error boundaries or handling rendering failures.
+
+## Browser DOM Binding
+
+Call `initBrowserDomBinding()` in a browser environment to register the builtin DOM implementation backed by the global `document`. The binding manipulates real DOM nodes directly and thus requires a real browser environment. It will not function in runtimes without `document`, such as Node.js, unless a polyfill like `jsdom` is provided.

--- a/src/star/dom-binding/browser.ts
+++ b/src/star/dom-binding/browser.ts
@@ -1,0 +1,34 @@
+import { DomBinding, VElement, VNode, VText, setDomBinding } from "../dom-binding.js";
+
+const browserBinding: DomBinding = {
+  createElement(tag: string): VElement {
+    return document.createElement(tag) as unknown as VElement;
+  },
+  createTextNode(text: string): VText {
+    return document.createTextNode(text) as unknown as VText;
+  },
+  setAttribute(el: VElement, name: string, value: string): void {
+    (el as unknown as Element).setAttribute(name, value);
+  },
+  removeAttribute(el: VElement, name: string): void {
+    (el as unknown as Element).removeAttribute(name);
+  },
+  appendChild(parent: VNode, child: VNode): void {
+    (parent as unknown as Node).appendChild(child as unknown as Node);
+  },
+  removeChild(parent: VNode, child: VNode): void {
+    (parent as unknown as Node).removeChild(child as unknown as Node);
+  },
+  insertBefore(parent: VNode, child: VNode, ref: VNode | null): void {
+    (parent as unknown as Node).insertBefore(child as unknown as Node, ref as unknown as Node | null);
+  },
+  setText(node: VNode, text: string): void {
+    (node as unknown as Node).textContent = text;
+  },
+};
+
+export function initBrowserDomBinding(): void {
+  setDomBinding(browserBinding);
+}
+
+export default browserBinding;


### PR DESCRIPTION
## Summary
- implement DOM binding using the browser's `document`
- expose `initBrowserDomBinding()` to register the browser binding
- document browser binding usage and limitations in the Star spec

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e41a3f570832aba36a10b78c180f8