### PR TITLE
Add html macro for VNode creation

### DIFF
--- a/docs/star.voyd.md
+++ b/docs/star.voyd.md
@@ -100,6 +100,24 @@ const tree = element("div", { class: "greeting" }, [
 ```
 
 
+## html Macro
+
+The `html` macro transforms inline HTML syntax into calls that construct
+virtual DOM nodes.
+
+```voyd
+use ::star macros all
+
+fn view() -> VNode
+  html <div class="greeting">hello</div>
+```
+
+Expands to:
+
+```voyd
+element("div", dict("class" "greeting"), (array text("hello")))
+```
+
 ## Server-side Rendering with jsdom
 
 When running star.voyd on the server, `jsdom` provides the DOM implementation. Use the helper below to set up the binding:

--- a/std/star/index.voyd
+++ b/std/star/index.voyd
@@ -1,3 +1,4 @@
 use std::macros::all
 
 pub mod dom::all
+pub mod macros::all

--- a/std/star/macros.voyd
+++ b/std/star/macros.voyd
@@ -1,0 +1,20 @@
+use std::macros::all
+
+pub macro html()
+  macro_let render = (node) =>
+    if node.is_list() then:
+      if node.extract(0) == "array" then:
+        let first = node.extract(1).extract(1)
+        ` text($first)
+      else:
+        let tag = node.extract(0)
+        let attrs = node.extract(1).extract(2)
+        let children =
+          if node.length > 2 then:
+            node.extract(2).extract(2).map(render)
+          else:
+            `()
+        ` element($tag, $attrs, `(array $@children))
+    else:
+      node
+  render(body.extract(0))


### PR DESCRIPTION
## Summary
- add `html` macro for generating virtual DOM nodes
- re-export star macros for easier use
- document `html` macro syntax and expansion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e4a5cac44832aa0b9ce8ca9058f70