### PR TITLE
feat: add SSR demo with wasm fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:w": "vitest",
     "snapshot": "vitest -u",
     "build": "npx tsc",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc",
+    "ssr:demo": "node --loader ts-node/esm src/host/node-ssr.ts"
   },
   "bin": {
     "voyd": "./dist/cli/cli.js",

--- a/src/host/node-ssr.ts
+++ b/src/host/node-ssr.ts
@@ -1,28 +1,59 @@
 import { JSDOM } from "jsdom";
 import { DomRuntime } from "./dom-runtime-core.js";
 import { VoydHost } from "./bindings.js";
+import { promises as fs, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-export async function runSsr(wasmBytes: ArrayBuffer) {
+const MOCK_WASM_BASE64 =
+  "AGFzbQEAAAABEQRgAn9/AGAAAGABfwBgAAF/AiwCA2VudhZob3N0X2FwcGx5X3BhdGNoX2ZyYW1lAAADZW52Bm1lbW9yeQIAAQMGBQECAwMAB1gFBm1lbW9yeQIACXZveWRfaW5pdAACFHZveWRfZ2V0X3NjcmF0Y2hfcHRyAAMUdm95ZF9nZXRfc2NyYXRjaF9jYXAABBF2b3lkX2hhbmRsZV9ldmVudAAFCAEBChoFCABBAEETEAALAgALBABBAAsEAEEACwIACwsZAQBBAAsTAQICaDECAwVIZWxsbwQCAwQBAg==";
+
+export async function runSsr(wasmBytes?: Uint8Array) {
   const dom = new JSDOM('<!doctype html><div id="root"></div>');
   const document = dom.window.document;
+  (globalThis as any).document = document;
   const root = document.getElementById("root")!;
 
   const runtime = new DomRuntime(root);
 
+  let memory: WebAssembly.Memory;
   const imports = {
     env: {
       host_apply_patch_frame: (ptr: number, len: number) => {
-        const bytes = new Uint8Array(instance.exports.memory.buffer, ptr, len);
+        const bytes = new Uint8Array(memory.buffer, ptr, len);
         runtime.applyPatchFrame(bytes);
       },
       host_log: (ptr: number, len: number) => {
-        const u8 = new Uint8Array(instance.exports.memory.buffer, ptr, len);
+        const u8 = new Uint8Array(memory.buffer, ptr, len);
         console.log(new TextDecoder().decode(u8));
       },
     },
   } as any;
 
-  const { instance } = await WebAssembly.instantiate(wasmBytes, imports);
+  let instance: WebAssembly.Instance;
+
+  if (!wasmBytes) {
+    const wasmPath = path.resolve("voyd.wasm");
+    if (existsSync(wasmPath)) {
+      wasmBytes = new Uint8Array(await fs.readFile(wasmPath));
+    }
+  }
+
+  if (wasmBytes) {
+    const instantiated: any = await WebAssembly.instantiate(
+      wasmBytes,
+      imports
+    );
+    instance = instantiated.instance;
+    memory = (instance.exports as any).memory as WebAssembly.Memory;
+  } else {
+    memory = new WebAssembly.Memory({ initial: 1 });
+    imports.env.memory = memory;
+    const mockBytes = new Uint8Array(Buffer.from(MOCK_WASM_BASE64, "base64"));
+    const module = new WebAssembly.Module(mockBytes);
+    instance = new WebAssembly.Instance(module, imports);
+  }
+
   const voyd = new VoydHost(instance.exports as any);
 
   // Wire event egress: serialize to MessagePack and call back into Wasm
@@ -48,4 +79,8 @@ export async function runSsr(wasmBytes: ArrayBuffer) {
   (instance.exports as any).voyd_init(/*root_hid=*/ 1);
 
   return dom.serialize();
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  runSsr().then((html) => console.log(html));
 }

--- a/src/host/web/main.ts
+++ b/src/host/web/main.ts
@@ -8,20 +8,21 @@ import { VoydHost } from "../bindings.js";
 
   const runtime = new DomRuntime(document.getElementById("root")!);
 
+  let instance: WebAssembly.Instance;
   const imports = {
     env: {
       host_apply_patch_frame: (ptr: number, len: number) => {
-        const bytes = new Uint8Array(instance.exports.memory.buffer, ptr, len);
+        const bytes = new Uint8Array((instance.exports as any).memory.buffer, ptr, len);
         runtime.applyPatchFrame(bytes);
       },
       host_log: (ptr: number, len: number) => {
-        const u8 = new Uint8Array(instance.exports.memory.buffer, ptr, len);
+        const u8 = new Uint8Array((instance.exports as any).memory.buffer, ptr, len);
         console.log(new TextDecoder().decode(u8));
       },
     },
   } as any;
 
-  const instance = await WebAssembly.instantiate(
+  instance = await WebAssembly.instantiate(
     await WebAssembly.compile(wasmBytes),
     imports
   );


### PR DESCRIPTION
## Summary
- add Node SSR helper that loads `voyd.wasm` or falls back to an embedded mock module producing `<h1>Hello</h1>`
- expose a `ssr:demo` npm script to render to HTML
- tidy web host to reference memory in a type-safe manner

## Testing
- `npm run ssr:demo`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eca9c2b20832ab29caf2d9dc43c42