### PR TITLE
feat: enhance module import flexibility

### DIFF
--- a/src/__tests__/fixtures/linear-memory.ts
+++ b/src/__tests__/fixtures/linear-memory.ts
@@ -1,8 +1,17 @@
 export const linearMemoryVoyd = `
-use std::linear_memory::all
+use std::linear_memory::{ grow: grow_linear_mem, store, load_i32 }
 
 pub fn run() -> i32
-  grow(1)
+  grow_linear_mem(1)
   store(0, 42)
   load_i32(0)
+`;
+
+export const linearMemoryModuleVoyd = `
+use std::linear_memory
+
+pub fn run() -> i32
+  linear_memory::grow(1)
+  linear_memory::store(0, 42)
+  linear_memory::load_i32(0)
 `;

--- a/src/__tests__/linear-memory.e2e.test.ts
+++ b/src/__tests__/linear-memory.e2e.test.ts
@@ -1,18 +1,24 @@
-import { linearMemoryVoyd } from "./fixtures/linear-memory.js";
+import {
+  linearMemoryVoyd,
+  linearMemoryModuleVoyd,
+} from "./fixtures/linear-memory.js";
 import { compile } from "../compiler.js";
-import { beforeAll, describe, test } from "vitest";
+import { describe, test } from "vitest";
 import assert from "node:assert";
 import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
 
 describe("E2E linear memory", () => {
-  let instance: WebAssembly.Instance;
-
-  beforeAll(async () => {
+  test("load/store roundtrip with picked imports", async (t) => {
     const mod = await compile(linearMemoryVoyd);
-    instance = getWasmInstance(mod);
+    const instance = getWasmInstance(mod);
+    const fn = getWasmFn("run", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "run returns stored value").toEqual(42);
   });
 
-  test("load/store roundtrip", (t) => {
+  test("load/store roundtrip with module access", async (t) => {
+    const mod = await compile(linearMemoryModuleVoyd);
+    const instance = getWasmInstance(mod);
     const fn = getWasmFn("run", instance);
     assert(fn, "Function exists");
     t.expect(fn(), "run returns stored value").toEqual(42);

--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -10,12 +10,26 @@ import { getCallFn } from "./get-call-fn.js";
 import { getExprType, getIdentifierType } from "./get-expr-type.js";
 import { resolveObjectType } from "./resolve-object-type.js";
 import { resolveEntities } from "./resolve-entities.js";
-import { resolveExport } from "./resolve-use.js";
+import { resolveExport, resolveModulePath } from "./resolve-use.js";
 import { combineTypes } from "./combine-types.js";
 import { resolveTypeExpr } from "./resolve-type-expr.js";
 
 export const resolveCall = (call: Call): Call => {
   if (call.type) return call;
+  if (call.calls("::")) {
+    const [left, right] = call.argsArray();
+    if (right?.isCall()) {
+      const path = new List(["::", left, right.fnName]);
+      path.parent = call.parent ?? call.parentModule;
+      const entity = resolveModulePath(path)[0]?.e;
+      if (entity?.isFn()) {
+        right.fn = entity;
+        right.args = right.args.map(resolveEntities);
+        return resolveCall(right);
+      }
+    }
+    return call;
+  }
   if (call.calls("export")) return resolveExport(call);
   if (call.calls("if")) return resolveIf(call);
   if (call.calls(":")) return resolveLabeledArg(call);
@@ -23,6 +37,20 @@ export const resolveCall = (call: Call): Call => {
   if (call.calls("FixedArray")) return resolveFixedArray(call);
   if (call.calls("binaryen")) return resolveBinaryen(call);
   call.args = call.args.map(resolveEntities);
+
+  const moduleArg = call.argAt(0);
+  if (moduleArg?.isIdentifier()) {
+    const moduleEntity = moduleArg.resolve();
+    if (moduleEntity?.isModule()) {
+      const exported = moduleEntity.resolveExport(call.fnName);
+      if (exported.length) {
+        const fnEntity = exported[0];
+        if (fnEntity.isFn()) call.fn = fnEntity;
+        call.args = new List({ value: call.args.toArray().slice(1) });
+        call.args.parent = call;
+      }
+    }
+  }
 
   const memberAccessCall = getMemberAccessCall(call);
   if (memberAccessCall) return memberAccessCall;
@@ -37,10 +65,16 @@ export const resolveCall = (call: Call): Call => {
     call.typeArgs = call.typeArgs.map(resolveTypeExpr);
   }
 
-  call.fn = getCallFn(call);
+  if (!call.fn) {
+    call.fn = getCallFn(call);
+  }
   expandObjectArg(call);
 
-  call.type = call.fn?.returnType;
+  call.type = call.fn?.isFn()
+    ? call.fn.returnType
+    : call.fn?.isObjectType()
+    ? call.fn
+    : undefined;
   return call;
 };
 

--- a/src/semantics/resolution/resolve-use.ts
+++ b/src/semantics/resolution/resolve-use.ts
@@ -88,7 +88,10 @@ const resolveObjectPath = (path: Call | List, module: VoydModule) => {
 
   const imports = path.argsArray();
   for (const imp of imports) {
-    if ((imp.isCall() || imp.isList()) && imp.calls("as")) {
+    if (
+      (imp.isCall() || imp.isList()) &&
+      (imp.calls(":") || imp.calls("as"))
+    ) {
       const args = imp.argsArray();
       const entityId = args.at(0);
       const alias = args.at(1);


### PR DESCRIPTION
## Summary
- support selective and renamed imports using colon syntax
- allow module access via `module::fn` without bulk importing
- add comprehensive tests for module import variants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a00ccd3440832a813a9ae91315f772