### PR TITLE
refactor: streamline functional notation parsing

### DIFF
--- a/src/parser/syntax-macros/functional-notation.ts
+++ b/src/parser/syntax-macros/functional-notation.ts
@@ -1,88 +1,68 @@
 import { idIs, isOp } from "../grammar.js";
 import { Expr, List, ListValue } from "../../syntax-objects/index.js";
 
-// Note: The current version of this function was modified by GPT o1.
-// I wrote the original version an have made modifications to the version
-// produced by o1. The intent was to have o1 improve the performance. But
-// now I'm not sure the added complexity produced by o1 was worth the cost.
-// Might still be worth re-writing again to something similar to the original.
+// Simplified and optimized version of functional notation parsing.
+// Uses a single pass with a basic for-loop to minimize overhead.
 
 export const functionalNotation = (list: List): List => {
   const array = list.toArray();
+  const result: ListValue[] = [];
+  const tupleAttr = list.getAttribute("tuple?");
+  let skip = 0;
   let isTuple = false;
 
-  const { result } = array.reduce(
-    (acc, expr, index) => {
-      if (acc.skip > 0) {
-        acc.skip--;
-        return acc;
-      }
+  for (let index = 0; index < array.length; index++) {
+    const expr = array[index];
 
-      if (expr.isList()) {
-        acc.result.push(functionalNotation(expr));
-        return acc;
-      }
-
-      if (expr.isWhitespace()) {
-        acc.result.push(expr);
-        return acc;
-      }
-
-      const nextExpr = array[index + 1];
-
-      if (nextExpr && nextExpr.isList() && !(isOp(expr) || idIs(expr, ","))) {
-        return handleNextExpression(acc, expr, nextExpr, array, index);
-      }
-
-      if (list.getAttribute("tuple?") && idIs(expr, ",")) {
-        isTuple = true;
-      }
-
-      acc.result.push(expr);
-      return acc;
-    },
-    { result: [], skip: 0 } as Accumulator
-  );
-
-  return finalizeResult(result, isTuple, list);
-};
-
-type Accumulator = { result: ListValue[]; skip: number };
-
-const handleNextExpression = (
-  acc: Accumulator,
-  expr: Expr,
-  nextExpr: List,
-  array: Expr[],
-  index: number
-) => {
-  if (nextExpr.calls("generics")) {
-    const generics = nextExpr;
-    const nextNextExpr = array[index + 2];
-    if (nextNextExpr && nextNextExpr.isList()) {
-      acc.result.push(processGenerics(expr, generics, nextNextExpr as List));
-      acc.skip = 2; // Skip next two expressions
-    } else {
-      acc.result.push(processGenerics(expr, generics));
-      acc.skip = 1; // Skip next expression
+    if (skip > 0) {
+      skip--;
+      continue;
     }
-  } else {
-    acc.result.push(processParamList(expr, nextExpr as List));
-    acc.skip = 1; // Skip next expression
-  }
-  return acc;
-};
 
-const finalizeResult = (
-  result: ListValue[],
-  isTuple: boolean,
-  originalList: List
-): List => {
+    if (expr.isList()) {
+      result.push(functionalNotation(expr));
+      continue;
+    }
+
+    if (expr.isWhitespace()) {
+      result.push(expr);
+      continue;
+    }
+
+    const nextExpr = array[index + 1];
+
+    if (nextExpr && nextExpr.isList() && !(isOp(expr) || idIs(expr, ","))) {
+      if (nextExpr.calls("generics")) {
+        const generics = nextExpr;
+        const nextNextExpr = array[index + 2];
+        if (nextNextExpr && nextNextExpr.isList()) {
+          result.push(
+            processGenerics(expr, generics, nextNextExpr as List)
+          );
+          skip = 2;
+        } else {
+          result.push(processGenerics(expr, generics));
+          skip = 1;
+        }
+      } else {
+        result.push(processParamList(expr, nextExpr as List));
+        skip = 1;
+      }
+      continue;
+    }
+
+    if (tupleAttr && idIs(expr, ",")) {
+      isTuple = true;
+    }
+
+    result.push(expr);
+  }
+
   if (isTuple) {
     result.unshift(",");
     result.unshift("tuple");
   }
-  return new List({ ...originalList.metadata, value: result });
+  return new List({ ...list.metadata, value: result });
 };
 
 const processGenerics = (expr: Expr, generics: List, params?: List): List => {


### PR DESCRIPTION
## Summary
- simplify functional notation parsing by replacing reduce and helper functions with a single for-loop
- inline result finalization to eliminate extra allocations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a10251fbe0832ab84036d5b1844eff