### PR TITLE
Optimize primary parser to reduce overhead

### DIFF
--- a/src/semantics/__tests__/__snapshots__/regular-macros.test.ts.snap
+++ b/src/semantics/__tests__/__snapshots__/regular-macros.test.ts.snap
@@ -7,7 +7,7 @@ exports[`regular macro expansion 1`] = `
   [
     "exports",
     [
-      "std#924",
+      "std#895",
     ],
   ],
   [
@@ -47,7 +47,7 @@ exports[`regular macro expansion 1`] = `
         ],
         [
           "regular-macro",
-          "\`#953",
+          "\`#924",
           [
             "parameters",
           ],
@@ -68,7 +68,7 @@ exports[`regular macro expansion 1`] = `
         ],
         [
           "regular-macro",
-          "let#1000",
+          "let#971",
           [
             "parameters",
           ],
@@ -121,7 +121,7 @@ exports[`regular macro expansion 1`] = `
         ],
         [
           "regular-macro",
-          "fn#1793",
+          "fn#1764",
           [
             "parameters",
           ],


### PR DESCRIPTION
## Summary
- streamline primary syntax macro parsing by using a single precedence loop that handles unary and binary operators, avoiding extra function calls
- reduce list allocations when parsing expression lists for faster evaluation
- update semantic macro snapshot

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a102618438832a86393f2ca4181b8c