### PR TITLE
Fix generic trait method resolution

### DIFF
--- a/src/__tests__/fixtures/iterable.ts
+++ b/src/__tests__/fixtures/iterable.ts
@@ -1,0 +1,21 @@
+export const iterableVoyd = `
+use std::all
+
+trait BoxLike<T>
+  fn get(self) -> T
+
+obj ValueBox<T> {
+  value: T
+}
+
+impl<T> BoxLike<T> for ValueBox<T>
+  fn get(self) -> T
+    self.value
+
+fn take_and_double(b: BoxLike<i32>) -> i32
+  b.get() * 2
+
+pub fn run() -> i32
+  let b = ValueBox<i32> { value: 4 }
+  take_and_double(b)
+`;

--- a/src/__tests__/iterable-trait.e2e.test.ts
+++ b/src/__tests__/iterable-trait.e2e.test.ts
@@ -1,0 +1,8 @@
+import { iterableVoyd } from "./fixtures/iterable.js";
+import { compile } from "../compiler.js";
+import { describe, test } from "vitest";
+describe("E2E generic trait objects", () => {
+  test("calls method on generic trait object", async (t) => {
+    await t.expect(compile(iterableVoyd)).resolves.toBeTruthy();
+  });
+});

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -45,7 +45,14 @@ const getCandidates = (call: Call): Fn[] => {
     const implFns = arg1Type.implementations
       ?.flatMap((impl) => impl.exports)
       .filter((fn) => fn.name.is(call.fnName.value));
-    fns.push(...(implFns ?? []));
+    if (implFns?.length) {
+      fns.push(...implFns);
+    } else {
+      const traitFns = arg1Type.methods
+        ?.toArray()
+        .filter((fn) => fn.name.is(call.fnName.value));
+      fns.push(...(traitFns ?? []));
+    }
   }
 
   return fns;
@@ -123,7 +130,7 @@ const parametersMatch = (candidate: Fn, call: Call) => {
     if (!argType) return false;
     const argLabel = getExprLabel(arg);
     const labelsMatch = p.label?.value === argLabel;
-    return typesAreCompatible(argType, p.type!) && labelsMatch;
+    return (!p.type || typesAreCompatible(argType, p.type)) && labelsMatch;
   });
   if (directMatch) return true;
 

--- a/src/semantics/resolution/types-are-compatible.ts
+++ b/src/semantics/resolution/types-are-compatible.ts
@@ -86,8 +86,8 @@ export const typesAreCompatible = (
   }
 
   if (a.isObjectType() && b.isTraitType()) {
-    const matchesTrait = a.implementations?.some(
-      (impl) => impl.trait?.id === b.id
+    const matchesTrait = a.implementations?.some((impl) =>
+      impl.trait ? typesAreCompatible(impl.trait, b, opts, visited) : false
     );
     if (matchesTrait) return true;
     return a.parentObjType
@@ -96,8 +96,8 @@ export const typesAreCompatible = (
   }
 
   if (a.isTraitType() && b.isObjectType()) {
-    const matchesTrait = b.implementations?.some(
-      (impl) => impl.trait?.id === a.id
+    const matchesTrait = b.implementations?.some((impl) =>
+      impl.trait ? typesAreCompatible(a, impl.trait, opts, visited) : false
     );
     if (matchesTrait) return true;
     return b.parentObjType
@@ -106,7 +106,11 @@ export const typesAreCompatible = (
   }
 
   if (a.isTraitType() && b.isTraitType()) {
-    if (a.genericParent && a.genericParent.id === b.genericParent?.id) {
+    if (
+      a.genericParent &&
+      b.genericParent &&
+      a.genericParent.id === b.genericParent.id
+    ) {
       return !!a.appliedTypeArgs?.every((arg, index) =>
         typesAreCompatible(
           getExprType(arg),
@@ -116,6 +120,10 @@ export const typesAreCompatible = (
         )
       );
     }
+
+    if (a.genericParent && a.genericParent.id === b.id) return true;
+    if (b.genericParent && b.genericParent.id === a.id) return true;
+
     return a.id === b.id;
   }
 


### PR DESCRIPTION
## Summary
- handle generic trait compatibility in `typesAreCompatible`
- fall back to trait methods when implementations are absent
- add E2E test covering generic trait objects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a187c530dc832aa9a12fc2afe8073c