### PR TITLE
Fix trait object method resolution with generics

### DIFF
--- a/src/__tests__/fixtures/generic-trait.ts
+++ b/src/__tests__/fixtures/generic-trait.ts
@@ -1,0 +1,19 @@
+export const genericTraitVoyd = `
+use std::all
+
+trait Trait<T>
+  fn id(self) -> T
+
+obj Wrapper<T> {
+  value: T
+}
+
+impl<T> Trait<T> for Wrapper<T>
+  fn id(self) -> T
+    self.value
+
+pub fn run() -> i32
+  let w = Wrapper<i32> { value: 1 }
+  let t: Trait<i32> = w
+  t.id()
+`;

--- a/src/__tests__/fixtures/nested-generic-trait.ts
+++ b/src/__tests__/fixtures/nested-generic-trait.ts
@@ -1,0 +1,28 @@
+export const nestedGenericTraitVoyd = `
+use std::all
+
+trait Iterator<T>
+  fn next(self) -> Optional<T>
+
+trait Iterable<T>
+  fn iterate(self) -> Iterator<T>
+
+obj Box<T> {
+  value: T
+}
+
+impl<T> Iterator<T> for Box<T>
+  fn next(self) -> Optional<T>
+    None {}
+
+impl<T> Iterable<T> for Box<T>
+  fn iterate(self) -> Iterator<T>
+    self
+
+pub fn run() -> i32
+  let b = Box<i32> { value: 1 }
+  let it: Iterable<i32> = b
+  let iterator = it.iterate()
+  iterator.next()
+  0
+`;

--- a/src/__tests__/generic-trait.e2e.test.ts
+++ b/src/__tests__/generic-trait.e2e.test.ts
@@ -1,0 +1,20 @@
+import { genericTraitVoyd } from "./fixtures/generic-trait.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E generic trait objects", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(genericTraitVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("run returns correct value", (t) => {
+    const fn = getWasmFn("run", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "run returns correct value").toEqual(1);
+  });
+});

--- a/src/__tests__/nested-generic-trait.e2e.test.ts
+++ b/src/__tests__/nested-generic-trait.e2e.test.ts
@@ -1,0 +1,20 @@
+import { nestedGenericTraitVoyd } from "./fixtures/nested-generic-trait.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E nested generic trait objects", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(nestedGenericTraitVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("run returns correct value", (t) => {
+    const fn = getWasmFn("run", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "run returns correct value").toEqual(0);
+  });
+});

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -123,6 +123,25 @@ const parametersMatch = (candidate: Fn, call: Call) => {
     if (!argType) return false;
     const argLabel = getExprLabel(arg);
     const labelsMatch = p.label?.value === argLabel;
+    // Calling a method on a trait object is resolved by looking up the
+    // implementation methods for that trait. In that scenario the first
+    // parameter of the candidate function will be the concrete
+    // implementation type (e.g. `Array<i32>`), while the argument type is the
+    // trait itself (e.g. `Iterable<i32>`). These are not nominally compatible
+    // and would previously cause the resolution to fail. Since the candidate
+    // was sourced from the trait's implementations we can assume it is valid
+    // for the trait object and skip the compatibility check for this
+    // parameter.
+
+    if (i === 0 && argType.isTraitType() && candidate.parentImpl?.trait) {
+      const candidateTrait =
+        candidate.parentImpl.trait.genericParent ?? candidate.parentImpl.trait;
+      const argTrait = argType.genericParent ?? argType;
+      if (candidateTrait.id === argTrait.id) {
+        return labelsMatch;
+      }
+    }
+
     return typesAreCompatible(argType, p.type!) && labelsMatch;
   });
   if (directMatch) return true;


### PR DESCRIPTION
## Summary
- avoid parameter type mismatch when calling trait methods on generic trait objects
- add end-to-end tests for generic trait methods and nested trait object calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a18ca8f804832a8393339a51c50702