### PR TITLE
feat: support recursive closures

### DIFF
--- a/src/__tests__/closure-recursion.e2e.test.ts
+++ b/src/__tests__/closure-recursion.e2e.test.ts
@@ -1,0 +1,17 @@
+import { closureRecursionVoyd } from "./fixtures/closure-recursion.js";
+import { compile } from "../compiler.js";
+import { describe, test } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E recursive closures", () => {
+  test("closure can call itself recursively", async (t) => {
+    const mod = await compile(closureRecursionVoyd);
+    const instance = getWasmInstance(mod);
+    const fn = getWasmFn("run", instance);
+    assert(fn, "Function exists");
+    t
+      .expect(fn(), "run returns recursive closure result")
+      .toEqual(15);
+  });
+});

--- a/src/__tests__/fixtures/closure-recursion.ts
+++ b/src/__tests__/fixtures/closure-recursion.ts
@@ -1,0 +1,11 @@
+export const closureRecursionVoyd = `
+use std::all
+
+pub fn run() -> i32
+  let sum: (n: i32) -> i32 = (n: i32) =>
+    if n <= 1 then:
+      n
+    else:
+      n + sum(n - 1)
+  sum(5)
+`;

--- a/src/assembler/compile-identifier.ts
+++ b/src/assembler/compile-identifier.ts
@@ -16,6 +16,9 @@ export const compile = (opts: CompileExprOpts<Identifier>) => {
   if (entity.isVariable() || entity.isParameter()) {
     if (expr.parentFn?.isClosure() && entity.parentFn !== expr.parentFn) {
       const closure = expr.parentFn;
+      if (entity.isVariable() && entity.initializer === closure) {
+        return mod.local.get(0, getClosureSuperType(mod));
+      }
       const envType = getClosureEnvType(closure.syntaxId)!;
       const fieldIndex = closure.captures.indexOf(entity) + 1;
       return structGetFieldValue({

--- a/src/semantics/resolution/resolve-entities.ts
+++ b/src/semantics/resolution/resolve-entities.ts
@@ -67,6 +67,7 @@ const captureIdentifier = (id: Identifier) => {
   if (
     (entity.isVariable() || entity.isParameter()) &&
     entity.parentFn !== parentFn &&
+    !(entity.isVariable() && entity.initializer === parentFn) &&
     !parentFn.captures.includes(entity)
   ) {
     parentFn.captures.push(entity);
@@ -80,16 +81,19 @@ const resolveBlock = (block: Block): Block => {
 };
 
 export const resolveVar = (variable: Variable): Variable => {
+  if (variable.typeExpr) {
+    variable.typeExpr = resolveTypeExpr(variable.typeExpr);
+    variable.annotatedType = getExprType(variable.typeExpr);
+    variable.type = variable.annotatedType;
+  }
+
   const initializer = resolveEntities(variable.initializer);
   variable.initializer = initializer;
   variable.inferredType = getExprType(initializer);
 
-  if (variable.typeExpr) {
-    variable.typeExpr = resolveTypeExpr(variable.typeExpr);
-    variable.annotatedType = getExprType(variable.typeExpr);
+  if (!variable.type) {
+    variable.type = variable.inferredType;
   }
-
-  variable.type = variable.annotatedType ?? variable.inferredType;
   return variable;
 };
 


### PR DESCRIPTION
## Summary
- allow closures to reference themselves recursively
- resolve annotated variable types before initializing to enable recursion
- add end-to-end test for recursive closures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a19997c398832a8113b6da06142a81