### PR TITLE
Fix trait method resolution for generic trait objects

### DIFF
--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -42,7 +42,11 @@ const getCandidates = (call: Call): Fn[] => {
   }
 
   if (arg1Type?.isTraitType()) {
-    const implFns = arg1Type.implementations
+    let impls = arg1Type.implementations;
+    if (!impls?.length && arg1Type.genericParent) {
+      impls = arg1Type.genericParent.implementations;
+    }
+    const implFns = impls
       ?.flatMap((impl) => impl.exports)
       .filter((fn) => fn.name.is(call.fnName.value));
     fns.push(...(implFns ?? []));

--- a/src/semantics/resolution/resolve-fn.ts
+++ b/src/semantics/resolution/resolve-fn.ts
@@ -5,6 +5,7 @@ import { Implementation } from "../../syntax-objects/implementation.js";
 import { List } from "../../syntax-objects/list.js";
 import { Parameter } from "../../syntax-objects/parameter.js";
 import { TypeAlias } from "../../syntax-objects/types.js";
+import { TraitType } from "../../syntax-objects/types/trait.js";
 import { getExprType } from "./get-expr-type.js";
 import { resolveEntities } from "./resolve-entities.js";
 import { resolveTypeExpr } from "./resolve-type-expr.js";
@@ -59,7 +60,12 @@ const resolveParameters = (params: Parameter[]) => {
 
     if (p.name.is("self")) {
       const impl = getParentImpl(p);
-      if (impl) p.type = impl.targetType;
+      if (impl) {
+        p.type = impl.targetType;
+      } else {
+        const trait = getParentTrait(p);
+        if (trait) p.type = trait;
+      }
       return;
     }
 
@@ -119,5 +125,11 @@ const resolveGenericsWithTypeArgs = (fn: Fn, args: List): Fn => {
 const getParentImpl = (expr: Expr): Implementation | undefined => {
   if (expr.syntaxType === "implementation") return expr;
   if (expr.parent) return getParentImpl(expr.parent);
+  return undefined;
+};
+
+const getParentTrait = (expr: Expr): TraitType | undefined => {
+  if (expr instanceof TraitType) return expr;
+  if (expr.parent) return getParentTrait(expr.parent);
   return undefined;
 };


### PR DESCRIPTION
## Summary
- infer `self` parameter types inside trait definitions
- resolve trait method calls by consulting generic parent implementations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a22da3c5d8832a8be7334a7dbdc82a