### PR TITLE
fix: resolve generic trait object parameters

### DIFF
--- a/src/__tests__/fixtures/generic-trait-param.ts
+++ b/src/__tests__/fixtures/generic-trait-param.ts
@@ -1,0 +1,43 @@
+export const genericTraitParamVoyd = `
+use std::all
+
+trait Iterator<T>
+  fn next(self) -> Optional<T>
+
+trait Iterable<T>
+  fn iterate(self) -> Iterator<T>
+
+obj Box<T> {
+  value: T
+}
+
+impl<T> Iterator<T> for Box<T>
+  fn next(self) -> Optional<T>
+    Some { value: self.value }
+
+impl<T> Iterable<T> for Box<T>
+  fn iterate(self) -> Iterator<T>
+    self
+
+pub fn run_a() -> i32
+  let b = Box<i32> { value: 4 }
+  let it: Iterable<i32> = b
+  let iterator = it.iterate()
+  iterator.next().match(o)
+    Some<i32>:
+      o.value
+    None:
+      -1
+
+pub fn run_b() -> i32
+  let b = Box<i32> { value: 4 }
+  call_iterator(b)
+
+fn call_iterator(it: Iterable<i32>)
+  let iterator = it.iterate()
+  iterator.next().match(o)
+    Some<i32>:
+      o.value
+    None:
+      -1
+`;

--- a/src/__tests__/generic-trait-param.e2e.test.ts
+++ b/src/__tests__/generic-trait-param.e2e.test.ts
@@ -1,0 +1,26 @@
+import { genericTraitParamVoyd } from "./fixtures/generic-trait-param.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E generic trait object parameters", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(genericTraitParamVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("run_a returns correct value", (t) => {
+    const fn = getWasmFn("run_a", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "run_a returns correct value").toEqual(4);
+  });
+
+  test("run_b returns correct value", (t) => {
+    const fn = getWasmFn("run_b", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "run_b returns correct value").toEqual(4);
+  });
+});

--- a/src/semantics/resolution/resolve-impl.ts
+++ b/src/semantics/resolution/resolve-impl.ts
@@ -36,6 +36,12 @@ export const resolveImpl = (
   impl.trait = getTrait(impl);
   if (impl.trait) {
     impl.trait.implementations.push(impl);
+    // Propagate this implementation to any already resolved generic trait
+    // instances. When a trait generic instance is created before this impl is
+    // resolved, it will have copied the trait's implementations at that time
+    // (which may not have included this one). Updating existing instances here
+    // ensures they can also resolve calls through the trait object.
+    impl.trait.genericInstances?.forEach((t) => t.implementations.push(impl));
   }
 
   if (!targetType) return impl;

--- a/src/semantics/resolution/resolve-trait.ts
+++ b/src/semantics/resolution/resolve-trait.ts
@@ -46,11 +46,12 @@ const resolveGenericTraitVersion = (
   });
 
   trait.registerGenericInstance(newTrait);
+  // Propagate existing implementations to this generic instance. Any future
+  // implementations will be added via resolveImpl when they are resolved.
+  newTrait.implementations = [...trait.implementations];
   // Resolve methods for the new trait
   newTrait.methods.applyMap((fn) => resolveFn(fn));
   newTrait.typesResolved = true;
-  // Clear implementations, resolveImpl will re-add as needed
-  newTrait.implementations = [];
 
   return newTrait;
 };


### PR DESCRIPTION
## Summary
- propagate implementations to generic trait instances
- update generic trait instances when new implementations are resolved
- add E2E test covering generic trait object parameters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a23625f150832aaeef1dd7f9e86633