### PR TITLE
Fix array field member access handling

### DIFF
--- a/src/__tests__/array-field-access.e2e.test.ts
+++ b/src/__tests__/array-field-access.e2e.test.ts
@@ -1,0 +1,20 @@
+import { arrayFieldAccessVoyd } from "./fixtures/array-field-access.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E array field access", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(arrayFieldAccessVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("run returns correct value", (t) => {
+    const fn = getWasmFn("run", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "run returns correct value").toEqual(1);
+  });
+});

--- a/src/__tests__/fixtures/array-field-access.ts
+++ b/src/__tests__/fixtures/array-field-access.ts
@@ -1,0 +1,16 @@
+export const arrayFieldAccessVoyd = `
+use std::all
+
+obj ArrayIterator<T> {
+  index: i32,
+  array: Array<T>
+}
+
+pub fn run() -> i32
+  let a = [1, 2, 3]
+  let b = ArrayIterator<i32> { index: 0, array: a }
+  b.array.get(b.index).match(v)
+    Some<i32>: v.value
+    None:
+      -1
+`;

--- a/src/parser/reader-macros/array-literal.ts
+++ b/src/parser/reader-macros/array-literal.ts
@@ -4,6 +4,8 @@ export const arrayLiteralMacro: ReaderMacro = {
   match: (t) => t.value === "[",
   macro: (file, { reader }) => {
     const items = reader(file, "]");
-    return items.insert("array").insert(",", 1);
+    const result = items.insert("array").insert(",", 1);
+    result.setAttribute("array-literal", true);
+    return result;
   },
 };

--- a/src/semantics/init-entities.ts
+++ b/src/semantics/init-entities.ts
@@ -63,7 +63,7 @@ export const initEntities: SemanticProcessor = (expr) => {
   }
 
   // Array literal
-  if (expr.calls("array")) {
+  if (expr.calls("array") && expr.hasAttribute("array-literal")) {
     return initArrayLiteral(expr);
   }
 


### PR DESCRIPTION
## Summary
- prevent array macro from shadowing field access by marking reader-macro produced arrays
- handle only marked lists as array literals during entity initialization
- add end-to-end test for accessing `array` field on object

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a24f20cb8c832a9bd8e77f290f7d7f