### PR TITLE
fix trait resolution with multiple generic function versions

### DIFF
--- a/src/__tests__/fixtures/trait-object-multi-version.ts
+++ b/src/__tests__/fixtures/trait-object-multi-version.ts
@@ -1,0 +1,48 @@
+export const traitObjectMultiVersionVoyd = `
+use std::all
+
+trait Iterator<T>
+  fn next(self) -> Optional<T>
+
+trait Iterable<T>
+  fn iterate(self) -> Iterator<T>
+
+obj Box<T> {
+  value: T
+}
+
+impl<T> Iterator<T> for Box<T>
+  fn next(self) -> Optional<T>
+    Some { value: self.value }
+
+impl<T> Iterable<T> for Box<T>
+  fn iterate(self) -> Iterator<T>
+    self
+
+pub fn run() -> i32
+  let bi = Box<i32> { value: 4 }
+  let bf = Box<f64> { value: 2.0 }
+  let a = bi.sum_iterable()
+  let b = bf.sum_iterable()
+  if b > 1.5 then:
+    a + 1
+  else:
+    a
+
+fn sum_iterable(it: Iterable<i32>) -> i32
+  let iterator = it.iterate()
+  iterator.next().match(o)
+    Some<i32>:
+      o.value
+    None:
+      -1
+
+fn sum_iterable(it: Iterable<f64>) -> f64
+  let iterator = it.iterate()
+  iterator.next().match(o)
+    Some<f64>:
+      o.value
+    None:
+      -1.0
+`;
+

--- a/src/__tests__/trait-object-multi-version.e2e.test.ts
+++ b/src/__tests__/trait-object-multi-version.e2e.test.ts
@@ -1,0 +1,21 @@
+import { traitObjectMultiVersionVoyd } from "./fixtures/trait-object-multi-version.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E trait object with multiple function versions", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(traitObjectMultiVersionVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("run returns correct value", (t) => {
+    const fn = getWasmFn("run", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "run returns correct value").toEqual(5);
+  });
+});
+

--- a/src/semantics/resolution/resolve-fn.ts
+++ b/src/semantics/resolution/resolve-fn.ts
@@ -2,6 +2,7 @@ import { Call } from "../../syntax-objects/call.js";
 import { Expr } from "../../syntax-objects/expr.js";
 import { Fn } from "../../syntax-objects/fn.js";
 import { Implementation } from "../../syntax-objects/implementation.js";
+import { TraitType } from "../../syntax-objects/types/trait.js";
 import { List } from "../../syntax-objects/list.js";
 import { Parameter } from "../../syntax-objects/parameter.js";
 import { TypeAlias } from "../../syntax-objects/types.js";
@@ -59,8 +60,15 @@ const resolveParameters = (params: Parameter[]) => {
 
     if (p.name.is("self")) {
       const impl = getParentImpl(p);
-      if (impl) p.type = impl.targetType;
-      return;
+      if (impl) {
+        p.type = impl.targetType;
+        return;
+      }
+      const trait = getParentTrait(p);
+      if (trait) {
+        p.type = trait;
+        return;
+      }
     }
 
     if (!p.typeExpr) {
@@ -119,5 +127,12 @@ const resolveGenericsWithTypeArgs = (fn: Fn, args: List): Fn => {
 const getParentImpl = (expr: Expr): Implementation | undefined => {
   if (expr.syntaxType === "implementation") return expr;
   if (expr.parent) return getParentImpl(expr.parent);
+  return undefined;
+};
+
+const getParentTrait = (expr: Expr | TraitType): TraitType | undefined => {
+  if (expr instanceof TraitType) return expr;
+  const parent = (expr as any).parent;
+  if (parent) return getParentTrait(parent);
   return undefined;
 };


### PR DESCRIPTION
## Summary
- ensure `self` params inside trait methods resolve to the trait type
- instantiate trait implementations using applied type arguments
- add e2e coverage for multiple trait-object function overloads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a26b81583c832aabc85150f5967dcf