### PR TITLE
test: add multi param trait object example

### DIFF
--- a/src/__tests__/fixtures/trait-object-multiple-params.ts
+++ b/src/__tests__/fixtures/trait-object-multiple-params.ts
@@ -1,0 +1,63 @@
+export const traitObjectMultipleParamsVoyd = `
+use std::all
+
+trait Iterator<T>
+  fn next(self) -> Optional<T>
+
+trait Iterable<T>
+  fn iterate(self) -> Iterator<T>
+
+obj ArrayIterator<T> {
+  index: i32,
+  array: Array<T>
+}
+
+impl<T> Iterator<T> for ArrayIterator<T>
+  fn next(self) -> Optional<T>
+    if self.index >= self.array.length then:
+      None {}
+    else:
+      let r = self.array.get(self.index)
+      self.index = self.index + 1
+      r
+
+impl<T> Iterable<T> for Array<T>
+  fn iterate(self) -> Iterator<T>
+    ArrayIterator<T> { index: 0, array: self }
+
+pub fn run() -> i32
+  let f_arr = [1.0, 2.0, 3.0]
+  let i_arr = [1, 2, 3]
+  f_arr.sum2(i_arr)
+
+fn sum_iterable(it: Iterable<i32>) -> i32
+  let iterator = it.iterate()
+  let looper: (s: i32) -> i32 = (start: i32) =>
+    iterator.next().match(opt)
+      Some<i32>:
+        looper(start + opt.value)
+      None:
+        start
+  looper(0)
+
+fn sum_iterable(it: Iterable<f64>) -> f64
+  let iterator = it.iterate()
+  let looper: (s: f64) -> f64 = (start: f64) =>
+    iterator.next().match(opt)
+      Some<f64>:
+        looper(start + opt.value)
+      None:
+        start
+  looper(0.0)
+
+fn sum2(it1: Iterable<f64>, it2: Iterable<i32>) -> i32
+  let f_sum = it1.sum_iterable()
+  let i_sum = it2.sum_iterable()
+  if f_sum > 20.0 then:
+    1
+  else:
+    if i_sum > 2 then:
+      2
+    else:
+      3
+`;

--- a/src/__tests__/trait-object-multiple-params.e2e.test.ts
+++ b/src/__tests__/trait-object-multiple-params.e2e.test.ts
@@ -1,0 +1,21 @@
+import { traitObjectMultipleParamsVoyd } from "./fixtures/trait-object-multiple-params.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E trait object resolution with multiple params", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(traitObjectMultipleParamsVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("run returns correct value", (t) => {
+    const fn = getWasmFn("run", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "run returns correct value").toEqual(2);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add fixture demonstrating trait object calls with multiple params
- verify iterator traits work with arrays of `f64` and `i32`

## Testing
- `npm test`
- `npx vitest run src/__tests__/trait-object-multiple-params.e2e.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a2ac36d714832ab76864e0ad0a77af