### PR TITLE
Handle trait Self type during resolution

### DIFF
--- a/src/semantics/resolution/get-expr-type.ts
+++ b/src/semantics/resolution/get-expr-type.ts
@@ -33,7 +33,10 @@ export const getExprType = (expr?: Expr): Type | undefined => {
 export const getIdentifierType = (id: Identifier): Type | undefined => {
   const entity = id.resolve();
   if (!entity && id.is("self") && (id.parentImpl || id.parentTrait)) {
-    id.type = id.parentImpl?.targetType ?? selfType;
+    // When resolving the type of `self` inside a trait, use a scoped
+    // `Self` type so that later compatibility checks know which trait the
+    // `Self` belongs to. Implementations get their concrete target type.
+    id.type = id.parentImpl?.targetType ?? selfType.clone(id);
   }
   if (!entity) return;
   if (entity.isVariable()) return entity.type;

--- a/src/semantics/resolution/resolve-fn.ts
+++ b/src/semantics/resolution/resolve-fn.ts
@@ -59,7 +59,11 @@ const resolveParameters = (params: Parameter[]) => {
 
     if (p.name.is("self")) {
       const impl = getParentImpl(p);
-      p.type = impl ? impl.targetType : selfType;
+      // Use a Self type that is scoped to the surrounding trait so trait
+      // methods can properly resolve their `Self` parameter. This allows
+      // compatibility checks to detect when a concrete implementation is
+      // providing the first parameter expected by a trait method.
+      p.type = impl ? impl.targetType : selfType.clone(p);
       return;
     }
 


### PR DESCRIPTION
## Summary
- clone the `Self` type within trait signatures and identifiers so trait methods know their parent trait
- allow compatibility checks to match trait methods with concrete implementations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a42b1ed8c4832abbd5c66410da5bf1