### PR TITLE
Fix self type compatibility

### DIFF
--- a/src/semantics/resolution/types-are-compatible.ts
+++ b/src/semantics/resolution/types-are-compatible.ts
@@ -57,13 +57,13 @@ export const typesAreCompatible = (
     return true;
   }
 
-  // Attempt to get implementation self parameters to match to their trait method. Don't think its working.
-  if (
-    (a.isObjectType() && b.isSelfType() && b.parentTrait) ||
-    (b.isObjectType() && a.isSelfType() && a.parentTrait)
-  ) {
-    return true;
-  }
+  // Handle `Self` parameters. When either side is a `SelfType` it should be
+  // considered compatible with any object type. Trait methods will replace the
+  // `SelfType` with the concrete implementation type and object methods always
+  // refer to their target type, so allowing this loose comparison enables
+  // method resolution before all implementations have been fully resolved.
+  if (a.isObjectType() && b.isSelfType()) return true;
+  if (b.isObjectType() && a.isSelfType()) return true;
 
   if (a.isPrimitiveType() && b.isPrimitiveType()) {
     return a.id === b.id;


### PR DESCRIPTION
## Summary
- allow object types to always match SelfType values during type compatibility checks

## Testing
- `npx vitest run src/__tests__/compiler.test.ts -t "Compiler kitchen sink"` *(fails: No function found for call /workspace/voyd/std/array.voyd:28:8-39)*

------
https://chatgpt.com/codex/tasks/task_e_68a49e956eb4832aa55e8576d3dc5814