### PR TITLE
Instantiate trait implementations for trait params

### DIFF
--- a/src/__tests__/fixtures/iterable-map-single.ts
+++ b/src/__tests__/fixtures/iterable-map-single.ts
@@ -1,0 +1,15 @@
+export const iterableMapSingleVoyd = `
+use std::all
+
+pub fn run() -> i32
+  let arr = [1, 2, 3]
+  let arr_mapped = map<i32, i32>(arr, (n: i32) => n + 1)
+  let arr_val = arr_mapped.get(2).match(v)
+    Some<i32>:
+      v.value
+    None:
+      0
+
+  arr_val
+`;
+

--- a/src/__tests__/iterable-map-single.e2e.test.ts
+++ b/src/__tests__/iterable-map-single.e2e.test.ts
@@ -1,0 +1,21 @@
+import { iterableMapSingleVoyd } from "./fixtures/iterable-map-single.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E iterable map (single)", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(iterableMapSingleVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("run returns correct value", (t) => {
+    const fn = getWasmFn("run", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "run returns correct value").toEqual(4);
+  });
+});
+

--- a/src/semantics/resolution/__tests__/resolve-call.test.ts
+++ b/src/semantics/resolution/__tests__/resolve-call.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  Call,
+  Fn,
+  Identifier,
+  Int,
+  List,
+  MockIdentifier,
+  Variable,
+  i32,
+} from "../../../syntax-objects/index.js";
+import { TraitType } from "../../../syntax-objects/types/trait.js";
+import { resolveCall } from "../resolve-call.js";
+import * as getCallFnModule from "../get-call-fn.js";
+
+describe("resolveCall", () => {
+  test("uses trait method return type while still triggering candidate search", () => {
+    const traitMethod = new Fn({
+      name: Identifier.from("run"),
+      parameters: [],
+    });
+    traitMethod.returnType = i32;
+    const trait = new TraitType({
+      name: Identifier.from("Run"),
+      methods: [traitMethod],
+    });
+
+    const variable = new Variable({
+      name: Identifier.from("r"),
+      isMutable: false,
+      initializer: new Int({ value: 0 }),
+      type: trait,
+    });
+
+    const arg = new MockIdentifier({ value: "r", entity: variable });
+
+    const call = new Call({
+      fnName: Identifier.from("run"),
+      args: new List({ value: [arg] }),
+    });
+
+    const implFn = new Fn({ name: Identifier.from("run"), parameters: [] });
+    implFn.returnType = i32;
+
+    const getCallFnSpy = vi
+      .spyOn(getCallFnModule, "getCallFn")
+      .mockReturnValue(implFn);
+
+    resolveCall(call);
+
+    expect(getCallFnSpy).toHaveBeenCalledOnce();
+    expect(call.fn).toBe(traitMethod);
+    expect(call.type).toBe(traitMethod.returnType);
+
+    getCallFnSpy.mockRestore();
+  });
+});

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -4,7 +4,7 @@ import { typesAreCompatible } from "./types-are-compatible.js";
 import { resolveFn, resolveFnSignature } from "./resolve-fn.js";
 import { resolveTypeExpr } from "./resolve-type-expr.js";
 import { resolveEntities } from "./resolve-entities.js";
-import { resolveImpl } from "./resolve-impl.js";
+import { resolveObjectType } from "./resolve-object-type.js";
 
 export const getCallFn = (call: Call): Fn | undefined => {
   if (isPrimitiveFnCall(call)) return undefined;
@@ -135,26 +135,9 @@ const parametersMatch = (candidate: Fn, call: Call) => {
 
     const argType = getExprType(arg);
     if (!argType) return false;
-    const paramType = p.type;
 
-    // If the parameter expects a trait and the argument is a concrete object
-    // type, ensure that the object's trait implementations are instantiated
-    // before performing compatibility checks. Free functions like `map`
-    // require this so that calls with concrete types (e.g. `Array<i32>`) can
-    // satisfy trait bounds (`Iterable<i32>`).
-    if (paramType?.isTraitType() && argType.isObjectType()) {
-      const traitId = paramType.id;
-      argType.genericParent?.implementations?.forEach((impl) => {
-        try {
-          // Resolve the generic implementation's trait so we can compare ids
-          resolveImpl(impl);
-          if (impl.trait?.id === traitId) {
-            resolveImpl(impl.clone(), argType);
-          }
-        } catch {
-          /* ignore */
-        }
-      });
+    if (p.type?.isTraitType() && argType.isObjectType()) {
+      resolveObjectType(argType);
     }
 
     const argLabel = getExprLabel(arg);

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -144,22 +144,17 @@ const parametersMatch = (candidate: Fn, call: Call) => {
     // satisfy trait bounds (`Iterable<i32>`).
     if (paramType?.isTraitType() && argType.isObjectType()) {
       const traitId = paramType.id;
-      const hasImpl = argType.implementations?.some(
-        (impl) => impl.trait?.id === traitId
-      );
-      if (!hasImpl) {
-        argType.genericParent?.implementations?.forEach((impl) => {
-          try {
-            // Resolve the generic implementation's trait so we can compare ids
-            resolveImpl(impl);
-            if (impl.trait?.id === traitId) {
-              resolveImpl(impl.clone(), argType);
-            }
-          } catch {
-            /* ignore */
+      argType.genericParent?.implementations?.forEach((impl) => {
+        try {
+          // Resolve the generic implementation's trait so we can compare ids
+          resolveImpl(impl);
+          if (impl.trait?.id === traitId) {
+            resolveImpl(impl.clone(), argType);
           }
-        });
-      }
+        } catch {
+          /* ignore */
+        }
+      });
     }
 
     const argLabel = getExprLabel(arg);

--- a/src/semantics/resolution/resolve-object-type.ts
+++ b/src/semantics/resolution/resolve-object-type.ts
@@ -123,9 +123,13 @@ const resolveGenericsWithTypeArgs = (
   obj.registerGenericInstance(newObj);
   const resolvedObj = resolveObjectType(newObj);
 
-  newObj.implementations
+  // Replace any cloned generic implementations with resolved versions specific
+  // to the concrete object instance.
+  resolvedObj.implementations = [];
+
+  obj.implementations
     ?.filter((impl) => implIsCompatible(impl, resolvedObj))
-    .forEach((impl) => resolveImpl(impl, resolvedObj));
+    .forEach((impl) => resolveImpl(impl.clone(), resolvedObj));
 
   return resolvedObj;
 };

--- a/src/semantics/resolution/resolve-object-type.ts
+++ b/src/semantics/resolution/resolve-object-type.ts
@@ -123,12 +123,9 @@ const resolveGenericsWithTypeArgs = (
   obj.registerGenericInstance(newObj);
   const resolvedObj = resolveObjectType(newObj);
 
-  const implementations = newObj.implementations;
-  newObj.implementations = []; // Clear implementations to avoid duplicates, resolveImpl will re-add them
-
-  implementations
-    .filter((impl) => implIsCompatible(impl, resolvedObj))
-    .map((impl) => resolveImpl(impl, resolvedObj));
+  newObj.implementations
+    ?.filter((impl) => implIsCompatible(impl, resolvedObj))
+    .forEach((impl) => resolveImpl(impl, resolvedObj));
 
   return resolvedObj;
 };


### PR DESCRIPTION
## Summary
- Instantiate missing trait implementations when parameter expects a trait and argument is a concrete type
- Call trait-method candidate search for side effects without altering trait method resolution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4e25a127c832aa0129e4dddcbc305