### PR TITLE
fix: handle closures calling closures

### DIFF
--- a/src/__tests__/closure-calls-closure.e2e.test.ts
+++ b/src/__tests__/closure-calls-closure.e2e.test.ts
@@ -1,0 +1,20 @@
+import { closureCallsClosureVoyd } from "./fixtures/closure-calls-closure.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E closure invoking closure", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(closureCallsClosureVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("closures can call other closures", (t) => {
+    const fn = getWasmFn("main", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "main returns updated value").toEqual(4);
+  });
+});

--- a/src/__tests__/fixtures/closure-calls-closure.ts
+++ b/src/__tests__/fixtures/closure-calls-closure.ts
@@ -1,0 +1,15 @@
+export const closureCallsClosureVoyd = `
+use std::all
+
+fn call_it(v: i32, cb: (v: i32) -> i32)
+  let hi: () -> i32 = () => cb(v)
+  hi()
+
+pub fn main() -> i32
+  let sum = { val: 0 }
+  let set: (v: i32) -> i32 = (v: i32) =>
+    sum.val = v
+    0
+  call_it(4, set)
+  sum.val
+`;

--- a/src/semantics/__tests__/closure.test.ts
+++ b/src/semantics/__tests__/closure.test.ts
@@ -1,11 +1,13 @@
 import { parse } from "../../parser/parser.js";
 import { Block } from "../../syntax-objects/block.js";
+import { Call } from "../../syntax-objects/call.js";
 import { Identifier } from "../../syntax-objects/identifier.js";
 import { Closure } from "../../syntax-objects/closure.js";
 import { Fn } from "../../syntax-objects/fn.js";
 import { Parameter } from "../../syntax-objects/parameter.js";
 import { Variable } from "../../syntax-objects/variable.js";
 import { Int } from "../../syntax-objects/int.js";
+import { List } from "../../syntax-objects/list.js";
 import { initEntities } from "../init-entities.js";
 import { resolveEntities } from "../resolution/resolve-entities.js";
 import { test } from "vitest";
@@ -43,6 +45,22 @@ test("closure captures parameter from enclosing function", (t) => {
   const closure = new Closure({
     body: new Block({ body: [Identifier.from("x")] }),
   });
+  const fn = new Fn({
+    name: Identifier.from("outer"),
+    parameters: [param],
+    body: new Block({ body: [closure] }),
+  });
+
+  resolveEntities(closure);
+
+  t.expect(closure.captures.length).toBe(1);
+  t.expect(closure.captures[0]).toBe(param);
+});
+
+test("closure captures parameter used as callee", (t) => {
+  const param = new Parameter({ name: Identifier.from("cb") });
+  const call = new Call({ fnName: Identifier.from("cb"), args: new List({ value: [] }) });
+  const closure = new Closure({ body: new Block({ body: [call] }) });
   const fn = new Fn({
     name: Identifier.from("outer"),
     parameters: [param],

--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -40,6 +40,10 @@ export const resolveCall = (call: Call): Call => {
     : undefined;
   if (memberAccessCall) return memberAccessCall;
 
+  // Ensure the call identifier is processed so closures can capture it when
+  // referenced as the callee.
+  call.fnName = resolveEntities(call.fnName) as Identifier;
+
   // Constructor fn. TODO:
   const type = getIdentifierType(call.fnName);
   call.fnName.type = type;


### PR DESCRIPTION
## Summary
- ensure resolveCall processes callee identifiers so closures capture them
- add regression tests for invoking closures from closures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a55e05a868832a87f89c38f0388480