### PR TITLE
feat: add void return support

### DIFF
--- a/src/__tests__/fixtures/void-type.ts
+++ b/src/__tests__/fixtures/void-type.ts
@@ -1,0 +1,16 @@
+export const voidTypeVoyd = `
+use std::all
+
+fn call_it(it: (v: i32) -> voyd) -> voyd
+  it(5)
+
+pub fn main() -> i32
+  let sum = { val: 0 }
+
+  let set = (v: i32) -> voyd =>
+    sum.val = v
+
+  call_it(set)
+  sum.val
+`;
+

--- a/src/__tests__/void-type.e2e.test.ts
+++ b/src/__tests__/void-type.e2e.test.ts
@@ -1,0 +1,21 @@
+import { voidTypeVoyd } from "./fixtures/void-type.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E void return types", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(voidTypeVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("functions returning voyd ignore body return values", (t) => {
+    const fn = getWasmFn("main", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "main returns correct value").toEqual(5);
+  });
+});
+

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -121,7 +121,8 @@ export const mapBinaryenType = (
   if (isPrimitiveId(type, "f32")) return binaryen.f32;
   if (isPrimitiveId(type, "i64")) return binaryen.i64;
   if (isPrimitiveId(type, "f64")) return binaryen.f64;
-  if (isPrimitiveId(type, "voyd")) return binaryen.none;
+  if (isPrimitiveId(type, "voyd") || isPrimitiveId(type, "void"))
+    return binaryen.none;
   if (isPrimitiveId(type, "string")) return getI32ArrayType(opts.mod);
 
   if (type.isObjectType()) {

--- a/src/semantics/init-entities.ts
+++ b/src/semantics/init-entities.ts
@@ -163,9 +163,14 @@ const initFn = (expr: List): Fn => {
 const initClosure = (expr: List): Closure => {
   const paramsExpr = expr.at(1);
   let parameters: Parameter[] = [];
+  let returnTypeExpr: Expr | undefined;
 
   if (paramsExpr?.isList()) {
-    if (paramsExpr.calls(":")) {
+    if (paramsExpr.calls("->")) {
+      const fnType = initFnType(paramsExpr);
+      parameters = fnType.parameters;
+      returnTypeExpr = fnType.returnTypeExpr;
+    } else if (paramsExpr.calls(":")) {
       const param = listToParameter(paramsExpr);
       parameters = Array.isArray(param) ? param : [param];
     } else {
@@ -192,6 +197,7 @@ const initClosure = (expr: List): Closure => {
     ...expr.metadata,
     parameters,
     body,
+    returnTypeExpr,
   });
 };
 

--- a/src/semantics/resolution/resolve-closure.ts
+++ b/src/semantics/resolution/resolve-closure.ts
@@ -14,6 +14,13 @@ export const resolveClosure = (closure: Closure): Closure => {
   closure.captures = [];
   closure.body = resolveEntities(closure.body);
   closure.inferredReturnType = getExprType(closure.body);
+  if (
+    closure.annotatedReturnType?.isPrimitiveType() &&
+    (closure.annotatedReturnType.name.value === "void" ||
+      closure.annotatedReturnType.name.value === "voyd")
+  ) {
+    closure.inferredReturnType = closure.annotatedReturnType;
+  }
   closure.returnType =
     closure.annotatedReturnType ?? closure.inferredReturnType;
   closure.typesResolved = true;

--- a/src/semantics/resolution/resolve-fn.ts
+++ b/src/semantics/resolution/resolve-fn.ts
@@ -36,6 +36,13 @@ export const resolveFn = (fn: Fn, call?: Call): Fn => {
   fn.typesResolved = true;
   fn.body = fn.body ? resolveEntities(fn.body) : undefined;
   fn.inferredReturnType = getExprType(fn.body);
+  if (
+    fn.annotatedReturnType?.isPrimitiveType() &&
+    (fn.annotatedReturnType.name.value === "void" ||
+      fn.annotatedReturnType.name.value === "voyd")
+  ) {
+    fn.inferredReturnType = fn.annotatedReturnType;
+  }
   fn.returnType = fn.annotatedReturnType ?? fn.inferredReturnType;
   fn.parentImpl?.registerMethod(fn); // Maybe do this for module when not in an impl
 

--- a/src/semantics/resolution/types-are-compatible.ts
+++ b/src/semantics/resolution/types-are-compatible.ts
@@ -66,6 +66,12 @@ export const typesAreCompatible = (
   }
 
   if (a.isPrimitiveType() && b.isPrimitiveType()) {
+    if (
+      (a.name.value === "void" && b.name.value === "voyd") ||
+      (a.name.value === "voyd" && b.name.value === "void")
+    ) {
+      return true;
+    }
     return a.id === b.id;
   }
 


### PR DESCRIPTION
## Summary
- allow closures to declare return types with `=>` syntax
- treat `void` and `voyd` as interchangeable types during resolution and codegen
- add e2e coverage for void-returning closures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a57385ccbc832a962e26f6b3928024