### PR TITLE
fix: avoid returning values for void functions

### DIFF
--- a/src/__tests__/void-type.e2e.test.ts
+++ b/src/__tests__/void-type.e2e.test.ts
@@ -9,6 +9,7 @@ describe("E2E void return types", () => {
 
   beforeAll(async () => {
     const mod = await compile(voidTypeVoyd);
+    assert(mod.validate(), "Module is valid");
     instance = getWasmInstance(mod);
   });
 

--- a/src/assembler/compile-call.ts
+++ b/src/assembler/compile-call.ts
@@ -55,14 +55,11 @@ export const compile = (opts: CompileExprOpts<Call>): number => {
       const callType = getClosureFunctionType(opts, fnType);
       target = refCast(mod, funcRef, callType);
     } catch {}
-    const callExpr = callRef(
-      mod,
-      target,
-      args,
-      mapBinaryenType(opts, fnType.returnType),
-      false
-    );
-    return isReturnExpr ? mod.return(callExpr) : callExpr;
+    const returnType = mapBinaryenType(opts, fnType.returnType);
+    const callExpr = callRef(mod, target, args, returnType, false);
+    return isReturnExpr && returnType !== binaryen.none
+      ? mod.return(callExpr)
+      : callExpr;
   }
 
   if (!expr.fn) {
@@ -128,7 +125,9 @@ export const compile = (opts: CompileExprOpts<Call>): number => {
     });
     const returnType = mapBinaryenType(opts, traitFn.returnType!);
     const callExpr = callRef(mod, target, args, returnType);
-    return isReturnExpr ? mod.return(callExpr) : callExpr;
+    return isReturnExpr && returnType !== binaryen.none
+      ? mod.return(callExpr)
+      : callExpr;
   }
 
   const args = expr.args.toArray().map((arg, i) =>

--- a/src/assembler/compile-closure.ts
+++ b/src/assembler/compile-closure.ts
@@ -98,7 +98,7 @@ export const compile = (opts: CompileExprOpts<Closure>): number => {
   const body = compileExpression({
     ...opts,
     expr: closure.body,
-    isReturnExpr: true,
+    isReturnExpr: returnType !== binaryen.none,
   });
 
   const varTypes = closure.variables.map((v) => mapBinaryenType(opts, v.type!));

--- a/src/assembler/compile-function.ts
+++ b/src/assembler/compile-function.ts
@@ -21,7 +21,7 @@ export const compile = (opts: CompileExprOpts<Fn>): number => {
   const body = compileExpression({
     ...opts,
     expr: fn.body!,
-    isReturnExpr: true,
+    isReturnExpr: returnType !== binaryen.none,
   });
 
   const variableTypes = getFunctionVarTypes(opts, fn);


### PR DESCRIPTION
## Summary
- validate void return E2E module to catch invalid wasm
- skip generating return expressions for void functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a578bdf8e0832abaab22e6382770e4