### PR TITLE
Fix closure param inference for labeled arguments

### DIFF
--- a/src/__tests__/closure-param-infer.e2e.test.ts
+++ b/src/__tests__/closure-param-infer.e2e.test.ts
@@ -2,6 +2,7 @@ import {
   closureParamInferOneVoyd,
   closureParamInferTwoVoyd,
 } from "./fixtures/closure-param-infer.js";
+import { closureParamInferLabeledVoyd } from "./fixtures/closure-param-infer-labeled.js";
 import { compile } from "../compiler.js";
 import { describe, test } from "vitest";
 import assert from "node:assert";
@@ -22,5 +23,13 @@ describe("E2E closure parameter inference", () => {
     const fn = getWasmFn("main", instance);
     assert(fn, "Function exists");
     t.expect(fn(), "main returns correct value").toEqual(7);
+  });
+
+  test("infers labeled closure parameters", async (t) => {
+    const mod = await compile(closureParamInferLabeledVoyd);
+    const instance = getWasmInstance(mod);
+    const fn = getWasmFn("main", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "main returns correct value").toEqual(6);
   });
 });

--- a/src/__tests__/fixtures/closure-param-infer-labeled.ts
+++ b/src/__tests__/fixtures/closure-param-infer-labeled.ts
@@ -1,0 +1,9 @@
+export const closureParamInferLabeledVoyd = `
+use std::all
+
+fn call_with_reducer({ start: i32, reducer cb: (acc: i32, current: i32) -> i32 }) -> i32
+  cb(start, 5)
+
+pub fn main() -> i32
+  call_with_reducer start: 1 reducer: (acc, current) => acc + current
+`;


### PR DESCRIPTION
## Summary
- handle labeled closure args during call resolution
- test closure parameter inference when passed as labeled argument

## Testing
- `npm test`
- `npx tsx src/cli/cli-dev.ts --run /tmp/reduce_bug.voyd`

------
https://chatgpt.com/codex/tasks/task_e_68a5fb490308832abae158b718f20ff1