### PR TITLE
Fix FnType cloning for generic return types

### DIFF
--- a/src/__tests__/fixtures/generic-array-reduce.ts
+++ b/src/__tests__/fixtures/generic-array-reduce.ts
@@ -1,0 +1,17 @@
+export const genericArrayReduceVoyd = `
+use std::all
+
+fn reduce<T>({ arr: Array<T>, start: T, reducer cb: (acc: T, current: T) -> T }) -> T
+  let iterator = arr.iterate()
+  let reducer: (acc: T) -> T = (acc: T) =>
+    iterator.next().match(opt)
+      Some<T>:
+        reducer(cb(acc, opt.value))
+      None:
+        acc
+  reducer(start)
+
+pub fn run() -> i32
+  let arr: Array<i32> = [1, 2, 3]
+  reduce<i32> arr: arr start: 0 reducer: (acc: i32, current: i32) => acc + current
+`;

--- a/src/__tests__/generic-array-reduce.e2e.test.ts
+++ b/src/__tests__/generic-array-reduce.e2e.test.ts
@@ -1,0 +1,20 @@
+import { genericArrayReduceVoyd } from "./fixtures/generic-array-reduce.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E generic array reduce", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(genericArrayReduceVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("run returns reduced sum", (t) => {
+    const fn = getWasmFn("run", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "run returns reduced sum").toEqual(6);
+  });
+});

--- a/src/syntax-objects/types.ts
+++ b/src/syntax-objects/types.ts
@@ -332,15 +332,22 @@ export class FnType extends BaseType {
     this.parameters = opts.parameters;
     this.returnType = opts.returnType;
     this.returnTypeExpr = opts.returnTypeExpr;
+    if (this.returnTypeExpr) {
+      this.returnTypeExpr.parent = this;
+    }
   }
 
   clone(parent?: Expr): FnType {
-    return new FnType({
+    const parameters = this.parameters.map((p) => p.clone());
+    const returnTypeExpr = this.returnTypeExpr?.clone();
+    const clone = new FnType({
       ...super.getCloneOpts(parent),
       returnType: this.returnType,
-      parameters: this.parameters,
-      returnTypeExpr: this.returnTypeExpr?.clone(),
+      parameters,
+      returnTypeExpr,
     });
+    parameters.forEach((p) => (p.parent = clone));
+    return clone;
   }
 
   toJSON(): TypeJSON {


### PR DESCRIPTION
## Summary
- ensure function type cloning preserves return type expression parent
- add regression test covering generic recursive reduce

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a615a13984832a8e57ad2a72461ed9