### PR TITLE
Add MessagePack helpers for JSON linear memory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.7.0",
       "license": "ISC",
       "dependencies": {
+        "@msgpack/msgpack": "^3.1.2",
         "@types/uniqid": "^4.1.3",
         "binaryen": "^119.0.0",
         "commander": "^5.1.0",
@@ -693,6 +694,15 @@
       "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.2.tgz",
+      "integrity": "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "@msgpack/msgpack": "^3.1.2",
     "@types/uniqid": "^4.1.3",
     "binaryen": "^119.0.0",
     "commander": "^5.1.0",

--- a/src/__tests__/fixtures/json-msgpack.ts
+++ b/src/__tests__/fixtures/json-msgpack.ts
@@ -1,0 +1,21 @@
+export const jsonMsgpackVoyd = `
+use std::linear_memory::{ grow, store8 }
+
+pub fn run(ptr: i32) -> i32
+  grow(1)
+  store8(ptr + 0, 131)
+  store8(ptr + 1, 161)
+  store8(ptr + 2, 97)
+  store8(ptr + 3, 1)
+  store8(ptr + 4, 161)
+  store8(ptr + 5, 98)
+  store8(ptr + 6, 146)
+  store8(ptr + 7, 195)
+  store8(ptr + 8, 162)
+  store8(ptr + 9, 104)
+  store8(ptr + 10, 105)
+  store8(ptr + 11, 161)
+  store8(ptr + 12, 99)
+  store8(ptr + 13, 192)
+  14
+`;

--- a/src/__tests__/json-msgpack.e2e.test.ts
+++ b/src/__tests__/json-msgpack.e2e.test.ts
@@ -1,0 +1,14 @@
+import { describe, test } from "vitest";
+import { readJson, writeJson } from "../lib/json.js";
+
+describe("JSON MessagePack via linear memory", () => {
+  test("roundtrip", (t) => {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const instance = { exports: { memory } } as unknown as WebAssembly.Instance;
+    const value = { a: 1, b: [true, "hi"], c: null };
+    const ptr = 0;
+    const len = writeJson(value, instance, ptr);
+    const result = readJson<typeof value>(ptr, len, instance);
+    t.expect(result).toEqual(value);
+  });
+});

--- a/src/lib/json.ts
+++ b/src/lib/json.ts
@@ -1,0 +1,48 @@
+import { encode, decode } from "@msgpack/msgpack";
+
+/**
+ * Write a JavaScript value to linear memory encoded with MessagePack.
+ *
+ * @param value The value to encode.
+ * @param instance The WebAssembly instance whose memory will receive the data.
+ * @param ptr The offset in linear memory to write to. Defaults to 0.
+ * @returns The number of bytes written.
+ */
+export const writeJson = (
+  value: unknown,
+  instance: WebAssembly.Instance,
+  ptr = 0
+): number => {
+  const memory = instance.exports.memory as WebAssembly.Memory;
+  const bytes = encode(value);
+  const buf = new Uint8Array(memory.buffer);
+
+  const required = ptr + bytes.length;
+  if (required > buf.length) {
+    const pageSize = 64 * 1024;
+    const currentPages = buf.length / pageSize;
+    const neededPages = Math.ceil(required / pageSize);
+    memory.grow(neededPages - currentPages);
+  }
+
+  new Uint8Array(memory.buffer, ptr, bytes.length).set(bytes);
+  return bytes.length;
+};
+
+/**
+ * Read a MessagePack encoded value from linear memory.
+ *
+ * @param ptr The offset in linear memory where the data lives.
+ * @param length The number of bytes to read.
+ * @param instance The WebAssembly instance whose memory holds the data.
+ * @returns The decoded JavaScript value.
+ */
+export const readJson = <T = unknown>(
+  ptr: number,
+  length: number,
+  instance: WebAssembly.Instance
+): T => {
+  const memory = instance.exports.memory as WebAssembly.Memory;
+  const bytes = new Uint8Array(memory.buffer, ptr, length);
+  return decode(bytes) as T;
+};

--- a/src/lib/wasm.ts
+++ b/src/lib/wasm.ts
@@ -1,13 +1,14 @@
 import binaryen from "binaryen";
 
 export const getWasmInstance = (
-  mod: Uint8Array | binaryen.Module
+  mod: Uint8Array | binaryen.Module,
+  imports?: WebAssembly.Imports
 ): WebAssembly.Instance => {
   const bin = (
     mod instanceof Uint8Array ? mod : mod.emitBinary()
   ) as unknown as BufferSource;
   const compiled = new WebAssembly.Module(bin);
-  return new WebAssembly.Instance(compiled);
+  return new WebAssembly.Instance(compiled, imports);
 };
 
 export const getWasmFn = (

--- a/src/types/msgpack.d.ts
+++ b/src/types/msgpack.d.ts
@@ -1,0 +1,2 @@
+declare module "@msgpack/msgpack";
+

--- a/std/json.voyd
+++ b/std/json.voyd
@@ -1,6 +1,11 @@
 use macros::all
 use array::all
 use map::all
+use linear_memory::all
+
+declare 'json'
+  pub fn write(ptr: i32, value: Json) -> i32
+  pub fn read(ptr: i32, len: i32) -> Json
 
 pub obj JsonNull {}
 pub obj JsonNumber { val: f64 }

--- a/std/linear_memory.voyd
+++ b/std/linear_memory.voyd
@@ -26,6 +26,12 @@ pub fn load_i64(ptr: i32) -> i64
     namespace: i64
     args: `(BnrConst(0), BnrConst(0), ptr)
 
+pub fn load_u8(ptr: i32) -> i32
+  binaryen
+    func: load8_u
+    namespace: i32
+    args: `(BnrConst(0), BnrConst(0), ptr)
+
 pub fn store(ptr: i32, value: i32) -> i32
   binaryen
     func: store
@@ -37,5 +43,12 @@ pub fn store(ptr: i32, value: i64) -> i64
   binaryen
     func: store
     namespace: i64
+    args: `(BnrConst(0), BnrConst(0), ptr, value)
+  value
+
+pub fn store8(ptr: i32, value: i32) -> i32
+  binaryen
+    func: store8
+    namespace: i32
     args: `(BnrConst(0), BnrConst(0), ptr, value)
   value


### PR DESCRIPTION
## Summary
- add `@msgpack/msgpack` dependency
- support writing/reading JSON values to linear memory using MessagePack
- test MessagePack JSON roundtrip

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6635a0854832a9e3f1fcda90aea0d