### PR TITLE
test: add iterator tests for map and string

### DIFF
--- a/src/__tests__/fixtures/map-string-iterator.ts
+++ b/src/__tests__/fixtures/map-string-iterator.ts
@@ -1,0 +1,26 @@
+export const mapStringIteratorVoyd = `
+use std::all
+
+pub fn map_iter_sum() -> i32
+  let m = new_map<i32>()
+  m.set("a", 1)
+  m.set("b", 2)
+  let iterator = m.iterate()
+  let looper: (s: i32) -> i32 = (acc: i32) =>
+    iterator.next().match(item)
+      Some<{ key: string, value: i32 }>:
+        looper(acc + item.value.value)
+      None:
+        acc
+  looper(0)
+
+pub fn string_iter_sum() -> i32
+  let iterator = new_string_iterator("ab")
+  let looper: (s: i32) -> i32 = (acc: i32) =>
+    iterator.next().match(ch)
+      Some<i32>:
+        looper(acc + ch.value)
+      None:
+        acc
+  looper(0)
+`;

--- a/src/__tests__/map-string-iterator.e2e.test.ts
+++ b/src/__tests__/map-string-iterator.e2e.test.ts
@@ -1,0 +1,26 @@
+import { mapStringIteratorVoyd } from "./fixtures/map-string-iterator.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E std iterators", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(mapStringIteratorVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("map iterator sums values", (t) => {
+    const fn = getWasmFn("map_iter_sum", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "map_iter_sum returns correct value").toEqual(3);
+  });
+
+  test("string iterator sums char codes", (t) => {
+    const fn = getWasmFn("string_iter_sum", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "string_iter_sum returns correct value").toEqual(195);
+  });
+});


### PR DESCRIPTION
## Summary
- add fixture and e2e test for Map and string iterators
- verify Map iterator sums values
- verify StringIterator walks characters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a67efdaaa0832aa275b24486c5a05d