### PR TITLE
feat: add msg pack encoder

### DIFF
--- a/src/__tests__/fixtures/msg-pack.ts
+++ b/src/__tests__/fixtures/msg-pack.ts
@@ -1,0 +1,8 @@
+export const msgPackVoyd = `
+use std::msg_pack
+use std::linear_memory
+
+pub fn run() -> i32
+  msg_pack::encode_json(42, 0)
+  linear_memory::load_i32(0)
+`;

--- a/src/__tests__/msg-pack.e2e.test.ts
+++ b/src/__tests__/msg-pack.e2e.test.ts
@@ -1,0 +1,15 @@
+import { msgPackVoyd } from "./fixtures/msg-pack.js";
+import { compile } from "../compiler.js";
+import { describe, test } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E msg pack encode", () => {
+  test("encodes number into memory", async (t) => {
+    const mod = await compile(msgPackVoyd);
+    const instance = getWasmInstance(mod);
+    const fn = getWasmFn("run", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "encoded number written").toEqual(42);
+  });
+});

--- a/std/index.voyd
+++ b/std/index.voyd
@@ -12,3 +12,4 @@ pub mod linear_memory
 pub mod string_lib
 pub mod map::all
 pub mod json::all
+pub mod msg_pack

--- a/std/msg_pack/encoder.voyd
+++ b/std/msg_pack/encoder.voyd
@@ -1,0 +1,44 @@
+use std::all
+use std::linear_memory
+
+obj Encoder {
+  ptr: i32,
+  pos: i32,
+}
+
+impl Encoder
+  fn ensure_capacity(self, add: i32) -> void
+    let required = self.ptr + self.pos + add
+    let current_bytes = linear_memory::size() * 65536
+    if required >= current_bytes then:
+      let needed = required - current_bytes
+      // compute pages to grow
+      let pages = (needed / 65536) + 1
+      linear_memory::grow(pages)
+
+  fn write_u8(self, value: i32) -> void
+    self.ensure_capacity(1)
+    binaryen
+      func: store8
+      namespace: i32
+      args: `(BnrConst(0), BnrConst(0), self.ptr + self.pos, value)
+    self.pos = self.pos + 1
+
+  fn encode_number(self, value: i32) -> void
+    if value >= 0 and value < 128 then:
+      // positive fixint
+      self.write_u8(value)
+    else:
+      // uint 32
+      self.write_u8(0xce)
+      self.write_u8(shift_ru(value, 24))
+      self.write_u8(bit_and(shift_ru(value, 16), 0xff))
+      self.write_u8(bit_and(shift_ru(value, 8), 0xff))
+      self.write_u8(bit_and(value, 0xff))
+
+pub fn encode_json(value: i32, ptr: i32) -> i32
+  if linear_memory::size() == 0 then:
+    linear_memory::grow(1)
+  let enc = Encoder { ptr: ptr, pos: 0 }
+  Encoder::encode_number(enc, value)
+  enc.pos

--- a/std/msg_pack/index.voyd
+++ b/std/msg_pack/index.voyd
@@ -1,0 +1,9 @@
+use std::macros::all
+use encoder::{ encode_json: internal_encode_json }
+
+pub fn encode_json(value: i32, ptr: i32) -> i32
+  internal_encode_json(value, ptr)
+
+pub fn decode_json(ptr: i32, len: i32) -> i32
+  // not yet implemented
+  0


### PR DESCRIPTION
## Summary
- scaffold msg_pack standard library module with encoder
- support basic integer encoding into linear memory
- add initial msg-pack encoding test fixture

## Testing
- `npm test` (fails: Invalid use statement, entity * is not exported at std/msg_pack/encoder.voyd:12:47-48)


------
https://chatgpt.com/codex/tasks/task_e_68a6812fd2d0832a838d79144ab29eb2