### PR TITLE
fix: validate methods in implementations

### DIFF
--- a/src/semantics/__tests__/impl-methods.test.ts
+++ b/src/semantics/__tests__/impl-methods.test.ts
@@ -1,0 +1,46 @@
+import { test } from "vitest";
+import { ObjectType, i32 } from "../../syntax-objects/types.js";
+import { Identifier } from "../../syntax-objects/identifier.js";
+import { Implementation } from "../../syntax-objects/implementation.js";
+import { Fn } from "../../syntax-objects/fn.js";
+import { Parameter } from "../../syntax-objects/parameter.js";
+import { Block } from "../../syntax-objects/block.js";
+import { Call } from "../../syntax-objects/call.js";
+import { List } from "../../syntax-objects/list.js";
+import { Int } from "../../syntax-objects/int.js";
+import { checkTypes } from "../check-types.js";
+
+// Regression test for ensuring unresolved calls within methods are detected
+// during type checking.
+test("unresolved fn calls inside methods throw", (t) => {
+  const obj = new ObjectType({
+    name: Identifier.from("Test"),
+    value: [{ name: "a", typeExpr: i32, type: i32 }],
+    implementations: [],
+  });
+
+  const impl = new Implementation({
+    parent: obj,
+    typeParams: [],
+    targetTypeExpr: Identifier.from("Test"),
+    body: new Block({ body: [] }),
+  });
+
+  const call = new Call({
+    fnName: Identifier.from("boop"),
+    args: new List({ value: [new Int({ value: 1 })] }),
+  });
+
+  const method = new Fn({
+    name: Identifier.from("foo"),
+    parameters: [new Parameter({ name: Identifier.from("self"), type: obj })],
+    body: new Block({ body: [call] }),
+    parent: impl,
+  });
+  method.returnType = i32;
+
+  impl.registerMethod(method);
+  obj.implementations.push(impl);
+
+  t.expect(() => checkTypes(obj)).toThrow(/Could not resolve fn boop/);
+});

--- a/src/semantics/check-types.ts
+++ b/src/semantics/check-types.ts
@@ -541,12 +541,16 @@ const checkImpl = (impl: Implementation): Implementation => {
   if (impl.traitExpr.value && !impl.trait) {
     throw new Error(`Unable to resolve trait for impl at ${impl.location}`);
   }
+  // Always validate method bodies
+  for (const method of impl.methods) {
+    checkFnTypes(method);
+  }
 
   if (!impl.trait) return impl;
 
   for (const method of impl.trait.methods.toArray()) {
     if (
-      !impl.exports.some((fn) =>
+      !impl.methods.some((fn) =>
         typesAreCompatible(fn.getType(), method.getType())
       )
     ) {
@@ -554,10 +558,6 @@ const checkImpl = (impl: Implementation): Implementation => {
         `Impl does not implement ${method.name} at ${impl.location}`
       );
     }
-  }
-
-  for (const method of impl.exports) {
-    checkFnTypes(method);
   }
 
   return impl;


### PR DESCRIPTION
## Summary
- ensure method bodies are type-checked for all implementations
- add regression test for unresolved calls in methods

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6cea653a8832aa12db67ee2cc0105