### PR TITLE
feat: encode strings in msg pack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.7.0",
       "license": "ISC",
       "dependencies": {
+        "@msgpack/msgpack": "^3.1.2",
         "@types/uniqid": "^4.1.3",
         "binaryen": "^123.0.0",
         "commander": "^5.1.0",
@@ -693,6 +694,15 @@
       "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.2.tgz",
+      "integrity": "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "@msgpack/msgpack": "^3.1.2",
     "@types/uniqid": "^4.1.3",
     "binaryen": "^123.0.0",
     "commander": "^5.1.0",

--- a/src/__tests__/fixtures/msg-pack.ts
+++ b/src/__tests__/fixtures/msg-pack.ts
@@ -5,4 +5,8 @@ use std::linear_memory
 pub fn run() -> i32
   msg_pack::encode_json(42, 0)
   linear_memory::load_i32(0)
+
+pub fn run_string() -> i32
+  msg_pack::encode_string("abc", 0)
+  linear_memory::load_i32(0)
 `;

--- a/src/__tests__/msg-pack.e2e.test.ts
+++ b/src/__tests__/msg-pack.e2e.test.ts
@@ -3,6 +3,7 @@ import { compile } from "../compiler.js";
 import { describe, test } from "vitest";
 import assert from "node:assert";
 import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+import { decode } from "@msgpack/msgpack";
 
 describe("E2E msg pack encode", () => {
   test("encodes number into memory", async (t) => {
@@ -18,6 +19,8 @@ describe("E2E msg pack encode", () => {
     const instance = getWasmInstance(mod);
     const fn = getWasmFn("run_string", instance);
     assert(fn, "Function exists");
-    t.expect(fn(), "encoded string written").toEqual(1667391907);
+    fn();
+    const memory = instance.exports["main_memory"] as WebAssembly.Memory;
+    t.expect(decode(memory.buffer.slice(0, 4))).toEqual("abc");
   });
 });

--- a/src/__tests__/msg-pack.e2e.test.ts
+++ b/src/__tests__/msg-pack.e2e.test.ts
@@ -12,4 +12,12 @@ describe("E2E msg pack encode", () => {
     assert(fn, "Function exists");
     t.expect(fn(), "encoded number written").toEqual(42);
   });
+
+  test("encodes string into memory", async (t) => {
+    const mod = await compile(msgPackVoyd);
+    const instance = getWasmInstance(mod);
+    const fn = getWasmFn("run_string", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "encoded string written").toEqual(1667391907);
+  });
 });

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -51,7 +51,7 @@ const buildingTypePlaceholders = new Map<ObjectType, TypeRef>();
 export const codegen = (ast: Expr) => {
   const mod = new binaryen.Module();
   mod.setFeatures(binaryen.Features.All);
-  mod.setMemory(0, 1, null, []);
+  mod.setMemory(0, 1, "main_memory", []);
   const extensionHelpers = initExtensionHelpers(mod);
   const fieldLookupHelpers = initFieldLookupHelpers(mod);
   const methodLookupHelpers = initMethodLookupHelpers(mod);

--- a/std/msg_pack/encoder.voyd
+++ b/std/msg_pack/encoder.voyd
@@ -36,9 +36,45 @@ impl Encoder
       self.write_u8(bit_and(shift_ru(value, 8), 255))
       self.write_u8(bit_and(value, 255))
 
-pub fn encode_json(value: i32, ptr: i32) -> i32
+  pub fn encode_string(self, value: string) -> void
+    let len = value.length
+    if len < 32 then:
+      // fixstr
+      self.write_u8(160 + len)
+    else:
+      if len < 256 then:
+        // str 8
+        self.write_u8(217)
+        self.write_u8(len)
+      else:
+        if len < 65536 then:
+          // str 16
+          self.write_u8(218)
+          self.write_u8(shift_ru(len, 8))
+          self.write_u8(bit_and(len, 255))
+        else:
+          // str 32
+          self.write_u8(219)
+          self.write_u8(shift_ru(len, 24))
+          self.write_u8(bit_and(shift_ru(len, 16), 255))
+          self.write_u8(bit_and(shift_ru(len, 8), 255))
+          self.write_u8(bit_and(len, 255))
+
+    var i = 0
+    while i < len do:
+      self.write_u8(value.char_code_at(i))
+      i = i + 1
+
+pub fn encode_json_i32(value: i32, ptr: i32) -> i32
   if linear_memory::size() == 0 then:
     linear_memory::grow(1)
   let enc = Encoder { ptr: ptr, pos: 0 }
   enc.encode_number(value)
+  enc.pos
+
+pub fn encode_json_string(value: string, ptr: i32) -> i32
+  if linear_memory::size() == 0 then:
+    linear_memory::grow(1)
+  let enc = Encoder { ptr: ptr, pos: 0 }
+  enc.encode_string(value)
   enc.pos

--- a/std/msg_pack/index.voyd
+++ b/std/msg_pack/index.voyd
@@ -1,8 +1,11 @@
 use std::macros::all
-use encoder::{ encode_json: internal_encode_json }
+use encoder::{ encode_json_i32, encode_json_string }
 
 pub fn encode_json(value: i32, ptr: i32) -> i32
-  internal_encode_json(value, ptr)
+  encode_json_i32(value, ptr)
+
+pub fn encode_string(value: string, ptr: i32) -> i32
+  encode_json_string(value, ptr)
 
 pub fn decode_json(ptr: i32, len: i32) -> i32
   // not yet implemented


### PR DESCRIPTION
## Summary
- support MessagePack string encoding
- add msg-pack string encoding E2E tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6d2f8d4a8832a98e640831ca73871