### PR TITLE
Handle Binaryen autoDrop removal

### DIFF
--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -73,6 +73,7 @@ export interface CompileExprOpts<T = Expr> {
   methodLookupHelpers: ReturnType<typeof initMethodLookupHelpers>;
   isReturnExpr?: boolean;
   loopBreakId?: string;
+  tailCallType?: binaryen.Type;
 }
 
 type CompilerFn = (opts: CompileExprOpts<any>) => number;

--- a/src/codegen/builtin-calls/compile-assign.ts
+++ b/src/codegen/builtin-calls/compile-assign.ts
@@ -21,7 +21,7 @@ export const compileAssign = (opts: CompileExprOpts<Call>): number => {
   const value = compileExpression({
     ...opts,
     expr: expr.argAt(1)!,
-    isReturnExpr: false,
+    isReturnExpr: true,
   });
 
   const entity = (identifier as Identifier).resolve();
@@ -50,7 +50,7 @@ const compileFieldAssign = (opts: CompileExprOpts<Call>) => {
   const value = compileExpression({
     ...opts,
     expr: expr.argAt(1)!,
-    isReturnExpr: false,
+    isReturnExpr: true,
   });
 
   const index = type.getFieldIndex(member);
@@ -61,7 +61,7 @@ const compileFieldAssign = (opts: CompileExprOpts<Call>) => {
 
   return gc.structSetFieldValue({
     mod,
-    ref: compileExpression({ ...opts, expr: target }),
+    ref: compileExpression({ ...opts, expr: target, isReturnExpr: true }),
     fieldIndex: memberIndex,
     value,
   });

--- a/src/codegen/builtin-calls/compile-if.ts
+++ b/src/codegen/builtin-calls/compile-if.ts
@@ -10,7 +10,7 @@ export const compileIf = (opts: CompileExprOpts<Call>) => {
   const condition = compileExpression({
     ...opts,
     expr: conditionNode,
-    isReturnExpr: false,
+    isReturnExpr: true,
   });
   const ifTrue = compileExpression({
     ...opts,

--- a/src/codegen/builtin-calls/compile-while.ts
+++ b/src/codegen/builtin-calls/compile-while.ts
@@ -15,7 +15,7 @@ export const compileWhile = (opts: CompileExprOpts<Call>) => {
           compileExpression({
             ...opts,
             expr: expr.exprArgAt(0),
-            isReturnExpr: false,
+            isReturnExpr: true,
           }),
           mod.i32.const(1)
         )

--- a/src/codegen/builtin-calls/compile-while.ts
+++ b/src/codegen/builtin-calls/compile-while.ts
@@ -1,5 +1,6 @@
 import { CompileExprOpts, compileExpression } from "../../codegen.js";
 import { Call } from "../../syntax-objects/call.js";
+import { asStmt } from "../../lib/binaryen-gc/index.js";
 
 export const compileWhile = (opts: CompileExprOpts<Call>) => {
   const { expr, mod } = opts;
@@ -19,12 +20,15 @@ export const compileWhile = (opts: CompileExprOpts<Call>) => {
           mod.i32.const(1)
         )
       ),
-      compileExpression({
-        ...opts,
-        expr: expr.labeledArg("do"),
-        loopBreakId: breakId,
-        isReturnExpr: false,
-      }),
+      asStmt(
+        mod,
+        compileExpression({
+          ...opts,
+          expr: expr.labeledArg("do"),
+          loopBreakId: breakId,
+          isReturnExpr: false,
+        })
+      ),
       mod.br(loopId),
     ])
   );

--- a/src/codegen/compile-block.ts
+++ b/src/codegen/compile-block.ts
@@ -1,16 +1,23 @@
+import binaryen from "binaryen";
 import { CompileExprOpts, compileExpression } from "../codegen.js";
 import { Block } from "../syntax-objects/block.js";
+import { asStmt } from "../lib/binaryen-gc/index.js";
 
 export const compile = (opts: CompileExprOpts<Block>) => {
+  const children = opts.expr.body.map((expr, index, array) => {
+    const isLast = index === array.length - 1;
+    const child = compileExpression({
+      ...opts,
+      expr,
+      isReturnExpr: opts.isReturnExpr && isLast,
+    });
+    return !opts.isReturnExpr || !isLast ? asStmt(opts.mod, child) : child;
+  });
+
   return opts.mod.block(
     null,
-    opts.expr.body.map((expr, index, array) => {
-      if (index === array.length - 1 && opts.isReturnExpr) {
-        return compileExpression({ ...opts, expr, isReturnExpr: true });
-      }
-
-      return compileExpression({ ...opts, expr, isReturnExpr: false });
-    })
+    children,
+    opts.isReturnExpr ? binaryen.auto : binaryen.none
   );
 };
 

--- a/src/codegen/compile-block.ts
+++ b/src/codegen/compile-block.ts
@@ -10,6 +10,7 @@ export const compile = (opts: CompileExprOpts<Block>) => {
       ...opts,
       expr,
       isReturnExpr: opts.isReturnExpr && isLast,
+      tailCallType: opts.tailCallType && isLast ? opts.tailCallType : undefined,
     });
     return !opts.isReturnExpr || !isLast ? asStmt(opts.mod, child) : child;
   });

--- a/src/codegen/compile-function.ts
+++ b/src/codegen/compile-function.ts
@@ -1,6 +1,7 @@
 import { CompileExprOpts, mapBinaryenType, compileExpression } from "../codegen.js";
 import { Fn } from "../syntax-objects/fn.js";
 import binaryen from "binaryen";
+import { asStmt } from "../lib/binaryen-gc/index.js";
 
 export const compile = (opts: CompileExprOpts<Fn>): number => {
   const { expr: fn, mod } = opts;
@@ -18,11 +19,14 @@ export const compile = (opts: CompileExprOpts<Fn>): number => {
   const parameterTypes = getFunctionParameterTypes(opts, fn);
   const returnType = mapBinaryenType(opts, fn.getReturnType());
 
-  const body = compileExpression({
+  let body = compileExpression({
     ...opts,
     expr: fn.body!,
     isReturnExpr: returnType !== binaryen.none,
   });
+  if (returnType === binaryen.none) {
+    body = asStmt(mod, body);
+  }
 
   const variableTypes = getFunctionVarTypes(opts, fn);
 

--- a/src/codegen/compile-function.ts
+++ b/src/codegen/compile-function.ts
@@ -23,6 +23,7 @@ export const compile = (opts: CompileExprOpts<Fn>): number => {
     ...opts,
     expr: fn.body!,
     isReturnExpr: returnType !== binaryen.none,
+    tailCallType: returnType !== binaryen.none ? returnType : undefined,
   });
   if (returnType === binaryen.none) {
     body = asStmt(mod, body);

--- a/src/codegen/compile-object-init.ts
+++ b/src/codegen/compile-object-init.ts
@@ -29,7 +29,7 @@ export const compileObjectInit = (opts: CompileExprOpts<Call>) => {
       compileExpression({
         ...opts,
         expr: field.initializer,
-        isReturnExpr: false,
+        isReturnExpr: true,
       })
     ),
   ]);

--- a/src/codegen/compile-variable.ts
+++ b/src/codegen/compile-variable.ts
@@ -6,7 +6,11 @@ export const compile = (opts: CompileExprOpts<Variable>) => {
   return mod.local.set(
     expr.getIndex(),
     expr.initializer
-      ? compileExpression({ ...opts, expr: expr.initializer })
+      ? compileExpression({
+          ...opts,
+          expr: expr.initializer,
+          isReturnExpr: true,
+        })
       : mod.nop()
   );
 };

--- a/src/codegen/rtt/field-accessor.ts
+++ b/src/codegen/rtt/field-accessor.ts
@@ -207,7 +207,7 @@ export const initFieldLookupHelpers = (mod: binaryen.Module) => {
       mod,
       fieldType: lookupTableType,
       fieldIndex: 1,
-      exprRef: compileExpression({ ...opts, expr: obj }),
+      exprRef: compileExpression({ ...opts, expr: obj, isReturnExpr: true }),
     });
 
     const funcRef = mod.call(
@@ -219,7 +219,7 @@ export const initFieldLookupHelpers = (mod: binaryen.Module) => {
     return callRef(
       mod,
       refCast(mod, funcRef, field.binaryenGetterType!),
-      [compileExpression({ ...opts, expr: obj })],
+      [compileExpression({ ...opts, expr: obj, isReturnExpr: true })],
       mapBinaryenType(opts, field.type!)
     );
   };
@@ -232,7 +232,7 @@ export const initFieldLookupHelpers = (mod: binaryen.Module) => {
     const value = compileExpression({
       ...opts,
       expr: expr.argAt(1)!,
-      isReturnExpr: false,
+      isReturnExpr: true,
     });
     const objType = target.getType() as ObjectType | IntersectionType;
 
@@ -251,7 +251,7 @@ export const initFieldLookupHelpers = (mod: binaryen.Module) => {
       mod,
       fieldType: lookupTableType,
       fieldIndex: 1,
-      exprRef: compileExpression({ ...opts, expr: target }),
+      exprRef: compileExpression({ ...opts, expr: target, isReturnExpr: true }),
     });
 
     const funcRef = mod.call(
@@ -263,7 +263,7 @@ export const initFieldLookupHelpers = (mod: binaryen.Module) => {
     return callRef(
       mod,
       refCast(mod, funcRef, field.binaryenSetterType!),
-      [compileExpression({ ...opts, expr: target }), value],
+      [compileExpression({ ...opts, expr: target, isReturnExpr: true }), value],
       mapBinaryenType(opts, field.type!)
     );
   };

--- a/src/codegen/rtt/method-accessor.ts
+++ b/src/codegen/rtt/method-accessor.ts
@@ -165,7 +165,7 @@ export const initMethodLookupHelpers = (mod: binaryen.Module) => {
       mod,
       fieldType: lookupTableType,
       fieldIndex: 2,
-      exprRef: compileExpression({ ...opts, expr: obj, isReturnExpr: false }),
+      exprRef: compileExpression({ ...opts, expr: obj, isReturnExpr: true }),
     });
 
     const funcRef = mod.call(
@@ -176,7 +176,9 @@ export const initMethodLookupHelpers = (mod: binaryen.Module) => {
     const target = refCast(mod, funcRef, fn.getAttribute("binaryenType") as number);
     const args = expr.args
       .toArray()
-      .map((arg) => compileExpression({ ...opts, expr: arg, isReturnExpr: false }));
+      .map((arg) =>
+        compileExpression({ ...opts, expr: arg, isReturnExpr: true })
+      );
     return callRef(mod, target, args, mapBinaryenType(opts, fn.returnType!));
   };
 

--- a/src/lib/binaryen-gc/README.md
+++ b/src/lib/binaryen-gc/README.md
@@ -50,8 +50,6 @@ export function main() {
 
   mod.addFunctionExport("main", "main");
 
-  mod.autoDrop();
-
   mod.validate();
 
   console.log(mod.emitText());

--- a/src/lib/binaryen-gc/index.ts
+++ b/src/lib/binaryen-gc/index.ts
@@ -278,3 +278,16 @@ export const annotateStructNames = (
     );
   }
 };
+
+export const asStmt = (
+  mod: binaryen.Module,
+  e: ExpressionRef
+): ExpressionRef => {
+  const t =
+    binaryen.getExpressionType(e) ?? binaryen.getExpressionInfo(e).type;
+
+  if (t === binaryen.none || t === binaryen.unreachable) return e;
+
+  const parts = binaryen.expandType ? binaryen.expandType(t) : [t];
+  return parts.length > 1 ? (mod as any).tuple.drop(e) : mod.drop(e);
+};

--- a/src/lib/binaryen-gc/test.ts
+++ b/src/lib/binaryen-gc/test.ts
@@ -104,7 +104,6 @@ export function testGc() {
   );
 
   mod.addFunctionExport("main", "main");
-  mod.autoDrop();
   mod.validate();
 
   // console.log(mod.emitText());


### PR DESCRIPTION
## Summary
- add `asStmt` helper and use it to drop values in statement position
- ensure blocks, functions, loops and conditionals drop unused results
- remove deprecated `mod.autoDrop` usages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a784255198832aa54ad5ba97cd2417