### PR TITLE
feat: manual drops for Binaryen

### DIFF
--- a/src/codegen/builtin-calls/compile-if.ts
+++ b/src/codegen/builtin-calls/compile-if.ts
@@ -1,4 +1,5 @@
 import { CompileExprOpts, compileExpression } from "../../codegen.js";
+import { asStmt } from "../../lib/as-stmt.js";
 import { Call } from "../../syntax-objects/call.js";
 
 export const compileIf = (opts: CompileExprOpts<Call>) => {
@@ -11,11 +12,29 @@ export const compileIf = (opts: CompileExprOpts<Call>) => {
     expr: conditionNode,
     isReturnExpr: false,
   });
-  const ifTrue = compileExpression({ ...opts, expr: ifTrueNode });
-  const ifFalse =
+  const ifTrueExpr = compileExpression({
+    ...opts,
+    expr: ifTrueNode,
+    isReturnExpr: opts.isReturnExpr,
+  });
+  const ifFalseExpr =
     ifFalseNode !== undefined
-      ? compileExpression({ ...opts, expr: ifFalseNode })
+      ? compileExpression({
+          ...opts,
+          expr: ifFalseNode,
+          isReturnExpr: opts.isReturnExpr,
+        })
       : undefined;
+
+  const ifTrue = opts.isReturnExpr
+    ? ifTrueExpr
+    : asStmt(mod, ifTrueExpr);
+  const ifFalse =
+    ifFalseExpr === undefined
+      ? undefined
+      : opts.isReturnExpr
+      ? ifFalseExpr
+      : asStmt(mod, ifFalseExpr);
 
   return mod.if(condition, ifTrue, ifFalse);
 };

--- a/src/codegen/builtin-calls/compile-while.ts
+++ b/src/codegen/builtin-calls/compile-while.ts
@@ -1,4 +1,5 @@
 import { CompileExprOpts, compileExpression } from "../../codegen.js";
+import { asStmt } from "../../lib/as-stmt.js";
 import { Call } from "../../syntax-objects/call.js";
 
 export const compileWhile = (opts: CompileExprOpts<Call>) => {
@@ -19,12 +20,15 @@ export const compileWhile = (opts: CompileExprOpts<Call>) => {
           mod.i32.const(1)
         )
       ),
-      compileExpression({
-        ...opts,
-        expr: expr.labeledArg("do"),
-        loopBreakId: breakId,
-        isReturnExpr: false,
-      }),
+      asStmt(
+        mod,
+        compileExpression({
+          ...opts,
+          expr: expr.labeledArg("do"),
+          loopBreakId: breakId,
+          isReturnExpr: false,
+        })
+      ),
       mod.br(loopId),
     ])
   );

--- a/src/codegen/compile-block.ts
+++ b/src/codegen/compile-block.ts
@@ -1,16 +1,21 @@
+import binaryen from "binaryen";
 import { CompileExprOpts, compileExpression } from "../codegen.js";
+import { asStmt } from "../lib/as-stmt.js";
 import { Block } from "../syntax-objects/block.js";
 
 export const compile = (opts: CompileExprOpts<Block>) => {
-  return opts.mod.block(
-    null,
-    opts.expr.body.map((expr, index, array) => {
-      if (index === array.length - 1 && opts.isReturnExpr) {
-        return compileExpression({ ...opts, expr, isReturnExpr: true });
-      }
+  const { mod, expr } = opts;
+  const children = expr.body.map((expr, index, array) => {
+    const isLast = index === array.length - 1;
+    const compiled = compileExpression({
+      ...opts,
+      expr,
+      isReturnExpr: opts.isReturnExpr && isLast,
+    });
+    return !opts.isReturnExpr || !isLast ? asStmt(mod, compiled) : compiled;
+  });
 
-      return compileExpression({ ...opts, expr, isReturnExpr: false });
-    })
-  );
+  const type = opts.isReturnExpr ? binaryen.auto : binaryen.none;
+  return mod.block(null, children, type);
 };
 

--- a/src/codegen/compile-module.ts
+++ b/src/codegen/compile-module.ts
@@ -1,11 +1,14 @@
+import binaryen from "binaryen";
 import { CompileExprOpts, compileExpression } from "../codegen.js";
+import { asStmt } from "../lib/as-stmt.js";
 import { VoydModule } from "../syntax-objects/module.js";
 
 export const compile = (opts: CompileExprOpts<VoydModule>) => {
-  const result = opts.mod.block(
-    opts.expr.id,
-    opts.expr.value.map((expr) => compileExpression({ ...opts, expr }))
+  const { mod, expr } = opts;
+  const statements = expr.value.map((expr) =>
+    asStmt(mod, compileExpression({ ...opts, expr, isReturnExpr: false }))
   );
+  const result = mod.block(expr.id, statements, binaryen.none);
 
   if (opts.expr.isIndex) {
     opts.expr.getAllExports().forEach((entity) => {

--- a/src/lib/as-stmt.ts
+++ b/src/lib/as-stmt.ts
@@ -1,0 +1,10 @@
+import binaryen from "binaryen";
+
+export const asStmt = (mod: binaryen.Module, e: binaryen.ExpressionRef) => {
+  const bin = binaryen as any;
+  const t = bin.getExpressionType(e) ?? bin.getExpressionInfo(e).type;
+  if (t === binaryen.none || t === binaryen.unreachable) return e;
+  const parts = bin.expandType ? bin.expandType(t) : [t];
+  if (parts.length > 1) return (mod as any).tuple.drop(e);
+  return mod.drop(e);
+};

--- a/src/lib/binaryen-gc/README.md
+++ b/src/lib/binaryen-gc/README.md
@@ -50,8 +50,6 @@ export function main() {
 
   mod.addFunctionExport("main", "main");
 
-  mod.autoDrop();
-
   mod.validate();
 
   console.log(mod.emitText());

--- a/src/lib/binaryen-gc/test.ts
+++ b/src/lib/binaryen-gc/test.ts
@@ -104,7 +104,6 @@ export function testGc() {
   );
 
   mod.addFunctionExport("main", "main");
-  mod.autoDrop();
   mod.validate();
 
   // console.log(mod.emitText());


### PR DESCRIPTION
## Summary
- add `asStmt` helper to drop expression results used as statements
- wrap non-return expressions with `asStmt` in block, module, if, and while codegen
- remove deprecated `mod.autoDrop` from docs and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a784255198832aa54ad5ba97cd2417