### PR TITLE
Allow multiple sibling labeled args to appear on the same line

### DIFF
--- a/src/parser/__tests__/__snapshots__/parser.test.ts.snap
+++ b/src/parser/__tests__/__snapshots__/parser.test.ts.snap
@@ -148,6 +148,44 @@ exports[`parser can parse a file into a syntax expanded ast 1`] = `
     ],
   ],
   [
+    "if",
+    [
+      "<",
+      "x",
+      {
+        "type": "f64",
+        "value": 0,
+      },
+    ],
+    [
+      ":",
+      "then",
+      -1,
+    ],
+    [
+      ":",
+      "elif",
+      [
+        "<",
+        "x",
+        {
+          "type": "f64",
+          "value": 2,
+        },
+      ],
+    ],
+    [
+      ":",
+      "then",
+      0,
+    ],
+    [
+      ":",
+      "else",
+      2,
+    ],
+  ],
+  [
     "reduce",
     "array",
     0,

--- a/src/parser/__tests__/fixtures/voyd-file.ts
+++ b/src/parser/__tests__/fixtures/voyd-file.ts
@@ -16,6 +16,10 @@ if x > 10 then:
 else:
   20
 
+if x < 0.0 then: -1
+elif: x < 2.0 then: 0
+else: 2
+
 array.reduce(0, 1, 2) hey: () =>
   log val
   acc + val

--- a/src/parser/syntax-macros/interpret-whitespace.ts
+++ b/src/parser/syntax-macros/interpret-whitespace.ts
@@ -167,9 +167,24 @@ const addSibling = (child: Expr, siblings: List, hadComma?: boolean) => {
   }
 
   if (isNamedArg(child) && !isNamedArg(olderSibling)) {
-    olderSibling.push(child);
+    olderSibling.push(...splitNamedArgs(child));
     return;
   }
 
   siblings.push(child);
+};
+
+const splitNamedArgs = (list: List): List[] => {
+  const result: List[] = [];
+  let start = 0;
+  for (let i = 2; i < list.length; i += 1) {
+    const expr = list.at(i);
+    const next = list.at(i + 1);
+    if (expr?.isIdentifier() && next?.isIdentifier() && next.is(":")) {
+      result.push(list.slice(start, i));
+      start = i;
+    }
+  }
+  result.push(list.slice(start));
+  return result;
 };

--- a/src/semantics/__tests__/__snapshots__/regular-macros.test.ts.snap
+++ b/src/semantics/__tests__/__snapshots__/regular-macros.test.ts.snap
@@ -7,7 +7,7 @@ exports[`regular macro expansion 1`] = `
   [
     "exports",
     [
-      "std#897",
+      "std#904",
     ],
   ],
   [
@@ -47,7 +47,7 @@ exports[`regular macro expansion 1`] = `
         ],
         [
           "regular-macro",
-          "\`#926",
+          "\`#933",
           [
             "parameters",
           ],
@@ -68,7 +68,7 @@ exports[`regular macro expansion 1`] = `
         ],
         [
           "regular-macro",
-          "let#973",
+          "let#980",
           [
             "parameters",
           ],
@@ -121,7 +121,7 @@ exports[`regular macro expansion 1`] = `
         ],
         [
           "regular-macro",
-          "fn#1766",
+          "fn#1773",
           [
             "parameters",
           ],


### PR DESCRIPTION
Allows us to support syntax like this:
```
if x < 0.0 then: -1
elif: x < 2.0 then: 0
else: 2
```