### PR TITLE
Fix resolution of overloaded functions from direct module calls

### DIFF
--- a/src/__tests__/fixtures/msg-pack.ts
+++ b/src/__tests__/fixtures/msg-pack.ts
@@ -2,11 +2,9 @@ export const msgPackVoyd = `
 use std::msg_pack
 use std::linear_memory
 
-pub fn run() -> i32
+pub fn run_i32() -> i32
   msg_pack::encode_json(42, 0)
-  linear_memory::load_i32(0)
 
 pub fn run_string() -> i32
-  msg_pack::encode_string("abc", 0)
-  linear_memory::load_i32(0)
+  msg_pack::encode_json("abc", 0)
 `;

--- a/src/__tests__/msg-pack.e2e.test.ts
+++ b/src/__tests__/msg-pack.e2e.test.ts
@@ -5,22 +5,24 @@ import assert from "node:assert";
 import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
 import { decode } from "@msgpack/msgpack";
 
-describe("E2E msg pack encode", () => {
+describe("E2E msg pack encode", async () => {
+  const mod = await compile(msgPackVoyd);
+  mod.validate();
+  const instance = getWasmInstance(mod);
+  const memory = instance.exports["main_memory"] as WebAssembly.Memory;
+
+  const call = (fnName: string): unknown => {
+    const fn = getWasmFn(fnName, instance);
+    assert(fn, `Function, ${fnName}, exists`);
+    const index = fn();
+    return decode(memory.buffer.slice(0, index));
+  };
+
   test("encodes number into memory", async (t) => {
-    const mod = await compile(msgPackVoyd);
-    const instance = getWasmInstance(mod);
-    const fn = getWasmFn("run", instance);
-    assert(fn, "Function exists");
-    t.expect(fn(), "encoded number written").toEqual(42);
+    t.expect(call("run_i32"), "encoded number written").toEqual(42);
   });
 
   test("encodes string into memory", async (t) => {
-    const mod = await compile(msgPackVoyd);
-    const instance = getWasmInstance(mod);
-    const fn = getWasmFn("run_string", instance);
-    assert(fn, "Function exists");
-    fn();
-    const memory = instance.exports["main_memory"] as WebAssembly.Memory;
-    t.expect(decode(memory.buffer.slice(0, 4))).toEqual("abc");
+    t.expect(call("run_string")).toEqual("abc");
   });
 });

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -5,14 +5,14 @@ import { resolveFn, resolveFnSignature } from "./resolve-fn.js";
 import { resolveTypeExpr } from "./resolve-type-expr.js";
 import { resolveEntities } from "./resolve-entities.js";
 
-export const getCallFn = (call: Call): Fn | undefined => {
+export const getCallFn = (call: Call, candidateFns?: Fn[]): Fn | undefined => {
   if (call.fn?.isFn() && call.fn.parentTrait) {
     return resolveFn(call.fn);
   }
 
   if (isPrimitiveFnCall(call)) return undefined;
 
-  const unfilteredCandidates = getCandidates(call);
+  const unfilteredCandidates = candidateFns ?? getCandidates(call);
   const candidates = filterCandidates(call, unfilteredCandidates);
 
   if (!candidates.length) {

--- a/std/msg_pack/encoder.voyd
+++ b/std/msg_pack/encoder.voyd
@@ -63,14 +63,14 @@ impl Encoder
       self.write_u8(value.char_code_at(i))
       i = i + 1
 
-pub fn encode_json_i32(value: i32, ptr: i32) -> i32
+pub fn encode_json(value: i32, ptr: i32) -> i32
   if linear_memory::size() == 0 then:
     linear_memory::grow(1)
   let enc = Encoder { ptr: ptr, pos: 0 }
   enc.encode_number(value)
   enc.pos
 
-pub fn encode_json_string(value: string, ptr: i32) -> i32
+pub fn encode_json(value: string, ptr: i32) -> i32
   if linear_memory::size() == 0 then:
     linear_memory::grow(1)
   let enc = Encoder { ptr: ptr, pos: 0 }

--- a/std/msg_pack/index.voyd
+++ b/std/msg_pack/index.voyd
@@ -1,11 +1,5 @@
 use std::macros::all
-use encoder::{ encode_json_i32, encode_json_string }
-
-pub fn encode_json(value: i32, ptr: i32) -> i32
-  encode_json_i32(value, ptr)
-
-pub fn encode_string(value: string, ptr: i32) -> i32
-  encode_json_string(value, ptr)
+pub use encoder::encode_json
 
 pub fn decode_json(ptr: i32, len: i32) -> i32
   // not yet implemented


### PR DESCRIPTION
Allows overloaded functions called directly on a module (ex `msg_pack::encode_json("abc", 0)`) to resolve correctly.