### PR TITLE
feat: encode arrays of strings in msg pack

### DIFF
--- a/src/__tests__/fixtures/msg-pack.ts
+++ b/src/__tests__/fixtures/msg-pack.ts
@@ -7,4 +7,7 @@ pub fn run_i32() -> i32
 
 pub fn run_string() -> i32
   msg_pack::encode_json("abc", 0)
+
+pub fn run_array() -> i32
+  msg_pack::encode_json(["hey", "there"])
 `;

--- a/src/__tests__/msg-pack.e2e.test.ts
+++ b/src/__tests__/msg-pack.e2e.test.ts
@@ -25,4 +25,8 @@ describe("E2E msg pack encode", async () => {
   test("encodes string into memory", async (t) => {
     t.expect(call("run_string")).toEqual("abc");
   });
+
+  test("encodes array into memory", async (t) => {
+    t.expect(call("run_array")).toEqual(["hey", "there"]);
+  });
 });

--- a/std/msg_pack/encoder.voyd
+++ b/std/msg_pack/encoder.voyd
@@ -1,6 +1,8 @@
 use std::all
 use std::linear_memory
 
+type Json = string
+
 obj Encoder {
   ptr: i32,
   pos: i32,
@@ -63,6 +65,32 @@ impl Encoder
       self.write_u8(value.char_code_at(i))
       i = i + 1
 
+  fn encode_array(self, value: Array<Json>) -> void
+    let len = value.length
+    if len < 16 then:
+      self.write_u8(144 + len)
+    elif: len < 65536 then:
+      self.write_u8(220)
+      self.write_u8(shift_ru(len, 8))
+      self.write_u8(bit_and(len, 255))
+    else:
+      self.write_u8(221)
+      self.write_u8(shift_ru(len, 24))
+      self.write_u8(bit_and(shift_ru(len, 16), 255))
+      self.write_u8(bit_and(shift_ru(len, 8), 255))
+      self.write_u8(bit_and(len, 255))
+
+    var i = 0
+    while i < len do:
+      value.get(i).match(item)
+        Some<Json>:
+          let s: string = item.value
+          self.encode_string(s)
+          0
+        None:
+          0
+      i = i + 1
+
 pub fn encode_json(value: i32, ptr: i32) -> i32
   if linear_memory::size() == 0 then:
     linear_memory::grow(1)
@@ -78,5 +106,8 @@ pub fn encode_json(value: string, ptr: i32) -> i32
   enc.pos
 
 pub fn encode_json(value: Array<Json>) -> i32
-  // Stub
-  0
+  if linear_memory::size() == 0 then:
+    linear_memory::grow(1)
+  let enc = Encoder { ptr: 0, pos: 0 }
+  enc.encode_array(value)
+  enc.pos

--- a/std/msg_pack/encoder.voyd
+++ b/std/msg_pack/encoder.voyd
@@ -1,8 +1,6 @@
 use std::all
 use std::linear_memory
 
-type Json = string
-
 obj Encoder {
   ptr: i32,
   pos: i32,
@@ -65,7 +63,7 @@ impl Encoder
       self.write_u8(value.char_code_at(i))
       i = i + 1
 
-  fn encode_array(self, value: Array<Json>) -> void
+  pub fn encode_array(self, value: Array<string>) -> void
     let len = value.length
     if len < 16 then:
       self.write_u8(144 + len)
@@ -83,9 +81,8 @@ impl Encoder
     var i = 0
     while i < len do:
       value.get(i).match(item)
-        Some<Json>:
-          let s: string = item.value
-          self.encode_string(s)
+        Some<string>:
+          self.encode_string(item.value)
           0
         None:
           0
@@ -105,7 +102,7 @@ pub fn encode_json(value: string, ptr: i32) -> i32
   enc.encode_string(value)
   enc.pos
 
-pub fn encode_json(value: Array<Json>) -> i32
+pub fn encode_json(value: Array<string>) -> i32
   if linear_memory::size() == 0 then:
     linear_memory::grow(1)
   let enc = Encoder { ptr: 0, pos: 0 }


### PR DESCRIPTION
## Summary
- add array encoding to msg pack encoder
- test array roundtrip with msg pack

## Testing
- `npm test` *(fails: s of type string is not assignable to union)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e291aac8832a8f068f3a09888fdf