### PR TITLE
Fix structural compatibility for object fields

### DIFF
--- a/src/__tests__/fixtures/map-get-some.ts
+++ b/src/__tests__/fixtures/map-get-some.ts
@@ -1,0 +1,12 @@
+export const mapGetSomeVoyd = `
+use std::all
+
+pub fn run() -> i32
+  let m = new_map<i32>()
+  m.set("a", 1)
+  m.get("a").match(v)
+    Some<i32>:
+      v.value
+    None:
+      0
+`;

--- a/src/__tests__/map-get-some.e2e.test.ts
+++ b/src/__tests__/map-get-some.e2e.test.ts
@@ -1,0 +1,20 @@
+import { mapGetSomeVoyd } from "./fixtures/map-get-some.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E Map.get returns Some", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(mapGetSomeVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("run returns stored value", (t) => {
+    const fn = getWasmFn("run", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "run returns correct value").toEqual(1);
+  });
+});

--- a/src/semantics/resolution/types-are-compatible.ts
+++ b/src/semantics/resolution/types-are-compatible.ts
@@ -82,7 +82,7 @@ export const typesAreCompatible = (
       return b.fields.every((field) => {
         const match = a.fields.find((f) => f.name === field.name);
         return (
-          match && typesAreCompatible(field.type, match.type, opts, visited)
+          match && typesAreCompatible(match.type, field.type, opts, visited)
         );
       });
     }


### PR DESCRIPTION
## Summary
- ensure typesAreCompatible checks literal fields against expected ones
- add regression test validating Map.get constructs Some<T>

## Testing
- `npm test` *(fails: Match does not handle all possibilities of union)*

------
https://chatgpt.com/codex/tasks/task_e_68a89ea69c84832abcd4180a3107308d