### PR TITLE
Fix recursive type call overflow and add recursive union test

### DIFF
--- a/src/__tests__/fixtures/recursive-union.ts
+++ b/src/__tests__/fixtures/recursive-union.ts
@@ -1,0 +1,14 @@
+export const recursiveUnionVoyd = `
+obj Box<T> { val: T }
+
+type Recursive = Box<Recursive> | Box<i32>
+
+fn find_int(r: Recursive) -> i32
+  match(r)
+    Box<Recursive>: find_int(r.val)
+    Box<i32>: r.val
+
+pub fn main() -> i32
+  let r: Recursive = Box<Recursive> { val: Box { val: 5 } }
+  find_int(r)
+`;

--- a/src/__tests__/recursive-union.e2e.test.ts
+++ b/src/__tests__/recursive-union.e2e.test.ts
@@ -1,0 +1,21 @@
+import { recursiveUnionVoyd } from "./fixtures/recursive-union.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E recursive unions", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(recursiveUnionVoyd);
+    assert(mod.validate(), "Module is valid");
+    instance = getWasmInstance(mod);
+  });
+
+  test("can find ints in recursive boxes", (t) => {
+    const fn = getWasmFn("main", instance);
+    assert(fn, "Function exists");
+    t.expect(fn()).toEqual(5);
+  });
+});

--- a/src/semantics/resolution/resolve-type-expr.ts
+++ b/src/semantics/resolution/resolve-type-expr.ts
@@ -19,6 +19,15 @@ export const resolveTypeExpr = (typeExpr: Expr): Expr => {
     typeExpr.type = typeEntity;
     return typeExpr;
   }
+  if (typeExpr.isTypeAlias()) {
+    if (typeExpr.type || !typeExpr.typeExpr) return typeExpr;
+    if (typeExpr.resolutionPhase > 0) return typeExpr;
+    typeExpr.resolutionPhase = 1;
+    typeExpr.typeExpr = resolveTypeExpr(typeExpr.typeExpr);
+    typeExpr.type = getExprType(typeExpr.typeExpr);
+    typeExpr.resolutionPhase = 2;
+    return typeExpr;
+  }
   if (typeExpr.isObjectType()) return resolveObjectType(typeExpr);
   if (typeExpr.isIntersectionType()) return resolveIntersectionType(typeExpr);
   if (typeExpr.isUnionType()) return resolveUnionType(typeExpr);
@@ -30,9 +39,15 @@ export const resolveTypeExpr = (typeExpr: Expr): Expr => {
 
 /** Resolves type calls */
 const resolveTypeCall = (call: Call): Call => {
+  // Avoid infinite recursion when resolving recursive type calls
+  if ((call as any).__resolving) return call;
+  (call as any).__resolving = true;
   const type = call.fnName.resolve();
 
-  if (!type?.isType()) return call;
+  if (!type?.isType()) {
+    (call as any).__resolving = false;
+    return call;
+  }
 
   if (call.typeArgs) {
     call.typeArgs = call.typeArgs.map(resolveTypeExpr);
@@ -41,36 +56,43 @@ const resolveTypeCall = (call: Call): Call => {
   if (type.isObjectType()) {
     call.fn = type;
     call.type = resolveObjectType(type, call);
+    (call as any).__resolving = false;
     return call;
   }
 
   if (type.isTraitType()) {
     call.type = resolveTrait(type, call);
+    (call as any).__resolving = false;
     return call;
   }
 
   if (type.isFixedArrayType()) {
     call.type = resolveFixedArrayType(type);
+    (call as any).__resolving = false;
     return call;
   }
 
   if (type.isUnionType()) {
     call.type = resolveUnionType(type);
-    return call;
+     (call as any).__resolving = false;
+     return call;
   }
 
   if (type.isIntersectionType()) {
     call.type = resolveIntersectionType(type);
+    (call as any).__resolving = false;
     return call;
   }
 
   if (type.isTypeAlias()) {
     call = resolveTypeAlias(call, type);
+    (call as any).__resolving = false;
     return call;
   }
 
   call.type = type;
 
+  (call as any).__resolving = false;
   return call;
 };
 


### PR DESCRIPTION
## Summary
- prevent infinite recursion in type resolution by guarding recursive type calls and handling type aliases
- add end-to-end test covering recursive unions

## Testing
- `npm test -- src/__tests__/compiler.test.ts`
- `npm test -- src/__tests__/recursive-union.e2e.test.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e9a95ff0832ab6597d76fa8a3575