### PR TITLE
Fix type inference parentage issue

### DIFF
--- a/src/semantics/check-types.ts
+++ b/src/semantics/check-types.ts
@@ -660,12 +660,6 @@ const checkObjectMatch = (match: Match) => {
       );
     }
 
-    if (!mCase.matchType.extends(match.baseType)) {
-      throw new Error(
-        `Match case type ${mCase.matchType.name} does not extend ${match.baseType.name} at ${mCase.expr.location}`
-      );
-    }
-
     if (!typesAreCompatible(mCase.expr.type, match.type)) {
       throw new Error(
         `All cases must return the same type for now ${mCase.expr.location}`

--- a/src/semantics/resolution/infer-type-args.ts
+++ b/src/semantics/resolution/infer-type-args.ts
@@ -1,8 +1,10 @@
 import { Expr } from "../../syntax-objects/expr.js";
 import { Identifier } from "../../syntax-objects/identifier.js";
+import { nop } from "../../syntax-objects/index.js";
 import { List } from "../../syntax-objects/list.js";
-import { Type } from "../../syntax-objects/types.js";
+import { Type, TypeAlias } from "../../syntax-objects/types.js";
 import { getExprType } from "./get-expr-type.js";
+import { resolveTypeExpr } from "./resolve-type-expr.js";
 
 export type TypeArgInferencePair = {
   typeExpr: Expr;
@@ -22,7 +24,12 @@ export const inferTypeArgs = (
 
     for (const { typeExpr, argExpr } of pairs) {
       if (typeExpr.isIdentifier() && typeExpr.is(tp)) {
-        inferredType = getExprType(argExpr);
+        inferredType = new TypeAlias({
+          name: typeExpr.clone(),
+          typeExpr: nop(),
+        });
+        resolveTypeExpr(argExpr);
+        inferredType.type = getExprType(argExpr);
         break;
       }
     }

--- a/src/semantics/resolution/resolve-fn.ts
+++ b/src/semantics/resolution/resolve-fn.ts
@@ -90,9 +90,7 @@ const attemptToResolveFnWithGenerics = (fn: Fn, call: Call): Fn => {
   if (!args) return fn;
 
   call.typeArgs = args;
-  const existing = fn.genericInstances?.find((c) =>
-    fnTypeArgsMatch(args, c)
-  );
+  const existing = fn.genericInstances?.find((c) => fnTypeArgsMatch(args, c));
   if (existing) return fn;
 
   return resolveGenericsWithTypeArgs(fn, args);

--- a/src/semantics/resolution/resolve-match.ts
+++ b/src/semantics/resolution/resolve-match.ts
@@ -44,7 +44,7 @@ const resolveCase = (
   const expr = resolveEntities(c.expr) as Call | Block;
 
   return {
-    matchType: type?.isObjectType() ? type : undefined,
+    matchType: type?.isRefType() ? type : undefined,
     expr,
     matchTypeExpr: c.matchTypeExpr,
   };

--- a/src/semantics/resolution/resolve-object-type.ts
+++ b/src/semantics/resolution/resolve-object-type.ts
@@ -63,6 +63,7 @@ const resolveGenericObjVersion = (
 
   if (!call.typeArgs) return;
 
+  // THAR BE DRAGONS HERE. We don't check for multiple existing matches, which means that unions may sometimes overlap.
   const existing = type.genericInstances?.find((c) => typeArgsMatch(call, c));
   if (existing) return existing;
   return resolveGenericsWithTypeArgs(type, call.typeArgs);

--- a/src/semantics/resolution/resolve-type-expr.ts
+++ b/src/semantics/resolution/resolve-type-expr.ts
@@ -6,19 +6,14 @@ import {
   TypeAlias,
   FnType,
 } from "../../syntax-objects/index.js";
-import { getExprType, getIdentifierType } from "./get-expr-type.js";
+import { getExprType } from "./get-expr-type.js";
 import { resolveIntersectionType } from "./resolve-intersection.js";
 import { resolveObjectType } from "./resolve-object-type.js";
 import { resolveUnionType } from "./resolve-union.js";
 import { resolveTrait } from "./resolve-trait.js";
 
 export const resolveTypeExpr = (typeExpr: Expr): Expr => {
-  if (typeExpr.isIdentifier()) {
-    const typeEntity = getIdentifierType(typeExpr);
-    if (typeEntity) resolveTypeExpr(typeEntity);
-    typeExpr.type = typeEntity;
-    return typeExpr;
-  }
+  if (typeExpr.isIdentifier()) return typeExpr;
   if (typeExpr.isTypeAlias()) {
     if (typeExpr.type || !typeExpr.typeExpr) return typeExpr;
     if (typeExpr.resolutionPhase > 0) return typeExpr;

--- a/src/semantics/resolution/resolve-union.ts
+++ b/src/semantics/resolution/resolve-union.ts
@@ -8,7 +8,7 @@ export const resolveUnionType = (union: UnionType): UnionType => {
   union.types = union.childTypeExprs.toArray().flatMap((expr) => {
     const resolved = resolveTypeExpr(expr);
     const type = getExprType(resolved);
-    return type?.isObjectType() ? [type] : [];
+    return type?.isRefType() ? [type] : [];
   });
   return union;
 };

--- a/src/syntax-objects/match.ts
+++ b/src/syntax-objects/match.ts
@@ -5,12 +5,12 @@ import { Identifier } from "./identifier.js";
 import { LexicalContext } from "./lib/lexical-context.js";
 import { ScopedSyntax } from "./scoped-entity.js";
 import { Syntax, SyntaxMetadata } from "./syntax.js";
-import { ObjectType, Type } from "./types.js";
+import { VoydRefType, Type } from "./types.js";
 import { Variable } from "./variable.js";
 
 export type MatchCase = {
   /** The type to match the base type against */
-  matchType?: ObjectType;
+  matchType?: VoydRefType;
   matchTypeExpr?: Expr;
   expr: Block | Call;
 };

--- a/src/syntax-objects/syntax.ts
+++ b/src/syntax-objects/syntax.ts
@@ -28,6 +28,8 @@ import type {
   UnionType,
   IntersectionType,
   SelfType,
+  VoydRefType,
+  TupleType,
 } from "./types.js";
 import type { Variable } from "./variable.js";
 import type { Whitespace } from "./whitespace.js";
@@ -243,6 +245,10 @@ export abstract class Syntax {
     return this.isType() && this.kindOfType === "trait";
   }
 
+  isTupleType(): this is TupleType {
+    return this.isType() && this.kindOfType === "tuple";
+  }
+
   isObjectType(): this is ObjectType {
     return this.isType() && this.kindOfType === "object";
   }
@@ -345,6 +351,17 @@ export abstract class Syntax {
 
   isArrayLiteral(): this is ArrayLiteral {
     return this.syntaxType === "array-literal";
+  }
+
+  isRefType(): this is VoydRefType {
+    // TODO: Make this more efficient
+    return (
+      this.isObjectType() ||
+      this.isIntersectionType() ||
+      this.isUnionType() ||
+      this.isTupleType() ||
+      (this.isPrimitiveType() && this.name.is("string"))
+    );
   }
 
   setEndLocationToStartOf(location?: SourceLocation) {

--- a/src/syntax-objects/types.ts
+++ b/src/syntax-objects/types.ts
@@ -111,7 +111,7 @@ export class UnionType extends BaseType {
   readonly kindOfType = "union";
   resolutionPhase = 0; // No clone
   childTypeExprs: ChildList<Expr>;
-  types: (ObjectType | IntersectionType | UnionType)[] = [];
+  types: VoydRefType[] = [];
 
   constructor(opts: NamedEntityOpts & { childTypeExprs?: Expr[] }) {
     super(opts);
@@ -406,3 +406,10 @@ export const voydBaseObject = new ObjectType({
   name: "Object",
   value: [],
 });
+
+export type VoydRefType =
+  | ObjectType
+  | UnionType
+  | IntersectionType
+  | TupleType
+  | PrimitiveType; // string only. TODO: Make string something else idk. This is not very dev friendly


### PR DESCRIPTION
Parent refs were a terrible idea. That took me HOURS to debug.

Note to self. ALWAYS use the TypeAlias container to avoid accidental parent switches. At least until we get rid of parent refs.