### PR TITLE
Use structural type equality for generic resolution

### DIFF
--- a/src/semantics/resolution/__tests__/types-are-equal.test.ts
+++ b/src/semantics/resolution/__tests__/types-are-equal.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import {
+  ObjectType,
+  UnionType,
+  PrimitiveType,
+  Identifier,
+  TypeAlias,
+} from "../../../syntax-objects/index.js";
+import { typesAreEqual } from "../types-are-equal.js";
+
+describe("typesAreEqual", () => {
+  test("treats different generic args as distinct", () => {
+    const string = PrimitiveType.from("string");
+    const jsonObj = new ObjectType({ name: "JsonObj", value: [] });
+
+    const json = new UnionType({ name: "Json", childTypeExprs: [] });
+    json.types = [jsonObj, string];
+
+    const miniJson = new UnionType({ name: "MiniJson", childTypeExprs: [] });
+    miniJson.types = [string];
+
+    const array = new ObjectType({
+      name: "Array",
+      value: [],
+      typeParameters: [new Identifier({ value: "T" })],
+    });
+
+    const arrJson = array.clone();
+    arrJson.genericParent = array;
+    const argJson = new TypeAlias({
+      name: new Identifier({ value: "T" }),
+      typeExpr: new Identifier({ value: "Json" }),
+    });
+    argJson.type = json;
+    arrJson.appliedTypeArgs = [argJson];
+
+    const arrMini = array.clone();
+    arrMini.genericParent = array;
+    const argMini = new TypeAlias({
+      name: new Identifier({ value: "T" }),
+      typeExpr: new Identifier({ value: "MiniJson" }),
+    });
+    argMini.type = miniJson;
+    arrMini.appliedTypeArgs = [argMini];
+
+    expect(typesAreEqual(arrJson, arrMini)).toBe(false);
+  });
+});

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -1,6 +1,7 @@
 import { Call, Expr, Fn } from "../../syntax-objects/index.js";
 import { getExprType } from "./get-expr-type.js";
 import { typesAreCompatible } from "./types-are-compatible.js";
+import { typesAreEqual } from "./types-are-equal.js";
 import { resolveFn, resolveFnSignature } from "./resolve-fn.js";
 import { resolveTypeExpr } from "./resolve-type-expr.js";
 import { resolveEntities } from "./resolve-entities.js";
@@ -115,9 +116,7 @@ const typeArgsMatch = (call: Call, candidate: Fn): boolean =>
         if (arg) resolveTypeExpr(arg);
         const argType = getExprType(arg);
         const appliedType = getExprType(t);
-        return typesAreCompatible(argType, appliedType, {
-          exactNominalMatch: true,
-        });
+        return typesAreEqual(argType, appliedType);
       })
     : true;
 

--- a/src/semantics/resolution/index.ts
+++ b/src/semantics/resolution/index.ts
@@ -1,3 +1,4 @@
 export { resolveEntities } from "./resolve-entities.js";
 export { typesAreCompatible } from "./types-are-compatible.js";
+export { typesAreEqual } from "./types-are-equal.js";
 export { resolveModulePath } from "./resolve-use.js";

--- a/src/semantics/resolution/resolve-fn.ts
+++ b/src/semantics/resolution/resolve-fn.ts
@@ -9,7 +9,7 @@ import { getExprType } from "./get-expr-type.js";
 import { resolveEntities } from "./resolve-entities.js";
 import { resolveTypeExpr } from "./resolve-type-expr.js";
 import { inferTypeArgs, TypeArgInferencePair } from "./infer-type-args.js";
-import { typesAreCompatible } from "./types-are-compatible.js";
+import { typesAreEqual } from "./types-are-equal.js";
 
 export type ResolveFnTypesOpts = {
   typeArgs?: List;
@@ -114,9 +114,7 @@ const fnTypeArgsMatch = (args: List, candidate: Fn): boolean =>
     ? candidate.appliedTypeArgs.every((t, i) => {
         const argType = getExprType(args.at(i));
         const appliedType = getExprType(t);
-        return typesAreCompatible(argType, appliedType, {
-          exactNominalMatch: true,
-        });
+        return typesAreEqual(argType, appliedType);
       })
     : false;
 

--- a/src/semantics/resolution/resolve-object-type.ts
+++ b/src/semantics/resolution/resolve-object-type.ts
@@ -9,7 +9,7 @@ import {
 import { getExprType } from "./get-expr-type.js";
 import { inferTypeArgs, TypeArgInferencePair } from "./infer-type-args.js";
 import { implIsCompatible, resolveImpl } from "./resolve-impl.js";
-import { typesAreCompatible } from "./types-are-compatible.js";
+import { typesAreEqual } from "./types-are-equal.js";
 import { resolveTypeExpr } from "./resolve-type-expr.js";
 
 export const resolveObjectType = (obj: ObjectType, call?: Call): ObjectType => {
@@ -119,8 +119,6 @@ const typeArgsMatch = (call: Call, candidate: ObjectType): boolean =>
     ? candidate.appliedTypeArgs.every((t, i) => {
         const argType = getExprType(call.typeArgs?.at(i));
         const appliedType = getExprType(t);
-        return typesAreCompatible(argType, appliedType, {
-          exactNominalMatch: true,
-        });
+        return typesAreEqual(argType, appliedType);
       })
     : true;

--- a/src/semantics/resolution/resolve-trait.ts
+++ b/src/semantics/resolution/resolve-trait.ts
@@ -5,7 +5,7 @@ import { TypeAlias } from "../../syntax-objects/types.js";
 import { resolveFn } from "./resolve-fn.js";
 import { resolveTypeExpr } from "./resolve-type-expr.js";
 import { getExprType } from "./get-expr-type.js";
-import { typesAreCompatible } from "./types-are-compatible.js";
+import { typesAreEqual } from "./types-are-equal.js";
 import { resolveImpl } from "./resolve-impl.js";
 
 export const resolveTrait = (trait: TraitType, call?: Call): TraitType => {
@@ -62,10 +62,6 @@ const resolveGenericTraitVersion = (
 const typeArgsMatch = (call: Call, candidate: TraitType): boolean =>
   call.typeArgs && candidate.appliedTypeArgs
     ? candidate.appliedTypeArgs.every((t, i) =>
-        typesAreCompatible(
-          getExprType(call.typeArgs!.at(i)),
-          getExprType(t),
-          { exactNominalMatch: true }
-        )
+        typesAreEqual(getExprType(call.typeArgs!.at(i)), getExprType(t))
       )
     : true;

--- a/src/semantics/resolution/types-are-equal.ts
+++ b/src/semantics/resolution/types-are-equal.ts
@@ -1,0 +1,121 @@
+import { Type, UnionType } from "../../syntax-objects/index.js";
+import { getExprType } from "./get-expr-type.js";
+
+const flattenUnion = (type: Type): Type[] => {
+  if (!type.isUnionType()) return [type];
+
+  const result: Type[] = [];
+  const queue: Type[] = [type];
+  const seen = new Set<string>();
+
+  while (queue.length) {
+    const current = queue.pop()!;
+
+    if (current.isUnionType()) {
+      for (const child of current.types) {
+        if (!seen.has(child.id)) {
+          seen.add(child.id);
+          queue.push(child);
+        }
+      }
+      continue;
+    }
+
+    result.push(current);
+  }
+
+  return result;
+};
+
+export const typesAreEqual = (
+  a?: Type,
+  b?: Type,
+  visited: Set<string> = new Set()
+): boolean => {
+  if (!a || !b) return false;
+  const key = `${a.id}|${b.id}`;
+  if (visited.has(key)) return true;
+  visited.add(key);
+
+  if (a.isSelfType() && b.isSelfType()) return true;
+
+  if (a.isPrimitiveType() && b.isPrimitiveType()) {
+    return a.id === b.id;
+  }
+
+  if (a.isObjectType() && b.isObjectType()) {
+    const structural = a.isStructural || b.isStructural;
+    if (structural) {
+      return (
+        a.fields.length === b.fields.length &&
+        a.fields.every((field) => {
+          const match = b.fields.find((f) => f.name === field.name);
+          return match && typesAreEqual(field.type, match.type, visited);
+        })
+      );
+    }
+    if (a.genericParent && a.genericParent.id === b.genericParent?.id) {
+      return !!a.appliedTypeArgs?.every((arg, index) =>
+        typesAreEqual(
+          getExprType(arg),
+          getExprType(b.appliedTypeArgs?.[index]),
+          visited
+        )
+      );
+    }
+    return a.id === b.id;
+  }
+
+  if (a.isTraitType() && b.isTraitType()) {
+    if (a.genericParent && a.genericParent.id === b.genericParent?.id) {
+      return !!a.appliedTypeArgs?.every((arg, index) =>
+        typesAreEqual(
+          getExprType(arg),
+          getExprType(b.appliedTypeArgs?.[index]),
+          visited
+        )
+      );
+    }
+    return a.id === b.id;
+  }
+
+  if (a.isUnionType() && b.isUnionType()) {
+    const aTypes = flattenUnion(a as UnionType);
+    const bTypes = flattenUnion(b as UnionType);
+    if (aTypes.length !== bTypes.length) return false;
+
+    const used: boolean[] = bTypes.map(() => false);
+    return aTypes.every((aType) => {
+      const idx = bTypes.findIndex(
+        (bType, i) => !used[i] && typesAreEqual(aType, bType, visited)
+      );
+      if (idx === -1) return false;
+      used[idx] = true;
+      return true;
+    });
+  }
+
+  if (a.isIntersectionType() && b.isIntersectionType()) {
+    return (
+      typesAreEqual(a.nominalType, b.nominalType, visited) &&
+      typesAreEqual(a.structuralType, b.structuralType, visited)
+    );
+  }
+
+  if (a.isFixedArrayType() && b.isFixedArrayType()) {
+    return typesAreEqual(a.elemType, b.elemType, visited);
+  }
+
+  if (a.isFnType() && b.isFnType()) {
+    if (a.parameters.length !== b.parameters.length) return false;
+    return (
+      typesAreEqual(a.returnType, b.returnType, visited) &&
+      a.parameters.every((p, i) =>
+        typesAreEqual(p.type, b.parameters[i]?.type, visited)
+      )
+    );
+  }
+
+  return false;
+};
+


### PR DESCRIPTION
## Summary
- add `typesAreEqual` for structural type comparison and export it
- require exact type-argument matches when resolving generic objects, functions, traits, and calls
- cover distinct generic specializations with a unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a93af2cdc0832a97937de8209e0803