### PR TITLE
Use structural type equality for generic resolution

### DIFF
--- a/src/__tests__/fixtures/mini-json.ts
+++ b/src/__tests__/fixtures/mini-json.ts
@@ -1,0 +1,11 @@
+export const miniJsonVoyd = `
+pub obj JsonNull {}
+pub obj JsonNumber { val: i32 }
+
+pub type Json = Map<Json> | Array<Json> | JsonNumber | JsonNull | string
+
+type MiniJson = Array<MiniJson> | string
+
+pub fn main() -> i32
+  0
+`;

--- a/src/__tests__/mini-json.e2e.test.ts
+++ b/src/__tests__/mini-json.e2e.test.ts
@@ -1,0 +1,21 @@
+import { miniJsonVoyd } from "./fixtures/mini-json.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E MiniJson generic resolution", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(miniJsonVoyd);
+    assert(mod.validate(), "Module is valid");
+    instance = getWasmInstance(mod);
+  });
+
+  test("compiles with recursive arrays", (t) => {
+    const fn = getWasmFn("main", instance);
+    assert(fn, "Function exists");
+    t.expect(fn()).toEqual(0);
+  });
+});

--- a/src/semantics/resolution/__tests__/types-are-compatible.test.ts
+++ b/src/semantics/resolution/__tests__/types-are-compatible.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { ObjectType, UnionType, SelfType } from "../../../syntax-objects/index.js";
+import {
+  ObjectType,
+  UnionType,
+  SelfType,
+  PrimitiveType,
+} from "../../../syntax-objects/index.js";
 import { typesAreCompatible } from "../types-are-compatible.js";
 
 describe("typesAreCompatible - unions", () => {
@@ -54,5 +59,18 @@ describe("typesAreCompatible - unions", () => {
 
   test("considers self types compatible", () => {
     expect(typesAreCompatible(new SelfType(), new SelfType())).toBe(true);
+  });
+
+  test("handles primitives within unions", () => {
+    const strOrNum = new UnionType({ name: "StrOrNum", childTypeExprs: [] });
+    const str = PrimitiveType.from("string");
+    const num = PrimitiveType.from("i32");
+    strOrNum.types = [str, num];
+
+    expect(typesAreCompatible(str, strOrNum)).toBe(true);
+    const bool = PrimitiveType.from("bool");
+    const boolOrNum = new UnionType({ name: "BoolOrNum", childTypeExprs: [] });
+    boolOrNum.types = [bool, num];
+    expect(typesAreCompatible(str, boolOrNum)).toBe(false);
   });
 });

--- a/src/semantics/resolution/__tests__/types-are-equal.test.ts
+++ b/src/semantics/resolution/__tests__/types-are-equal.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import {
+  ObjectType,
+  UnionType,
+  PrimitiveType,
+  Identifier,
+  TypeAlias,
+} from "../../../syntax-objects/index.js";
+import { typesAreEqual } from "../types-are-equal.js";
+
+describe("typesAreEqual", () => {
+  test("treats different generic args as distinct", () => {
+    const string = PrimitiveType.from("string");
+    const jsonObj = new ObjectType({ name: "JsonObj", value: [] });
+
+    const json = new UnionType({ name: "Json", childTypeExprs: [] });
+    json.types = [jsonObj, string];
+
+    const miniJson = new UnionType({ name: "MiniJson", childTypeExprs: [] });
+    miniJson.types = [string];
+
+    const array = new ObjectType({
+      name: "Array",
+      value: [],
+      typeParameters: [new Identifier({ value: "T" })],
+    });
+
+    const arrJson = array.clone();
+    arrJson.genericParent = array;
+    const argJson = new TypeAlias({
+      name: new Identifier({ value: "T" }),
+      typeExpr: new Identifier({ value: "Json" }),
+    });
+    argJson.type = json;
+    arrJson.appliedTypeArgs = [argJson];
+
+    const arrMini = array.clone();
+    arrMini.genericParent = array;
+    const argMini = new TypeAlias({
+      name: new Identifier({ value: "T" }),
+      typeExpr: new Identifier({ value: "MiniJson" }),
+    });
+    argMini.type = miniJson;
+    arrMini.appliedTypeArgs = [argMini];
+
+    expect(typesAreEqual(arrJson, arrMini)).toBe(false);
+  });
+});

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -1,6 +1,7 @@
 import { Call, Expr, Fn } from "../../syntax-objects/index.js";
 import { getExprType } from "./get-expr-type.js";
 import { typesAreCompatible } from "./types-are-compatible.js";
+import { typesAreEqual } from "./types-are-equal.js";
 import { resolveFn, resolveFnSignature } from "./resolve-fn.js";
 import { resolveTypeExpr } from "./resolve-type-expr.js";
 import { resolveEntities } from "./resolve-entities.js";
@@ -115,9 +116,7 @@ const typeArgsMatch = (call: Call, candidate: Fn): boolean =>
         if (arg) resolveTypeExpr(arg);
         const argType = getExprType(arg);
         const appliedType = getExprType(t);
-        return typesAreCompatible(argType, appliedType, {
-          exactNominalMatch: true,
-        });
+        return typesAreEqual(argType, appliedType);
       })
     : true;
 

--- a/src/semantics/resolution/index.ts
+++ b/src/semantics/resolution/index.ts
@@ -1,3 +1,4 @@
 export { resolveEntities } from "./resolve-entities.js";
 export { typesAreCompatible } from "./types-are-compatible.js";
+export { typesAreEqual } from "./types-are-equal.js";
 export { resolveModulePath } from "./resolve-use.js";

--- a/src/semantics/resolution/resolve-fn.ts
+++ b/src/semantics/resolution/resolve-fn.ts
@@ -9,7 +9,7 @@ import { getExprType } from "./get-expr-type.js";
 import { resolveEntities } from "./resolve-entities.js";
 import { resolveTypeExpr } from "./resolve-type-expr.js";
 import { inferTypeArgs, TypeArgInferencePair } from "./infer-type-args.js";
-import { typesAreCompatible } from "./types-are-compatible.js";
+import { typesAreEqual } from "./types-are-equal.js";
 
 export type ResolveFnTypesOpts = {
   typeArgs?: List;
@@ -114,9 +114,7 @@ const fnTypeArgsMatch = (args: List, candidate: Fn): boolean =>
     ? candidate.appliedTypeArgs.every((t, i) => {
         const argType = getExprType(args.at(i));
         const appliedType = getExprType(t);
-        return typesAreCompatible(argType, appliedType, {
-          exactNominalMatch: true,
-        });
+        return typesAreEqual(argType, appliedType);
       })
     : false;
 

--- a/src/semantics/resolution/resolve-object-type.ts
+++ b/src/semantics/resolution/resolve-object-type.ts
@@ -9,7 +9,7 @@ import {
 import { getExprType } from "./get-expr-type.js";
 import { inferTypeArgs, TypeArgInferencePair } from "./infer-type-args.js";
 import { implIsCompatible, resolveImpl } from "./resolve-impl.js";
-import { typesAreCompatible } from "./types-are-compatible.js";
+import { typesAreEqual } from "./types-are-equal.js";
 import { resolveTypeExpr } from "./resolve-type-expr.js";
 
 export const resolveObjectType = (obj: ObjectType, call?: Call): ObjectType => {
@@ -119,8 +119,6 @@ const typeArgsMatch = (call: Call, candidate: ObjectType): boolean =>
     ? candidate.appliedTypeArgs.every((t, i) => {
         const argType = getExprType(call.typeArgs?.at(i));
         const appliedType = getExprType(t);
-        return typesAreCompatible(argType, appliedType, {
-          exactNominalMatch: true,
-        });
+        return typesAreEqual(argType, appliedType);
       })
     : true;

--- a/src/semantics/resolution/resolve-trait.ts
+++ b/src/semantics/resolution/resolve-trait.ts
@@ -5,7 +5,7 @@ import { TypeAlias } from "../../syntax-objects/types.js";
 import { resolveFn } from "./resolve-fn.js";
 import { resolveTypeExpr } from "./resolve-type-expr.js";
 import { getExprType } from "./get-expr-type.js";
-import { typesAreCompatible } from "./types-are-compatible.js";
+import { typesAreEqual } from "./types-are-equal.js";
 import { resolveImpl } from "./resolve-impl.js";
 
 export const resolveTrait = (trait: TraitType, call?: Call): TraitType => {
@@ -62,10 +62,6 @@ const resolveGenericTraitVersion = (
 const typeArgsMatch = (call: Call, candidate: TraitType): boolean =>
   call.typeArgs && candidate.appliedTypeArgs
     ? candidate.appliedTypeArgs.every((t, i) =>
-        typesAreCompatible(
-          getExprType(call.typeArgs!.at(i)),
-          getExprType(t),
-          { exactNominalMatch: true }
-        )
+        typesAreEqual(getExprType(call.typeArgs!.at(i)), getExprType(t))
       )
     : true;

--- a/src/semantics/resolution/types-are-compatible.ts
+++ b/src/semantics/resolution/types-are-compatible.ts
@@ -167,10 +167,6 @@ export const typesAreCompatible = (
       ? [a as UnionType, b]
       : [b as UnionType, a];
 
-    if (!nonUnionType.isObjectType() && !nonUnionType.isIntersectionType()) {
-      return false;
-    }
-
     return unionType.types.some((t) =>
       typesAreCompatible(nonUnionType, t, opts, visited)
     );

--- a/src/semantics/resolution/types-are-equal.ts
+++ b/src/semantics/resolution/types-are-equal.ts
@@ -1,0 +1,121 @@
+import { Type, UnionType } from "../../syntax-objects/index.js";
+import { getExprType } from "./get-expr-type.js";
+
+const flattenUnion = (type: Type): Type[] => {
+  if (!type.isUnionType()) return [type];
+
+  const result: Type[] = [];
+  const queue: Type[] = [type];
+  const seen = new Set<string>();
+
+  while (queue.length) {
+    const current = queue.pop()!;
+
+    if (current.isUnionType()) {
+      for (const child of current.types) {
+        if (!seen.has(child.id)) {
+          seen.add(child.id);
+          queue.push(child);
+        }
+      }
+      continue;
+    }
+
+    result.push(current);
+  }
+
+  return result;
+};
+
+export const typesAreEqual = (
+  a?: Type,
+  b?: Type,
+  visited: Set<string> = new Set()
+): boolean => {
+  if (!a || !b) return false;
+  const key = `${a.id}|${b.id}`;
+  if (visited.has(key)) return true;
+  visited.add(key);
+
+  if (a.isSelfType() && b.isSelfType()) return true;
+
+  if (a.isPrimitiveType() && b.isPrimitiveType()) {
+    return a.id === b.id;
+  }
+
+  if (a.isObjectType() && b.isObjectType()) {
+    const structural = a.isStructural || b.isStructural;
+    if (structural) {
+      return (
+        a.fields.length === b.fields.length &&
+        a.fields.every((field) => {
+          const match = b.fields.find((f) => f.name === field.name);
+          return match && typesAreEqual(field.type, match.type, visited);
+        })
+      );
+    }
+    if (a.genericParent && a.genericParent.id === b.genericParent?.id) {
+      return !!a.appliedTypeArgs?.every((arg, index) =>
+        typesAreEqual(
+          getExprType(arg),
+          getExprType(b.appliedTypeArgs?.[index]),
+          visited
+        )
+      );
+    }
+    return a.id === b.id;
+  }
+
+  if (a.isTraitType() && b.isTraitType()) {
+    if (a.genericParent && a.genericParent.id === b.genericParent?.id) {
+      return !!a.appliedTypeArgs?.every((arg, index) =>
+        typesAreEqual(
+          getExprType(arg),
+          getExprType(b.appliedTypeArgs?.[index]),
+          visited
+        )
+      );
+    }
+    return a.id === b.id;
+  }
+
+  if (a.isUnionType() && b.isUnionType()) {
+    const aTypes = flattenUnion(a as UnionType);
+    const bTypes = flattenUnion(b as UnionType);
+    if (aTypes.length !== bTypes.length) return false;
+
+    const used: boolean[] = bTypes.map(() => false);
+    return aTypes.every((aType) => {
+      const idx = bTypes.findIndex(
+        (bType, i) => !used[i] && typesAreEqual(aType, bType, visited)
+      );
+      if (idx === -1) return false;
+      used[idx] = true;
+      return true;
+    });
+  }
+
+  if (a.isIntersectionType() && b.isIntersectionType()) {
+    return (
+      typesAreEqual(a.nominalType, b.nominalType, visited) &&
+      typesAreEqual(a.structuralType, b.structuralType, visited)
+    );
+  }
+
+  if (a.isFixedArrayType() && b.isFixedArrayType()) {
+    return typesAreEqual(a.elemType, b.elemType, visited);
+  }
+
+  if (a.isFnType() && b.isFnType()) {
+    if (a.parameters.length !== b.parameters.length) return false;
+    return (
+      typesAreEqual(a.returnType, b.returnType, visited) &&
+      a.parameters.every((p, i) =>
+        typesAreEqual(p.type, b.parameters[i]?.type, visited)
+      )
+    );
+  }
+
+  return false;
+};
+


### PR DESCRIPTION
## Summary
- add `typesAreEqual` for structural type comparison and export it
- require exact type-argument matches when resolving generic objects, functions, traits, and calls
- cover distinct generic specializations with a unit test
- allow primitive types when checking union compatibility
- add MiniJson recursion E2E test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a93af2cdc0832a97937de8209e0803