### PR TITLE
Cast union call arguments

### DIFF
--- a/src/__tests__/fixtures/mini-json.ts
+++ b/src/__tests__/fixtures/mini-json.ts
@@ -1,0 +1,11 @@
+export const miniJsonVoyd = `
+obj JsonObj { val: i32 }
+
+type MiniJson = JsonObj | string
+
+fn takes(j: MiniJson) -> i32
+  3
+
+pub fn main() -> i32
+  takes("hello")
+`;

--- a/src/__tests__/mini-json.e2e.test.ts
+++ b/src/__tests__/mini-json.e2e.test.ts
@@ -1,0 +1,12 @@
+import { miniJsonVoyd } from "./fixtures/mini-json.js";
+import { compile } from "../compiler.js";
+import { describe, test } from "vitest";
+import assert from "node:assert";
+
+describe("E2E MiniJson unions", () => {
+  test("casts call arguments to union type", async (t) => {
+    const mod = await compile(miniJsonVoyd);
+    assert(mod.validate(), "Module is valid");
+    t.expect(mod.emitText()).toContain("ref.cast");
+  });
+});

--- a/src/codegen/compile-call.ts
+++ b/src/codegen/compile-call.ts
@@ -130,15 +130,20 @@ export const compile = (opts: CompileExprOpts<Call>): number => {
       : callExpr;
   }
 
-  const args = expr.args.toArray().map((arg, i) =>
-    compileExpression({
+  const fn = expr.fn as Fn;
+  const args = expr.args.toArray().map((arg, i) => {
+    const compiled = compileExpression({
       ...opts,
       expr: arg,
       isReturnExpr: false,
-    })
-  );
+    });
+    const param = fn.parameters[i];
+    if (param?.type?.isUnionType()) {
+      return refCast(mod, compiled, mapBinaryenType(opts, param.type));
+    }
+    return compiled;
+  });
 
-  const fn = expr.fn as Fn;
   const id = fn.id;
   const returnType = mapBinaryenType(opts, fn.returnType!);
 


### PR DESCRIPTION
## Summary
- Cast function call arguments to union parameter types with `ref.cast`
- Add MiniJson example and test to guard union argument casting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a983a107d8832a9d365c39c2a3178b