### PR TITLE
Cast FixedArray elements to union element type

### DIFF
--- a/src/__tests__/fixed-array-union.e2e.test.ts
+++ b/src/__tests__/fixed-array-union.e2e.test.ts
@@ -1,0 +1,21 @@
+import { fixedArrayUnionVoyd } from "./fixtures/fixed-array-union.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("FixedArray unions with primitives", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(fixedArrayUnionVoyd);
+    assert(mod.validate(), "Module is valid");
+    instance = getWasmInstance(mod);
+  });
+
+  test("creates arrays of union types including primitives", (t) => {
+    const fn = getWasmFn("main", instance);
+    assert(fn, "Function exists");
+    t.expect(fn()).toEqual(2);
+  });
+});

--- a/src/__tests__/fixtures/fixed-array-union.ts
+++ b/src/__tests__/fixtures/fixed-array-union.ts
@@ -1,0 +1,15 @@
+export const fixedArrayUnionVoyd = `
+use std::all
+
+obj BoxedInt { value: i32 }
+obj BoxedStr { value: string }
+
+type StrOrInt = BoxedStr | BoxedInt
+
+pub fn main() -> i32
+  let arr: FixedArray<StrOrInt> = FixedArray<StrOrInt>(
+    BoxedStr { value: "a" },
+    BoxedInt { value: 1 }
+  )
+  arr.length<StrOrInt>()
+`;

--- a/src/codegen/builtin-calls/compile-fixed-array.ts
+++ b/src/codegen/builtin-calls/compile-fixed-array.ts
@@ -5,9 +5,18 @@ import * as gc from "../../lib/binaryen-gc/index.js";
 
 export const compileFixedArray = (opts: CompileExprOpts<Call>) => {
   const type = opts.expr.type as FixedArrayType;
+  const elemType = type.elemType!;
+  const elemBinaryenType = mapBinaryenType(opts, elemType);
+  const values = opts.expr.argArrayMap((expr) => {
+    const compiled = compileExpression({ ...opts, expr });
+    return elemType.isRefType()
+      ? gc.refCast(opts.mod, compiled, elemBinaryenType)
+      : compiled;
+  });
+  const arrayType = mapBinaryenType(opts, type);
   return gc.arrayNewFixed(
     opts.mod,
-    gc.binaryenTypeToHeapType(mapBinaryenType(opts, type)),
-    opts.expr.argArrayMap((expr) => compileExpression({ ...opts, expr }))
+    gc.binaryenTypeToHeapType(arrayType),
+    values
   );
 };


### PR DESCRIPTION
## Summary
- cast FixedArray call arguments to their element type before creating the array
- add regression test for building FixedArray with a union element type

## Testing
- `npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68a9839fe698832a87d49cc678b53752