### PR TITLE
Cast object and array call arguments to expected ref types

### DIFF
--- a/src/__tests__/array-struct-union.e2e.test.ts
+++ b/src/__tests__/array-struct-union.e2e.test.ts
@@ -1,0 +1,12 @@
+import { arrayStructUnionVoyd } from "./fixtures/array-struct-union.js";
+import { compile } from "../compiler.js";
+import { describe, test } from "vitest";
+import assert from "node:assert";
+
+describe("arrays with structural unions", () => {
+  test("casts nested union array arguments", async (t) => {
+    const mod = await compile(arrayStructUnionVoyd);
+    assert(mod.validate(), "Module is valid");
+    t.expect(mod.emitText()).toContain("ref.cast");
+  });
+});

--- a/src/__tests__/fixtures/array-struct-union.ts
+++ b/src/__tests__/fixtures/array-struct-union.ts
@@ -1,0 +1,16 @@
+export const arrayStructUnionVoyd = `
+use std::all
+
+pub obj JsonNull {}
+pub obj JsonNumber { val: i32 }
+
+pub type Json = Map<Json> | Array<Json> | JsonNumber | JsonNull | string
+
+type MiniJson = Array<MiniJson> | string
+
+fn work(val: Array<MiniJson>) -> i32
+  1
+
+pub fn main() -> i32
+  work(["hey"])
+`;

--- a/src/codegen/compile-call.ts
+++ b/src/codegen/compile-call.ts
@@ -138,8 +138,14 @@ export const compile = (opts: CompileExprOpts<Call>): number => {
       isReturnExpr: false,
     });
     const param = fn.parameters[i];
-    if (param?.type?.isUnionType()) {
-      return refCast(mod, compiled, mapBinaryenType(opts, param.type));
+    if (!param?.type) return compiled;
+    const paramType = param.type;
+    if (
+      paramType.isUnionType() ||
+      paramType.isObjectType() ||
+      paramType.isFixedArrayType()
+    ) {
+      return refCast(mod, compiled, mapBinaryenType(opts, paramType));
     }
     return compiled;
   });


### PR DESCRIPTION
## Summary
- cast call arguments for unions, objects, and fixed arrays to their expected Binaryen reference types
- add e2e test covering arrays that contain union values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa17de89b4832a8133fc64c23846a3