### PR TITLE
fix whitespace parsing trailing indent block

### DIFF
--- a/src/parser/__tests__/array-whitespace.test.ts
+++ b/src/parser/__tests__/array-whitespace.test.ts
@@ -1,0 +1,36 @@
+import { parse } from "../parser.js";
+import { test } from "vitest";
+
+const toPlain = (code: string) => JSON.parse(JSON.stringify(parse(code).toJSON()));
+
+test("does not insert empty block after nested array", (t) => {
+  const code = [
+    "pub fn main() -> i32",
+    "  work([",
+    "    JsonNumber { val: 23 },",
+    "    [",
+    "      JsonNumber { val: 43 }",
+    "    ]",
+    "  ])",
+  ].join("\n");
+
+  t.expect(toPlain(code)).toEqual([
+    "ast",
+    [
+      "pub",
+      "fn",
+      ["->", ["main"], "i32"],
+      [
+        "block",
+        [
+          "work",
+          [
+            "array",
+            ["JsonNumber", ["object", [":", "val", 23]]],
+            ["array", ["JsonNumber", ["object", [":", "val", 43]]]]
+          ]
+        ]
+      ]
+    ]
+  ]);
+});

--- a/src/parser/syntax-macros/interpret-whitespace.ts
+++ b/src/parser/syntax-macros/interpret-whitespace.ts
@@ -107,8 +107,9 @@ const elideParens = (list: Expr, startIndentLevel?: number): Expr => {
  */
 const nextExprIndentLevel = (list: List, startIndex = 0) => {
   let nextIndentLevel = 0;
+  let i = startIndex;
 
-  for (let i = startIndex; i < list.length; i++) {
+  for (; i < list.length; i++) {
     const expr = list.at(i)!;
     if (isNewline(expr)) {
       nextIndentLevel = 0;
@@ -124,6 +125,8 @@ const nextExprIndentLevel = (list: List, startIndex = 0) => {
 
     break;
   }
+
+  if (i >= list.length) return 0;
 
   return nextIndentLevel;
 };


### PR DESCRIPTION
## Summary
- fix whitespace interpreter to ignore trailing indent at list end
- add regression test for nested array whitespace

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa41523d3c832ab00fa1c84703ab1b