### PR TITLE
feat: treat string as object

### DIFF
--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -6,6 +6,7 @@ import {
   ObjectType,
   FixedArrayType,
   voydBaseObject,
+  voydString,
   UnionType,
   IntersectionType,
 } from "./syntax-objects/types.js";
@@ -131,7 +132,7 @@ export const mapBinaryenType = (
   if (isPrimitiveId(type, "f64")) return binaryen.f64;
   if (isPrimitiveId(type, "voyd") || isPrimitiveId(type, "void"))
     return binaryen.none;
-  if (isPrimitiveId(type, "string")) return getI32ArrayType(opts.mod);
+  if (type === voydString) return getI32ArrayType(opts.mod);
 
   if (type.isObjectType()) {
     if (buildingTypePlaceholders.has(type)) {

--- a/src/semantics/check-types.ts
+++ b/src/semantics/check-types.ts
@@ -21,7 +21,6 @@ import {
   IntersectionType,
   FixedArrayType,
   Closure,
-  voydString,
 } from "../syntax-objects/index.js";
 import { Match } from "../syntax-objects/match.js";
 import { getExprType } from "./resolution/get-expr-type.js";
@@ -679,10 +678,7 @@ const checkUnionType = (union: UnionType) => {
 
   union.types.forEach((t) => {
     const isObjectType =
-      t.isObjectType() ||
-      t.isIntersectionType() ||
-      t.isUnionType() ||
-      t === voydString;
+      t.isObjectType() || t.isIntersectionType() || t.isUnionType();
     if (!isObjectType) {
       throw new Error(
         `Union must be made up of object types ${union.location}`

--- a/src/semantics/resolution/__tests__/types-are-equal.test.ts
+++ b/src/semantics/resolution/__tests__/types-are-equal.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, test } from "vitest";
 import {
   ObjectType,
   UnionType,
-  PrimitiveType,
   Identifier,
   TypeAlias,
+  voydString,
 } from "../../../syntax-objects/index.js";
 import { typesAreEqual } from "../types-are-equal.js";
 
 describe("typesAreEqual", () => {
   test("treats different generic args as distinct", () => {
-    const string = PrimitiveType.from("string");
+    const string = voydString;
     const jsonObj = new ObjectType({ name: "JsonObj", value: [] });
 
     const json = new UnionType({ name: "Json", childTypeExprs: [] });

--- a/src/syntax-objects/syntax.ts
+++ b/src/syntax-objects/syntax.ts
@@ -359,8 +359,7 @@ export abstract class Syntax {
       this.isObjectType() ||
       this.isIntersectionType() ||
       this.isUnionType() ||
-      this.isTupleType() ||
-      (this.isPrimitiveType() && this.name.is("string"))
+      this.isTupleType()
     );
   }
 

--- a/src/syntax-objects/types.ts
+++ b/src/syntax-objects/types.ts
@@ -387,8 +387,7 @@ export type Primitive =
   | ReferenceType
   | "void"
   | "voyd"
-  | "bool"
-  | "string";
+  | "bool";
 
 export type NumericType = "i32" | "f32" | "i64" | "f64";
 export type ReferenceType = "funcref" | "externref";
@@ -400,16 +399,19 @@ export const f64 = PrimitiveType.from("f64");
 export const bool = PrimitiveType.from("bool");
 export const dVoid = PrimitiveType.from("void");
 export const dVoyd = PrimitiveType.from("voyd");
-export const voydString = PrimitiveType.from("string");
 export const selfType = new SelfType();
 export const voydBaseObject = new ObjectType({
   name: "Object",
   value: [],
+});
+export const voydString = new ObjectType({
+  name: "string",
+  value: [],
+  parentObj: voydBaseObject,
 });
 
 export type VoydRefType =
   | ObjectType
   | UnionType
   | IntersectionType
-  | TupleType
-  | PrimitiveType; // string only. TODO: Make string something else idk. This is not very dev friendly
+  | TupleType;


### PR DESCRIPTION
## Summary
- convert built-in `string` into an `ObjectType` extending `Object`
- update type/reference checks and Binaryen mapping for new string type
- adjust tests for `typesAreEqual`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa48e1c41c832abce9f59a72cf6756