### PR TITLE
feat: widen array literal element types with expected types

### DIFF
--- a/src/__tests__/array-param-widen.e2e.test.ts
+++ b/src/__tests__/array-param-widen.e2e.test.ts
@@ -1,0 +1,20 @@
+import { arrayParamWidenVoyd } from "./fixtures/array-param-widen.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E array param type widening", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(arrayParamWidenVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("main accepts inline array literal", (t) => {
+    const fn = getWasmFn("main", instance);
+    assert(fn, "Function exists");
+    t.expect(fn(), "main returns 1").toEqual(1);
+  });
+});

--- a/src/__tests__/fixtures/array-param-widen.ts
+++ b/src/__tests__/fixtures/array-param-widen.ts
@@ -1,0 +1,16 @@
+export const arrayParamWidenVoyd = `
+use std::all
+
+pub obj JsonNull {}
+pub obj JsonNumber { val: i32 }
+
+type MiniJson = Array<MiniJson> | JsonNumber
+
+fn work(val: Array<MiniJson>) -> i32
+  1
+
+pub fn main() -> i32
+  let a: Array<MiniJson> = [JsonNumber { val: 23 }]
+  work(a)
+  work([JsonNumber { val: 23 }])
+`;


### PR DESCRIPTION
## Summary
- allow resolveArrayLiteral to accept an expected element type and use it for array literals
- re-resolve array literal arguments based on parameter types and annotated variable types
- add e2e test for passing JsonNumber array literal to Array<MiniJson>

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa5b9065b8832a96f69fd4ac566a1d