### PR TITLE
test: reproduce structural branch cast bug

### DIFF
--- a/src/__tests__/fixtures/struct-branch-node.ts
+++ b/src/__tests__/fixtures/struct-branch-node.ts
@@ -1,0 +1,40 @@
+export const structBranchNodeVoyd = `
+use std::all
+
+obj Box { val: i32 }
+
+type Branch = Optional<Node> | Box
+
+type Node = {
+  value: i32,
+  left: Branch,
+  right: Branch
+}
+
+fn work(node: Node, sum: i32) -> i32
+  let extract = (branch: Branch) -> i32 =>
+    branch.match(l)
+      Some<Node>:
+        work(l.value, sum)
+      None:
+        0
+      Box:
+        l.val
+
+  let left = extract(node.left)
+  let right = extract(node.right)
+  node.value + sum + left + right
+
+pub fn main() -> i32
+  work({
+    value: 3,
+    left: Box { val: 5 },
+    right: Some {
+      value: {
+        value: 2,
+        left: None {},
+        right: None {}
+      }
+    }
+  }, 0)
+`;

--- a/src/__tests__/struct-branch-node.e2e.test.ts
+++ b/src/__tests__/struct-branch-node.e2e.test.ts
@@ -1,0 +1,20 @@
+import { structBranchNodeVoyd } from "./fixtures/struct-branch-node.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E structural optional branch handling", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(structBranchNodeVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test.skip("main walks structural branches", (t) => {
+    const fn = getWasmFn("main", instance);
+    assert(fn, "Function exists");
+    t.expect(fn()).toEqual(10);
+  });
+});


### PR DESCRIPTION
## Summary
- add skipped e2e test exercising structural branch matching
- illustrate runtime `illegal cast` when matching `Optional<Node>` with structural `Node`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa8c42ce6c832abe930c67a891bd2b