### PR TITLE
Improve type checker error messages

### DIFF
--- a/src/__tests__/type-checker-errors.test.ts
+++ b/src/__tests__/type-checker-errors.test.ts
@@ -1,0 +1,27 @@
+import { compile } from "../compiler.js";
+import { describe, test } from "vitest";
+
+describe("Type checker error messages", () => {
+  test("reports variable initialization type mismatch clearly", async (t) => {
+    const code = `
+pub fn main()
+  let x: i32 = 1.5
+  x
+`;
+    await t.expect(compile(code)).rejects.toThrow(
+      /x is declared as i32 but initialized with f64/
+    );
+  });
+
+  test("reports assignment type mismatch clearly", async (t) => {
+    const code = `
+pub fn main()
+  var x: i32 = 1
+  x = 1.5
+  x
+`;
+    await t.expect(compile(code)).rejects.toThrow(
+      /Cannot assign f64 to variable x of type i32/
+    );
+  });
+});

--- a/src/semantics/check-types.ts
+++ b/src/semantics/check-types.ts
@@ -224,7 +224,12 @@ export const checkAssign = (call: Call) => {
   const initType = getExprType(initExpr);
 
   if (!typesAreCompatible(variable.type, initType)) {
-    throw new Error(`${id} cannot be assigned to ${initType}`);
+    const variableTypeName = variable.type?.name.value ?? "unknown";
+    const initTypeName = initType?.name.value ?? "unknown";
+    const location = call.location ?? id.location;
+    throw new Error(
+      `Cannot assign ${initTypeName} to variable ${id} of type ${variableTypeName} at ${location}`
+    );
   }
 
   return call;
@@ -421,12 +426,10 @@ const checkVarTypes = (variable: Variable): Variable => {
     variable.annotatedType &&
     !typesAreCompatible(variable.inferredType, variable.annotatedType)
   ) {
+    const annotatedName = variable.annotatedType.name.value;
+    const inferredName = variable.inferredType.name.value;
     throw new Error(
-      `${variable.name} of type ${JSON.stringify(
-        variable.type
-      )} is not assignable to ${JSON.stringify(variable.inferredType)} at ${
-        variable.location
-      }`
+      `${variable.name} is declared as ${annotatedName} but initialized with ${inferredName} at ${variable.location}`
     );
   }
 


### PR DESCRIPTION
## Summary
- clarify type mismatch errors for assignments by including variable and initializer types
- improve variable initialization error messaging
- add tests covering the new error messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab5fd0a3a8832aba9131d1924b2ef0