### PR TITLE
feat: improve match type error messages

### DIFF
--- a/src/semantics/__tests__/type-checker-errors.test.ts
+++ b/src/semantics/__tests__/type-checker-errors.test.ts
@@ -68,7 +68,7 @@ pub fn main()
     A: 1
 `;
     await expect(compile(code)).rejects.toThrow(
-      /Match does not handle all possibilities of union/,
+      /Match on AB is not exhaustive.*Missing cases: B/,
     );
   });
 
@@ -88,7 +88,7 @@ pub fn main()
     else: 0
 `;
     await expect(compile(code)).rejects.toThrow(
-      /Match cases mismatch union/,
+      /Match case C is not part of union AB/,
     );
   });
 
@@ -102,7 +102,7 @@ pub fn main()
     Point: 1
 `;
     await expect(compile(code)).rejects.toThrow(
-      /Match must have a default case/,
+      /Match on Point must have a default case/,
     );
   });
 
@@ -120,7 +120,7 @@ pub fn main()
     B: 1.5
 `;
     await expect(compile(code)).rejects.toThrow(
-      /All cases must return the same type/,
+      /returns f64 but expected i32/,
     );
   });
 });


### PR DESCRIPTION
## Summary
- clarify match case return type mismatches
- detail union match exhaustiveness and mismatched cases
- note required default case in object matches
- update tests for new diagnostics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab728b02b8832aa6357a350eab9b7c