### PR TITLE
Expose trait methods and mark mutable test objects

### DIFF
--- a/src/__tests__/fixtures/closures.ts
+++ b/src/__tests__/fixtures/closures.ts
@@ -33,7 +33,7 @@ pub fn param_infer_labeled() -> i32
   call_with_reducer start: 1 reducer: (acc, current) => acc + current
 
 pub fn calls_closure() -> i32
-  let sum = { val: 0 }
+  let sum = &{ val: 0 }
   let set: (v: i32) -> i32 = (v: i32) =>
     sum.val = v
     0

--- a/src/__tests__/fixtures/void-type.ts
+++ b/src/__tests__/fixtures/void-type.ts
@@ -5,7 +5,7 @@ fn call_it(it: (v: i32) -> voyd) -> voyd
   it(5)
 
 pub fn main() -> i32
-  let sum = { val: 0 }
+  let sum = &{ val: 0 }
 
   let set = (v: i32) -> voyd =>
     sum.val = v

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -48,14 +48,19 @@ const getCandidates = (call: Call): Fn[] => {
     const implFns = isInsideImpl
       ? [] // internal methods already in scope
       : arg1Type.implementations
-          ?.flatMap((impl) => impl.exports)
+          ?.flatMap((impl) =>
+            // Trait implementations expose all methods, even when not
+            // explicitly exported.  Non-trait implementations continue to
+            // expose only their public exports.
+            impl.trait ? impl.methods : impl.exports
+          )
           .filter((fn) => fn.name.is(call.fnName.value));
     fns.push(...(implFns ?? []));
   }
 
   if (arg1Type?.isTraitType()) {
     const implFns = arg1Type.implementations
-      ?.flatMap((impl) => impl.exports)
+      ?.flatMap((impl) => impl.methods)
       .filter((fn) => fn.name.is(call.fnName.value));
     fns.push(...(implFns ?? []));
   }

--- a/src/semantics/resolution/resolve-entities.ts
+++ b/src/semantics/resolution/resolve-entities.ts
@@ -6,6 +6,7 @@ import { VoydModule } from "../../syntax-objects/module.js";
 import { ObjectLiteral } from "../../syntax-objects/object-literal.js";
 import { Call } from "../../syntax-objects/call.js";
 import { Identifier } from "../../syntax-objects/identifier.js";
+import { Fn } from "../../syntax-objects/fn.js";
 import { ArrayLiteral } from "../../syntax-objects/array-literal.js";
 import {
   ObjectType,
@@ -254,7 +255,14 @@ export const resolveArrayLiteral = (
     args: new List({ value: [objLiteral] }),
     typeArgs,
   });
+  let candidates: Fn[] = arr.resolveFns(Identifier.from("new_array"));
+  if (!candidates.length) {
+    const arrayModule =
+      arr.resolveModule("array") ?? arr.resolveModule("std")?.resolveModule("array");
+    const exports = arrayModule?.resolveExport("new_array") ?? [];
+    candidates = exports.filter((e): e is Fn => e.isFn());
+  }
   newArrayCall.setTmpAttribute("arrayLiteral", original);
-  return resolveEntities(newArrayCall);
+  return resolveCall(newArrayCall, candidates);
 };
 


### PR DESCRIPTION
## Summary
- include trait implementation methods in candidate lookup so iterator calls resolve
- mark closure test fixtures with mutable objects to satisfy mutability checks
- attempt to resolve `new_array` in array literals by searching the `array` module when not already imported

## Testing
- `npm test` *(fails: Could not resolve fn new_array(ObjectLiteral-304906); No overload matches length(69545); Could not resolve fn iterate(Array); and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab87fadfa8832a9f732cd12a5bb369