### PR TITLE
Return references from standard iterators

### DIFF
--- a/std/array.voyd
+++ b/std/array.voyd
@@ -196,5 +196,5 @@ impl<T> Iterator<T> for ArrayIterator<T>
       r
 
 impl<T> Iterable<T> for Array<T>
-  fn iterate(self) -> Iterator<T>
-    ArrayIterator<T> { index: 0, array: self }
+  fn iterate(self) -> &Iterator<T>
+    &ArrayIterator<T> { index: 0, array: self }

--- a/std/map.voyd
+++ b/std/map.voyd
@@ -49,8 +49,8 @@ impl<T> Iterator<{ key: String, value: T }> for MapIterator<T>
           self.next()
 
 impl<T> Iterable<{ key: String, value: T }> for Map<T>
-  fn iterate(self) -> Iterator<{ key: String, value: T }>
-    MapIterator<T> { map: self, bucket_index: 0, item_index: 0 }
+  fn iterate(self) -> &Iterator<{ key: String, value: T }>
+    &MapIterator<T> { map: self, bucket_index: 0, item_index: 0 }
 
 impl<T> Map<T>
   fn hash(self, key: String) -> i32

--- a/std/string.voyd
+++ b/std/string.voyd
@@ -83,8 +83,8 @@ impl String
       })
       String { storage: new_storage, count: new_length }
 
-pub fn new_string_iterator(str: String) -> StringIterator
-  StringIterator { str: str, index: 0 }
+pub fn new_string_iterator(str: String) -> &StringIterator
+  &StringIterator { str: str, index: 0 }
 
 pub fn read_next_char(iterator: &StringIterator) -> i32
   if iterator.index >= iterator.str.length then:
@@ -104,7 +104,7 @@ impl Iterator<i32> for StringIterator
       Some<i32> { value: char }
 
 impl Iterable<i32> for String
-  fn iterate(self) -> Iterator<i32>
+  fn iterate(self) -> &Iterator<i32>
     new_string_iterator(self)
 
 pub fn '=='(a: String, b: String) -> bool


### PR DESCRIPTION
## Summary
- Return iterator constructors by reference
- Update Array, Map, and String iterate methods to yield `&Iterator`

## Testing
- `npm test` *(fails: Invalid type entity)*

------
https://chatgpt.com/codex/tasks/task_e_68ab91cade24832a9568a26b9ec5b7c6