### PR TITLE
Ensure iterator operations use mutable references

### DIFF
--- a/src/__tests__/fixtures/generic-array-reduce.ts
+++ b/src/__tests__/fixtures/generic-array-reduce.ts
@@ -2,7 +2,7 @@ export const genericArrayReduceVoyd = `
 use std::all
 
 fn reduce<T>({ arr: Array<T>, start: T, reducer cb: (acc: T, current: T) -> T }) -> T
-  let iterator = arr.iterate()
+  let iterator = &arr.iterate()
   let reducer: (acc: T) -> T = (acc: T) =>
     iterator.next().match(opt)
       Some<T>:

--- a/src/__tests__/fixtures/html-array.ts
+++ b/src/__tests__/fixtures/html-array.ts
@@ -6,7 +6,7 @@ obj Box { val: i32 }
 type Html = Array<Html> | String
 
 fn work(html: Array<Html>, sum: i32) -> i32
-  let it = html.iterate()
+  let it = &html.iterate()
   let reducer: (sum: i32) -> i32 = (sum: i32) -> i32 =>
     it.next().match(opt)
       Some<Html>:

--- a/src/__tests__/fixtures/html-union.ts
+++ b/src/__tests__/fixtures/html-union.ts
@@ -6,7 +6,7 @@ type Html = Array<Html> | String
 fn work(html: Html, sum: i32) -> i32
   match(html)
     Array<Html>:
-      let it = html.iterate()
+      let it = &html.iterate()
       let reducer: (acc: i32) -> i32 = (acc: i32) -> i32 =>
         it.next().match(opt)
           Some<Html>:

--- a/src/__tests__/fixtures/map-string-iterator.ts
+++ b/src/__tests__/fixtures/map-string-iterator.ts
@@ -5,7 +5,7 @@ pub fn map_iter_sum() -> i32
   let m = new_map<i32>()
   m.set("a", 1)
   m.set("b", 2)
-  let iterator = m.iterate()
+  let iterator = &m.iterate()
   let looper: (s: i32) -> i32 = (acc: i32) =>
     iterator.next().match(item)
       Some<{ key: String, value: i32 }>:
@@ -15,7 +15,7 @@ pub fn map_iter_sum() -> i32
   looper(0)
 
 pub fn string_iter_sum() -> i32
-  let iterator = new_string_iterator("ab")
+  let iterator = &new_string_iterator("ab")
   let looper: (s: i32) -> i32 = (acc: i32) =>
     iterator.next().match(ch)
       Some<i32>:

--- a/src/__tests__/fixtures/mini-json-array.ts
+++ b/src/__tests__/fixtures/mini-json-array.ts
@@ -7,7 +7,7 @@ pub obj JsonNumber: JsonNull { val: i32 }
 type MiniJson = Array<MiniJson> | JsonNumber
 
 fn work(val: Array<MiniJson>, sum: i32) -> i32
-  let it = val.iterate()
+  let it = &val.iterate()
   let reducer: (sum: i32) -> i32 = (sum: i32) -> i32 =>
     it.next().match(opt)
       Some<MiniJson>:

--- a/src/__tests__/fixtures/trait-object.ts
+++ b/src/__tests__/fixtures/trait-object.ts
@@ -44,7 +44,7 @@ impl<T> MyIterable<T> for Array<T>
     ArrayMyIterator<T> { index: 0, array: self }
 
 fn sum_iterable(it: MyIterable<i32>) -> i32
-  let iterator = it.iterate()
+  let iterator = &it.iterate()
   let looper: (s: i32) -> i32 = (start: i32) =>
     iterator.next().match(opt)
       Some<i32>:
@@ -54,7 +54,7 @@ fn sum_iterable(it: MyIterable<i32>) -> i32
   looper(0)
 
 fn sum_iterable(it: MyIterable<f64>) -> f64
-  let iterator = it.iterate()
+  let iterator = &it.iterate()
   let looper: (s: f64) -> f64 = (start: f64) =>
     iterator.next().match(opt)
       Some<f64>:
@@ -108,7 +108,7 @@ impl<T> MyIterable<T> for Box<T>
     self
 
 fn call_iterator(it: MyIterable<i32>) -> i32
-  let iterator = it.iterate()
+  let iterator = &it.iterate()
   iterator.next().match(o)
     Some<i32>:
       o.value

--- a/std/fixed_array.voyd
+++ b/std/fixed_array.voyd
@@ -53,5 +53,5 @@ impl<T> Iterator<T> for FixedArrayIterator<T>
       Some<T> { value: value }
 
 impl<T> Iterable<T> for FixedArray<T>
-  fn iterate(self) -> Iterator<T>
-    FixedArrayIterator<T> { index: 0, array: self }
+  fn iterate(self) -> &Iterator<T>
+    &FixedArrayIterator<T> { index: 0, array: self }

--- a/std/iter.voyd
+++ b/std/iter.voyd
@@ -3,10 +3,10 @@ use array::all
 use optional::all
 
 pub trait Iterator<T>
-  fn next(self) -> Optional<T>
+  fn next(&self) -> Optional<T>
 
 pub trait Iterable<T>
-  fn iterate(self) -> Iterator<T>
+  fn iterate(self) -> &Iterator<T>
 
 pub fn map<I, O>(it: Iterable<I>, f: (v: I) -> O) -> Array<O>
   let iterator = it.iterate()


### PR DESCRIPTION
## Summary
- Borrow iterators mutably in fixture programs so `next()` mutates the same iterator
- Update `Iterator`/`Iterable` traits and `FixedArray` implementation to return iterator references

## Testing
- `npm test` *(fails: Invalid type entity)*

------
https://chatgpt.com/codex/tasks/task_e_68ab93138ce8832abba888d4b838522e