### PR TITLE
feat: add mutable reference checks

### DIFF
--- a/src/semantics/__tests__/mutability.test.ts
+++ b/src/semantics/__tests__/mutability.test.ts
@@ -1,0 +1,76 @@
+import { test, vi } from "vitest";
+import { List } from "../../syntax-objects/list.js";
+import { Identifier } from "../../syntax-objects/identifier.js";
+import { Fn } from "../../syntax-objects/fn.js";
+import { Parameter } from "../../syntax-objects/parameter.js";
+import { Block } from "../../syntax-objects/block.js";
+import { Call } from "../../syntax-objects/call.js";
+import { initEntities } from "../init-entities.js";
+import { checkTypes } from "../check-types/index.js";
+import { dVoid } from "../../syntax-objects/types.js";
+
+test("initEntities marks & parameters as mutable", (t) => {
+  const fnAst = new List([
+    "define_function",
+    Identifier.from("bump"),
+    new List([
+      "parameters",
+      new List([":", new List(["&", Identifier.from("v")]), Identifier.from("Vec")]),
+    ]),
+    new List(["return_type", Identifier.from("voyd")]),
+    new List(["block"]),
+  ]);
+  const fn = initEntities(fnAst) as Fn;
+  t.expect(fn.parameters[0].hasAttribute("mutable")).toBe(true);
+});
+
+test("initEntities handles labeled mutable parameters", (t) => {
+  const fnAst = new List([
+    "define_function",
+    Identifier.from("bump"),
+    new List([
+      "parameters",
+      new List([
+        "object",
+        new List([":", new List(["&", Identifier.from("v")]), Identifier.from("Vec")]),
+      ]),
+    ]),
+    new List(["return_type", Identifier.from("voyd")]),
+    new List(["block"]),
+  ]);
+  const fn = initEntities(fnAst) as Fn;
+  const param = fn.parameters[0];
+  t.expect(param.label?.value).toBe("v");
+  t.expect(param.hasAttribute("mutable")).toBe(true);
+});
+
+test("checkTypes warns on member access for non-mutable parameter", (t) => {
+  const param = new Parameter({ name: Identifier.from("v") });
+  const call = new Call({
+    fnName: Identifier.from("member-access"),
+    args: new List({ value: [Identifier.from("v"), Identifier.from("x")] }),
+  });
+  const block = new Block({ body: [call] });
+  const fn = new Fn({ name: Identifier.from("f"), parameters: [param], body: block });
+  fn.returnType = dVoid;
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  checkTypes(call);
+  t.expect(warn).toHaveBeenCalled();
+  warn.mockRestore();
+});
+
+test("checkTypes allows member access on mutable parameter", (t) => {
+  const param = new Parameter({ name: Identifier.from("v") });
+  param.setAttribute("mutable", true);
+  const call = new Call({
+    fnName: Identifier.from("member-access"),
+    args: new List({ value: [Identifier.from("v"), Identifier.from("x")] }),
+  });
+  const block = new Block({ body: [call] });
+  const fn = new Fn({ name: Identifier.from("f"), parameters: [param], body: block });
+  fn.returnType = dVoid;
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  checkTypes(call);
+  t.expect(warn).not.toHaveBeenCalled();
+  warn.mockRestore();
+});

--- a/src/semantics/check-types/check-call.ts
+++ b/src/semantics/check-types/check-call.ts
@@ -24,7 +24,7 @@ export const checkCallTypes = (call: Call): Call | ObjectLiteral => {
   if (call.calls("=")) return checkAssign(call);
   if (call.calls("while")) return checkWhile(call);
   if (call.calls("FixedArray")) return checkFixedArrayInit(call);
-  if (call.calls("member-access")) return call; // TODO
+  if (call.calls("member-access")) return checkMemberAccess(call);
   if (call.fn?.isObjectType()) return checkObjectInit(call);
 
   call.args = call.args.map(checkTypes);
@@ -137,6 +137,19 @@ const checkFixedArrayInit = (call: Call) => {
     }
   });
 
+  return call;
+};
+
+const checkMemberAccess = (call: Call): Call => {
+  const obj = call.argAt(0);
+  if (obj) checkTypes(obj);
+  const identifier = obj?.isIdentifier() ? obj : undefined;
+  const entity = identifier?.resolve();
+  if (entity?.isVariable() || entity?.isParameter()) {
+    if (!entity.hasAttribute("mutable")) {
+      console.warn(`${identifier} is not mutable at ${identifier?.location}`);
+    }
+  }
   return call;
 };
 


### PR DESCRIPTION
## Summary
- track `&` in initEntities and mark identifiers as mutable
- warn on member access of non-mutable params or vars
- add unit tests for mutable references and labeled params

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abb0d6b634832ab84984222f0583c1