### PR TITLE
Deduplicate function candidates to avoid ambiguous resolution

### DIFF
--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -15,7 +15,9 @@ export const getCallFn = (call: Call, candidateFns?: Fn[]): Fn | undefined => {
   if (isPrimitiveFnCall(call)) return undefined;
 
   const unfilteredCandidates = candidateFns ?? getCandidates(call);
-  const candidates = filterCandidates(call, unfilteredCandidates);
+  const candidates = dedupeCandidates(
+    filterCandidates(call, unfilteredCandidates)
+  );
 
   if (!candidates.length) {
     return undefined;
@@ -61,6 +63,15 @@ const getCandidates = (call: Call): Fn[] => {
   }
 
   return fns;
+};
+
+const dedupeCandidates = (fns: Fn[]): Fn[] => {
+  const unique = new Map<string, Fn>();
+  fns.forEach((fn) => {
+    const key = `${fn.location?.toString() ?? fn.id}:${formatFnSignature(fn)}`;
+    if (!unique.has(key)) unique.set(key, fn);
+  });
+  return [...unique.values()];
 };
 
 const filterCandidates = (call: Call, candidates: Fn[]): Fn[] =>


### PR DESCRIPTION
## Summary
- remove duplicate function candidates based on location and signature
- use deduped candidates during call resolution to prevent ambiguous matches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac10c9fe18832ab68e8c5e3d287334