### PR TITLE
feat: infer nested generic type arguments

### DIFF
--- a/src/semantics/resolution/__tests__/infer-type-args.test.ts
+++ b/src/semantics/resolution/__tests__/infer-type-args.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+import { Call, Identifier, List, i32 } from "../../../syntax-objects/index.js";
+import { inferTypeArgs } from "../infer-type-args.js";
+import { getExprType } from "../get-expr-type.js";
+
+describe("inferTypeArgs", () => {
+  test("infers type params in nested structures", () => {
+    const T = new Identifier({ value: "T" });
+    const stringId = new Identifier({ value: "String" });
+
+    const tupleParam = new List({
+      value: [
+        new Identifier({ value: "tuple" }),
+        stringId.clone(),
+        T.clone(),
+      ],
+    });
+
+    const typeExpr = new Call({
+      fnName: new Identifier({ value: "Array" }),
+      args: new List({}),
+      typeArgs: new List({ value: [tupleParam] }),
+    });
+
+    const tupleArg = new List({
+      value: [
+        new Identifier({ value: "tuple" }),
+        stringId.clone(),
+        i32.clone(),
+      ],
+    });
+
+    const argExpr = new Call({
+      fnName: new Identifier({ value: "Array" }),
+      args: new List({}),
+      typeArgs: new List({ value: [tupleArg] }),
+    });
+
+    const result = inferTypeArgs([T], [{ typeExpr, argExpr }]);
+
+    expect(result).toBeInstanceOf(List);
+    const alias = result?.exprAt(0);
+    expect(alias?.isTypeAlias()).toBe(true);
+    const type = getExprType(alias!);
+    expect(type?.isPrimitiveType()).toBe(true);
+    expect(type?.name.value).toBe("i32");
+  });
+});
+

--- a/src/semantics/resolution/infer-type-args.ts
+++ b/src/semantics/resolution/infer-type-args.ts
@@ -11,6 +11,105 @@ export type TypeArgInferencePair = {
   argExpr: Expr;
 };
 
+/**
+ * Recursively walks the type expression and corresponding argument expression
+ * to find the sub-expression of the argument that maps to the given type
+ * parameter identifier. Traverses calls (generics), tuples and object field
+ * types.
+ */
+const findMatchingExpr = (
+  typeExpr: Expr,
+  argExpr: Expr,
+  tp: Identifier
+): Expr | undefined => {
+  // Direct identifier match
+  if (typeExpr.isIdentifier() && typeExpr.is(tp)) return argExpr;
+
+  // Generic calls such as Array<T>
+  if (typeExpr.isCall()) {
+    const typeArgs = typeExpr.typeArgs?.toArray();
+    if (typeArgs?.length) {
+      let argTypeArgs: Expr[] | undefined;
+
+      if (argExpr.isCall() && argExpr.typeArgs?.length) {
+        argTypeArgs = argExpr.typeArgs.toArray();
+      } else {
+        const argType = getExprType(argExpr);
+        if (argType?.isObjectType() && argType.appliedTypeArgs) {
+          argTypeArgs = argType.appliedTypeArgs;
+        } else if (argType?.isFixedArrayType()) {
+          // FixedArray<T>
+          argTypeArgs = [argType.elemTypeExpr];
+        } else if (argType && (argType as any).appliedTypeArgs) {
+          // TraitType and other generics
+          argTypeArgs = (argType as any).appliedTypeArgs as Expr[];
+        }
+      }
+
+      if (argTypeArgs) {
+        for (let i = 0; i < typeArgs.length && i < argTypeArgs.length; i++) {
+          const match = findMatchingExpr(typeArgs[i], argTypeArgs[i], tp);
+          if (match) return match;
+        }
+      }
+    }
+  }
+
+  // Tuple types represented as (a, b, ...)
+  if (typeExpr.isList() && typeExpr.calls("tuple")) {
+    const typeElems = typeExpr.toArray().slice(1);
+    let argElems: Expr[] | undefined;
+
+    if (argExpr.isList() && argExpr.calls("tuple")) {
+      argElems = argExpr.toArray().slice(1);
+    } else {
+      const argType = getExprType(argExpr);
+      if (argType?.isTupleType()) {
+        argElems = argType.value;
+      }
+    }
+
+    if (argElems) {
+      for (let i = 0; i < typeElems.length && i < argElems.length; i++) {
+        const match = findMatchingExpr(typeElems[i], argElems[i], tp);
+        if (match) return match;
+      }
+    }
+  }
+
+  // Object type fields
+  if (typeExpr.isObjectType()) {
+    let argFields: { name: string; expr: Expr }[] | undefined;
+
+    if (argExpr.isObjectLiteral()) {
+      argFields = argExpr.fields.map((f) => ({
+        name: f.name,
+        expr: f.initializer,
+      }));
+    } else {
+      const argType = getExprType(argExpr);
+      if (argType?.isObjectType()) {
+        argFields = argType.fields.map((f) => ({
+          name: f.name,
+          expr: f.typeExpr,
+        }));
+      }
+    }
+
+    if (argFields) {
+      for (const field of typeExpr.fields) {
+        const argField = argFields.find((f) => f.name === field.name);
+        if (argField) {
+          const match = findMatchingExpr(field.typeExpr, argField.expr, tp);
+          if (match) return match;
+        }
+      }
+    }
+  }
+
+  return undefined;
+};
+
 export const inferTypeArgs = (
   typeParams: Identifier[] | undefined,
   pairs: TypeArgInferencePair[]
@@ -23,15 +122,16 @@ export const inferTypeArgs = (
     let inferredType: Type | undefined;
 
     for (const { typeExpr, argExpr } of pairs) {
-      if (typeExpr.isIdentifier() && typeExpr.is(tp)) {
-        inferredType = new TypeAlias({
-          name: typeExpr.clone(),
-          typeExpr: nop(),
-        });
-        resolveTypeExpr(argExpr);
-        inferredType.type = getExprType(argExpr);
-        break;
-      }
+      const match = findMatchingExpr(typeExpr, argExpr, tp);
+      if (!match) continue;
+
+      resolveTypeExpr(match);
+      const type = getExprType(match);
+      if (!type) continue;
+
+      inferredType = new TypeAlias({ name: tp.clone(), typeExpr: nop() });
+      inferredType.type = type;
+      break;
     }
 
     if (!inferredType) return undefined;


### PR DESCRIPTION
## Summary
- add recursive matching to infer type arguments from nested structures
- infer type args for arrays, tuples, and object fields
- test nested generic inference like Array<(String, T)>

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae6f57779c832a8eae210d45491ef7