### PR TITLE
Avoid re-evaluating expanded object arguments

### DIFF
--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -122,7 +122,7 @@ const handleObjectConstruction = (call: Call, type: ObjectType): void => {
         type,
         call.metadata
       );
-      if (expanded) call.args.set(0, resolveObjectLiteral(expanded, type));
+      if (expanded) call.args.set(0, resolveEntities(expanded));
     }
   }
 };

--- a/src/semantics/resolution/resolve-entities.ts
+++ b/src/semantics/resolution/resolve-entities.ts
@@ -180,7 +180,7 @@ const resolveWithExpected = (expr: Expr, expected?: Type): Expr => {
           resolved.metadata
         );
         if (expanded) {
-          resolved.args.set(0, resolveObjectLiteral(expanded, objType));
+          resolved.args.set(0, resolveEntities(expanded));
         }
       }
       return resolved;


### PR DESCRIPTION
## Summary
- Ensure object argument expansions capture the source expression once
- Expand constructor args using the cached value to avoid repeated evaluation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b10745fea8832aa1265af1672ca3a0