### PR TITLE
feat: expand union type arg inference

### DIFF
--- a/src/__tests__/fixtures/generics-union-infer-negative.ts
+++ b/src/__tests__/fixtures/generics-union-infer-negative.ts
@@ -1,0 +1,13 @@
+export const genericsUnionInferNegativeVoyd = `
+use std::all
+
+fn use_union<T>(val: Array<T> | String) -> i32
+  7
+
+pub fn bad() -> i32
+  // This produces a union with an extra variant (i32) that is not accepted
+  // by the parameter type (Array<T> | String)
+  let v = if true then: (if true then: [1, 2, 3] else: 42) else: "x"
+  use_union(v)
+`;
+

--- a/src/__tests__/fixtures/generics-union-infer.ts
+++ b/src/__tests__/fixtures/generics-union-infer.ts
@@ -5,7 +5,18 @@ use std::all
 fn use_union<T>(val: Array<T> | String) -> i32
   7
 
+// Alias-based union type
+type Html<T> = Array<T> | String
+
+fn use_alias<T>(val: Html<T>) -> i32
+  9
+
 // Ensure pairwise union-variant unification infers T from the union argument
 pub fn test1() -> i32
-  use_union(if true then: [1, 2, 3] else: "x")
+  // Argument variants are out-of-order relative to parameter union
+  use_union(if true then: "x" else: [1, 2, 3])
+
+// Also infer through a union type alias
+pub fn test2() -> i32
+  use_alias(if true then: "x" else: [1, 2, 3])
 `;

--- a/src/__tests__/fixtures/generics-union-infer.ts
+++ b/src/__tests__/fixtures/generics-union-infer.ts
@@ -1,0 +1,11 @@
+export const genericsUnionInferVoyd = `
+use std::all
+
+// Generic function with a union-typed parameter
+fn use_union<T>(val: Array<T> | String) -> i32
+  7
+
+// Ensure pairwise union-variant unification infers T from the union argument
+pub fn test1() -> i32
+  use_union(if true then: [1, 2, 3] else: "x")
+`;

--- a/src/__tests__/generics-union-infer-negative.e2e.test.ts
+++ b/src/__tests__/generics-union-infer-negative.e2e.test.ts
@@ -1,0 +1,10 @@
+import { genericsUnionInferNegativeVoyd } from "./fixtures/generics-union-infer-negative.js";
+import { compile } from "../compiler.js";
+import { describe, test } from "vitest";
+
+describe("E2E union generic inference (negative)", () => {
+  test("rejects arg union that is a strict superset of parameter union", async (t) => {
+    await t.expect(compile(genericsUnionInferNegativeVoyd)).rejects.toThrow();
+  });
+});
+

--- a/src/__tests__/generics-union-infer.e2e.test.ts
+++ b/src/__tests__/generics-union-infer.e2e.test.ts
@@ -12,10 +12,12 @@ describe("E2E union generic inference", () => {
     instance = getWasmInstance(mod);
   });
 
-  test("infers T from (Array<T> | String) given (Array<i32> | String)", (t) => {
-    const fn = getWasmFn("test1", instance);
-    assert(fn, "test1 exists");
-    t.expect(fn()).toEqual(7);
-  });
+  const expecteds = [7, 9];
+  for (let i = 0; i < expecteds.length; i++) {
+    test(`test${i + 1} returns expected`, (t) => {
+      const fn = getWasmFn(`test${i + 1}`, instance);
+      assert(fn, `test${i + 1} exists`);
+      t.expect(fn()).toEqual(expecteds[i]);
+    });
+  }
 });
-

--- a/src/__tests__/generics-union-infer.e2e.test.ts
+++ b/src/__tests__/generics-union-infer.e2e.test.ts
@@ -1,0 +1,21 @@
+import { genericsUnionInferVoyd } from "./fixtures/generics-union-infer.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E union generic inference", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(genericsUnionInferVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("infers T from (Array<T> | String) given (Array<i32> | String)", (t) => {
+    const fn = getWasmFn("test1", instance);
+    assert(fn, "test1 exists");
+    t.expect(fn()).toEqual(7);
+  });
+});
+

--- a/src/semantics/resolution/__tests__/infer-type-args-union.test.ts
+++ b/src/semantics/resolution/__tests__/infer-type-args-union.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from "vitest";
+import { inferTypeArgs } from "../infer-type-args.js";
+import { Identifier, Call, List } from "../../../syntax-objects/index.js";
+import { ObjectType, TypeAlias, UnionType, f32 } from "../../../syntax-objects/types.js";
+import { resolveUnionType } from "../resolve-union.js";
+
+const typeCall = (name: string, typeArgs: any[] = []) =>
+  new Call({
+    fnName: Identifier.from(name),
+    args: new List({ value: [] }),
+    typeArgs: new List({ value: typeArgs }),
+  });
+
+describe("inferTypeArgs union", () => {
+  test("infers T from (Array<T> | String) given (Array<f32> | String)", () => {
+    const arrayGeneric = new ObjectType({
+      name: Identifier.from("Array"),
+      value: [],
+      typeParameters: [Identifier.from("T")],
+    });
+    const stringType = new ObjectType({ name: Identifier.from("String"), value: [] });
+
+    const arrayF32 = arrayGeneric.clone();
+    const applied = new TypeAlias({ name: Identifier.from("T"), typeExpr: Identifier.from("T") });
+    applied.type = f32;
+    arrayF32.genericParent = arrayGeneric;
+    arrayF32.appliedTypeArgs = [applied];
+
+    const paramUnion = new UnionType({
+      name: Identifier.from("Union"),
+      childTypeExprs: [typeCall("Array", [Identifier.from("T")]), stringType],
+    });
+    const argUnion = new UnionType({
+      name: Identifier.from("Union"),
+      childTypeExprs: [arrayF32, stringType],
+    });
+    resolveUnionType(argUnion);
+
+    const typeParams = [Identifier.from("T")];
+    const pairs = [{ typeExpr: paramUnion, argExpr: argUnion }];
+    const inferred = inferTypeArgs(typeParams, pairs);
+    expect(inferred).toBeDefined();
+    const alias = inferred!.exprAt(0) as TypeAlias;
+    expect(alias.name.value).toBe("T");
+    expect(alias.type?.id).toBe(f32.id);
+  });
+});


### PR DESCRIPTION
## Summary
- support pairwise union-variant unification during type argument inference
- add test covering inference from `(Array<T> | String)`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b10d48abd0832aa60a74a6c5d0e72e