### PR TITLE
feat: cache std library compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test.voyd
 /playground
 /sb
 /*.sb.*
+std.wasm

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -6,13 +6,16 @@ import {
   parseModuleFromSrc,
   parseModule,
 } from "./parser/index.js";
+import { getStdLib } from "./lib/std-cache.js";
 
 export const compile = async (text: string) => {
+  await getStdLib();
   const parsedModule = await parseModule(text);
   return compileParsedModule(parsedModule);
 };
 
 export const compileSrc = async (path: string) => {
+  await getStdLib();
   const parsedModule = await parseModuleFromSrc(path);
   return compileParsedModule(parsedModule);
 };

--- a/src/lib/std-cache.ts
+++ b/src/lib/std-cache.ts
@@ -1,0 +1,42 @@
+import binaryen from "binaryen";
+import { parseStd, stdPath } from "../parser/index.js";
+import { ParsedModule } from "../parser/utils/parse-module.js";
+import { processSemantics } from "../semantics/index.js";
+import { codegen } from "../codegen.js";
+import { RootModule } from "../syntax-objects/module.js";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+let cached: { root: RootModule; binary: Uint8Array } | undefined;
+const cacheFile = path.resolve(stdPath, "..", "std.wasm");
+
+export const getStdLib = async () => {
+  if (!cached) {
+    try {
+      const binary = await fs.readFile(cacheFile);
+      const files = await parseStd();
+      const parsed: ParsedModule = {
+        files,
+        indexPath: path.join(stdPath, "index.voyd"),
+      };
+      const root = processSemantics(parsed) as RootModule;
+      cached = { root, binary: new Uint8Array(binary) };
+    } catch {
+      const files = await parseStd();
+      const parsed: ParsedModule = {
+        files,
+        indexPath: path.join(stdPath, "index.voyd"),
+      };
+      const root = processSemantics(parsed) as RootModule;
+      const mod = codegen(root);
+      const binary = mod.emitBinary() as Uint8Array;
+      cached = { root, binary };
+      try {
+        await fs.writeFile(cacheFile, Buffer.from(binary));
+      } catch {}
+    }
+  }
+
+  const mod = binaryen.readBinary(cached.binary);
+  return { root: cached.root.clone() as RootModule, mod };
+};

--- a/src/parser/utils/parse-module.ts
+++ b/src/parser/utils/parse-module.ts
@@ -13,11 +13,14 @@ export type ParsedModule = {
 };
 
 /** Parses voyd text and std lib into a module unit */
-export const parseModule = async (text: string): Promise<ParsedModule> => {
+export const parseModule = async (
+  text: string,
+  opts: { includeStd?: boolean } = {}
+): Promise<ParsedModule> => {
   return {
     files: {
       index: parse(text),
-      ...(await parseStd()),
+      ...(opts.includeStd === false ? {} : await parseStd()),
     },
     indexPath: "index",
   };
@@ -25,7 +28,8 @@ export const parseModule = async (text: string): Promise<ParsedModule> => {
 
 /** Parses a voyd codebase source and std into a module unit */
 export const parseModuleFromSrc = async (
-  path: string
+  path: string,
+  opts: { includeStd?: boolean } = {}
 ): Promise<ParsedModule> => {
   const src = await resolveSrc(path);
 
@@ -36,7 +40,7 @@ export const parseModuleFromSrc = async (
   return {
     files: {
       ...srcFiles,
-      ...(await parseStd()),
+      ...(opts.includeStd === false ? {} : await parseStd()),
     },
     srcPath: src.srcRootPath,
     indexPath: src.indexPath,

--- a/src/semantics/index.ts
+++ b/src/semantics/index.ts
@@ -7,6 +7,7 @@ import { expandRegularMacros } from "./regular-macros.js";
 import { ParsedModule } from "../parser/index.js";
 import { Expr } from "../syntax-objects/expr.js";
 import { resolveEntities } from "./resolution/resolve-entities.js";
+import { VoydModule } from "../syntax-objects/module.js";
 
 const semanticPhases: SemanticProcessor[] = [
   expandRegularMacros, // Also handles use and module declaration initialization
@@ -16,7 +17,10 @@ const semanticPhases: SemanticProcessor[] = [
   checkTypes,
 ];
 
-export const processSemantics = (parsedModule: ParsedModule): Expr => {
-  const expr = registerModules(parsedModule);
+export const processSemantics = (
+  parsedModule: ParsedModule,
+  rootModule?: VoydModule
+): Expr => {
+  const expr = registerModules(parsedModule, rootModule);
   return semanticPhases.reduce((e, checker) => checker(e), expr as Expr);
 };

--- a/src/semantics/modules.ts
+++ b/src/semantics/modules.ts
@@ -3,10 +3,11 @@ import { List } from "../syntax-objects/list.js";
 import { RootModule, VoydModule } from "../syntax-objects/module.js";
 
 /** Registers submodules of a parsed module for future import resolution */
-export const registerModules = (opts: ParsedModule): VoydModule => {
+export const registerModules = (
+  opts: ParsedModule,
+  rootModule: VoydModule = new RootModule({})
+): VoydModule => {
   const { srcPath, files } = opts;
-
-  const rootModule = new RootModule({});
 
   for (const [filePath, file] of Object.entries(files)) {
     const resolvedPath = filePathToModulePath(


### PR DESCRIPTION
## Summary
- add `getStdLib` helper to cache compiled std library and persist to `std.wasm`
- allow parser to skip std files and semantics to accept existing roots
- load std cache before compiling to warm cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b15a211ea8832aa880e9b3f55395af