### PR TITLE
Refactor resolution helpers to reduce duplication

### DIFF
--- a/src/semantics/resolution/resolve-object-type.ts
+++ b/src/semantics/resolution/resolve-object-type.ts
@@ -39,42 +39,42 @@ export const resolveObjectType = (obj: ObjectType, call?: Call): ObjectType => {
 // Detects whether a type-argument expression contains an unresolved type
 // identifier (e.g., an unbound generic name like `T`).
 const containsUnresolvedTypeId = (expr: any): boolean => {
-  const visitExpr = (e: any): boolean => {
-    if (!e) return false;
-    if (e.isIdentifier && e.isIdentifier()) {
+  const stack = [expr];
+  while (stack.length) {
+    const e = stack.pop();
+    if (!e) continue;
+    if (e.isIdentifier?.()) {
       const entity = e.resolve?.();
       const ty = getExprType(e);
-      return !entity && !ty;
+      if (!entity && !ty) return true;
+      continue;
     }
-    if (e.isCall && e.isCall()) {
-      if (e.typeArgs) return e.typeArgs.toArray().some(visitExpr);
-      return false;
+    if (e.isCall?.()) {
+      if (e.typeArgs) stack.push(...e.typeArgs.toArray());
+      continue;
     }
-    if (e.isType && e.isType()) {
-      if (e.isObjectType && e.isObjectType()) {
-        return e.fields.some((f: any) => visitExpr(f.typeExpr));
+    if (e.isType?.()) {
+      if (e.isObjectType?.()) {
+        stack.push(...e.fields.map((f: any) => f.typeExpr));
+        continue;
       }
-      if (e.isIntersectionType && e.isIntersectionType()) {
-        return (
-          visitExpr(e.nominalTypeExpr?.value) ||
-          visitExpr(e.structuralTypeExpr?.value)
-        );
+      if (e.isIntersectionType?.()) {
+        stack.push(e.nominalTypeExpr?.value, e.structuralTypeExpr?.value);
+        continue;
       }
-      if (e.isFixedArrayType && e.isFixedArrayType()) {
-        return visitExpr(e.elemTypeExpr);
+      if (e.isFixedArrayType?.()) {
+        stack.push(e.elemTypeExpr);
+        continue;
       }
-      if (e.isFnType && e.isFnType()) {
-        return (
-          e.parameters.some((p: any) => visitExpr(p.typeExpr)) ||
-          (!!e.returnTypeExpr && visitExpr(e.returnTypeExpr))
-        );
+      if (e.isFnType?.()) {
+        stack.push(...e.parameters.map((p: any) => p.typeExpr));
+        if (e.returnTypeExpr) stack.push(e.returnTypeExpr);
+        continue;
       }
-      return false;
     }
-    if (e.isList && e.isList()) return e.toArray().some(visitExpr);
-    return false;
-  };
-  return visitExpr(expr);
+    if (e.isList?.()) stack.push(...e.toArray());
+  }
+  return false;
 };
 
 const resolveGenericObjVersion = (


### PR DESCRIPTION
## Summary
- streamline type-call resolution with shared `finish` helper
- simplify unresolved generic type detection using a stack-based walk

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3874c9214832ab9599b0c2a21c660