### PR TITLE
Allow structural supertype inference for objects

### DIFF
--- a/src/__tests__/fixtures/structural-inference.ts
+++ b/src/__tests__/fixtures/structural-inference.ts
@@ -1,0 +1,10 @@
+export const structuralInferenceVoyd = `
+use std::all
+
+fn get_x<T>(o: { x: T }) -> T
+  o.x
+
+pub fn test1() -> i32
+  let obj = { x: 1, y: 2 }
+  get_x(obj)
+`;

--- a/src/__tests__/structural-inference.e2e.test.ts
+++ b/src/__tests__/structural-inference.e2e.test.ts
@@ -1,0 +1,20 @@
+import { structuralInferenceVoyd } from "./fixtures/structural-inference.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("E2E structural inference", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(structuralInferenceVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("infers generic field type with extra object fields", (t) => {
+    const fn = getWasmFn("test1", instance);
+    assert(fn, "test1 exists");
+    t.expect(fn()).toEqual(1);
+  });
+});

--- a/src/semantics/resolution/infer-type-args.ts
+++ b/src/semantics/resolution/infer-type-args.ts
@@ -115,17 +115,16 @@ export const unifyTypeParams = (
       return true;
     }
 
-    // Tuple/structural object types: unify field-by-field against the
-    // structural side of the argument when available.
+    // Tuple/structural object types: unify the parameter fields against
+    // the structural portion of the argument. Extra fields on the
+    // argument side are permitted, enabling structural subtyping
+    // (i.e. the argument may be a superset of the parameter).
     if (p.isObjectType()) {
       const paramObj = p;
       const target = arg.isIntersectionType()
         ? arg.structuralType ?? arg.nominalType // prefer structural, but fall back to nominal if provided
         : arg;
       if (!target || !target.isObjectType()) return false;
-
-      // For now require exact field correspondence (tuple-like behavior).
-      if (paramObj.fields.length !== target.fields.length) return false;
 
       for (const field of paramObj.fields) {
         const match = target.getField(field.name);


### PR DESCRIPTION
## Summary
- allow structural object arguments with extra fields when inferring generic type parameters
- add E2E test covering structural inference on object with additional fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3cca74adc832aad9e84335e4988de