### PR TITLE
Refactor match guards and closure call casting

### DIFF
--- a/src/codegen/compile-match.ts
+++ b/src/codegen/compile-match.ts
@@ -8,13 +8,15 @@ import {
 import { Match, MatchCase } from "../syntax-objects/match.js";
 import { compile as compileVariable } from "./compile-variable.js";
 import { compile as compileIdentifier } from "./compile-identifier.js";
-import { structGetFieldValue } from "../lib/binaryen-gc/index.js";
+import { refTest } from "../lib/binaryen-gc/index.js";
 
 export const compile = (opts: CompileExprOpts<Match>) => {
   const { expr, mod } = opts;
   const returnType = expr.type ? mapBinaryenType(opts, expr.type) : binaryen.none;
   const wrap = (e: number) =>
     returnType === binaryen.none ? asStmt(mod, e) : e;
+
+  const operandRef = compileIdentifier({ ...opts, expr: expr.bindIdentifier });
 
   const constructIfChain = (cases: MatchCase[]): number => {
     const nextCase = cases.shift();
@@ -24,23 +26,13 @@ export const compile = (opts: CompileExprOpts<Match>) => {
       return wrap(compileExpression({ ...opts, expr: nextCase.expr }));
     }
 
-    return mod.if(
-      opts.mod.call(
-        "__extends",
-        [
-          opts.mod.i32.const(nextCase.matchType!.syntaxId),
-          structGetFieldValue({
-            mod: opts.mod,
-            fieldType: opts.extensionHelpers.i32Array,
-            fieldIndex: 0,
-            exprRef: compileIdentifier({ ...opts, expr: expr.bindIdentifier }),
-          }),
-        ],
-        binaryen.i32
-      ),
-      wrap(compileExpression({ ...opts, expr: nextCase.expr })),
-      returnType === binaryen.none ? asStmt(mod, constructIfChain(cases)) : constructIfChain(cases)
-    );
+    const caseHeapType = mapBinaryenType(opts, nextCase.matchType!);
+    const thenBranch = wrap(compileExpression({ ...opts, expr: nextCase.expr }));
+    const elseBranch =
+      returnType === binaryen.none
+        ? asStmt(mod, constructIfChain(cases))
+        : constructIfChain(cases);
+    return mod.if(refTest(mod, operandRef, caseHeapType), thenBranch, elseBranch);
   };
 
   const ifChain = constructIfChain(


### PR DESCRIPTION
## Summary
- replace nominal `__extends` check with `ref.test` for match guards
- cast closure calls to concrete function types with resolved return types
- add helper to unwrap type aliases when forming closure call signatures

## Testing
- `npx tsx src/cli/cli-dev.ts --run -m test.voyd` *(fails: RuntimeError: illegal cast)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6180f15a4832a8177c7346c392778