### PR TITLE
Fix closure inference without overwriting body types

### DIFF
--- a/src/__tests__/type-checker.e2e.test.ts
+++ b/src/__tests__/type-checker.e2e.test.ts
@@ -15,3 +15,16 @@ pub fn main()
       /Available overloads: takes\(arr: Array<String>\) -> void/s
     );
 });
+
+test("rejects closure with incompatible return type", async (t) => {
+  const source = `use std::all
+
+fn takes(cb: () -> i32) -> void 0
+
+pub fn main()
+  takes(() => "str")
+`;
+  await t
+    .expect(compile(source))
+    .rejects.toThrow(/No overload matches/);
+});

--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -278,7 +278,6 @@ const resolveClosureArgs = (call: Call) => {
       const ret = expected.returnType.isTypeAlias()
         ? expected.returnType.type ?? expected.returnType
         : expected.returnType;
-      resolved.inferredReturnType = ret;
       resolved.returnType = ret;
     }
     if (isLabeled) {


### PR DESCRIPTION
## Summary
- avoid overriding a closure's inferred return type when resolving call arguments
- add e2e test ensuring incompatible closure return types are rejected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b62d765f84832aa97ca9afd89a725a