### PR TITLE
fix: detect web worker environments for std loader

### DIFF
--- a/src/parser/utils/parse-std.test.ts
+++ b/src/parser/utils/parse-std.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Tests environment detection logic for parse-std
+
+describe("parse-std environment detection", () => {
+  it("uses browser path when process lacks node version", async () => {
+    const original = (globalThis as any).process;
+    (globalThis as any).process = { ...original, versions: {} };
+    vi.resetModules();
+    const mod = await import("./parse-std.js");
+    expect(mod.stdPath).toBe("std");
+    const parsed = await mod.parseStd();
+    expect(Object.keys(parsed).length).toBeGreaterThan(0);
+    (globalThis as any).process = original;
+  });
+
+  it("uses node path when process is defined", async () => {
+    vi.resetModules();
+    const mod = await import("./parse-std.js");
+    expect(mod.stdPath).not.toBe("std");
+  });
+});

--- a/src/parser/utils/parse-std.ts
+++ b/src/parser/utils/parse-std.ts
@@ -2,7 +2,8 @@ import type { ParsedFiles } from "./parse-directory.js";
 import { parse } from "../parser.js";
 
 // Runtime env detection without relying on DOM types
-const isBrowser = () => typeof (globalThis as any).window !== "undefined";
+const isBrowser = () =>
+  typeof (globalThis as any).process?.versions?.node === "undefined";
 
 // Compute stdPath per environment:
 // - Node: absolute filesystem path to std directory


### PR DESCRIPTION
## Summary
- detect browser by absence of Node's `process.versions.node`
- add tests covering worker-like environment for `parseStd`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7e85beed8832aa279a2231ca1bdc1