### PR TITLE
Fix deeply nested call resolution

### DIFF
--- a/src/__tests__/inference.e2e.test.ts
+++ b/src/__tests__/inference.e2e.test.ts
@@ -114,10 +114,21 @@ pub fn test10() -> i32
 
 // ---- msg-pack map with preceding HTML element ----
 pub fn component11() -> Map<MsgPack>
-  let a = ["Alex", "Abby"]
   <div>
-    <div><p>hi</p></div>
-    {a.map(item => <span style="boop">{item}</span>)}
+    <div>
+      <div></div>
+      <h2>Voyd + VSX</h2>
+    </div>
+
+    <p>
+      Build reactive UIs with clean, minimal syntax.
+    </p>
+
+    <div>
+      {["No virtual DOM", "WASM speed", "Composable", "Tiny footprint"].map(tag =>
+        <span>{tag}</span>
+      )}
+    </div>
   </div>
 
 pub fn test11() -> i32
@@ -187,14 +198,58 @@ describe("E2E Inference (kitchen sink)", () => {
     const index = fn();
     const decoded = decode(memory.buffer.slice(0, index));
     t.expect(decoded).toEqual({
-      name: "div",
       attributes: {},
+      name: "div",
       children: [
-        { name: "div", attributes: {}, children: [{ name: "p", attributes: {}, children: ["hi"] }] },
-        [
-          { name: "span", attributes: { style: "boop" }, children: ["Alex"] },
-          { name: "span", attributes: { style: "boop" }, children: ["Abby"] },
-        ],
+        {
+          attributes: {},
+          name: "div",
+          children: [
+            {
+              attributes: {},
+              name: "div",
+              children: [],
+            },
+            {
+              attributes: {},
+              name: "h2",
+              children: ["Voyd + VSX"],
+            },
+          ],
+        },
+        {
+          attributes: {},
+          name: "p",
+          children: ["Build reactive UIs with clean, minimal syntax. "],
+        },
+        {
+          attributes: {},
+          name: "div",
+          children: [
+            [
+              {
+                attributes: {},
+                name: "span",
+                children: ["No virtual DOM"],
+              },
+              {
+                attributes: {},
+                name: "span",
+                children: ["WASM speed"],
+              },
+              {
+                attributes: {},
+                name: "span",
+                children: ["Composable"],
+              },
+              {
+                attributes: {},
+                name: "span",
+                children: ["Tiny footprint"],
+              },
+            ],
+          ],
+        },
       ],
     });
   });

--- a/src/__tests__/inference.e2e.test.ts
+++ b/src/__tests__/inference.e2e.test.ts
@@ -111,6 +111,17 @@ pub fn component10() -> Map<MsgPack>
 
 pub fn test10() -> i32
   msg_pack::encode(component10())
+
+// ---- msg-pack map with preceding HTML element ----
+pub fn component11() -> Map<MsgPack>
+  let a = ["Alex", "Abby"]
+  <div>
+    <div><p>hi</p></div>
+    {a.map(item => <span style="boop">{item}</span>)}
+  </div>
+
+pub fn test11() -> i32
+  msg_pack::encode(component11())
 `;
 
 describe("E2E Inference (kitchen sink)", () => {
@@ -165,6 +176,24 @@ describe("E2E Inference (kitchen sink)", () => {
         [
           { name: "p", attributes: {}, children: ["hi ", "Alex"] },
           { name: "p", attributes: {}, children: ["hi ", "Abby"] },
+        ],
+      ],
+    });
+  });
+
+  test("msg-pack array.map works when preceded by an HTML element", (t) => {
+    const fn = getWasmFn("test11", instance);
+    assert(fn, "test11 exists");
+    const index = fn();
+    const decoded = decode(memory.buffer.slice(0, index));
+    t.expect(decoded).toEqual({
+      name: "div",
+      attributes: {},
+      children: [
+        { name: "div", attributes: {}, children: [{ name: "p", attributes: {}, children: ["hi"] }] },
+        [
+          { name: "span", attributes: { style: "boop" }, children: ["Alex"] },
+          { name: "span", attributes: { style: "boop" }, children: ["Abby"] },
         ],
       ],
     });

--- a/src/semantics/resolution/__tests__/get-call-fn.test.ts
+++ b/src/semantics/resolution/__tests__/get-call-fn.test.ts
@@ -11,6 +11,8 @@ import {
   ObjectType,
   Parameter,
 } from "../../../syntax-objects/index.js";
+import { UnionType } from "../../../syntax-objects/types.js";
+import { resolveUnionType } from "../resolve-union.js";
 import { TraitType } from "../../../syntax-objects/types/trait.js";
 import { Implementation } from "../../../syntax-objects/implementation.js";
 import { getCallFn } from "../get-call-fn.js";
@@ -232,6 +234,79 @@ describe("getCallFn", () => {
     expect(() => getCallFn(call)).toThrow(
       /Ambiguous call hi\(i32\).*hi\(arg1: i32\) -> i32.*hi\(arg2: i32\) -> i32/
     );
+  });
+
+  test("selects candidate whose return type union covers others", () => {
+    const label = new Identifier({ value: "arg1" });
+    const fnName = new Identifier({ value: "hi" });
+
+    const objA = new ObjectType({ name: new Identifier({ value: "A" }), value: [] });
+    const objB = new ObjectType({ name: new Identifier({ value: "B" }), value: [] });
+
+    const candidate1 = new Fn({
+      name: fnName,
+      parameters: [new Parameter({ name: label, type: i32 })],
+    });
+    candidate1.returnType = objA;
+    candidate1.annotatedReturnType = objA;
+
+    const union = new UnionType({
+      name: new Identifier({ value: "U" }),
+      childTypeExprs: [objA, objB],
+    });
+    resolveUnionType(union);
+
+    const candidate2 = new Fn({
+      name: fnName,
+      parameters: [new Parameter({ name: label, type: i32 })],
+    });
+    candidate2.returnType = union;
+    candidate2.annotatedReturnType = union;
+
+    const call = new Call({
+      fnName,
+      args: new List({ value: [new Int({ value: 2 })] }),
+    });
+    call.resolveFns = vi.fn().mockReturnValue([candidate1, candidate2]);
+
+    expect(getCallFn(call)).toBe(candidate2);
+  });
+
+  test("selects candidate whose parameter type union covers others", () => {
+    const label = new Identifier({ value: "arg1" });
+    const fnName = new Identifier({ value: "hi" });
+
+    const objA = new ObjectType({ name: new Identifier({ value: "A" }), value: [] });
+    const objB = new ObjectType({ name: new Identifier({ value: "B" }), value: [] });
+
+    const union = new UnionType({
+      name: new Identifier({ value: "U" }),
+      childTypeExprs: [objA, objB],
+    });
+    resolveUnionType(union);
+
+    const candidate1 = new Fn({
+      name: fnName,
+      parameters: [new Parameter({ name: label, type: objA })],
+    });
+    candidate1.returnType = i32;
+    candidate1.annotatedReturnType = i32;
+
+    const candidate2 = new Fn({
+      name: fnName,
+      parameters: [new Parameter({ name: label, type: union })],
+    });
+    candidate2.returnType = i32;
+    candidate2.annotatedReturnType = i32;
+
+    const arg = new MockIdentifier({ value: "a", entity: objA });
+    const call = new Call({
+      fnName,
+      args: new List({ value: [arg] }),
+    });
+    call.resolveFns = vi.fn().mockReturnValue([candidate1, candidate2]);
+
+    expect(getCallFn(call)).toBe(candidate2);
   });
 
   test("returns trait method for trait object calls", () => {

--- a/src/semantics/resolution/__tests__/get-call-fn.test.ts
+++ b/src/semantics/resolution/__tests__/get-call-fn.test.ts
@@ -174,6 +174,35 @@ describe("getCallFn", () => {
     );
   });
 
+  test("throws error when overloads only differ by return type", () => {
+    const label = new Identifier({ value: "arg1" });
+    const fnName = new Identifier({ value: "hi" });
+
+    const candidate1 = new Fn({
+      name: fnName,
+      parameters: [new Parameter({ name: label, type: i32 })],
+    });
+    candidate1.returnType = i32;
+    candidate1.annotatedReturnType = i32;
+
+    const candidate2 = new Fn({
+      name: fnName,
+      parameters: [new Parameter({ name: label, type: i32 })],
+    });
+    candidate2.returnType = f32;
+    candidate2.annotatedReturnType = f32;
+
+    const call = new Call({
+      fnName,
+      args: new List({ value: [new Int({ value: 2 })] }),
+    });
+    call.resolveFns = vi.fn().mockReturnValue([candidate1, candidate2]);
+
+    expect(() => getCallFn(call)).toThrow(
+      /Ambiguous call hi\(i32\).*hi\(arg1: i32\) -> i32.*hi\(arg1: i32\) -> f32/
+    );
+  });
+
   test("returns trait method for trait object calls", () => {
     const objType = new ObjectType({ name: "Obj", value: [] });
     const traitMethod = new Fn({

--- a/src/semantics/resolution/__tests__/get-call-fn.test.ts
+++ b/src/semantics/resolution/__tests__/get-call-fn.test.ts
@@ -203,6 +203,37 @@ describe("getCallFn", () => {
     );
   });
 
+  test("keeps ambiguity when ranked return types tie", () => {
+    const label1 = new Identifier({ value: "arg1" });
+    const label2 = new Identifier({ value: "arg2" });
+    const fnName = new Identifier({ value: "hi" });
+
+    const candidate1 = new Fn({
+      name: fnName,
+      parameters: [new Parameter({ name: label1, type: i32 })],
+    });
+    candidate1.returnType = i32;
+    candidate1.annotatedReturnType = i32;
+
+    const candidate2 = new Fn({
+      name: fnName,
+      parameters: [new Parameter({ name: label2, type: i32 })],
+    });
+    candidate2.returnType = i32;
+    candidate2.annotatedReturnType = i32;
+
+    const call = new Call({
+      fnName,
+      args: new List({ value: [new Int({ value: 2 })] }),
+    });
+    call.resolveFns = vi.fn().mockReturnValue([candidate1, candidate2]);
+    call.getAttribute = vi.fn().mockReturnValue(i32);
+
+    expect(() => getCallFn(call)).toThrow(
+      /Ambiguous call hi\(i32\).*hi\(arg1: i32\) -> i32.*hi\(arg2: i32\) -> i32/
+    );
+  });
+
   test("returns trait method for trait object calls", () => {
     const objType = new ObjectType({ name: "Obj", value: [] });
     const traitMethod = new Fn({

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -1,4 +1,4 @@
-import { Call, Expr, Fn, Parameter } from "../../syntax-objects/index.js";
+import { Call, Expr, Fn, Parameter, Type } from "../../syntax-objects/index.js";
 import { getExprType } from "./get-expr-type.js";
 import { formatFnSignature } from "../fn-signature.js";
 import { formatTypeName } from "../type-format.js";
@@ -46,24 +46,29 @@ export const getCallFn = (call: Call, candidateFns?: Fn[]): Fn | undefined => {
     }
   }
 
+  const unwrapAlias = (t: Type): Type =>
+    t.isTypeAlias?.() ? t.type ?? t : t;
+
   // Tie-break using contextual expected return type if available. Prefer the
   // candidate whose return type exactly matches the expected branch (by
   // nominal head) when the expected type is a union alias like MsgPack.
   const expected =
-    call.getAttribute && (call.getAttribute("expectedType") as any);
+    call.getAttribute &&
+    (call.getAttribute("expectedType") as Type | undefined);
   if (expected) {
-    const headKeyFromType = (t: any): string | undefined => {
-      if (!t) return undefined;
-      if (t.isObjectType && t.isObjectType()) {
-        return t.genericParent ? t.genericParent.name.value : t.name.value;
+    const headKeyFromType = (t: Type | undefined): string | undefined => {
+      const u = t ? unwrapAlias(t) : undefined;
+      if (!u) return undefined;
+      if (u.isObjectType && u.isObjectType()) {
+        return u.genericParent ? u.genericParent.name.value : u.name.value;
       }
-      if (t.isPrimitiveType && t.isPrimitiveType()) return t.name.value;
-      if (t.isTraitType && t.isTraitType()) return t.name.value;
-      if (t.isFixedArrayType && t.isFixedArrayType()) return "FixedArray";
-      if (t.isIntersectionType && t.isIntersectionType())
-        return headKeyFromType(t.nominalType ?? t.structuralType);
-      if (t.isTypeAlias && t.isTypeAlias()) return headKeyFromType(t.type);
-      return t.name?.value;
+      if (u.isPrimitiveType && u.isPrimitiveType()) return u.name.value;
+      if (u.isTraitType && u.isTraitType()) return u.name.value;
+      if (u.isFixedArrayType && u.isFixedArrayType()) return "FixedArray";
+      if (u.isIntersectionType && u.isIntersectionType())
+        return headKeyFromType(u.nominalType ?? u.structuralType);
+      if (u.isTypeAlias && u.isTypeAlias()) return headKeyFromType(u.type);
+      return u.name?.value;
     };
     const expectedBranch = (() => {
       if (expected.isUnionType && expected.isUnionType()) {
@@ -75,7 +80,7 @@ export const getCallFn = (call: Call, candidateFns?: Fn[]): Fn | undefined => {
         );
         const single = heads.size === 1 ? [...heads][0] : undefined;
         return single
-          ? expected.types.find((t: any) => headKeyFromType(t) === single)
+          ? expected.types.find((t) => headKeyFromType(t) === single)
           : undefined;
       }
       return expected;
@@ -87,9 +92,9 @@ export const getCallFn = (call: Call, candidateFns?: Fn[]): Fn | undefined => {
       if (exact.length === 1) return exact[0];
 
       // Rank candidates by closeness to expected branch.
-      const rank = (ret: any): number => {
+      const rank = (ret: Type | undefined): number => {
         if (typesAreEqual(ret, expectedBranch)) return 3;
-        if (typesAreCompatible(ret, expectedBranch)) {
+        if (ret && typesAreCompatible(ret, expectedBranch)) {
           // When both are Array<...> or the same nominal head, prefer the one
           // whose applied type arguments exactly match the expected branch's
           // applied type arguments.
@@ -102,14 +107,9 @@ export const getCallFn = (call: Call, candidateFns?: Fn[]): Fn | undefined => {
             ret.isObjectType?.() &&
             expectedBranch.isObjectType?.()
           ) {
-            const ra = (ret.appliedTypeArgs ?? []).map((a: any) => a.type ?? a);
-            const ea = (expectedBranch.appliedTypeArgs ?? []).map(
-              (a: any) => a.type ?? a
-            );
-            if (
-              ra.length === ea.length &&
-              ra.every((t: any, i: number) => typesAreEqual(t, ea[i]))
-            )
+            const ra = (ret.appliedTypeArgs ?? []).map(unwrapAlias);
+            const ea = (expectedBranch.appliedTypeArgs ?? []).map(unwrapAlias);
+            if (ra.length === ea.length && ra.every((t, i) => typesAreEqual(t, ea[i])))
               return 2;
           }
           return 1;
@@ -144,23 +144,33 @@ export const getCallFn = (call: Call, candidateFns?: Fn[]): Fn | undefined => {
   });
   if (concreteReturn.length === 1) return concreteReturn[0];
 
-  // Final fallback: prefer the candidate with the most specific formatted
-  // return type, which biases toward concretely-applied generics like
-  // Array<MsgPack> over Array<T> when other tie-breakers remain inconclusive.
-  const bySpecificity = [...candidates].sort(
-    (a, b) =>
-      formatTypeName(a.returnType).length - formatTypeName(b.returnType).length
+  // Prefer a candidate whose return type union covers all other return types.
+  const toBranches = (t: Type): Type[] => {
+    const u = unwrapAlias(t);
+    return u.isUnionType?.() ? u.types : [u];
+  };
+  const covers = (a?: Type, b?: Type): boolean => {
+    if (!a || !b) return false;
+    const aBranches = toBranches(a);
+    const bBranches = toBranches(b);
+    return bBranches.every((bt) =>
+      aBranches.some((at) => typesAreEqual(at, bt))
+    );
+  };
+  const covering = candidates.filter((c) =>
+    candidates.every((o) => c === o || covers(c.returnType, o.returnType))
   );
-  const mostSpecific = bySpecificity.at(-1);
-  const next = bySpecificity.at(-2);
-  if (
-    mostSpecific &&
-    (!next ||
-      formatTypeName(mostSpecific.returnType).length >
-        formatTypeName(next.returnType).length)
-  ) {
-    return mostSpecific;
-  }
+  if (covering.length === 1) return covering[0];
+
+  // Prefer a candidate whose parameter type unions cover all other candidates'.
+  const argCovering = candidates.filter((c) =>
+    candidates.every(
+      (o) =>
+        c === o ||
+        c.parameters.every((p, i) => covers(p.type, o.parameters[i]?.type))
+    )
+  );
+  if (argCovering.length === 1) return argCovering[0];
 
   const argTypes = call.args
     .toArray()

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -95,16 +95,18 @@ export const getCallFn = (call: Call, candidateFns?: Fn[]): Fn | undefined => {
         }
         return 0;
       };
-      let best: Fn | undefined;
+      let best: Fn[] = [];
       let bestScore = -1;
       for (const c of candidates) {
         const score = rank(c.returnType);
         if (score > bestScore) {
-          best = c;
+          best = [c];
           bestScore = score;
+        } else if (score === bestScore) {
+          best.push(c);
         }
       }
-      if (best && bestScore > 0) return best;
+      if (bestScore > 0 && best.length === 1) return best[0];
     }
   }
 

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -121,23 +121,6 @@ export const getCallFn = (call: Call, candidateFns?: Fn[]): Fn | undefined => {
   });
   if (concreteReturn.length === 1) return concreteReturn[0];
 
-  // Fallback heuristic: prefer the candidate with the most specific (longest)
-  // formatted return type. This biases toward concretely-applied generics like
-  // Array<MsgPack> over Array<O> when other tie-breakers fail.
-  const bySpecificity = [...candidates].sort((a, b) =>
-    formatTypeName(a.returnType).length - formatTypeName(b.returnType).length
-  );
-  const mostSpecific = bySpecificity.at(-1);
-  const next = bySpecificity.at(-2);
-  if (
-    mostSpecific &&
-    (!next ||
-      formatTypeName(mostSpecific.returnType).length >
-        formatTypeName(next.returnType).length)
-  ) {
-    return mostSpecific;
-  }
-
   const argTypes = call.args
     .toArray()
     .map((arg) => formatTypeName(getExprType(arg)))


### PR DESCRIPTION
Fixes calls like this (which caused an ambiguous call before:
```
pub fn component11() -> Map<MsgPack>
  let a = ["Alex", "Abby"]
  <div>
    <div><p>hi</p></div>
    {a.map(item => <span style="boop">{item}</span>)}
  </div>
```

In this case, the nested `p` triggered the issue.