### PR TITLE
Fix deeply nested call resolution

### DIFF
--- a/src/semantics/resolution/__tests__/get-call-fn.test.ts
+++ b/src/semantics/resolution/__tests__/get-call-fn.test.ts
@@ -174,6 +174,35 @@ describe("getCallFn", () => {
     );
   });
 
+  test("throws error when overloads only differ by return type", () => {
+    const label = new Identifier({ value: "arg1" });
+    const fnName = new Identifier({ value: "hi" });
+
+    const candidate1 = new Fn({
+      name: fnName,
+      parameters: [new Parameter({ name: label, type: i32 })],
+    });
+    candidate1.returnType = i32;
+    candidate1.annotatedReturnType = i32;
+
+    const candidate2 = new Fn({
+      name: fnName,
+      parameters: [new Parameter({ name: label, type: i32 })],
+    });
+    candidate2.returnType = f32;
+    candidate2.annotatedReturnType = f32;
+
+    const call = new Call({
+      fnName,
+      args: new List({ value: [new Int({ value: 2 })] }),
+    });
+    call.resolveFns = vi.fn().mockReturnValue([candidate1, candidate2]);
+
+    expect(() => getCallFn(call)).toThrow(
+      /Ambiguous call hi\(i32\).*hi\(arg1: i32\) -> i32.*hi\(arg1: i32\) -> f32/
+    );
+  });
+
   test("returns trait method for trait object calls", () => {
     const objType = new ObjectType({ name: "Obj", value: [] });
     const traitMethod = new Fn({

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -121,23 +121,6 @@ export const getCallFn = (call: Call, candidateFns?: Fn[]): Fn | undefined => {
   });
   if (concreteReturn.length === 1) return concreteReturn[0];
 
-  // Fallback heuristic: prefer the candidate with the most specific (longest)
-  // formatted return type. This biases toward concretely-applied generics like
-  // Array<MsgPack> over Array<O> when other tie-breakers fail.
-  const bySpecificity = [...candidates].sort((a, b) =>
-    formatTypeName(a.returnType).length - formatTypeName(b.returnType).length
-  );
-  const mostSpecific = bySpecificity.at(-1);
-  const next = bySpecificity.at(-2);
-  if (
-    mostSpecific &&
-    (!next ||
-      formatTypeName(mostSpecific.returnType).length >
-        formatTypeName(next.returnType).length)
-  ) {
-    return mostSpecific;
-  }
-
   const argTypes = call.args
     .toArray()
     .map((arg) => formatTypeName(getExprType(arg)))


### PR DESCRIPTION
## Summary
- avoid arbitrary overload resolution by return-type string length
- add regression test for overloads differing only in return type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9008f2b28832aa9f05c74ba46a078