### PR TITLE
Fix deeply nested call resolution

### DIFF
--- a/src/semantics/resolution/__tests__/get-call-fn.test.ts
+++ b/src/semantics/resolution/__tests__/get-call-fn.test.ts
@@ -203,6 +203,37 @@ describe("getCallFn", () => {
     );
   });
 
+  test("keeps ambiguity when ranked return types tie", () => {
+    const label1 = new Identifier({ value: "arg1" });
+    const label2 = new Identifier({ value: "arg2" });
+    const fnName = new Identifier({ value: "hi" });
+
+    const candidate1 = new Fn({
+      name: fnName,
+      parameters: [new Parameter({ name: label1, type: i32 })],
+    });
+    candidate1.returnType = i32;
+    candidate1.annotatedReturnType = i32;
+
+    const candidate2 = new Fn({
+      name: fnName,
+      parameters: [new Parameter({ name: label2, type: i32 })],
+    });
+    candidate2.returnType = i32;
+    candidate2.annotatedReturnType = i32;
+
+    const call = new Call({
+      fnName,
+      args: new List({ value: [new Int({ value: 2 })] }),
+    });
+    call.resolveFns = vi.fn().mockReturnValue([candidate1, candidate2]);
+    call.getAttribute = vi.fn().mockReturnValue(i32);
+
+    expect(() => getCallFn(call)).toThrow(
+      /Ambiguous call hi\(i32\).*hi\(arg1: i32\) -> i32.*hi\(arg2: i32\) -> i32/
+    );
+  });
+
   test("returns trait method for trait object calls", () => {
     const objType = new ObjectType({ name: "Obj", value: [] });
     const traitMethod = new Fn({

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -95,16 +95,18 @@ export const getCallFn = (call: Call, candidateFns?: Fn[]): Fn | undefined => {
         }
         return 0;
       };
-      let best: Fn | undefined;
+      let best: Fn[] = [];
       let bestScore = -1;
       for (const c of candidates) {
         const score = rank(c.returnType);
         if (score > bestScore) {
-          best = c;
+          best = [c];
           bestScore = score;
+        } else if (score === bestScore) {
+          best.push(c);
         }
       }
-      if (best && bestScore > 0) return best;
+      if (bestScore > 0 && best.length === 1) return best[0];
     }
   }
 


### PR DESCRIPTION
## Summary
- handle tie scores when ranking overload return types to avoid nondeterministic selection
- add regression test to keep ambiguity when return types tie

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b902d680b4832a92907c3729235141