### PR TITLE
feat: support optional parameters

### DIFF
--- a/reference/functions.md
+++ b/reference/functions.md
@@ -103,6 +103,27 @@ catch(e):
 [1] The compiler will typically optimize this away, so there is no performance
 penalty for using labeled arguments.
 
+## Optional parameters
+
+Parameters may be marked optional by adding `?` before the colon. The parameter's
+type becomes [`Optional`](./types/objects.md#optional) of the specified type.
+
+```voyd
+fn greet(name: String, middle?: String)
+  // middle has type Optional<String>
+  match(middle)
+    Some<String>:
+      name + " " + middle.value
+    None:
+      name
+
+greet("Ada")          // middle -> none()
+greet("Ada", "Lovelace") // middle -> some("Lovelace")
+```
+
+When an optional parameter is omitted, `none()` is inserted automatically. When a
+non-optional value is supplied, it is wrapped with `some(...)` at the call site.
+
 ## Uniform Function Call Syntax (Dot Notation)
 
 The dot (or period) operator applies the expression on the left as an argument

--- a/src/__tests__/fixtures/optional-params.ts
+++ b/src/__tests__/fixtures/optional-params.ts
@@ -27,6 +27,9 @@ pub fn banner_with_subtitle() -> i32
 pub fn banner_without_subtitle() -> i32
   banner(title: "Hi")
 
+pub fn banner_obj_without_subtitle() -> i32
+  banner({ title: "Hi" })
+
 pub fn closure_with_arg() -> i32
   let f = (name: String, middle?: String) => greet(name, middle)
   f("John", "Quincy")

--- a/src/__tests__/fixtures/optional-params.ts
+++ b/src/__tests__/fixtures/optional-params.ts
@@ -1,0 +1,29 @@
+export const optionalParamsVoyd = `
+use std::all
+
+fn greet(name: String, middle?: String) -> i32
+  match(middle)
+    Some<String>:
+      2
+    None:
+      1
+
+pub fn greet_with_middle() -> i32
+  greet("John", "Quincy")
+
+pub fn greet_without_middle() -> i32
+  greet("John")
+
+fn banner({ title: String, subtitle?: String }) -> i32
+  match(subtitle)
+    Some<String>:
+      2
+    None:
+      1
+
+pub fn banner_with_subtitle() -> i32
+  banner(title: "Hi", subtitle: "There")
+
+pub fn banner_without_subtitle() -> i32
+  banner(title: "Hi")
+`;

--- a/src/__tests__/fixtures/optional-params.ts
+++ b/src/__tests__/fixtures/optional-params.ts
@@ -54,3 +54,17 @@ fn sum(a: i32, b?: i32, {c: i32}) -> i32
 pub fn leftover_arg() -> i32
   sum(1, c: 2, 3)
 `;
+
+export const requiredOptionalVoyd = `
+use std::all
+
+fn expects(opt: Optional<String>) -> i32
+  match(opt)
+    Some<String>:
+      1
+    None:
+      0
+
+pub fn call_missing_opt() -> i32
+  expects()
+`;

--- a/src/__tests__/fixtures/optional-params.ts
+++ b/src/__tests__/fixtures/optional-params.ts
@@ -30,6 +30,12 @@ pub fn banner_without_subtitle() -> i32
 pub fn banner_obj_without_subtitle() -> i32
   banner({ title: "Hi" })
 
+fn sum(a: i32, b?: i32, {c: i32}) -> i32
+  a + c
+
+pub fn skip_optional_labeled() -> i32
+  sum(1, c: 2)
+
 pub fn closure_with_arg() -> i32
   let f = (name: String, middle?: String) => greet(name, middle)
   f("John", "Quincy")
@@ -37,4 +43,14 @@ pub fn closure_with_arg() -> i32
 pub fn closure_without_arg() -> i32
   let f = (name: String, middle?: String) => greet(name, middle)
   f("John")
+`;
+
+export const leftoverArgVoyd = `
+use std::all
+
+fn sum(a: i32, b?: i32, {c: i32}) -> i32
+  a + c
+
+pub fn leftover_arg() -> i32
+  sum(1, c: 2, 3)
 `;

--- a/src/__tests__/fixtures/optional-params.ts
+++ b/src/__tests__/fixtures/optional-params.ts
@@ -26,4 +26,12 @@ pub fn banner_with_subtitle() -> i32
 
 pub fn banner_without_subtitle() -> i32
   banner(title: "Hi")
+
+pub fn closure_with_arg() -> i32
+  let f = (name: String, middle?: String) => greet(name, middle)
+  f("John", "Quincy")
+
+pub fn closure_without_arg() -> i32
+  let f = (name: String, middle?: String) => greet(name, middle)
+  f("John")
 `;

--- a/src/__tests__/optional-params.e2e.test.ts
+++ b/src/__tests__/optional-params.e2e.test.ts
@@ -1,6 +1,7 @@
 import {
   optionalParamsVoyd,
   leftoverArgVoyd,
+  requiredOptionalVoyd,
 } from "./fixtures/optional-params.js";
 import { compile } from "../compiler.js";
 import { describe, test, beforeAll } from "vitest";
@@ -33,6 +34,10 @@ describe("optional parameters", () => {
 
   test("reject leftover argument after skipping optional", async (t) => {
     await t.expect(compile(leftoverArgVoyd)).rejects.toThrow();
+  });
+
+  test("required Optional<T> parameter is not optional", async (t) => {
+    await t.expect(compile(requiredOptionalVoyd)).rejects.toThrow();
   });
 
   test("labeled optional parameter", (t) => {

--- a/src/__tests__/optional-params.e2e.test.ts
+++ b/src/__tests__/optional-params.e2e.test.ts
@@ -31,4 +31,14 @@ describe("optional parameters", () => {
     assert(withoutSub, "Function exists");
     t.expect(withoutSub()).toEqual(1);
   });
+
+  test("closure optional parameter", (t) => {
+    const withArg = getWasmFn("closure_with_arg", instance);
+    assert(withArg, "Function exists");
+    t.expect(withArg()).toEqual(2);
+
+    const withoutArg = getWasmFn("closure_without_arg", instance);
+    assert(withoutArg, "Function exists");
+    t.expect(withoutArg()).toEqual(1);
+  });
 });

--- a/src/__tests__/optional-params.e2e.test.ts
+++ b/src/__tests__/optional-params.e2e.test.ts
@@ -30,6 +30,13 @@ describe("optional parameters", () => {
     const withoutSub = getWasmFn("banner_without_subtitle", instance);
     assert(withoutSub, "Function exists");
     t.expect(withoutSub()).toEqual(1);
+
+    const withoutSubObj = getWasmFn(
+      "banner_obj_without_subtitle",
+      instance
+    );
+    assert(withoutSubObj, "Function exists");
+    t.expect(withoutSubObj()).toEqual(1);
   });
 
   test("closure optional parameter", (t) => {

--- a/src/__tests__/optional-params.e2e.test.ts
+++ b/src/__tests__/optional-params.e2e.test.ts
@@ -1,0 +1,34 @@
+import { optionalParamsVoyd } from "./fixtures/optional-params.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("optional parameters", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(optionalParamsVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("unlabeled optional parameter", (t) => {
+    const withMiddle = getWasmFn("greet_with_middle", instance);
+    assert(withMiddle, "Function exists");
+    t.expect(withMiddle()).toEqual(2);
+
+    const withoutMiddle = getWasmFn("greet_without_middle", instance);
+    assert(withoutMiddle, "Function exists");
+    t.expect(withoutMiddle()).toEqual(1);
+  });
+
+  test("labeled optional parameter", (t) => {
+    const withSub = getWasmFn("banner_with_subtitle", instance);
+    assert(withSub, "Function exists");
+    t.expect(withSub()).toEqual(2);
+
+    const withoutSub = getWasmFn("banner_without_subtitle", instance);
+    assert(withoutSub, "Function exists");
+    t.expect(withoutSub()).toEqual(1);
+  });
+});

--- a/src/__tests__/optional-params.e2e.test.ts
+++ b/src/__tests__/optional-params.e2e.test.ts
@@ -1,4 +1,7 @@
-import { optionalParamsVoyd } from "./fixtures/optional-params.js";
+import {
+  optionalParamsVoyd,
+  leftoverArgVoyd,
+} from "./fixtures/optional-params.js";
 import { compile } from "../compiler.js";
 import { describe, test, beforeAll } from "vitest";
 import assert from "node:assert";
@@ -20,6 +23,16 @@ describe("optional parameters", () => {
     const withoutMiddle = getWasmFn("greet_without_middle", instance);
     assert(withoutMiddle, "Function exists");
     t.expect(withoutMiddle()).toEqual(1);
+  });
+
+  test("skipping optional parameter before labeled arg", (t) => {
+    const skip = getWasmFn("skip_optional_labeled", instance);
+    assert(skip, "Function exists");
+    t.expect(skip()).toEqual(3);
+  });
+
+  test("reject leftover argument after skipping optional", async (t) => {
+    await t.expect(compile(leftoverArgVoyd)).rejects.toThrow();
   });
 
   test("labeled optional parameter", (t) => {

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -294,13 +294,21 @@ const parametersMatch = (candidate: Fn, call: Call) =>
     paramsDirectlyMatch(candidate, call)) ||
   objectArgSuppliesLabeledParams(candidate, call);
 
-const paramsDirectlyMatch = (candidate: Fn, call: Call) =>
-  candidate.parameters.every((p, i) => {
-    const arg = call.argAt(i);
+const paramsDirectlyMatch = (candidate: Fn, call: Call) => {
+  let argIndex = 0;
+  const matches = candidate.parameters.every((p) => {
+    const arg = call.argAt(argIndex);
     if (!arg)
       return p.typeExpr?.isCall() && p.typeExpr.fnName.is("Optional");
-    return argumentMatchesParam(call, p, i);
+    const argLabel = getExprLabel(arg);
+    if (argLabel && argLabel !== p.label?.value)
+      return p.typeExpr?.isCall() && p.typeExpr.fnName.is("Optional");
+    const matches = argumentMatchesParam(call, p, argIndex);
+    if (matches) argIndex++;
+    return matches;
   });
+  return matches && argIndex === call.args.length;
+};
 
 const argumentMatchesParam = (
   call: Call,

--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -71,6 +71,7 @@ const cloneParams = (params: Parameter[]): Parameter[] =>
   params.map((p) => {
     const cloned = p.clone();
     cloned.type = p.type;
+    cloned.isOptional = p.isOptional;
     return cloned;
   });
 

--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -299,8 +299,7 @@ const resolveOptionalArgs = (call: Call) => {
   const fn = call.fn;
   if (!fn?.isFn()) return;
   fn.parameters.forEach((param, index) => {
-    const paramTypeExpr = param.typeExpr;
-    if (!paramTypeExpr?.isCall() || !paramTypeExpr.fnName.is("Optional")) return;
+    if (!param.isOptional) return;
     const label = param.label?.value;
 
     let argIndex = index;
@@ -376,9 +375,7 @@ const expandObjectArg = (call: Call) => {
   const allLabeled = labeledParams.length === params.length;
   if (!allLabeled) return;
 
-  const requiredParams = labeledParams.filter(
-    (p) => !(p.typeExpr?.isCall() && p.typeExpr.fnName.is("Optional"))
-  );
+  const requiredParams = labeledParams.filter((p) => !p.isOptional);
 
   // Case 1: direct object literal supplied
   if (objArg.isObjectLiteral()) {
@@ -417,10 +414,8 @@ const expandObjectArg = (call: Call) => {
     : undefined;
   if (!structType) return;
 
-  const coversRequired = requiredParams.every(
-    (p) =>
-      structType.hasField(p.label!.value) ||
-      (p.typeExpr?.isCall() && p.typeExpr.fnName.is("Optional"))
+  const coversRequired = requiredParams.every((p) =>
+    structType.hasField(p.label!.value)
   );
   if (!coversRequired) return;
 

--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -318,7 +318,16 @@ const resolveOptionalArgs = (call: Call) => {
         argExpr = wrapper.argAt(1);
       }
     } else {
-      argExpr = call.args.at(index);
+      const candidate = call.args.at(index);
+      const labelExpr =
+        candidate?.isCall() && candidate.calls(":")
+          ? candidate.argAt(0)
+          : undefined;
+      argExpr =
+        labelExpr?.isIdentifier() &&
+        fn.parameters.some((p, i) => i >= index && p.label?.is(labelExpr))
+          ? undefined
+          : candidate;
     }
 
     if (!argExpr) {

--- a/src/semantics/resolution/resolve-closure.ts
+++ b/src/semantics/resolution/resolve-closure.ts
@@ -1,6 +1,9 @@
 import { Closure } from "../../syntax-objects/closure.js";
 import { Parameter } from "../../syntax-objects/parameter.js";
 import { FnType } from "../../syntax-objects/types.js";
+import { Call } from "../../syntax-objects/call.js";
+import { Identifier } from "../../syntax-objects/identifier.js";
+import { List } from "../../syntax-objects/list.js";
 import { getExprType } from "./get-expr-type.js";
 import { resolveEntities } from "./resolve-entities.js";
 import { resolveTypeExpr } from "./resolve-type-expr.js";
@@ -56,6 +59,14 @@ const resolveParameters = (params: Parameter[]) => {
     }
 
     if (!p.typeExpr) return;
+    if (p.isOptional) {
+      p.typeExpr = new Call({
+        ...p.typeExpr.metadata,
+        fnName: Identifier.from("Optional"),
+        args: new List({ value: [] }),
+        typeArgs: new List({ value: [p.typeExpr] }),
+      });
+    }
 
     p.typeExpr = resolveTypeExpr(p.typeExpr);
     p.type = getExprType(p.typeExpr);

--- a/src/semantics/resolution/resolve-fn.ts
+++ b/src/semantics/resolution/resolve-fn.ts
@@ -4,6 +4,7 @@ import { Fn } from "../../syntax-objects/fn.js";
 import { Implementation } from "../../syntax-objects/implementation.js";
 import { List } from "../../syntax-objects/list.js";
 import { Parameter } from "../../syntax-objects/parameter.js";
+import { Identifier } from "../../syntax-objects/identifier.js";
 import { TypeAlias, selfType } from "../../syntax-objects/types.js";
 import { nop } from "../../syntax-objects/index.js";
 import { getExprType } from "./get-expr-type.js";
@@ -84,6 +85,15 @@ const resolveParameters = (params: Parameter[]) => {
 
     if (!p.typeExpr) {
       throw new Error(`Unable to determine type for ${p}`);
+    }
+
+    if (p.isOptional) {
+      p.typeExpr = new Call({
+        ...p.typeExpr.metadata,
+        fnName: Identifier.from("Optional"),
+        args: new List({ value: [] }),
+        typeArgs: new List({ value: [p.typeExpr] }),
+      });
     }
 
     p.typeExpr = resolveTypeExpr(p.typeExpr);

--- a/src/syntax-objects/parameter.ts
+++ b/src/syntax-objects/parameter.ts
@@ -10,6 +10,7 @@ export class Parameter extends NamedEntity {
   originalType?: Type;
   type?: Type;
   typeExpr?: Expr;
+  isOptional?: boolean;
   requiresCast = false;
 
   constructor(
@@ -17,12 +18,14 @@ export class Parameter extends NamedEntity {
       label?: Identifier;
       type?: Type;
       typeExpr?: Expr;
+      isOptional?: boolean;
     }
   ) {
     super(opts);
     this.label = opts.label;
     this.type = opts.type;
     this.typeExpr = opts.typeExpr;
+    this.isOptional = opts.isOptional;
     if (this.typeExpr) {
       this.typeExpr.parent = this;
     }
@@ -45,10 +48,17 @@ export class Parameter extends NamedEntity {
       ...super.getCloneOpts(parent),
       label: this.label,
       typeExpr: this.typeExpr?.clone(),
+      isOptional: this.isOptional,
     });
   }
 
   toJSON() {
-    return ["define-parameter", this.name, ["label", this.label], this.type];
+    return [
+      "define-parameter",
+      this.name,
+      ["label", this.label],
+      this.type,
+      ["is-optional", this.isOptional],
+    ];
   }
 }


### PR DESCRIPTION
## Summary
- allow `param?: Type` declarations and track `isOptional`
- resolve optional parameters and arguments with `none()/some()` coercions
- document optional parameters and add end-to-end tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b93d9b15cc832ab04bdcc26ebc53e4