### PR TITLE
fix: expand object arg optional fields

### DIFF
--- a/src/__tests__/fixtures/optional-params.ts
+++ b/src/__tests__/fixtures/optional-params.ts
@@ -27,6 +27,9 @@ pub fn banner_with_subtitle() -> i32
 pub fn banner_without_subtitle() -> i32
   banner(title: "Hi")
 
+pub fn banner_obj_without_subtitle() -> i32
+  banner({ title: "Hi" })
+
 pub fn closure_with_arg() -> i32
   let f = (name: String, middle?: String) => greet(name, middle)
   f("John", "Quincy")

--- a/src/__tests__/optional-params.e2e.test.ts
+++ b/src/__tests__/optional-params.e2e.test.ts
@@ -30,6 +30,13 @@ describe("optional parameters", () => {
     const withoutSub = getWasmFn("banner_without_subtitle", instance);
     assert(withoutSub, "Function exists");
     t.expect(withoutSub()).toEqual(1);
+
+    const withoutSubObj = getWasmFn(
+      "banner_obj_without_subtitle",
+      instance
+    );
+    assert(withoutSubObj, "Function exists");
+    t.expect(withoutSubObj()).toEqual(1);
   });
 
   test("closure optional parameter", (t) => {

--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -368,25 +368,32 @@ const expandObjectArg = (call: Call) => {
   const allLabeled = labeledParams.length === params.length;
   if (!allLabeled) return;
 
+  const requiredParams = labeledParams.filter(
+    (p) => !(p.typeExpr?.isCall() && p.typeExpr.fnName.is("Optional"))
+  );
+
   // Case 1: direct object literal supplied
   if (objArg.isObjectLiteral()) {
-    const coversAll = labeledParams.every((p) =>
+    const coversRequired = requiredParams.every((p) =>
       objArg.fields.some((f) => f.name === p.label!.value)
     );
-    if (!coversAll) return;
+    if (!coversRequired) return;
 
-    const newArgs = labeledParams.map((p) => {
-      const fieldName = p.label!.value;
-      const field = objArg.fields.find((f) => f.name === fieldName)!;
-      return new Call({
-        ...call.metadata,
-        fnName: Identifier.from(":"),
-        args: new List({
-          value: [Identifier.from(fieldName), field.initializer],
-        }),
-        type: getExprType(field.initializer),
-      });
-    });
+    const newArgs = labeledParams
+      .map((p) => {
+        const fieldName = p.label!.value;
+        const field = objArg.fields.find((f) => f.name === fieldName);
+        if (!field) return undefined;
+        return new Call({
+          ...call.metadata,
+          fnName: Identifier.from(":"),
+          args: new List({
+            value: [Identifier.from(fieldName), field.initializer],
+          }),
+          type: getExprType(field.initializer),
+        });
+      })
+      .filter((a): a is Call => !!a);
 
     call.args = new List({ value: newArgs });
     call.args.parent = call;
@@ -402,30 +409,35 @@ const expandObjectArg = (call: Call) => {
     : undefined;
   if (!structType) return;
 
-  const coversAll = labeledParams.every((p) =>
-    structType.hasField(p.label!.value)
+  const coversRequired = requiredParams.every(
+    (p) =>
+      structType.hasField(p.label!.value) ||
+      (p.typeExpr?.isCall() && p.typeExpr.fnName.is("Optional"))
   );
-  if (!coversAll) return;
+  if (!coversRequired) return;
 
-  const newArgs = labeledParams.map((p) => {
-    const fieldName = p.label!.value;
-    const fieldType = structType.getField(fieldName)?.type;
-    const objClone = resolveEntities(objArg.clone());
-    const access = new Call({
-      ...call.metadata,
-      fnName: Identifier.from("member-access"),
-      args: new List({
-        value: [objClone, Identifier.from(fieldName)],
-      }),
-      type: fieldType,
-    });
-    return new Call({
-      ...call.metadata,
-      fnName: Identifier.from(":"),
-      args: new List({ value: [Identifier.from(fieldName), access] }),
-      type: fieldType,
-    });
-  });
+  const newArgs = labeledParams
+    .map((p) => {
+      const fieldName = p.label!.value;
+      if (!structType.hasField(fieldName)) return undefined;
+      const fieldType = structType.getField(fieldName)?.type;
+      const objClone = resolveEntities(objArg.clone());
+      const access = new Call({
+        ...call.metadata,
+        fnName: Identifier.from("member-access"),
+        args: new List({
+          value: [objClone, Identifier.from(fieldName)],
+        }),
+        type: fieldType,
+      });
+      return new Call({
+        ...call.metadata,
+        fnName: Identifier.from(":"),
+        args: new List({ value: [Identifier.from(fieldName), access] }),
+        type: fieldType,
+      });
+    })
+    .filter((a): a is Call => !!a);
 
   call.args = new List({ value: newArgs });
   call.args.parent = call;

--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -332,8 +332,7 @@ const resolveOptionalArgs = (call: Call) => {
       const toInsert = label
         ? resolveEntities(makeLabeled(label, noneCall, call.metadata))
         : noneCall;
-      if (label) call.args.push(toInsert);
-      else call.args.insert(toInsert, index);
+      call.args.insert(toInsert, index);
       return;
     }
 


### PR DESCRIPTION
## Summary
- allow object arguments to omit optional fields by expanding only required labels
- extend optional parameter tests to cover object argument calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b94e8e03e4832aa7c7624a32a1641c