### PR TITLE
fix: expand object arg optional fields

### DIFF
--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -447,9 +447,9 @@ const normalizeArgsForResolvedFn = (call: Call) => {
   // Expand object-arg into labeled args first so array literals inside
   // labeled params can be coerced with the correct element types.
   expandObjectArg(call);
-  resolveOptionalArgs(call);
   resolveArrayArgs(call);
   resolveClosureArgs(call);
+  resolveOptionalArgs(call);
 };
 
 export const resolveModuleAccess = (call: Call) => {


### PR DESCRIPTION
## Summary
- allow object arguments to omit optional fields by expanding only required labels
- extend optional parameter tests to cover object argument calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b4c83104832a9cf753c2966a38ca