### PR TITLE
fix: preserve labels when skipping optional params

### DIFF
--- a/src/__tests__/fixtures/optional-params.ts
+++ b/src/__tests__/fixtures/optional-params.ts
@@ -30,6 +30,12 @@ pub fn banner_without_subtitle() -> i32
 pub fn banner_obj_without_subtitle() -> i32
   banner({ title: "Hi" })
 
+fn sum(a: i32, b?: i32, {c: i32}) -> i32
+  a + c
+
+pub fn skip_optional_labeled() -> i32
+  sum(1, c: 2)
+
 pub fn closure_with_arg() -> i32
   let f = (name: String, middle?: String) => greet(name, middle)
   f("John", "Quincy")

--- a/src/__tests__/optional-params.e2e.test.ts
+++ b/src/__tests__/optional-params.e2e.test.ts
@@ -22,6 +22,12 @@ describe("optional parameters", () => {
     t.expect(withoutMiddle()).toEqual(1);
   });
 
+  test("skipping optional parameter before labeled arg", (t) => {
+    const skip = getWasmFn("skip_optional_labeled", instance);
+    assert(skip, "Function exists");
+    t.expect(skip()).toEqual(3);
+  });
+
   test("labeled optional parameter", (t) => {
     const withSub = getWasmFn("banner_with_subtitle", instance);
     assert(withSub, "Function exists");

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -294,13 +294,20 @@ const parametersMatch = (candidate: Fn, call: Call) =>
     paramsDirectlyMatch(candidate, call)) ||
   objectArgSuppliesLabeledParams(candidate, call);
 
-const paramsDirectlyMatch = (candidate: Fn, call: Call) =>
-  candidate.parameters.every((p, i) => {
-    const arg = call.argAt(i);
+const paramsDirectlyMatch = (candidate: Fn, call: Call) => {
+  let argIndex = 0;
+  return candidate.parameters.every((p) => {
+    const arg = call.argAt(argIndex);
     if (!arg)
       return p.typeExpr?.isCall() && p.typeExpr.fnName.is("Optional");
-    return argumentMatchesParam(call, p, i);
+    const argLabel = getExprLabel(arg);
+    if (argLabel && argLabel !== p.label?.value)
+      return p.typeExpr?.isCall() && p.typeExpr.fnName.is("Optional");
+    const matches = argumentMatchesParam(call, p, argIndex);
+    if (matches) argIndex++;
+    return matches;
   });
+};
 
 const argumentMatchesParam = (
   call: Call,

--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -318,7 +318,16 @@ const resolveOptionalArgs = (call: Call) => {
         argExpr = wrapper.argAt(1);
       }
     } else {
-      argExpr = call.args.at(index);
+      const candidate = call.args.at(index);
+      const labelExpr =
+        candidate?.isCall() && candidate.calls(":")
+          ? candidate.argAt(0)
+          : undefined;
+      argExpr =
+        labelExpr?.isIdentifier() &&
+        fn.parameters.some((p, i) => i >= index && p.label?.is(labelExpr))
+          ? undefined
+          : candidate;
     }
 
     if (!argExpr) {


### PR DESCRIPTION
## Summary
- avoid consuming labeled arguments meant for later parameters when optional params are omitted
- ensure function resolution skips optional params without losing labeled args
- test skipping optional parameter before a labeled argument

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9bf425528832aae0099d4ae2b6e0b