### PR TITLE
fix: reject leftover args after skipping optionals

### DIFF
--- a/src/__tests__/fixtures/optional-params.ts
+++ b/src/__tests__/fixtures/optional-params.ts
@@ -44,3 +44,13 @@ pub fn closure_without_arg() -> i32
   let f = (name: String, middle?: String) => greet(name, middle)
   f("John")
 `;
+
+export const leftoverArgVoyd = `
+use std::all
+
+fn sum(a: i32, b?: i32, {c: i32}) -> i32
+  a + c
+
+pub fn leftover_arg() -> i32
+  sum(1, c: 2, 3)
+`;

--- a/src/__tests__/optional-params.e2e.test.ts
+++ b/src/__tests__/optional-params.e2e.test.ts
@@ -1,4 +1,7 @@
-import { optionalParamsVoyd } from "./fixtures/optional-params.js";
+import {
+  optionalParamsVoyd,
+  leftoverArgVoyd,
+} from "./fixtures/optional-params.js";
 import { compile } from "../compiler.js";
 import { describe, test, beforeAll } from "vitest";
 import assert from "node:assert";
@@ -26,6 +29,10 @@ describe("optional parameters", () => {
     const skip = getWasmFn("skip_optional_labeled", instance);
     assert(skip, "Function exists");
     t.expect(skip()).toEqual(3);
+  });
+
+  test("reject leftover argument after skipping optional", async (t) => {
+    await t.expect(compile(leftoverArgVoyd)).rejects.toThrow();
   });
 
   test("labeled optional parameter", (t) => {

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -296,7 +296,7 @@ const parametersMatch = (candidate: Fn, call: Call) =>
 
 const paramsDirectlyMatch = (candidate: Fn, call: Call) => {
   let argIndex = 0;
-  return candidate.parameters.every((p) => {
+  const matches = candidate.parameters.every((p) => {
     const arg = call.argAt(argIndex);
     if (!arg)
       return p.typeExpr?.isCall() && p.typeExpr.fnName.is("Optional");
@@ -307,6 +307,7 @@ const paramsDirectlyMatch = (candidate: Fn, call: Call) => {
     if (matches) argIndex++;
     return matches;
   });
+  return matches && argIndex === call.args.length;
 };
 
 const argumentMatchesParam = (


### PR DESCRIPTION
## Summary
- ensure `paramsDirectlyMatch` rejects calls with leftover arguments after skipping optional params
- add regression test for leftover argument after optional

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9c32eb35c832ab4f9a5201c309da2