### PR TITLE
fix: restrict optional arg coercion to '?' params

### DIFF
--- a/src/__tests__/fixtures/optional-params.ts
+++ b/src/__tests__/fixtures/optional-params.ts
@@ -54,3 +54,17 @@ fn sum(a: i32, b?: i32, {c: i32}) -> i32
 pub fn leftover_arg() -> i32
   sum(1, c: 2, 3)
 `;
+
+export const requiredOptionalVoyd = `
+use std::all
+
+fn expects(opt: Optional<String>) -> i32
+  match(opt)
+    Some<String>:
+      1
+    None:
+      0
+
+pub fn call_missing_opt() -> i32
+  expects()
+`;

--- a/src/__tests__/optional-params.e2e.test.ts
+++ b/src/__tests__/optional-params.e2e.test.ts
@@ -1,6 +1,7 @@
 import {
   optionalParamsVoyd,
   leftoverArgVoyd,
+  requiredOptionalVoyd,
 } from "./fixtures/optional-params.js";
 import { compile } from "../compiler.js";
 import { describe, test, beforeAll } from "vitest";
@@ -33,6 +34,10 @@ describe("optional parameters", () => {
 
   test("reject leftover argument after skipping optional", async (t) => {
     await t.expect(compile(leftoverArgVoyd)).rejects.toThrow();
+  });
+
+  test("required Optional<T> parameter is not optional", async (t) => {
+    await t.expect(compile(requiredOptionalVoyd)).rejects.toThrow();
   });
 
   test("labeled optional parameter", (t) => {

--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -299,8 +299,7 @@ const resolveOptionalArgs = (call: Call) => {
   const fn = call.fn;
   if (!fn?.isFn()) return;
   fn.parameters.forEach((param, index) => {
-    const paramTypeExpr = param.typeExpr;
-    if (!paramTypeExpr?.isCall() || !paramTypeExpr.fnName.is("Optional")) return;
+    if (!param.isOptional) return;
     const label = param.label?.value;
 
     let argIndex = index;
@@ -376,9 +375,7 @@ const expandObjectArg = (call: Call) => {
   const allLabeled = labeledParams.length === params.length;
   if (!allLabeled) return;
 
-  const requiredParams = labeledParams.filter(
-    (p) => !(p.typeExpr?.isCall() && p.typeExpr.fnName.is("Optional"))
-  );
+  const requiredParams = labeledParams.filter((p) => !p.isOptional);
 
   // Case 1: direct object literal supplied
   if (objArg.isObjectLiteral()) {
@@ -417,10 +414,8 @@ const expandObjectArg = (call: Call) => {
     : undefined;
   if (!structType) return;
 
-  const coversRequired = requiredParams.every(
-    (p) =>
-      structType.hasField(p.label!.value) ||
-      (p.typeExpr?.isCall() && p.typeExpr.fnName.is("Optional"))
+  const coversRequired = requiredParams.every((p) =>
+    structType.hasField(p.label!.value)
   );
   if (!coversRequired) return;
 


### PR DESCRIPTION
## Summary
- normalize optional arguments only when `param.isOptional`
- use `isOptional` to determine required fields in object argument expansion and resolution
- add negative coverage for required `Optional<T>` parameters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c9549048832ab2a43146652828ac