### PR TITLE
feat: support optional parameters

### DIFF
--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -71,6 +71,7 @@ const cloneParams = (params: Parameter[]): Parameter[] =>
   params.map((p) => {
     const cloned = p.clone();
     cloned.type = p.type;
+    cloned.isOptional = p.isOptional;
     return cloned;
   });
 


### PR DESCRIPTION
## Summary
- allow `param?: Type` declarations and track `isOptional`
- resolve optional parameters and arguments with `none()/some()` coercions
- document optional parameters and add end-to-end tests
- copy optional flag when cloning parameters to preserve optional semantics

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9cff4afc8832a8f667e4edf7e40b3