### PR TITLE
feat: detect lowercase namespaced components

### DIFF
--- a/src/__tests__/vsx-combined.e2e.test.ts
+++ b/src/__tests__/vsx-combined.e2e.test.ts
@@ -226,3 +226,37 @@ pub fn App()
     );
   });
 });
+
+describe("HTML parser handles built-in tags with internal capitals", () => {
+  test("<foreignObject> remains a built-in element", () => {
+    const text = `
+use std::all
+use std::vsx::create_element
+
+pub fn App()
+  <svg>
+    <foreignObject />
+  </svg>
+`;
+
+    const astJson = parse(text).toJSON();
+    const plain = JSON.parse(JSON.stringify(astJson));
+
+    const calls: unknown[] = [];
+    const walk = (node: unknown): void => {
+      if (Array.isArray(node)) {
+        calls.push(node);
+        node.forEach(walk);
+      } else if (node && typeof node === "object") {
+        Object.values(node as Record<string, unknown>).forEach(walk);
+      }
+    };
+    walk(plain);
+
+    const componentCall = (calls as unknown[][]).find(
+      (c) => c[0] === "foreignObject",
+    );
+
+    expect(componentCall, "No foreignObject component call").toBeUndefined();
+  });
+});

--- a/src/__tests__/vsx-combined.e2e.test.ts
+++ b/src/__tests__/vsx-combined.e2e.test.ts
@@ -176,4 +176,53 @@ pub fn App()
       true
     );
   });
+
+  test("<ui::Card ...> under lowercase module is treated as component", () => {
+    const text = `
+use std::all
+use std::vsx::create_element
+use std::msg_pack
+use std::msg_pack::MsgPack
+
+pub mod ui
+  use std::all
+  pub fn Card({ name: String, children?: Array<MsgPack> })
+    0
+
+pub fn App()
+  <div>
+    <ui::Card name=\"Alpha\" />
+  </div>
+`;
+
+    const astJson = parse(text).toJSON();
+    const plain = JSON.parse(JSON.stringify(astJson));
+
+    const calls: unknown[] = [];
+    const walk = (node: unknown): void => {
+      if (Array.isArray(node)) {
+        if (node[0] === "::") calls.push(node);
+        node.forEach(walk);
+      } else if (node && typeof node === "object") {
+        Object.values(node as Record<string, unknown>).forEach(walk);
+      }
+    };
+    walk(plain);
+
+    const match = (calls as unknown[][]).find((c) => {
+      if (c.length !== 3) return false;
+      const left = c[1] as unknown;
+      const right = c[2] as unknown;
+      const leftIsUi =
+        left === "ui" ||
+        (Array.isArray(left) && (left as unknown[]).includes("ui"));
+      const rightIsCardCall =
+        Array.isArray(right) && (right as unknown[])[0] === "Card";
+      return leftIsUi && rightIsCardCall;
+    });
+
+    expect(!!match, "Found namespaced component call ::(ui, Card(...))").toBe(
+      true
+    );
+  });
 });

--- a/src/parser/reader-macros/html/html-parser.ts
+++ b/src/parser/reader-macros/html/html-parser.ts
@@ -52,7 +52,7 @@ export class HTMLParser {
 
     const tagName = startElement ?? this.parseTagName();
     const lastSegment = tagName.split("::").pop() ?? "";
-    const isComponent = /[A-Z]/.test(lastSegment);
+    const isComponent = /^[A-Z]/.test(lastSegment);
     // Parse attributes/props before closing the tag
     const propsOrAttrs = isComponent
       ? this.parseComponentPropsObject()

--- a/src/parser/reader-macros/html/html-parser.ts
+++ b/src/parser/reader-macros/html/html-parser.ts
@@ -51,7 +51,8 @@ export class HTMLParser {
     if (!startElement && this.stream.consumeChar() !== "<") return null;
 
     const tagName = startElement ?? this.parseTagName();
-    const isComponent = /[A-Z]/.test(tagName[0] ?? "");
+    const lastSegment = tagName.split("::").pop() ?? "";
+    const isComponent = /[A-Z]/.test(lastSegment);
     // Parse attributes/props before closing the tag
     const propsOrAttrs = isComponent
       ? this.parseComponentPropsObject()


### PR DESCRIPTION
## Summary
- handle lowercase-namespaced tags as components by checking the last module segment for capitals
- cover lowercase namespaced component parsing with a regression test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcb5d5e1f4832aa6520da7f21cca1d