### PR TITLE
fix: restrict component detection to capitalized segment prefix

### DIFF
--- a/src/__tests__/vsx-combined.e2e.test.ts
+++ b/src/__tests__/vsx-combined.e2e.test.ts
@@ -226,3 +226,37 @@ pub fn App()
     );
   });
 });
+
+describe("HTML parser handles built-in tags with internal capitals", () => {
+  test("<foreignObject> remains a built-in element", () => {
+    const text = `
+use std::all
+use std::vsx::create_element
+
+pub fn App()
+  <svg>
+    <foreignObject />
+  </svg>
+`;
+
+    const astJson = parse(text).toJSON();
+    const plain = JSON.parse(JSON.stringify(astJson));
+
+    const calls: unknown[] = [];
+    const walk = (node: unknown): void => {
+      if (Array.isArray(node)) {
+        calls.push(node);
+        node.forEach(walk);
+      } else if (node && typeof node === "object") {
+        Object.values(node as Record<string, unknown>).forEach(walk);
+      }
+    };
+    walk(plain);
+
+    const componentCall = (calls as unknown[][]).find(
+      (c) => c[0] === "foreignObject",
+    );
+
+    expect(componentCall, "No foreignObject component call").toBeUndefined();
+  });
+});

--- a/src/parser/reader-macros/html/html-parser.ts
+++ b/src/parser/reader-macros/html/html-parser.ts
@@ -52,7 +52,7 @@ export class HTMLParser {
 
     const tagName = startElement ?? this.parseTagName();
     const lastSegment = tagName.split("::").pop() ?? "";
-    const isComponent = /[A-Z]/.test(lastSegment);
+    const isComponent = /^[A-Z]/.test(lastSegment);
     // Parse attributes/props before closing the tag
     const propsOrAttrs = isComponent
       ? this.parseComponentPropsObject()


### PR DESCRIPTION
## Summary
- check only the first character of the final tag segment when deciding if a tag is a component
- add regression test ensuring camel-case built-ins like `foreignObject` stay built-in elements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcb8925614832ab85c0fee5e6ce2a6