### PR TITLE
fix: use closure return type for overload matching

### DIFF
--- a/src/semantics/resolution/__tests__/closure-overload-return-type.test.ts
+++ b/src/semantics/resolution/__tests__/closure-overload-return-type.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import {
+  Call,
+  Closure,
+  Fn,
+  FnType,
+  Identifier,
+  Int,
+  List,
+  Parameter,
+  i32,
+  i64,
+} from "../../../syntax-objects/index.js";
+import { getCallFn } from "../get-call-fn.js";
+
+describe("getCallFn uses closure's actual return type for overloads", () => {
+  test("selects overload matching the closure body return type", () => {
+    const fnName = Identifier.from("apply");
+    const paramA = new Parameter({
+      name: Identifier.from("f"),
+      type: new FnType({
+        name: Identifier.from("fnA"),
+        parameters: [new Parameter({ name: Identifier.from("x"), type: i32 })],
+        returnType: i32,
+      }),
+    });
+    const fnA = new Fn({ name: fnName.clone(), parameters: [paramA] });
+    fnA.returnType = i32;
+
+    const paramB = new Parameter({
+      name: Identifier.from("f"),
+      type: new FnType({
+        name: Identifier.from("fnB"),
+        parameters: [new Parameter({ name: Identifier.from("x"), type: i32 })],
+        returnType: i64,
+      }),
+    });
+    const fnB = new Fn({ name: fnName.clone(), parameters: [paramB] });
+    fnB.returnType = i32;
+
+    const closure = new Closure({
+      parameters: [new Parameter({ name: Identifier.from("x") })],
+      body: new Int({ value: 1 }),
+    });
+    const call = new Call({
+      fnName: fnName.clone(),
+      args: new List({ value: [closure] }),
+    });
+
+    expect(getCallFn(call, [fnA, fnB])).toBe(fnA);
+  });
+});

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -378,10 +378,14 @@ const argumentMatchesParam = (
       const expected = paramType.parameters[j]?.type;
       if (!cp.type && expected) cp.type = expected;
     });
-    // Do NOT resolve the closure body here; just assume the contextual
-    // function type’s return type so compatibility can be checked without
-    // forcing body resolution (which may depend on the chosen overload).
-    cloned.returnType = paramType.returnType;
+    // Resolve the cloned closure so compatibility uses its real return type
+    // without mutating the original argument. If resolution fails (e.g. due to
+    // complex inference), fall back to the contextual return type.
+    try {
+      resolveClosure(cloned);
+    } catch {
+      cloned.returnType = paramType.returnType;
+    }
     probeVal = cloned;
   }
 


### PR DESCRIPTION
## Summary
- resolve closure arguments to use their actual return type when matching overloads
- add regression test for closure overload return type

## Testing
- `npm test src/semantics/resolution/__tests__/closure-overload-return-type.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bcc0d89024832a82b035722618e9c8