### PR TITLE
feat: add canonical type normalization

### DIFF
--- a/src/semantics/resolution/__tests__/call-resolution.test.ts
+++ b/src/semantics/resolution/__tests__/call-resolution.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  Call,
+  Fn,
+  Identifier,
+  Int,
+  List,
+  Parameter,
+  MockIdentifier,
+} from "../../../syntax-objects/index.js";
+import {
+  TypeAlias,
+  UnionType,
+  IntersectionType,
+  ObjectType,
+  i32,
+  f32,
+} from "../../../syntax-objects/types.js";
+import { resolveCall } from "../resolve-call.js";
+
+describe("call resolution canonicalization", () => {
+  test("resolves calls with alias parameters", () => {
+    const alias = new TypeAlias({
+      name: Identifier.from("Alias"),
+      typeExpr: Identifier.from("i32"),
+    });
+    alias.type = i32;
+
+    const fnName = Identifier.from("foo");
+    const fn = new Fn({
+      name: fnName,
+      parameters: [new Parameter({ name: Identifier.from("p"), type: alias })],
+    });
+
+    const call = new Call({
+      fnName,
+      args: new List({ value: [new Int({ value: 1 })] }),
+    });
+    call.resolveFns = vi.fn().mockReturnValue([fn]);
+
+    resolveCall(call);
+    expect(call.fn).toBe(fn);
+  });
+
+  test("handles union aliases", () => {
+    const aObj = new ObjectType({ name: "A", value: [] });
+    const bObj = new ObjectType({ name: "B", value: [] });
+    const union = new UnionType({ name: "AB", childTypeExprs: [] });
+    union.types = [aObj, bObj];
+    const alias = new TypeAlias({
+      name: Identifier.from("ABAlias"),
+      typeExpr: Identifier.from("AB"),
+    });
+    alias.type = union;
+
+    const fnName = Identifier.from("bar");
+    const fn = new Fn({
+      name: fnName,
+      parameters: [new Parameter({ name: Identifier.from("p"), type: alias })],
+    });
+
+    const arg = new MockIdentifier({ value: "a", entity: aObj });
+    const call = new Call({
+      fnName,
+      args: new List({ value: [arg] }),
+    });
+    call.resolveFns = vi.fn().mockReturnValue([fn]);
+
+    resolveCall(call);
+    expect(call.fn).toBe(fn);
+  });
+
+  test("handles intersection aliases", () => {
+    const nominal = new ObjectType({ name: "Nom", value: [] });
+    const structural = new ObjectType({
+      name: "Struct",
+      value: [
+        { name: "x", typeExpr: Identifier.from("i32"), type: i32 },
+      ],
+      isStructural: true,
+    });
+    const inter = new IntersectionType({
+      name: "Both",
+      nominalObjectExpr: Identifier.from("Nom"),
+      structuralObjectExpr: Identifier.from("Struct"),
+    });
+    inter.nominalType = nominal;
+    inter.structuralType = structural;
+
+    const alias = new TypeAlias({
+      name: Identifier.from("AliasBoth"),
+      typeExpr: Identifier.from("Both"),
+    });
+    alias.type = inter;
+
+    const child = new ObjectType({
+      name: "Child",
+      value: [
+        { name: "x", typeExpr: Identifier.from("i32"), type: i32 },
+      ],
+      parentObj: nominal,
+    });
+    const arg = new MockIdentifier({ value: "c", entity: child });
+
+    const fnName = Identifier.from("baz");
+    const fn = new Fn({
+      name: fnName,
+      parameters: [new Parameter({ name: Identifier.from("p"), type: alias })],
+    });
+
+    const call = new Call({
+      fnName,
+      args: new List({ value: [arg] }),
+    });
+    call.resolveFns = vi.fn().mockReturnValue([fn]);
+
+    resolveCall(call);
+    expect(call.fn).toBe(fn);
+  });
+});

--- a/src/semantics/types/canonicalize.ts
+++ b/src/semantics/types/canonicalize.ts
@@ -1,0 +1,52 @@
+import { Type } from "../../syntax-objects/types.js";
+
+export const canonicalType = (t: Type, seen: Set<Type> = new Set()): Type => {
+  if (seen.has(t)) return t;
+  seen.add(t);
+  if (t.isTypeAlias?.()) {
+    const target = t.type;
+    // Avoid infinite recursion on self-referential aliases
+    if (!target || seen.has(target)) return t;
+    return canonicalType(target, seen);
+  }
+
+  if (t.isUnionType?.()) {
+    const parts: Type[] = [];
+    t.types.forEach((child) => {
+      const c = canonicalType(child, seen) as Type;
+      // Skip self references which can appear when an alias resolves to this union
+      if (c === t) return;
+      if ((c as any).isUnionType?.()) parts.push(...((c as any).types as Type[]));
+      else parts.push(c);
+    });
+    t.types = parts as any;
+    return t;
+  }
+
+  if (t.isIntersectionType?.()) {
+    const nom = t.nominalType
+      ? (canonicalType(t.nominalType, seen) as Type)
+      : undefined;
+    const str = t.structuralType
+      ? (canonicalType(t.structuralType, seen) as Type)
+      : undefined;
+    // Prevent self references
+    t.nominalType = nom === t ? undefined : (nom as any);
+    t.structuralType = str === t ? undefined : (str as any);
+    if (!t.nominalType) return t.structuralType as Type;
+    if (!t.structuralType) return t.nominalType;
+    return t;
+  }
+
+  if (t.isFnType?.()) {
+    if (t.returnType) t.returnType = canonicalType(t.returnType, seen);
+    t.parameters.forEach((p) => {
+      if (p.type) p.type = canonicalType(p.type, seen);
+    });
+    return t;
+  }
+
+  return t;
+};
+
+export default canonicalType;


### PR DESCRIPTION
## Summary
- add canonical type helper to normalize aliases and composite types
- centralize alias handling in call resolution helpers
- test call resolution against alias, union, and intersection cases
- stabilize canonicalization and type formatting to avoid recursive cycles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcd2866004832a974530fe25d9a967