### PR TITLE
Canonicalize applied type arguments for objects and traits

### DIFF
--- a/src/semantics/resolution/resolve-fn.ts
+++ b/src/semantics/resolution/resolve-fn.ts
@@ -14,6 +14,7 @@ import { inferTypeArgs, TypeArgInferencePair, unifyTypeParams } from "./infer-ty
 import { typesAreEqual } from "./types-are-equal.js";
 import { typesAreCompatible } from "./types-are-compatible.js";
 import { Type } from "../../syntax-objects/types.js";
+import { canonicalType } from "../types/canonicalize.js";
 
 export type ResolveFnTypesOpts = {
   typeArgs?: List;
@@ -201,7 +202,9 @@ const fnTypeArgsMatch = (args: List, candidate: Fn): boolean =>
     ? candidate.appliedTypeArgs.every((t, i) => {
         const argType = getExprType(args.at(i));
         const appliedType = getExprType(t);
-        return typesAreEqual(argType, appliedType);
+        const canonArg = argType && canonicalType(argType);
+        const canonApplied = appliedType && canonicalType(appliedType);
+        return typesAreEqual(canonArg, canonApplied);
       })
     : false;
 

--- a/src/semantics/resolution/resolve-object-type.ts
+++ b/src/semantics/resolution/resolve-object-type.ts
@@ -11,6 +11,7 @@ import { inferTypeArgs, TypeArgInferencePair } from "./infer-type-args.js";
 import { implIsCompatible, resolveImpl } from "./resolve-impl.js";
 import { typesAreEqual } from "./types-are-equal.js";
 import { resolveTypeExpr } from "./resolve-type-expr.js";
+import { canonicalType } from "../types/canonicalize.js";
 
 export const resolveObjectType = (obj: ObjectType, call?: Call): ObjectType => {
   if (obj.typesResolved) return obj;
@@ -183,6 +184,8 @@ const typeArgsMatch = (call: Call, candidate: ObjectType): boolean =>
     ? candidate.appliedTypeArgs.every((t, i) => {
         const argType = getExprType(call.typeArgs?.at(i));
         const appliedType = getExprType(t);
-        return typesAreEqual(argType, appliedType);
+        const canonArg = argType && canonicalType(argType);
+        const canonApplied = appliedType && canonicalType(appliedType);
+        return typesAreEqual(canonArg, canonApplied);
       })
     : true;

--- a/src/semantics/resolution/resolve-trait.ts
+++ b/src/semantics/resolution/resolve-trait.ts
@@ -7,6 +7,7 @@ import { resolveTypeExpr } from "./resolve-type-expr.js";
 import { getExprType } from "./get-expr-type.js";
 import { typesAreEqual } from "./types-are-equal.js";
 import { resolveImpl } from "./resolve-impl.js";
+import { canonicalType } from "../types/canonicalize.js";
 
 export const resolveTrait = (trait: TraitType, call?: Call): TraitType => {
   if (trait.typeParameters) {
@@ -61,7 +62,11 @@ const resolveGenericTraitVersion = (
 
 const typeArgsMatch = (call: Call, candidate: TraitType): boolean =>
   call.typeArgs && candidate.appliedTypeArgs
-    ? candidate.appliedTypeArgs.every((t, i) =>
-        typesAreEqual(getExprType(call.typeArgs!.at(i)), getExprType(t))
-      )
+    ? candidate.appliedTypeArgs.every((t, i) => {
+        const argType = getExprType(call.typeArgs!.at(i));
+        const appliedType = getExprType(t);
+        const canonArg = argType && canonicalType(argType);
+        const canonApplied = appliedType && canonicalType(appliedType);
+        return typesAreEqual(canonArg, canonApplied);
+      })
     : true;

--- a/src/semantics/types/__tests__/canonicalize.test.ts
+++ b/src/semantics/types/__tests__/canonicalize.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { ObjectType, TypeAlias, i32 } from "../../../syntax-objects/types.js";
+import { TraitType } from "../../../syntax-objects/types/trait.js";
+import { Identifier } from "../../../syntax-objects/index.js";
+import { canonicalType } from "../canonicalize.js";
+
+describe("canonicalType", () => {
+  test("resolves applied args on object types", () => {
+    const obj = new ObjectType({ name: "Box", value: [], typeParameters: [Identifier.from("T")] });
+    const alias = new TypeAlias({ name: Identifier.from("Alias"), typeExpr: Identifier.from("i32") });
+    alias.type = i32;
+    const inst = obj.clone();
+    inst.genericParent = obj;
+    inst.appliedTypeArgs = [alias];
+
+    const canon = canonicalType(inst) as ObjectType;
+    expect(canon.appliedTypeArgs?.[0]).toBe(i32);
+  });
+
+  test("resolves applied args on trait types", () => {
+    const trait = new TraitType({ name: Identifier.from("Iter"), methods: [], typeParameters: [Identifier.from("T")] });
+    const alias = new TypeAlias({ name: Identifier.from("Alias"), typeExpr: Identifier.from("i32") });
+    alias.type = i32;
+    const inst = trait.clone();
+    inst.genericParent = trait;
+    inst.appliedTypeArgs = [alias];
+
+    const canon = canonicalType(inst) as TraitType;
+    expect(canon.appliedTypeArgs?.[0]).toBe(i32);
+  });
+});

--- a/src/semantics/types/__tests__/canonicalize.test.ts
+++ b/src/semantics/types/__tests__/canonicalize.test.ts
@@ -15,6 +15,7 @@ describe("canonicalType", () => {
 
     const canon = canonicalType(inst) as ObjectType;
     expect(canon.appliedTypeArgs?.[0]).toBe(i32);
+    expect(() => canon.clone()).not.toThrow();
   });
 
   test("resolves applied args on trait types", () => {
@@ -27,5 +28,7 @@ describe("canonicalType", () => {
 
     const canon = canonicalType(inst) as TraitType;
     expect(canon.appliedTypeArgs?.[0]).toBe(i32);
+    expect(() => canon.clone()).not.toThrow();
+    expect(canon.id).toBe(inst.id);
   });
 });

--- a/src/semantics/types/canonicalize.ts
+++ b/src/semantics/types/canonicalize.ts
@@ -55,25 +55,35 @@ export const canonicalType = (t: Type, seen: Set<Type> = new Set()): Type => {
 
   if (t.isObjectType?.()) {
     if (t.appliedTypeArgs?.length) {
-      const copy = Object.assign(
-        Object.create(Object.getPrototypeOf(t)),
-        t,
-        { id: `${t.id}#canon` }
-      );
-      copy.appliedTypeArgs = t.appliedTypeArgs.map((arg) =>
-        canonicalType(arg, seen)
-      );
-      return copy;
+      const copy = new (t.constructor as any)({
+        name: t.name,
+        value: [],
+        parentObjExpr: t.parentObjExpr,
+        parentObj: t.parentObjType,
+        typeParameters: t.typeParameters,
+        implementations: t.implementations,
+        isStructural: t.isStructural,
+      });
+        Object.assign(copy, t);
+        copy.id = `${t.id}#canon`;
+        copy.appliedTypeArgs = t.appliedTypeArgs.map((arg) =>
+          canonicalType(arg, seen)
+        );
+        return copy;
+      }
+      return t;
     }
-    return t;
-  }
 
   if (t.isTraitType?.()) {
     if (t.appliedTypeArgs?.length) {
-      const copy = Object.assign(
-        Object.create(Object.getPrototypeOf(t)),
-        t
-      );
+      const copy = new (t.constructor as any)({
+        name: t.name,
+        methods: [],
+        typeParameters: t.typeParameters,
+        implementations: t.implementations,
+        lexicon: t.lexicon,
+      });
+      Object.assign(copy, t);
       copy.appliedTypeArgs = t.appliedTypeArgs.map((arg) =>
         canonicalType(arg, seen)
       );

--- a/src/semantics/types/canonicalize.ts
+++ b/src/semantics/types/canonicalize.ts
@@ -53,6 +53,35 @@ export const canonicalType = (t: Type, seen: Set<Type> = new Set()): Type => {
     return t;
   }
 
+  if (t.isObjectType?.()) {
+    if (t.appliedTypeArgs?.length) {
+      const copy = Object.assign(
+        Object.create(Object.getPrototypeOf(t)),
+        t,
+        { id: `${t.id}#canon` }
+      );
+      copy.appliedTypeArgs = t.appliedTypeArgs.map((arg) =>
+        canonicalType(arg, seen)
+      );
+      return copy;
+    }
+    return t;
+  }
+
+  if (t.isTraitType?.()) {
+    if (t.appliedTypeArgs?.length) {
+      const copy = Object.assign(
+        Object.create(Object.getPrototypeOf(t)),
+        t
+      );
+      copy.appliedTypeArgs = t.appliedTypeArgs.map((arg) =>
+        canonicalType(arg, seen)
+      );
+      return copy;
+    }
+    return t;
+  }
+
   return t;
 };
 


### PR DESCRIPTION
## Summary
- avoid mutating object and trait generics when canonicalizing type arguments
- adjust canonicalType tests to use returned canonical instances

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bceeacd2b4832ab07588540946c15e