### PR TITLE
Canonicalize applied type arguments for objects and traits

### DIFF
--- a/src/semantics/types/__tests__/canonicalize.test.ts
+++ b/src/semantics/types/__tests__/canonicalize.test.ts
@@ -15,6 +15,7 @@ describe("canonicalType", () => {
 
     const canon = canonicalType(inst) as ObjectType;
     expect(canon.appliedTypeArgs?.[0]).toBe(i32);
+    expect(() => canon.clone()).not.toThrow();
   });
 
   test("resolves applied args on trait types", () => {
@@ -27,5 +28,7 @@ describe("canonicalType", () => {
 
     const canon = canonicalType(inst) as TraitType;
     expect(canon.appliedTypeArgs?.[0]).toBe(i32);
+    expect(() => canon.clone()).not.toThrow();
+    expect(canon.id).toBe(inst.id);
   });
 });

--- a/src/semantics/types/canonicalize.ts
+++ b/src/semantics/types/canonicalize.ts
@@ -55,25 +55,35 @@ export const canonicalType = (t: Type, seen: Set<Type> = new Set()): Type => {
 
   if (t.isObjectType?.()) {
     if (t.appliedTypeArgs?.length) {
-      const copy = Object.assign(
-        Object.create(Object.getPrototypeOf(t)),
-        t,
-        { id: `${t.id}#canon` }
-      );
-      copy.appliedTypeArgs = t.appliedTypeArgs.map((arg) =>
-        canonicalType(arg, seen)
-      );
-      return copy;
+      const copy = new (t.constructor as any)({
+        name: t.name,
+        value: [],
+        parentObjExpr: t.parentObjExpr,
+        parentObj: t.parentObjType,
+        typeParameters: t.typeParameters,
+        implementations: t.implementations,
+        isStructural: t.isStructural,
+      });
+        Object.assign(copy, t);
+        copy.id = `${t.id}#canon`;
+        copy.appliedTypeArgs = t.appliedTypeArgs.map((arg) =>
+          canonicalType(arg, seen)
+        );
+        return copy;
+      }
+      return t;
     }
-    return t;
-  }
 
   if (t.isTraitType?.()) {
     if (t.appliedTypeArgs?.length) {
-      const copy = Object.assign(
-        Object.create(Object.getPrototypeOf(t)),
-        t
-      );
+      const copy = new (t.constructor as any)({
+        name: t.name,
+        methods: [],
+        typeParameters: t.typeParameters,
+        implementations: t.implementations,
+        lexicon: t.lexicon,
+      });
+      Object.assign(copy, t);
       copy.appliedTypeArgs = t.appliedTypeArgs.map((arg) =>
         canonicalType(arg, seen)
       );


### PR DESCRIPTION
## Summary
- canonicalize applied type arguments for object types without mutating original instances
- preserve trait instance ids during canonicalization so implementation lookups succeed
- add regression test ensuring canonicalized trait ids match source instances

## Testing
- `npx vitest run src/semantics/types/__tests__/canonicalize.test.ts`
- `npm test` *(fails: self is not mutable at raw:39:7-11)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf95ad10c832a856f7d2dd54981b6