### PR TITLE
Avoid mutating types during canonicalization

### DIFF
--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -277,21 +277,18 @@ const resolveClosureArgs = (call: Call) => {
     const inner = isLabeled ? arg.argAt(1) : arg;
     if (!inner?.isClosure()) return;
     const expected = paramType ? canonicalType(paramType) : undefined;
+    const expectedRet =
+      expected?.isFnType() && expected.returnType ? expected.returnType : undefined;
     if (expected?.isFnType()) {
       inner.parameters.forEach((p, i) => {
         const exp = expected.parameters[i]?.type;
-        if (!p.type && !p.typeExpr && exp) p.type = canonicalType(exp);
+        if (!p.type && !p.typeExpr && exp) p.type = exp;
       });
-      if (!inner.returnTypeExpr && !inner.annotatedReturnType) {
-        inner.annotatedReturnType =
-          expected.returnType && canonicalType(expected.returnType);
-      }
+      if (!inner.returnTypeExpr && !inner.annotatedReturnType)
+        inner.annotatedReturnType = expectedRet;
     }
     const resolved = resolveClosure(inner);
-    if (expected?.isFnType()) {
-      resolved.returnType =
-        expected.returnType && canonicalType(expected.returnType);
-    }
+    if (expectedRet) resolved.returnType = expectedRet;
     if (isLabeled) {
       arg.args.set(1, resolved);
       call.args.set(index, resolveEntities(arg));

--- a/src/semantics/types/canonicalize.ts
+++ b/src/semantics/types/canonicalize.ts
@@ -1,13 +1,26 @@
 import { Type } from "../../syntax-objects/types.js";
 
+const cache = new WeakMap<Type, Type>();
+
+/**
+ * Return a canonicalized version of a type without mutating the input.
+ *
+ * Each call produces a clone of any composite type it rewrites while caching
+ * results so repeated canonicalizations of the same input return the same
+ * instance.
+ */
 export const canonicalType = (t: Type, seen: Set<Type> = new Set()): Type => {
+  const cached = cache.get(t);
+  if (cached) return cached;
   if (seen.has(t)) return t;
   seen.add(t);
   if (t.isTypeAlias?.()) {
     const target = t.type;
     // Avoid infinite recursion on self-referential aliases
     if (!target || seen.has(target)) return t;
-    return canonicalType(target, seen);
+    const canon = canonicalType(target, seen);
+    cache.set(t, canon);
+    return canon;
   }
 
   if (t.isUnionType?.()) {
@@ -26,8 +39,10 @@ export const canonicalType = (t: Type, seen: Set<Type> = new Set()): Type => {
       ids.add(p.id);
       unique.push(p);
     });
-    t.types = unique as any;
-    return t;
+    const copy = t.clone();
+    copy.types = unique as any;
+    cache.set(t, copy);
+    return copy;
   }
 
   if (t.isIntersectionType?.()) {
@@ -37,20 +52,28 @@ export const canonicalType = (t: Type, seen: Set<Type> = new Set()): Type => {
     const str = t.structuralType
       ? (canonicalType(t.structuralType, seen) as Type)
       : undefined;
+    const copy = t.clone();
     // Prevent self references
-    t.nominalType = nom === t ? undefined : (nom as any);
-    t.structuralType = str === t ? undefined : (str as any);
-    if (!t.nominalType) return t.structuralType as Type;
-    if (!t.structuralType) return t.nominalType;
-    return t;
+    copy.nominalType = nom === t ? undefined : (nom as any);
+    copy.structuralType = str === t ? undefined : (str as any);
+    cache.set(t, copy);
+    if (!copy.nominalType) return copy.structuralType as Type;
+    if (!copy.structuralType) return copy.nominalType;
+    return copy;
   }
 
   if (t.isFnType?.()) {
-    if (t.returnType) t.returnType = canonicalType(t.returnType, seen);
-    t.parameters.forEach((p) => {
+    const copy = t.clone();
+    copy.parameters.forEach((p, i) => {
+      p.type = t.parameters[i]?.type;
+      p.originalType = t.parameters[i]?.originalType;
+    });
+    if (copy.returnType) copy.returnType = canonicalType(copy.returnType, seen);
+    copy.parameters.forEach((p) => {
       if (p.type) p.type = canonicalType(p.type, seen);
     });
-    return t;
+    cache.set(t, copy);
+    return copy;
   }
 
   if (t.isObjectType?.()) {
@@ -64,12 +87,13 @@ export const canonicalType = (t: Type, seen: Set<Type> = new Set()): Type => {
         implementations: t.implementations,
         isStructural: t.isStructural,
       });
-        Object.assign(copy, t);
-        copy.id = `${t.id}#canon`;
-        copy.appliedTypeArgs = t.appliedTypeArgs.map((arg) =>
-          canonicalType(arg, seen)
-        );
-        return copy;
+      Object.assign(copy, t);
+      copy.id = `${t.id}#canon`;
+      copy.appliedTypeArgs = t.appliedTypeArgs.map((arg) =>
+        canonicalType(arg, seen)
+      );
+      cache.set(t, copy);
+      return copy;
       }
       return t;
     }
@@ -87,11 +111,13 @@ export const canonicalType = (t: Type, seen: Set<Type> = new Set()): Type => {
       copy.appliedTypeArgs = t.appliedTypeArgs.map((arg) =>
         canonicalType(arg, seen)
       );
+      cache.set(t, copy);
       return copy;
     }
     return t;
   }
 
+  cache.set(t, t);
   return t;
 };
 


### PR DESCRIPTION
## Summary
- Ensure `canonicalType` caches and reuses clone results instead of generating new ones on each call
- Reuse canonicalized closure parameter and return types to avoid mismatched function signatures
- Clarify non-mutating behavior of `canonicalType`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd27c9306c832aa71f998cc1bbd4ab