### PR TITLE
Rename regular macros to functional macros

### DIFF
--- a/reference/macros.md
+++ b/reference/macros.md
@@ -1,6 +1,6 @@
 # Macros
 
-There are three types of macros in voyd, reader macros, regular macros, and
+There are three types of macros in voyd, reader macros, functional macros, and
 syntax macros. All macros are expected to return a syntax object.
 
 Reader macros are used to transform the source code while it is being parsed.
@@ -9,10 +9,10 @@ They are fed the source code as a stream of tokens.
 Syntax macros are used to transform the syntax tree after it has been parsed but
 before it is type checked. They are fed the entire syntax tree.
 
-Regular macros are called like functions directly in the source code. They are
+Functional macros are called like functions directly in the source code. They are
 fed the syntax object of their arguments.
 
-# Regular Macros
+# Functional Macros
 
 The `macro` macro is designed to make defining simple expansion macros easy and
 with minimal boiler plate. The body of a `macro` is automatically surrounded by
@@ -137,7 +137,7 @@ There are three types of macros:
 -   Reader Macros: Expanded during parsing, emit am ast
 -   Syntax Macros: Expanded after parsing, are passed the ast from the parser
   and produce the final ast
--   Regular Macros: Expanded by a syntax macro
+-   Functional Macros: Expanded by a syntax macro
 
 At a high level, the pipeline looks something like this: `file.voyd -> parser +
 reader macros -> syntax macros -> ast (the core language)`

--- a/reference/spec/surface.md
+++ b/reference/spec/surface.md
@@ -74,7 +74,7 @@ There are three types of macros:
 -   Reader Macros: Expanded during parsing, emit am ast
 -   Syntax Macros: Expanded after parsing, are passed the ast from the parser
   and produce the final ast
--   Regular Macros: Expanded by a syntax macro
+-   Functional Macros: Expanded by a syntax macro
 
 At a high level, the pipeline looks something like this: `file.voyd -> parser +
 reader macros -> syntax macros -> ast (the core language)`

--- a/src/semantics/README.md
+++ b/src/semantics/README.md
@@ -1,7 +1,7 @@
 # Semantic Processing
 
 - Resolves Modules
-- Expands Regular (Function) Macros
+- Expands Functional Macros
 - Resolves Entities (Types, Functions, Variables, etc)
 - Checks Types
 

--- a/src/semantics/__tests__/__snapshots__/functional-macros.test.ts.snap
+++ b/src/semantics/__tests__/__snapshots__/functional-macros.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`regular macro expansion 1`] = `
+exports[`functional macro expansion 1`] = `
 [
   "module",
   "root",
@@ -46,7 +46,7 @@ exports[`regular macro expansion 1`] = `
           ],
         ],
         [
-          "regular-macro",
+          "functional-macro",
           "\`#931",
           [
             "parameters",
@@ -67,7 +67,7 @@ exports[`regular macro expansion 1`] = `
           ],
         ],
         [
-          "regular-macro",
+          "functional-macro",
           "let#978",
           [
             "parameters",
@@ -120,7 +120,7 @@ exports[`regular macro expansion 1`] = `
           ],
         ],
         [
-          "regular-macro",
+          "functional-macro",
           "fn#1771",
           [
             "parameters",

--- a/src/semantics/__tests__/fixtures/functional-macros-ast.ts
+++ b/src/semantics/__tests__/fixtures/functional-macros-ast.ts
@@ -1,4 +1,4 @@
-export const regularMacrosAst = [
+export const functionalMacrosAst = [
   "module",
   "root",
   [
@@ -7,13 +7,13 @@ export const regularMacrosAst = [
       "test",
       [
         [
-          "regular-macro",
+          "functional-macro",
           "`#735",
           ["parameters"],
           ["block", ["block", ["quote", "quote", ["$@", "body"]]]],
         ],
         [
-          "regular-macro",
+          "functional-macro",
           "let#772",
           ["parameters"],
           [
@@ -37,7 +37,7 @@ export const regularMacrosAst = [
           ["is-mutable", false],
         ],
         [
-          "regular-macro",
+          "functional-macro",
           "fn#1251",
           ["parameters"],
           [

--- a/src/semantics/__tests__/fixtures/functional-macros-voyd-file.ts
+++ b/src/semantics/__tests__/fixtures/functional-macros-voyd-file.ts
@@ -1,4 +1,4 @@
-export const regularMacrosVoydFile = `
+export const functionalMacrosVoydFile = `
 macro \`()
   quote quote $@body
 

--- a/src/semantics/__tests__/functional-macros.test.ts
+++ b/src/semantics/__tests__/functional-macros.test.ts
@@ -1,13 +1,13 @@
 import { parse } from "../../parser/parser.js";
 import path from "node:path";
 import { registerModules } from "../modules.js";
-import { expandRegularMacros } from "../regular-macros.js";
-import { regularMacrosVoydFile } from "./fixtures/regular-macros-voyd-file.js";
+import { expandFunctionalMacros } from "../functional-macros.js";
+import { functionalMacrosVoydFile } from "./fixtures/functional-macros-voyd-file.js";
 import { test } from "vitest";
 import { List } from "../../syntax-objects/list.js";
 
-test("regular macro expansion", async (t) => {
-  const parserOutput = parse(regularMacrosVoydFile);
+test("functional macro expansion", async (t) => {
+  const parserOutput = parse(functionalMacrosVoydFile);
   const files = {
     std: new List([]),
     test: parserOutput,
@@ -17,6 +17,6 @@ test("regular macro expansion", async (t) => {
     srcPath: path.dirname("test"),
     indexPath: "test.voyd",
   });
-  const result = expandRegularMacros(resolvedModules);
+  const result = expandFunctionalMacros(resolvedModules);
   t.expect(result).toMatchSnapshot();
 });

--- a/src/semantics/index.ts
+++ b/src/semantics/index.ts
@@ -3,13 +3,13 @@ import { initPrimitiveTypes } from "./init-primitive-types.js";
 import { initEntities } from "./init-entities.js";
 import { SemanticProcessor } from "./types.js";
 import { registerModules } from "./modules.js";
-import { expandRegularMacros } from "./regular-macros.js";
+import { expandFunctionalMacros } from "./functional-macros.js";
 import type { ParsedModule } from "../parser/utils/parse-module.js";
 import { Expr } from "../syntax-objects/expr.js";
 import { resolveEntities } from "./resolution/resolve-entities.js";
 
 const semanticPhases: SemanticProcessor[] = [
-  expandRegularMacros, // Also handles use and module declaration initialization
+  expandFunctionalMacros, // Also handles use and module declaration initialization
   initPrimitiveTypes,
   initEntities,
   resolveEntities,

--- a/src/syntax-objects/expr.ts
+++ b/src/syntax-objects/expr.ts
@@ -49,7 +49,7 @@ export type Expr =
   | Closure;
 
 /**
- * These are the Expr types that must be returned until all macros have been expanded (reader, syntax, and regular)
+ * These are the Expr types that must be returned until all macros have been expanded (reader, syntax, and functional)
  */
 export type PrimitiveExpr =
   | Bool

--- a/src/syntax-objects/macros.ts
+++ b/src/syntax-objects/macros.ts
@@ -3,11 +3,11 @@ import type { Expr } from "./expr.js";
 import { Identifier } from "./identifier.js";
 import { ScopedNamedEntityOpts, ScopedNamedEntity } from "./named-entity.js";
 
-export type Macro = RegularMacro;
+export type Macro = FunctionalMacro;
 
-export class RegularMacro extends ScopedNamedEntity {
+export class FunctionalMacro extends ScopedNamedEntity {
   readonly syntaxType = "macro";
-  readonly macroType = "regular";
+  readonly macroType = "functional";
   readonly parameters: Identifier[] = [];
   readonly body: Block;
 
@@ -35,8 +35,8 @@ export class RegularMacro extends ScopedNamedEntity {
     return this.id;
   }
 
-  clone(parent?: Expr | undefined): RegularMacro {
-    return new RegularMacro({
+  clone(parent?: Expr | undefined): FunctionalMacro {
+    return new FunctionalMacro({
       ...super.getCloneOpts(parent),
       parameters: this.parameters.map((p) => p.clone()),
       body: this.body.clone(),
@@ -45,7 +45,7 @@ export class RegularMacro extends ScopedNamedEntity {
 
   toJSON() {
     return [
-      "regular-macro",
+      "functional-macro",
       this.id,
       ["parameters", ...this.parameters],
       this.body,

--- a/src/syntax-objects/module.ts
+++ b/src/syntax-objects/module.ts
@@ -24,8 +24,8 @@ export class VoydModule extends ScopedNamedEntity {
   #value = new ChildList(undefined, this);
   /**
    * 0 = init,
-   * 1 = expanding regular macros,
-   * 2 = regular macros expanded,
+   * 1 = expanding functional macros,
+   * 2 = functional macros expanded,
    * 3 = checking types,
    * 4 = types checked
    */


### PR DESCRIPTION
## Summary
- rename regular macro handling to functional macros
- update semantics pipeline and tests for functional macros
- revise documentation to describe functional macros

## Testing
- `npm test -- -u`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfb6ebb58c832a98e20ac776ece881