### PR TITLE
Improve generic inference for closures lacking type annotations

### DIFF
--- a/src/__tests__/inference.e2e.test.ts
+++ b/src/__tests__/inference.e2e.test.ts
@@ -33,9 +33,9 @@ pub fn test3() -> i32
   let arr: Array<(String, i32)> = [("a", 42)]
   wrap(arr)
 
-fn reduce_test<T>({ arr: Array<T>, start: T, reducer cb: (acc: T, current: T) -> T }) -> T
+fn reduce_2<T>(arr: Array<T>, { start: T, reducer cb: (acc: T, current: T) -> T }) -> T
   let iterator = arr.iterate()
-  let reducer: (acc: T) -> T = (acc: T) =>
+  let reducer: (acc: T) -> T = (acc: T) -> T =>
     iterator.next().match(opt)
       Some<T>:
         reducer(cb(acc, opt.value))
@@ -44,8 +44,9 @@ fn reduce_test<T>({ arr: Array<T>, start: T, reducer cb: (acc: T, current: T) ->
   reducer(start)
 
 pub fn test4() -> i32
-  let arr: Array<i32> = [1, 2, 3]
-  reduce_test<i32> arr: arr start: 0 reducer: (acc: i32, current: i32) => acc + current
+  [1, 2, 3]
+    .reduce_2 start: 0 reducer: (acc, current) =>
+      acc + current
 
 // ---- generics-union-infer ----
 fn use_union<T>(val: Array<T> | String) -> i32

--- a/src/semantics/resolution/infer-type-args.ts
+++ b/src/semantics/resolution/infer-type-args.ts
@@ -263,6 +263,10 @@ export const inferTypeArgs = (
     const resolvedTypeExpr = resolveTypeExpr(typeExpr);
     if (argExpr.isClosure() && resolvedTypeExpr.isFnType()) {
       argExpr.setAttribute("parameterFnType", resolvedTypeExpr);
+      const untyped = argExpr.parameters.some(
+        (p) => !p.type && !p.typeExpr
+      );
+      if (untyped) continue;
     }
 
     const resolveArgExpr = resolveEntities(argExpr);
@@ -274,9 +278,7 @@ export const inferTypeArgs = (
 
     for (const [k, v] of result.entries()) {
       const existing = merged.get(k);
-      if (existing && !typesAreEqual(existing, v)) {
-        return undefined; // conflicting inference
-      }
+      if (existing && !typesAreEqual(existing, v)) return undefined;
       merged.set(k, v);
     }
   }


### PR DESCRIPTION
## Summary
- Skip closure arguments without parameter annotations during type argument inference
- Add reduce_2 test case that infers generic type from array and start parameter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c11aeb2688832a986ed0148edc2e0a