### PR TITLE
Fix call resolution when function and method share name

### DIFF
--- a/src/__tests__/fn-vs-method-resolve.e2e.test.ts
+++ b/src/__tests__/fn-vs-method-resolve.e2e.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { compile } from "../compiler.js";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+const program = `
+use std::all
+
+fn reduce<T>(arr: Array<T>, { start: T, reducer cb: (acc: T, current: T) -> T }) -> T
+  let iterator = arr.iterate()
+  let reducer: (acc: T) -> T = (acc: T) -> T =>
+    iterator.next().match(opt)
+      Some<T>:
+        reducer(cb(acc, opt.value))
+      None:
+        acc
+  reducer(start)
+
+fn add<T>(a: T, b: T)
+  a + b
+
+pub fn main() -> i32
+  [1, 2, 3]
+    .reduce<i32> start: 0 reducer: (acc: i32, current: i32) =>
+      acc + current
+    .add(3)
+`;
+
+describe("call resolution chooses function when method shares name", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(program);
+    instance = getWasmInstance(mod);
+  });
+
+  test("main returns expected", (t) => {
+    const fn = getWasmFn("main", instance);
+    assert(fn, "main exists");
+    t.expect(fn()).toEqual(9);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure call resolution keeps top-level functions when labeled arguments are used even if a receiver type has methods of the same name
- add e2e test covering function vs method name overlap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c122f33a9c832a99f47a60f461529c