### PR TITLE
fix call resolution for function-method name conflicts

### DIFF
--- a/src/__tests__/fixtures/method-fn-conflict.ts
+++ b/src/__tests__/fixtures/method-fn-conflict.ts
@@ -1,0 +1,22 @@
+export const methodFnConflictVoyd = `
+use std::all
+
+fn reduce<T>(arr: Array<T>, { start: T, reducer cb: (acc: T, current: T) -> T }) -> T
+  let iterator = arr.iterate()
+  let reducer: (acc: T) -> T = (acc: T) -> T =>
+    iterator.next().match(opt)
+      Some<T>:
+        reducer(cb(acc, opt.value))
+      None:
+        acc
+  reducer(start)
+
+fn add<T>(a: T, b: T)
+  a + b
+
+pub fn test1() -> i32
+  [1, 2, 3]
+    .reduce<i32> start: 0 reducer: (acc, current) =>
+      acc + current
+    .add(3)
+`;

--- a/src/__tests__/method-fn-conflict.e2e.test.ts
+++ b/src/__tests__/method-fn-conflict.e2e.test.ts
@@ -1,0 +1,20 @@
+import { methodFnConflictVoyd } from "./fixtures/method-fn-conflict.js";
+import { compile } from "../compiler.js";
+import { describe, test, beforeAll } from "vitest";
+import assert from "node:assert";
+import { getWasmFn, getWasmInstance } from "../lib/wasm.js";
+
+describe("Function call resolution with method name conflict", () => {
+  let instance: WebAssembly.Instance;
+
+  beforeAll(async () => {
+    const mod = await compile(methodFnConflictVoyd);
+    instance = getWasmInstance(mod);
+  });
+
+  test("resolves to function when args use labels", (t) => {
+    const fn = getWasmFn("test1", instance);
+    assert(fn, "test1 exists");
+    t.expect(fn()).toEqual(9);
+  });
+});

--- a/src/semantics/resolution/get-call-fn.ts
+++ b/src/semantics/resolution/get-call-fn.ts
@@ -220,8 +220,13 @@ const getCandidates = (call: Call): Fn[] => {
 
   if (arg1Type?.isObjectType()) {
     const isInsideImpl = call.parentImpl?.targetType?.id === arg1Type.id;
-    const arg0 = call.argAt(0);
-    const isObjectArgForm = !!(arg0 && arg0.isCall() && arg0.calls(":"));
+    // Determine if the call is using object-arg form by checking for any
+    // labeled arguments beyond the receiver. When such labels are present we
+    // should consider both top-level functions and methods; otherwise we limit
+    // candidates to receiver methods.
+    const isObjectArgForm = call.args
+      .toArray()
+      .some((a, i) => i > 0 && a.isCall() && a.calls(":"));
     const implFns = arg1Type.implementations
       ?.flatMap((impl) => {
         // Include both exported methods and internal methods so resolution


### PR DESCRIPTION
## Summary
- allow top-level functions with labeled arguments to compete with methods sharing the same name
- add regression test ensuring labeled call resolves to function despite method name conflict

## Testing
- `npx vitest run src/__tests__/method-fn-conflict.e2e.test.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c122f33a9c832a99f47a60f461529c