### PR TITLE
Preserve labels when splicing macro results

### DIFF
--- a/src/semantics/__tests__/functional-macros.test.ts
+++ b/src/semantics/__tests__/functional-macros.test.ts
@@ -49,3 +49,32 @@ bin_type_to_heap_type(FixedArray<Int>)\n`;
     ["BnrType", ["generics", ["FixedArray", ["generics", "Int"]]]],
   ]);
 });
+
+test("$@ preserves labeled args", async (t) => {
+  const code = `\
+macro binaryen_gc_call_1(func, args)\n\
+  quote binaryen func: $func namespace: gc args: $args\n\
+macro wrap()\n\
+  quote $@(binaryen_gc_call_1(modBinaryenTypeToHeapType, quote (arg)))\n\
+wrap()\n`;
+  const parserOutput = parse(code);
+  const files = {
+    std: new List([]),
+    test: parserOutput,
+  };
+  const resolvedModules = registerModules({
+    files,
+    srcPath: path.dirname("test"),
+    indexPath: "test.voyd",
+  });
+  const result = expandFunctionalMacros(resolvedModules) as any;
+  const testModule = (result as any).value.at(-1) as any;
+  const last = testModule.value.at(-1) as List;
+  const rendered = JSON.parse(JSON.stringify(last));
+  t.expect(rendered).toEqual([
+    "binaryen",
+    [":", "func", "modBinaryenTypeToHeapType"],
+    [":", "namespace", "gc"],
+    [":", "args", ["arg"]],
+  ]);
+});


### PR DESCRIPTION
## Summary
- allow macro-time evaluation to skip selected builtin functions
- avoid stripping labeled arguments when splicing in `quote`
- add regression test for `$@` splicing of `binaryen_gc_call_1`

## Testing
- `npm test`
- `npx vitest run src/semantics/__tests__/functional-macros.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c128e67a04832a807dff9ecc0496b1