### PR TITLE
Updated Functional Macro and Optional Chain Semantics

### DIFF
--- a/example.voyd
+++ b/example.voyd
@@ -4,7 +4,7 @@ fn reduce<T>(arr: Array<T>, { start: T, reducer cb: (acc: T, current: T) -> T })
   let iterator = arr.iterate()
   let reducer: (acc: T) -> T = (acc: T) -> T =>
     iterator.next().match(opt)
-      Some<T>:
+      Some:
         reducer(cb(acc, opt.value))
       None:
         acc

--- a/reference/control-flow.md
+++ b/reference/control-flow.md
@@ -142,7 +142,7 @@ let structure = {
   }
 }
 
-// Optional coalesce
+// Optional chain
 let value: Some<i32> = a?.b?.c // 5
 
 if x := opt then:

--- a/src/__tests__/fixtures/e2e-file.ts
+++ b/src/__tests__/fixtures/e2e-file.ts
@@ -440,7 +440,7 @@ pub fn test6() -> i32
     sum = sum + n
   sum
 
-// Optional coalesce: nested chain returns 5
+// Optional chaining: nested chain returns 5
 pub fn test7() -> i32
   let structure = {
     a: some { b: some { c: 5 } }

--- a/src/__tests__/fixtures/e2e-file.ts
+++ b/src/__tests__/fixtures/e2e-file.ts
@@ -443,10 +443,10 @@ pub fn test6() -> i32
 // Optional chaining: nested chain returns 5
 pub fn test7() -> i32
   let structure = {
-    a: some { b: some { c: 5 } }
+    a: some { b: some { c: some 5 } }
   }
-  let v: Some<i32> = structure.a?.b?.c
-  v.value
+  let v = structure.a?.b?.c
+  if a := v then: a else: -1
 
 // If-match without else: returns 4
 pub fn test8() -> i32

--- a/src/parser/__tests__/__snapshots__/parser.test.ts.snap
+++ b/src/parser/__tests__/__snapshots__/parser.test.ts.snap
@@ -985,6 +985,32 @@ exports[`parser can parse a file into a syntax expanded ast 1`] = `
         ],
       ],
       [
+        "hi",
+        [
+          ":",
+          [
+            "there",
+            "what",
+          ],
+          "is",
+        ],
+        [
+          "up",
+        ],
+        [
+          ":",
+          [
+            "what",
+          ],
+          [
+            "is",
+            [
+              "up",
+            ],
+          ],
+        ],
+      ],
+      [
         "pub",
         "fn",
         [
@@ -998,7 +1024,7 @@ exports[`parser can parse a file into a syntax expanded ast 1`] = `
               "new_string",
               [
                 "object",
-                "ObjectLiteral-1089",
+                "ObjectLiteral-1111",
                 [
                   [
                     "from",
@@ -1023,7 +1049,7 @@ exports[`parser can parse a file into a syntax expanded ast 1`] = `
                   "new_string",
                   [
                     "object",
-                    "ObjectLiteral-1101",
+                    "ObjectLiteral-1123",
                     [
                       [
                         "from",
@@ -1044,7 +1070,7 @@ exports[`parser can parse a file into a syntax expanded ast 1`] = `
                     "new_string",
                     [
                       "object",
-                      "ObjectLiteral-1126",
+                      "ObjectLiteral-1148",
                       [
                         [
                           "from",
@@ -1077,7 +1103,7 @@ exports[`parser can parse a file into a syntax expanded ast 1`] = `
                   "new_string",
                   [
                     "object",
-                    "ObjectLiteral-1143",
+                    "ObjectLiteral-1165",
                     [
                       [
                         "from",
@@ -1098,7 +1124,7 @@ exports[`parser can parse a file into a syntax expanded ast 1`] = `
                     "new_string",
                     [
                       "object",
-                      "ObjectLiteral-1172",
+                      "ObjectLiteral-1194",
                       [
                         [
                           "from",

--- a/src/parser/__tests__/fixtures/voyd-file.ts
+++ b/src/parser/__tests__/fixtures/voyd-file.ts
@@ -143,6 +143,9 @@ fn main()
     z: { a: 10, b: 20 }
   }
 
+  hi there(what): is(up)
+  what(): is(up)
+
   pub fn main()
     <div>
       <p>

--- a/src/parser/grammar.ts
+++ b/src/parser/grammar.ts
@@ -36,9 +36,9 @@ export const isOpChar = newTest([
   "%",
   "^",
   "&",
-  "~",
   "\\",
   "#",
+  "|",
 ]);
 
 export const isDigit = (char: string) => char >= "0" && char <= "9";
@@ -100,7 +100,6 @@ export const prefixOps: OpMap = new Map([
   ["#", 0],
   ["&", 7],
   ["!", 7],
-  ["~", 7],
   ["%", 7],
   ["$", 7],
   ["@", 7],

--- a/src/parser/syntax-macros/functional-notation.ts
+++ b/src/parser/syntax-macros/functional-notation.ts
@@ -1,4 +1,4 @@
-import { idIs, isOp } from "../grammar.js";
+import { idIs, isOp, isPrefixOp } from "../grammar.js";
 import { Expr, List, ListValue } from "../../syntax-objects/index.js";
 
 // Simplified and optimized version of functional notation parsing.

--- a/src/semantics/__tests__/__snapshots__/functional-macros.test.ts.snap
+++ b/src/semantics/__tests__/__snapshots__/functional-macros.test.ts.snap
@@ -7,7 +7,7 @@ exports[`functional macro expansion 1`] = `
   [
     "exports",
     [
-      "std#902",
+      "std#900",
     ],
   ],
   [
@@ -47,7 +47,7 @@ exports[`functional macro expansion 1`] = `
         ],
         [
           "functional-macro",
-          "\`#931",
+          "\`#928",
           [
             "parameters",
           ],
@@ -58,17 +58,14 @@ exports[`functional macro expansion 1`] = `
               [
                 "quote",
                 "quote",
-                [
-                  "$@",
-                  "body",
-                ],
+                "~~body",
               ],
             ],
           ],
         ],
         [
           "functional-macro",
-          "let#983",
+          "let#979",
           [
             "parameters",
           ],
@@ -89,7 +86,7 @@ exports[`functional macro expansion 1`] = `
                 "quote",
                 "define",
                 [
-                  "$",
+                  "~",
                   [
                     "extract",
                     "equals_expr",
@@ -97,7 +94,7 @@ exports[`functional macro expansion 1`] = `
                   ],
                 ],
                 [
-                  "$",
+                  "~",
                   [
                     "extract",
                     "equals_expr",
@@ -121,7 +118,7 @@ exports[`functional macro expansion 1`] = `
         ],
         [
           "functional-macro",
-          "fn#1847",
+          "fn#1827",
           [
             "parameters",
           ],
@@ -378,23 +375,14 @@ exports[`functional macro expansion 1`] = `
               [
                 "quote",
                 "define_function",
-                [
-                  "$",
-                  "identifier",
-                ],
-                [
-                  "$",
-                  "params",
-                ],
+                "~identifier",
+                "~params",
                 [
                   "return_type",
-                  [
-                    "$@",
-                    "return_type",
-                  ],
+                  "~~return_type",
                 ],
                 [
-                  "$",
+                  "~",
                   [
                     "concat",
                     [

--- a/src/semantics/__tests__/__snapshots__/functional-macros.test.ts.snap
+++ b/src/semantics/__tests__/__snapshots__/functional-macros.test.ts.snap
@@ -56,8 +56,8 @@ exports[`functional macro expansion 1`] = `
             [
               "block",
               [
-                "quote",
-                "quote",
+                "syntax_template",
+                "syntax_template",
                 "~~body",
               ],
             ],
@@ -83,7 +83,7 @@ exports[`functional macro expansion 1`] = `
                 ],
               ],
               [
-                "quote",
+                "syntax_template",
                 "define",
                 [
                   "~",
@@ -311,7 +311,7 @@ exports[`functional macro expansion 1`] = `
                             ":",
                             "else",
                             [
-                              "quote",
+                              "syntax_template",
                             ],
                           ],
                         ],
@@ -373,7 +373,7 @@ exports[`functional macro expansion 1`] = `
                 ],
               ],
               [
-                "quote",
+                "syntax_template",
                 "define_function",
                 "~identifier",
                 "~params",
@@ -386,7 +386,7 @@ exports[`functional macro expansion 1`] = `
                   [
                     "concat",
                     [
-                      "quote",
+                      "syntax_template",
                       "block",
                     ],
                     "expressions",

--- a/src/semantics/__tests__/fixtures/functional-macros-voyd-file.ts
+++ b/src/semantics/__tests__/fixtures/functional-macros-voyd-file.ts
@@ -1,10 +1,10 @@
 export const functionalMacrosVoydFile = `
 macro \`()
-  quote quote $@body
+  quote quote ~~body
 
 macro let()
   define equals_expr body.extract(0)
-  \` define $(equals_expr.extract(1)) $(equals_expr.extract(2))
+  \` define ~(equals_expr.extract(1)) ~(equals_expr.extract(2))
 
 // Extracts typed parameters from a list where index 0 is fn name, and offset_index+ are labeled_expr
 macro_let extract_parameters = (definitions) =>
@@ -41,10 +41,10 @@ macro fn()
     else:
       body.slice(1)
   \`(define_function,
-    $identifier,
-    $params,
-    (return_type $@return_type),
-    $(\`(block).concat(expressions)))
+    ~identifier,
+    ~params,
+    (return_type ~~return_type),
+    ~(\`(block).concat(expressions)))
 
 fn fib(n: i32) -> i32
   let base = 1

--- a/src/semantics/__tests__/fixtures/functional-macros-voyd-file.ts
+++ b/src/semantics/__tests__/fixtures/functional-macros-voyd-file.ts
@@ -1,6 +1,6 @@
 export const functionalMacrosVoydFile = `
 macro \`()
-  quote quote ~~body
+  syntax_template syntax_template ~~body
 
 macro let()
   define equals_expr body.extract(0)

--- a/src/semantics/__tests__/functional-macros.test.ts
+++ b/src/semantics/__tests__/functional-macros.test.ts
@@ -24,7 +24,7 @@ test("functional macro expansion", async (t) => {
 test("nested functional macro expansion", async (t) => {
   const code = `\
 macro binaryen_gc_call(func, args)\n\
-  quote binaryen func: $func namespace: gc args: $args\n\
+  quote binaryen func: ~func namespace: gc args: ~args\n\
 macro bin_type_to_heap_type(type)\n\
   binaryen_gc_call(modBinaryenTypeToHeapType, BnrType<type>)\n\
 bin_type_to_heap_type(FixedArray<Int>)\n`;
@@ -50,12 +50,12 @@ bin_type_to_heap_type(FixedArray<Int>)\n`;
   ]);
 });
 
-test("$@ preserves labeled args", async (t) => {
+test("~~ preserves labeled args", async (t) => {
   const code = `\
 macro binaryen_gc_call_1(func, args)\n\
-  quote binaryen func: $func namespace: gc args: $args\n\
+  quote binaryen func: ~func namespace: gc args: ~args\n\
 macro wrap()\n\
-  quote $@(binaryen_gc_call_1(modBinaryenTypeToHeapType, quote arg))\n\
+  quote ~~(binaryen_gc_call_1(modBinaryenTypeToHeapType, quote arg))\n\
 wrap()\n`;
   const parserOutput = parse(code);
   const files = {

--- a/src/semantics/__tests__/functional-macros.test.ts
+++ b/src/semantics/__tests__/functional-macros.test.ts
@@ -24,7 +24,7 @@ test("functional macro expansion", async (t) => {
 test("nested functional macro expansion", async (t) => {
   const code = `\
 macro binaryen_gc_call(func, args)\n\
-  quote binaryen func: ~func namespace: gc args: ~args\n\
+  syntax_template binaryen func: ~func namespace: gc args: ~args\n\
 macro bin_type_to_heap_type(type)\n\
   binaryen_gc_call(modBinaryenTypeToHeapType, BnrType<type>)\n\
 bin_type_to_heap_type(FixedArray<Int>)\n`;
@@ -53,9 +53,9 @@ bin_type_to_heap_type(FixedArray<Int>)\n`;
 test("~~ preserves labeled args", async (t) => {
   const code = `\
 macro binaryen_gc_call_1(func, args)\n\
-  quote binaryen func: ~func namespace: gc args: ~args\n\
+  syntax_template binaryen func: ~func namespace: gc args: ~args\n\
 macro wrap()\n\
-  quote ~~(binaryen_gc_call_1(modBinaryenTypeToHeapType, quote arg))\n\
+  syntax_template ~~(binaryen_gc_call_1(modBinaryenTypeToHeapType, syntax_template arg))\n\
 wrap()\n`;
   const parserOutput = parse(code);
   const files = {

--- a/src/semantics/check-types/check-call.ts
+++ b/src/semantics/check-types/check-call.ts
@@ -161,7 +161,11 @@ const checkWhile = (call: Call) => {
 const checkObjectInit = (call: Call): Call => {
   const literal = call.argAt(0);
   if (!literal?.isObjectLiteral()) {
-    throw new Error(`Expected object literal, got ${JSON.stringify(literal)}`);
+    throw new Error(
+      `Expected object literal, got ${JSON.stringify(literal)} at ${
+        literal?.location
+      }`
+    );
   }
   checkTypes(literal);
 

--- a/src/semantics/functional-macros.ts
+++ b/src/semantics/functional-macros.ts
@@ -273,6 +273,17 @@ const functions: Record<string, MacroFn | undefined> = {
           return (expanded as List).toArray();
         }
 
+        if (exp.isIdentifier() && exp.value.startsWith("~")) {
+          const identifier = new Identifier({
+            value: exp.value.slice(1),
+            ...exp.metadata,
+          });
+          const evaluated = evalMacroExpr(identifier);
+          return evaluated.isList() && evaluated.calls("use")
+            ? evaluated
+            : expandFunctionalMacros(evaluated);
+        }
+
         if (exp.isList()) return expand(exp);
 
         return exp;

--- a/src/semantics/functional-macros.ts
+++ b/src/semantics/functional-macros.ts
@@ -107,7 +107,7 @@ const evalMacroDef = (list: List): Macro => {
         .slice(2)
         .map(expandFunctionalMacros)
         .map((expr) => {
-          if (expr.isList() && expr.calls("quote")) return expr;
+          if (expr.isList() && expr.calls("syntax_template")) return expr;
           return initializeMacroBlocks(expr);
         }),
     }),
@@ -116,7 +116,7 @@ const evalMacroDef = (list: List): Macro => {
 
 const initializeMacroBlocks = (list: Expr): Expr => {
   if (!list.isList()) return list;
-  if (list.calls("quote")) return list;
+  if (list.calls("syntax_template")) return list;
 
   if (list.calls("block")) {
     return new Block({
@@ -250,7 +250,7 @@ const functions: Record<string, MacroFn | undefined> = {
 
     return new MacroLambda({ parameters, body });
   },
-  quote: (quote: List) => {
+  syntax_template: (template: List) => {
     const expand = (body: List): List =>
       body.flatMap((exp) => {
         if (exp.isList() && exp.calls("~~")) {
@@ -302,7 +302,7 @@ const functions: Record<string, MacroFn | undefined> = {
         return exp;
       });
 
-    const result = expand(quote);
+    const result = expand(template);
 
     if (result.length === 1 && result.at(0)?.isList()) {
       return result.at(0)!;
@@ -416,7 +416,13 @@ const functions: Record<string, MacroFn | undefined> = {
     }),
 };
 
-const fnsToSkipArgEval = new Set(["if", "quote", "=>", "define", "="]);
+const fnsToSkipArgEval = new Set([
+  "if",
+  "syntax_template",
+  "=>",
+  "define",
+  "=",
+]);
 
 const handleOptionalConditionParenthesis = (expr: Expr): Expr => {
   if (expr.isList() && expr.first()?.isList()) {

--- a/src/semantics/resolution/resolve-call.ts
+++ b/src/semantics/resolution/resolve-call.ts
@@ -979,7 +979,8 @@ const resolveClosureCall = (call: Call): Call => {
     : getExprType(closure);
   // Propagate the expected function type identity to the callee identifier so
   // codegen can align the call_ref heap type with the closure's compiled type.
-  if (closureType?.isFnType()) closure.setAttribute("parameterFnType", closureType);
+  if (closureType?.isFnType())
+    closure.setAttribute("parameterFnType", closureType);
   const params = closure.isClosure()
     ? closure.parameters
     : closureType?.isFnType()
@@ -1021,7 +1022,7 @@ const hasUntypedClosure = (expr: Expr | undefined): boolean =>
 const specialCallResolvers: Record<string, (c: Call) => Expr> = {
   "::": resolveModuleAccess,
   export: resolveExport,
-  "?.": resolveOptionalCoalesce,
+  "?.": resolveOptionalChain,
   if: resolveIf,
   "call-closure": resolveClosureCall,
   ":": resolveLabeledArg,
@@ -1083,14 +1084,14 @@ export const resolveCall = (call: Call, candidateFns?: Fn[]): Expr => {
   return call;
 };
 
-// Optional coalesce: a?.b
+// Optional chaining: a?.b
 const isSomeObject = (type?: Type): boolean =>
   !!(
     type?.isObjectType() &&
     (type.name.is("Some") || type.genericParent?.name.is("Some"))
   );
 
-function resolveOptionalCoalesce(call: Call): Expr {
+function resolveOptionalChain(call: Call): Expr {
   const left = resolveEntities(call.argAt(0));
   const right = call.argAt(1);
 

--- a/std/macros.voyd
+++ b/std/macros.voyd
@@ -2,20 +2,20 @@ export
   macro pub()
     // handle syntax like "pub fn me" and "pub fn(me)"
     if body.length == 1 and body.extract(0).is_list() then:
-      quote export block($@body)
+      quote export block(~~body)
     else:
-      quote export block($body)
+      quote export block(~body)
 
 pub macro `()
-  quote quote $@body
+  quote quote ~~body
 
 pub macro let()
   define equals_expr body.extract(0)
-  ` define $(equals_expr.extract(1)) $(equals_expr.extract(2))
+  ` define ~(equals_expr.extract(1)) ~(equals_expr.extract(2))
 
 pub macro var()
   define equals_expr body.extract(0)
-  ` define_mut $(equals_expr.extract(1)) $(equals_expr.extract(2))
+  ` define_mut ~(equals_expr.extract(1)) ~(equals_expr.extract(2))
 
 // Extracts typed parameters from a list where index 0 is fn name, and offset_index+ are labeled_expr
 macro_let extract_parameters = (definitions) =>
@@ -53,14 +53,14 @@ pub macro fn()
       body.slice(1)
   `(
     define_function,
-    $identifier,
-    $params,
-    (return_type $@return_type),
-    $@expressions
+    ~identifier,
+    ~params,
+    (return_type ~~return_type),
+    ~~expressions
   )
 
 pub macro binaryen_gc_call(func, args, return_type)
-  ` binaryen func: $func namespace: gc args: $args return_type: $return_type
+  ` binaryen func: ~func namespace: gc args: ~args return_type: ~return_type
 
 pub macro bin_type_to_heap_type(type)
-  ` $@binaryen_gc_call(modBinaryenTypeToHeapType, list(BnrType<type>))
+  ` binaryen_gc_call(modBinaryenTypeToHeapType, list(BnrType<~type>))

--- a/std/macros.voyd
+++ b/std/macros.voyd
@@ -17,31 +17,6 @@ pub macro var()
   define equals_expr body.extract(0)
   ` define_mut $(equals_expr.extract(1)) $(equals_expr.extract(2))
 
-pub macro global()
-  let mutability = body.extract(0)
-  let equals_expr = body.extract(1)
-  let function =
-    if mutability == 'let' then:
-      ` define_global
-    else:
-      ` define_mut_global
-  `($@function,
-    $(equals_expr.extract(1)),
-    $(equals_expr.extract(2)))
-
-pub macro ';'()
-  let func = body.extract(0)
-  let block = body.extract(1)
-  let args =
-    if block.extract(0) == 'block' then:
-      block.slice(1)
-    else:
-      block
-  if is_list(func) then:
-    func.concat(args)
-  else:
-    `($func).concat(args)
-
 // Extracts typed parameters from a list where index 0 is fn name, and offset_index+ are labeled_expr
 macro_let extract_parameters = (definitions) =>
   `(parameters).concat definitions.slice(1)

--- a/std/macros.voyd
+++ b/std/macros.voyd
@@ -2,12 +2,12 @@ export
   macro pub()
     // handle syntax like "pub fn me" and "pub fn(me)"
     if body.length == 1 and body.extract(0).is_list() then:
-      quote export block(~~body)
+      syntax_template export block(~~body)
     else:
-      quote export block(~body)
+      syntax_template export block(~body)
 
 pub macro `()
-  quote quote ~~body
+  syntax_template syntax_template ~~body
 
 pub macro let()
   define equals_expr body.extract(0)

--- a/std/operators.voyd
+++ b/std/operators.voyd
@@ -1,13 +1,13 @@
 use std::macros::all
 
 macro def_wasm_operator(op, wasm_fn, arg_type, return_type)
-  let params = `(parameters, left: $arg_type, right: $arg_type)
+  let params = `(parameters, left: ~arg_type, right: ~arg_type)
   let body = ` binaryen
-    func: $wasm_fn
-    namespace: $arg_type
+    func: ~wasm_fn
+    namespace: ~arg_type
     args: list(left, right)
 
-  ` define_function $op $params return_type($return_type) $body
+  ` define_function ~op ~params return_type(~return_type) ~body
 
 pub def_wasm_operator('<', lt_s, i32, bool)
 pub def_wasm_operator('>', gt_s, i32, bool)

--- a/std/optional.voyd
+++ b/std/optional.voyd
@@ -16,18 +16,25 @@ pub fn some<T>(v: T) -> Some<T>
 pub fn none() -> None
   None {}
 
-// Todo equitable trait constraint
-pub fn equals<T>(a: Option<T>, b: Option<T>) -> bool
-  match(a)
+// Convenience function overloads for lifting values when method resolution is not available
+pub fn lift<T>(v: T) -> Optional<T>
+  some(v)
+
+pub fn lift<T>(v: Optional<T>) -> Optional<T>
+  v
+
+// Optional chaining operator macro: l?.r
+// Expands to: if __opc := l.lift() then: __opc.r.lift() else: none()
+pub macro '?.'(l, r)
+  ` if
+    (:= __opc $l)
+    (: then (lift (member-access __opc $r)))
+    (: else (none))
+
+// Helper to chain over Optional values
+pub fn opt_chain<T, O>(opt: Optional<T>, f: (v: T) -> Optional<O>) -> Optional<O>
+  match(opt)
     Some<T>:
-      match(b)
-        Some<T>:
-          a.value == b.value
-        None:
-          false
+      f(opt.value)
     None:
-      match(b)
-        Some<T>:
-          false
-        None:
-          true
+      none()

--- a/std/optional.voyd
+++ b/std/optional.voyd
@@ -18,4 +18,4 @@ pub fn none() -> None
 
 
 pub macro '?.'(l, r)
-  ` if __opc := $l then: __opc.~r else: none()
+  ` if __opc := ~l then: __opc.~r else: none()

--- a/std/optional.voyd
+++ b/std/optional.voyd
@@ -34,7 +34,7 @@ pub macro '?.'(l, r)
 // Helper to chain over Optional values
 pub fn opt_chain<T, O>(opt: Optional<T>, f: (v: T) -> Optional<O>) -> Optional<O>
   match(opt)
-    Some<T>:
+    Some:
       f(opt.value)
     None:
       none()

--- a/std/optional.voyd
+++ b/std/optional.voyd
@@ -10,31 +10,12 @@ pub obj None {}
 pub type Optional<T> = Some<T> | None
 pub type Option<T> = Optional<T>
 
-pub fn some<T>(v: T) -> Some<T>
-  Some { value: v }
+pub fn some<T>(v: T) -> Optional<T>
+  Some<T> { value: v }
 
 pub fn none() -> None
   None {}
 
-// Convenience function overloads for lifting values when method resolution is not available
-pub fn lift<T>(v: T) -> Optional<T>
-  some(v)
 
-pub fn lift<T>(v: Optional<T>) -> Optional<T>
-  v
-
-// Optional chaining operator macro: l?.r
-// Expands to: if __opc := l.lift() then: __opc.r.lift() else: none()
 pub macro '?.'(l, r)
-  ` if
-    (:= __opc $l)
-    (: then (lift (member-access __opc $r)))
-    (: else (none))
-
-// Helper to chain over Optional values
-pub fn opt_chain<T, O>(opt: Optional<T>, f: (v: T) -> Optional<O>) -> Optional<O>
-  match(opt)
-    Some:
-      f(opt.value)
-    None:
-      none()
+  ` if __opc := $l then: __opc.~r else: none()


### PR DESCRIPTION
# Overview

This PR replaces the macro "unquote" operators $ and $@ with ~ and ~~ respectively. It also updates the `?.` optional chain operator to only work on optional values.

As a result of this change, the `?.` is now defined as a functional macro in std lib.

# Why the ~ change

$ and $@ acted as operators. So `$hi` would get turned into `($ hi)`. This behavior prevented us from dynamically setting function names. Because `~` is not an operator character (anymore), `~hi` is treated as a uniform identifier by the parser. So the functional macro interpreter can more predictably insert syntax without the parser from modifying the syntax in unexpected ways.

Note: We also modify the syntax_macro function (fka quote) to unwrap lists containing a single nested list. This is intentional and required. Otherwise certain macros would be impossible due to how the parser parses syntax templates.