### PR TITLE
Add cond primitive

### DIFF
--- a/reference/spec/core.md
+++ b/reference/spec/core.md
@@ -39,7 +39,7 @@ Multiple conditions
 Syntax:
 
 ```lisp
-(cond ($condition:Boolean result:Expr)*)
+(cond (case: $condition:Boolean do: $expr:Expr)* (default: $expr:Expr)?)
 ```
 
 ## BNR

--- a/src/__tests__/control-flow.e2e.test.ts
+++ b/src/__tests__/control-flow.e2e.test.ts
@@ -27,5 +27,8 @@ describe("Control Flow sugar", () => {
     expect("test10", 1);
     expect("test11", 4);
     expect("test12", 12);
+    expect("test13", 3);
+    expect("test14", 1);
+    expect("test15", 3);
   });
 });

--- a/src/__tests__/fixtures/e2e-file.ts
+++ b/src/__tests__/fixtures/e2e-file.ts
@@ -485,6 +485,21 @@ pub fn test12() -> i32
   while iterator.next().match(x, Some) do:
     sum = sum + x.value
   sum
+
+pub fn test13() -> i32
+  let x = 5
+  cond case: x > 5 do: 1 case: x < 5 do: 2 default: 3
+
+pub fn test14() -> i32
+  var res = 0
+  let x = 6
+  cond case: x > 5 do: (res = 1) case: x < 5 do: (res = 2)
+  res
+
+pub fn test15() -> i32
+  let x = 5
+  let obj = cond case: x > 5 do: { a: 1 } case: x < 5 do: { a: 2 } default: { a: 3 }
+  obj.a
 `;
 
 export const goodTypeInferenceText = `

--- a/src/codegen/builtin-call-registry.ts
+++ b/src/codegen/builtin-call-registry.ts
@@ -2,6 +2,7 @@ import { CompileExprOpts, compileExpression } from "../codegen.js";
 import { Call } from "../syntax-objects/call.js";
 import { compileAssign } from "./builtin-calls/compile-assign.js";
 import { compileIf } from "./builtin-calls/compile-if.js";
+import { compileCond } from "./builtin-calls/compile-cond.js";
 import { compileExport } from "./builtin-calls/compile-export.js";
 import { compileMemberAccess } from "./builtin-calls/compile-member-access.js";
 import { compileWhile } from "./builtin-calls/compile-while.js";
@@ -14,6 +15,7 @@ export type CallCompiler = (opts: CompileExprOpts<Call>) => number;
 export const builtinCallCompilers = new Map<string, CallCompiler>([
   ["=", compileAssign],
   ["if", compileIf],
+  ["cond", compileCond],
   ["export", compileExport],
   ["mod", (opts) => opts.mod.nop()],
   ["member-access", compileMemberAccess],

--- a/src/codegen/builtin-calls/compile-cond.ts
+++ b/src/codegen/builtin-calls/compile-cond.ts
@@ -1,0 +1,48 @@
+import binaryen from "binaryen";
+import {
+  CompileExprOpts,
+  compileExpression,
+  asStmt,
+  mapBinaryenType,
+} from "../../codegen.js";
+import { Call } from "../../syntax-objects/call.js";
+import { ObjectLiteral } from "../../syntax-objects/object-literal.js";
+
+export const compileCond = (opts: CompileExprOpts<Call>) => {
+  const { expr, mod } = opts;
+  const args = expr.args.toArray();
+  const defaultExpr = args.at(-1)?.hasAttribute("condDefault")
+    ? args.pop()
+    : undefined;
+
+  const returnType = expr.getType()
+    ? mapBinaryenType(opts, expr.getType()!)
+    : binaryen.none;
+
+  let elseNode =
+    defaultExpr !== undefined
+      ? compileExpression({ ...opts, expr: defaultExpr })
+      : undefined;
+
+  for (let i = args.length - 1; i >= 0; i--) {
+    const pair = args[i] as ObjectLiteral;
+    const condExpr = pair.fields.find((f) => f.name === "case")!.initializer;
+    const thenExpr = pair.fields.find((f) => f.name === "do")!.initializer;
+    const condition = compileExpression({
+      ...opts,
+      expr: condExpr,
+      isReturnExpr: false,
+    });
+    const ifTrue = compileExpression({ ...opts, expr: thenExpr });
+    elseNode =
+      returnType === binaryen.none
+        ? mod.if(
+            condition,
+            asStmt(mod, ifTrue),
+            elseNode !== undefined ? asStmt(mod, elseNode) : undefined
+          )
+        : mod.if(condition, ifTrue, elseNode);
+  }
+
+  return elseNode!;
+};

--- a/src/semantics/check-types/check-call.ts
+++ b/src/semantics/check-types/check-call.ts
@@ -9,6 +9,7 @@ import { formatTypeName } from "../type-format.js";
 import { checkTypes } from "./check-types.js";
 import { checkAssign } from "./check-assign.js";
 import { checkIf } from "./check-if.js";
+import { checkCond } from "./check-cond.js";
 import { checkBinaryenCall } from "./check-binaryen-call.js";
 import { checkLabeledArg } from "./check-labeled-arg.js";
 import { checkFixedArrayType } from "./check-fixed-array-type.js";
@@ -16,6 +17,7 @@ import { checkFixedArrayType } from "./check-fixed-array-type.js";
 export const checkCallTypes = (call: Call): Call | ObjectLiteral => {
   if (call.calls("export")) return checkExport(call);
   if (call.calls("if")) return checkIf(call);
+  if (call.calls("cond")) return checkCond(call);
   if (call.calls("call-closure")) return checkClosureCall(call);
   if (call.calls("binaryen")) return checkBinaryenCall(call);
   if (call.calls("mod")) return call;

--- a/src/semantics/check-types/check-cond.ts
+++ b/src/semantics/check-types/check-cond.ts
@@ -1,0 +1,52 @@
+import { Call } from "../../syntax-objects/call.js";
+import { Expr, bool, dVoid } from "../../syntax-objects/index.js";
+import { getExprType } from "../resolution/get-expr-type.js";
+import { typesAreCompatible } from "../resolution/index.js";
+import { checkTypes } from "./check-types.js";
+
+export const checkCond = (call: Call) => {
+  const args = call.args.toArray();
+
+  const branchExprs: Expr[] = [];
+  let hasDefault = false;
+
+  args.forEach((arg) => {
+    if (arg.isObjectLiteral() && !arg.hasAttribute("condDefault")) {
+      const cond = checkTypes(
+        arg.fields.find((f) => f.name === "case")?.initializer
+      );
+      const condType = getExprType(cond);
+      if (!cond || !condType || !typesAreCompatible(condType, bool)) {
+        throw new Error(
+          `Cond conditions must resolve to a boolean at ${cond?.location}`
+        );
+      }
+      const thenExpr = arg.fields.find((f) => f.name === "do")?.initializer;
+      if (thenExpr) branchExprs.push(checkTypes(thenExpr));
+    } else {
+      hasDefault = true;
+      branchExprs.push(checkTypes(arg));
+    }
+  });
+
+  if (!call.type) {
+    throw new Error(`Unable to determine return type of cond at ${call.location}`);
+  }
+
+  if (!hasDefault) {
+    call.type = dVoid;
+    return call;
+  }
+
+  const expected = call.type;
+  branchExprs.forEach((expr) => {
+    const t = getExprType(expr);
+    if (!typesAreCompatible(t, expected)) {
+      throw new Error(
+        `Cond condition clauses do not return same type at ${call.location}`
+      );
+    }
+  });
+
+  return call;
+};


### PR DESCRIPTION
## Summary
- mark `cond` default branches with an attribute so object literals can be returned as the default
- detect the attribute in code generation and type checking
- add an end-to-end test covering object literal defaults

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6289fdb54832a89d43b83c24d9b87