### PR TITLE
Align generic compatibility with alias identity

### DIFF
--- a/src/semantics/resolution/types-are-compatible.ts
+++ b/src/semantics/resolution/types-are-compatible.ts
@@ -109,14 +109,16 @@ export const typesAreCompatible = (
     }
 
     if (a.genericParent && a.genericParent.id === b.genericParent?.id) {
-      return !!a.appliedTypeArgs?.every((arg, index) =>
-        typesAreCompatible(
-          getExprType(arg),
-          getExprType(b.appliedTypeArgs?.[index]),
-          opts,
-          visited
-        )
-      );
+      const aArgs = a.appliedTypeArgs ?? [];
+      const bArgs = b.appliedTypeArgs ?? [];
+      if (aArgs.length !== bArgs.length) return false;
+      return aArgs.every((arg, index) => {
+        const aType = getExprType(arg);
+        const bType = getExprType(bArgs[index]);
+        if (!aType || !bType) return false;
+        if (aType.id === bType.id) return true;
+        return typesAreCompatible(aType, bType, opts, visited);
+      });
     }
 
     if (a.idNum === b.idNum) return true;
@@ -148,14 +150,16 @@ export const typesAreCompatible = (
 
   if (a.isTraitType() && b.isTraitType()) {
     if (a.genericParent && a.genericParent.id === b.genericParent?.id) {
-      return !!a.appliedTypeArgs?.every((arg, index) =>
-        typesAreCompatible(
-          getExprType(arg),
-          getExprType(b.appliedTypeArgs?.[index]),
-          opts,
-          visited
-        )
-      );
+      const aArgs = a.appliedTypeArgs ?? [];
+      const bArgs = b.appliedTypeArgs ?? [];
+      if (aArgs.length !== bArgs.length) return false;
+      return aArgs.every((arg, index) => {
+        const aType = getExprType(arg);
+        const bType = getExprType(bArgs[index]);
+        if (!aType || !bType) return false;
+        if (aType.id === bType.id) return true;
+        return typesAreCompatible(aType, bType, opts, visited);
+      });
     }
     return a.id === b.id;
   }


### PR DESCRIPTION
## Summary
- guard generic compatibility checks with type argument identity so alias-based containers match when their arguments refer to the same type

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9da58045c832a8956efa221448b1e