### PR TITLE
Update open effect row syntax and rename try forward to try open

### DIFF
--- a/apps/smoke/fixtures/range-for.voyd
+++ b/apps/smoke/fixtures/range-for.voyd
@@ -38,7 +38,7 @@ pub fn range_iterator_inclusive_i32_max_stops() -> i32
 pub fn range_for_handles_tail_effects_after_host_seed() -> f64
   let ~rng = LocalRng::seeded_from_host()
 
-  try forward
+  try open
     var total = 0.0
     for value in 0..32:
       total = total + RangeForProbe::rand_f64()

--- a/apps/smoke/fixtures/vtrace-compute-benchmark.voyd
+++ b/apps/smoke/fixtures/vtrace-compute-benchmark.voyd
@@ -22,7 +22,7 @@ pub fn benchmark() -> i32
 pub fn debug_effect_rand_plain() -> f64
   let ~rng = LocalRng::seeded(to_i64(42))
 
-  try forward
+  try open
     RenderCtx::rand_f64()
   RenderCtx::rand_f64(tail):
     tail(rng.random_f64())
@@ -32,7 +32,7 @@ pub fn debug_effect_rand_plain() -> f64
 pub fn debug_effect_rand_range() -> f64
   let ~rng = LocalRng::seeded(to_i64(42))
 
-  try forward
+  try open
     RenderCtx::rand_f64(0.0..0.5)
   RenderCtx::rand_f64(tail):
     tail(rng.random_f64())
@@ -42,7 +42,7 @@ pub fn debug_effect_rand_range() -> f64
 pub fn debug_effect_rand_vec3_sum() -> f64
   let ~rng = LocalRng::seeded(to_i64(42))
 
-  try forward
+  try open
     let value = Vec3::random(0.0..0.5)
     value.x + value.y + value.z
   RenderCtx::rand_f64(tail):
@@ -53,7 +53,7 @@ pub fn debug_effect_rand_vec3_sum() -> f64
 pub fn debug_empty_world_checksum() -> i32
   let ~rng = LocalRng::seeded(to_i64(42))
 
-  try forward
+  try open
     Camera({
       aspect_ratio: 16.0 / 9.0,
       image_width: 48,
@@ -80,7 +80,7 @@ fn render_with_seed({
 }) -> i32
   let ~rng = LocalRng::seeded(seed)
 
-  try forward
+  try open
     let ~world = HittableList()
     let ground_material = Lambertian(Color(0.5, 0.5, 0.5))
     world.add(Sphere(center: Point3(0.0, -1000.0, 0.0), radius: 1000.0, mat: ground_material))

--- a/apps/smoke/src/open-callback-effect-rows.test.ts
+++ b/apps/smoke/src/open-callback-effect-rows.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { createSdk, type CompileResult } from "@voyd-lang/sdk";
+
+const source = `
+@effect(id: "com.example.async")
+eff Async
+  fn await(tail, value: i32) -> i32
+
+@effect(id: "com.example.log")
+eff Log
+  fn write(tail, value: i32) -> void
+
+fn call<T>(cb: fn() : (Async, open) -> T) : (open) -> T
+  try open
+    cb()
+  Async::await(tail, value):
+    tail(value + 1)
+
+pub fn main() -> i32
+  try
+    call(() =>
+      let value = Async::await(10)
+      Log::write(value)
+      value
+    )
+  Log::write(tail, value):
+    tail()
+`;
+
+const expectCompileSuccess = (
+  result: CompileResult
+): Extract<CompileResult, { success: true }> => {
+  expect(result.success).toBe(true);
+  if (!result.success) {
+    throw new Error(result.diagnostics.map((diagnostic) => diagnostic.message).join("\n"));
+  }
+  return result;
+};
+
+describe("smoke: open callback effect rows", () => {
+  it("handles a required callback effect and forwards the remaining tail", async () => {
+    const sdk = createSdk();
+    const compiled = expectCompileSuccess(await sdk.compile({ source }));
+
+    await expect(compiled.run<number>({ entryName: "main" })).resolves.toBe(11);
+  });
+});

--- a/apps/vscode/scripts/test-grammar.mjs
+++ b/apps/vscode/scripts/test-grammar.mjs
@@ -17,6 +17,9 @@ const stringPattern = grammar.repository.constants?.patterns?.find(
 const constantPattern = grammar.repository.constants?.patterns?.find(
   (pattern) => pattern.name === "constant.language.voyd"
 );
+const openEffectRowPattern = grammar.repository.keywords?.patterns?.find(
+  (pattern) => pattern.name === "keyword.other.effect-row.voyd"
+);
 
 assert(clausePattern, "Expected clause-call grammar pattern to exist");
 assert.equal(
@@ -59,6 +62,17 @@ assert(
 assert(
   !constantRegex.test("MyType"),
   "PascalCase type names should not be highlighted as named constants"
+);
+
+assert(openEffectRowPattern, "Expected explicit open effect-row grammar pattern to exist");
+const openEffectRowRegex = new RegExp(openEffectRowPattern.match, "g");
+assert(
+  openEffectRowRegex.test("fn call(cb: fn() : (Async, open) -> i32) -> i32"),
+  "Expected open callback effect-row markers to be highlighted"
+);
+assert(
+  !openEffectRowRegex.test("let open = 1"),
+  "Expected ordinary identifiers named open to avoid effect-row highlighting"
 );
 
 const interpolationRegex = new RegExp(interpolationPattern.begin, "g");

--- a/packages/compiler/src/__tests__/effects-pkg-root.test.ts
+++ b/packages/compiler/src/__tests__/effects-pkg-root.test.ts
@@ -303,7 +303,7 @@ eff Output
 
 pub fn draw(): Output -> void
   let seed = 7
-  try forward
+  try open
     let value = Random::next()
     Output::write(value)
   Random::next(tail):

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/effects-handled-before-host-boundary.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/effects-handled-before-host-boundary.voyd
@@ -11,7 +11,7 @@ fn helper(): Hidden -> i32
   Hidden::poke(Box { value: 41 })
 
 pub fn main(): Host -> i32
-  try forward
+  try open
     helper() + Host::next_i32()
   Hidden::poke(tail, payload: Box):
     tail(payload.value)

--- a/packages/compiler/src/codegen/expressions/effect-handler.ts
+++ b/packages/compiler/src/codegen/expressions/effect-handler.ts
@@ -1,5 +1,7 @@
 import binaryen from "binaryen";
 import {
+  binaryenTypeFromHeapType,
+  binaryenTypeToHeapType,
   defineStructType,
   initStruct,
   refFunc,
@@ -52,6 +54,21 @@ import {
 import { walkHirExpression } from "../hir-walk.js";
 
 const bin = binaryen as unknown as AugmentedBinaryen;
+
+const NON_REF_WASM_TYPES = new Set<number>([
+  binaryen.none,
+  binaryen.unreachable,
+  binaryen.i32,
+  binaryen.i64,
+  binaryen.f32,
+  binaryen.f64,
+  binaryen.v128,
+]);
+
+const ensureNullableRefType = (type: binaryen.Type): binaryen.Type =>
+  NON_REF_WASM_TYPES.has(type)
+    ? type
+    : binaryenTypeFromHeapType(binaryenTypeToHeapType(type), true);
 
 type HandlerCodegenState = {
   envLayouts: Map<
@@ -275,6 +292,7 @@ const emitClauseFunction = ({
   env,
   ctx,
   handlerResumeKind,
+  handlerResultTypeId,
   compileExpr,
   typeInstanceId,
 }: {
@@ -283,6 +301,7 @@ const emitClauseFunction = ({
   env: ReturnType<typeof buildClauseEnv>;
   ctx: CodegenContext;
   handlerResumeKind: ResumeKind;
+  handlerResultTypeId: TypeId;
   compileExpr: ExpressionCompiler;
   typeInstanceId?: ProgramFunctionInstanceId;
 }): { fnName: string; fnRefType: binaryen.Type } => {
@@ -512,23 +531,25 @@ const emitClauseFunction = ({
       continuationDesc.kind === "function"
         ? continuationDesc.parameters[0]?.type ?? ctx.program.primitives.void
         : resolvedReturnTypeId;
-    const continuationBinding = allocateTempLocal(
-      wasmTypeFor(continuationTypeId, ctx),
-      fnCtx,
-      continuationTypeId,
-      ctx,
-    );
-    initOps.push(
-      ctx.mod.local.set(
-        continuationBinding.index,
-        ctx.mod.ref.null(continuationBinding.type)
-      )
-    );
-    fnCtx.bindings.set(clause.parameters[0].symbol, {
-      ...continuationBinding,
-      kind: "local",
-      typeId: continuationTypeId,
-    });
+    if (continuationDesc.kind === "function") {
+      const continuationBinding = allocateTempLocal(
+        ensureNullableRefType(wasmTypeFor(continuationTypeId, ctx)),
+        fnCtx,
+        continuationTypeId,
+        ctx,
+      );
+      initOps.push(
+        ctx.mod.local.set(
+          continuationBinding.index,
+          ctx.mod.ref.null(ensureNullableRefType(continuationBinding.type))
+        )
+      );
+      fnCtx.bindings.set(clause.parameters[0].symbol, {
+        ...continuationBinding,
+        kind: "local",
+        typeId: continuationTypeId,
+      });
+    }
     fnCtx.continuations = new Map([
       [
         clause.parameters[0].symbol,
@@ -556,7 +577,7 @@ const emitClauseFunction = ({
     const storedArgType = wasmHeapFieldTypeFor(typeId, ctx, new Set(), "runtime");
     const storedArg =
       !argsType
-        ? ctx.mod.ref.null(storedArgType)
+        ? ctx.mod.ref.null(ensureNullableRefType(storedArgType))
         : structGetFieldValue({
             mod: ctx.mod,
             fieldIndex: index,
@@ -581,18 +602,18 @@ const emitClauseFunction = ({
     clause.parameters[0] &&
     typeof ctx.module.types.getValueType(clause.parameters[0].symbol) === "number"
       ? ((): TypeId => {
-          const continuationTypeId = ctx.module.types.getValueType(
+          const rawContinuationTypeId = ctx.module.types.getValueType(
             clause.parameters[0].symbol
           ) as TypeId;
-          const resolvedContinuationTypeId = substitution
-            ? ctx.program.types.substitute(continuationTypeId, substitution)
-            : continuationTypeId;
-          const desc = ctx.program.types.getTypeDesc(resolvedContinuationTypeId);
+          const continuationTypeId = activeSubstitution
+            ? ctx.program.types.substitute(rawContinuationTypeId, activeSubstitution)
+            : rawContinuationTypeId;
+          const desc = ctx.program.types.getTypeDesc(continuationTypeId);
           return desc.kind === "function"
             ? desc.returnType
-            : resolvedReturnTypeId;
+            : handlerResultTypeId;
         })()
-      : resolvedReturnTypeId;
+      : handlerResultTypeId;
   const body = compileExpr({
     exprId: clause.body,
     ctx,
@@ -672,6 +693,7 @@ export const compileEffectHandlerExpr = (
     throw new Error("effect handler requires an effectful function context");
   }
   const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+  const handlerResultTypeId = getRequiredExprType(expr.id, ctx, typeInstanceId);
 
   const env = buildClauseEnv({ expr, ctx, fnCtx });
   const prevHandlerLocal = allocateTempLocal(
@@ -724,6 +746,7 @@ export const compileEffectHandlerExpr = (
         env,
         ctx,
         handlerResumeKind: resumeKind,
+        handlerResultTypeId,
         compileExpr,
         typeInstanceId,
       });

--- a/packages/compiler/src/parser/__tests__/function-syntax.test.ts
+++ b/packages/compiler/src/parser/__tests__/function-syntax.test.ts
@@ -27,6 +27,106 @@ test("parses fn with effect annotation and =", (t) => {
   ]);
 });
 
+test("parses explicit open callback effect rows in parameter types", (t) => {
+  const code = `
+fn run(cb: fn() : (open) -> i32)
+  cb()`;
+
+  t.expect(toPlain(code)).toEqual([
+    "ast",
+    [
+      "fn",
+      [
+        "run",
+        [
+          ":",
+          [":", "cb", ["fn"]],
+          ["->", "open", "i32"],
+        ],
+      ],
+      ["block", ["cb"]],
+    ],
+  ]);
+});
+
+test("parses explicit open rows on function declarations", (t) => {
+  const code = `
+fn call() : (open) -> i32
+  1`;
+
+  t.expect(toPlain(code)).toEqual([
+    "ast",
+    [
+      "fn",
+      [
+        ":",
+        ["call"],
+        ["->", "open", "i32"],
+      ],
+      ["block", "1"],
+    ],
+  ]);
+});
+
+test("parses explicit open callback effect rows in local let annotations", (t) => {
+  const code = `
+fn main()
+  let cb: fn() : (open) -> i32 = () => 1
+  cb()`;
+
+  t.expect(toPlain(code)).toEqual([
+    "ast",
+    [
+      "fn",
+      ["main"],
+      [
+        "block",
+        [
+          "let",
+          [
+            "=",
+            [
+              ":",
+              [":", "cb", ["fn"]],
+              ["->", "open", "i32"],
+            ],
+            ["=>", [], "1"],
+          ],
+        ],
+        ["cb"],
+      ],
+    ],
+  ]);
+});
+
+test("parses explicit open rows on = declarations", (t) => {
+  t.expect(toPlain("fn run() : (open) -> i32 = 1")).toEqual([
+    "ast",
+    [
+      "fn",
+      ["=", [":", ["run"], ["->", "open", "i32"]], "1"],
+    ],
+  ]);
+});
+
+test("parses explicit open rows on trait default methods", (t) => {
+  const code = `
+trait T
+  fn run() : (open) -> i32 = 1`;
+
+  t.expect(toPlain(code)).toEqual([
+    "ast",
+    [
+      "trait",
+      "T",
+      [
+        "block",
+        ["fn", ["=", [":", ["run"], ["->", "open", "i32"]], "1"]],
+      ],
+    ],
+  ]);
+});
+
 test("ignores inline line comments in function bodies", (t) => {
   t.expect(toPlain("fn fib() = // comment\n  test()")) .toEqual([
     "ast",

--- a/packages/compiler/src/semantics/__tests__/effects-lowering.test.ts
+++ b/packages/compiler/src/semantics/__tests__/effects-lowering.test.ts
@@ -182,7 +182,7 @@ fn main(): Async -> i32
     expect(handler.handlers[0]?.parameters).toHaveLength(0);
   });
 
-  it("marks try forward handlers to propagate unhandled operations", () => {
+  it("marks try open handlers to propagate unhandled operations", () => {
     const hir = lower(`
 eff Async
   fn await(tail) -> i32
@@ -190,7 +190,7 @@ eff Log
   fn write(tail) -> void
 
 fn main(): (Async, Log) -> i32
-  try forward
+  try open
     let value = Async::await()
     Log::write()
     value
@@ -202,6 +202,6 @@ fn main(): (Async, Log) -> i32
     );
     expect(handler).toBeDefined();
     if (!handler || handler.exprKind !== "effect-handler") return;
-    expect(handler.forwardUnhandled).toBe(true);
+    expect(handler.openUnhandled).toBe(true);
   });
 });

--- a/packages/compiler/src/semantics/__tests__/lowering.test.ts
+++ b/packages/compiler/src/semantics/__tests__/lowering.test.ts
@@ -248,6 +248,130 @@ fn constrained<T: Named, U: { value: i32 }, V: Animal>(a: T, b: U, c: V) -> i32
     }
   });
 
+  it("lowers explicit open callback effect rows in function types", () => {
+    const source = `
+eff Async
+  fn await(tail) -> i32
+
+fn call(cb: fn() : (Async, open) -> i32)
+  cb()
+`;
+    const ast = parse(source, "main.voyd");
+    const symbolTable = new SymbolTable({ rootOwner: ast.syntaxId });
+    const moduleSymbol = symbolTable.declare({
+      name: "main.voyd",
+      kind: "module",
+      declaredAt: ast.syntaxId,
+    });
+    const binding = runBindingPipeline({ moduleForm: ast, symbolTable });
+    const builder = createHirBuilder({
+      path: "main.voyd",
+      scope: moduleSymbol,
+      ast: ast.syntaxId,
+      span: toSourceSpan(ast),
+    });
+
+    const hir = runLoweringPipeline({
+      builder,
+      binding,
+      moduleNodeId: ast.syntaxId,
+      modulePath: binding.modulePath,
+      packageId: binding.packageId,
+      isPackageRoot: binding.isPackageRoot,
+    });
+
+    const callSymbol = symbolTable.resolve("call", symbolTable.rootScope);
+    expect(typeof callSymbol).toBe("number");
+    if (typeof callSymbol !== "number") {
+      return;
+    }
+
+    const callFn = Array.from(hir.items.values()).find(
+      (item): item is HirFunction =>
+        item.kind === "function" && item.symbol === callSymbol
+    );
+    expect(callFn).toBeDefined();
+    if (!callFn) {
+      return;
+    }
+
+    const callbackType = callFn.parameters[0]?.type;
+    expect(callbackType?.typeKind).toBe("function");
+    if (callbackType?.typeKind !== "function") {
+      return;
+    }
+
+    expect(callbackType.effectType?.typeKind).toBe("tuple");
+    if (callbackType.effectType?.typeKind !== "tuple") {
+      return;
+    }
+
+    expect(
+      callbackType.effectType.elements.map((element) =>
+        element.typeKind === "named" ? element.path.join("::") : element.typeKind
+      )
+    ).toEqual(["Async", "open"]);
+  });
+
+  it("preserves ordinary type symbols named open outside effect rows", () => {
+    const source = `
+type open = i32
+
+fn id(value: open) -> open
+  value
+`;
+    const ast = parse(source, "main.voyd");
+    const symbolTable = new SymbolTable({ rootOwner: ast.syntaxId });
+    const moduleSymbol = symbolTable.declare({
+      name: "main.voyd",
+      kind: "module",
+      declaredAt: ast.syntaxId,
+    });
+    const binding = runBindingPipeline({ moduleForm: ast, symbolTable });
+    const builder = createHirBuilder({
+      path: "main.voyd",
+      scope: moduleSymbol,
+      ast: ast.syntaxId,
+      span: toSourceSpan(ast),
+    });
+
+    const hir = runLoweringPipeline({
+      builder,
+      binding,
+      moduleNodeId: ast.syntaxId,
+      modulePath: binding.modulePath,
+      packageId: binding.packageId,
+      isPackageRoot: binding.isPackageRoot,
+    });
+
+    const openSymbol = symbolTable.resolve("open", symbolTable.rootScope);
+    const idSymbol = symbolTable.resolve("id", symbolTable.rootScope);
+    expect(typeof openSymbol).toBe("number");
+    expect(typeof idSymbol).toBe("number");
+    if (typeof openSymbol !== "number" || typeof idSymbol !== "number") {
+      return;
+    }
+
+    const idFn = Array.from(hir.items.values()).find(
+      (item): item is HirFunction =>
+        item.kind === "function" && item.symbol === idSymbol
+    );
+    expect(idFn).toBeDefined();
+    if (!idFn) {
+      return;
+    }
+
+    const paramType = idFn.parameters[0]?.type;
+    expect(paramType?.typeKind).toBe("named");
+    expect(idFn.returnType?.typeKind).toBe("named");
+    if (paramType?.typeKind === "named") {
+      expect(paramType.symbol).toBe(openSymbol);
+    }
+    if (idFn.returnType?.typeKind === "named") {
+      expect(idFn.returnType.symbol).toBe(openSymbol);
+    }
+  });
+
   it("lowers nominal constructor literals with spreads as nominal object literals", () => {
     const name = "nominal_constructor_spread.voyd";
     const ast = loadAst(name);

--- a/packages/compiler/src/semantics/__tests__/lowering.test.ts
+++ b/packages/compiler/src/semantics/__tests__/lowering.test.ts
@@ -313,6 +313,77 @@ fn call(cb: fn() : (Async, open) -> i32)
     ).toEqual(["Async", "open"]);
   });
 
+  it("lowers explicit open rows in nested callback parameter types", () => {
+    const source = `
+eff Async
+  fn await(tail) -> i32
+
+fn call(cb: fn(inner: fn() : (Async, open) -> i32) -> i32)
+  cb(() => 1)
+`;
+    const ast = parse(source, "main.voyd");
+    const symbolTable = new SymbolTable({ rootOwner: ast.syntaxId });
+    const moduleSymbol = symbolTable.declare({
+      name: "main.voyd",
+      kind: "module",
+      declaredAt: ast.syntaxId,
+    });
+    const binding = runBindingPipeline({ moduleForm: ast, symbolTable });
+    const builder = createHirBuilder({
+      path: "main.voyd",
+      scope: moduleSymbol,
+      ast: ast.syntaxId,
+      span: toSourceSpan(ast),
+    });
+
+    const hir = runLoweringPipeline({
+      builder,
+      binding,
+      moduleNodeId: ast.syntaxId,
+      modulePath: binding.modulePath,
+      packageId: binding.packageId,
+      isPackageRoot: binding.isPackageRoot,
+    });
+
+    const callSymbol = symbolTable.resolve("call", symbolTable.rootScope);
+    expect(typeof callSymbol).toBe("number");
+    if (typeof callSymbol !== "number") {
+      return;
+    }
+
+    const callFn = Array.from(hir.items.values()).find(
+      (item): item is HirFunction =>
+        item.kind === "function" && item.symbol === callSymbol
+    );
+    expect(callFn).toBeDefined();
+    if (!callFn) {
+      return;
+    }
+
+    const callbackType = callFn.parameters[0]?.type;
+    expect(callbackType?.typeKind).toBe("function");
+    if (callbackType?.typeKind !== "function") {
+      return;
+    }
+
+    const innerCallbackType = callbackType.parameters[0]?.type;
+    expect(innerCallbackType?.typeKind).toBe("function");
+    if (innerCallbackType?.typeKind !== "function") {
+      return;
+    }
+
+    expect(innerCallbackType.effectType?.typeKind).toBe("tuple");
+    if (innerCallbackType.effectType?.typeKind !== "tuple") {
+      return;
+    }
+
+    expect(
+      innerCallbackType.effectType.elements.map((element) =>
+        element.typeKind === "named" ? element.path.join("::") : element.typeKind
+      )
+    ).toEqual(["Async", "open"]);
+  });
+
   it("preserves ordinary type symbols named open outside effect rows", () => {
     const source = `
 type open = i32

--- a/packages/compiler/src/semantics/__tests__/try-handler-clauses.test.ts
+++ b/packages/compiler/src/semantics/__tests__/try-handler-clauses.test.ts
@@ -59,7 +59,7 @@ eff Log
   fn write(tail) -> void
 
 fn forward_nested(flag: bool)
-  try forward
+  try open
     if
       flag:
         Async::await()
@@ -92,7 +92,7 @@ eff Log
   fn write(tail) -> void
 
 fn forward_nested_branch(flag: bool)
-  try forward
+  try open
     if
       flag:
         Async::await()

--- a/packages/compiler/src/semantics/__tests__/type-display.test.ts
+++ b/packages/compiler/src/semantics/__tests__/type-display.test.ts
@@ -169,7 +169,7 @@ describe("type display", () => {
         symbol: reducerParam.symbol,
         displayName: "reducer",
       }),
-    ).toBe("reducer: (T, T) -> T ! open effect row");
+    ).toBe("reducer: (T, T) -> T ! (open)");
   });
 
   it("supports compact formatting for nominal intersections", () => {

--- a/packages/compiler/src/semantics/binding/binders/expressions.ts
+++ b/packages/compiler/src/semantics/binding/binders/expressions.ts
@@ -148,9 +148,9 @@ const bindTry = (
 ): void => {
   const handlerEntries: Form[] = [];
   const markerExpr = form.at(1);
-  const hasForwardUnhandled =
-    isIdentifierAtom(markerExpr) && markerExpr.value === "forward";
-  const bodyIndex = hasForwardUnhandled ? 2 : 1;
+  const hasOpenUnhandled =
+    isIdentifierAtom(markerExpr) && markerExpr.value === "open";
+  const bodyIndex = hasOpenUnhandled ? 2 : 1;
   const body = form.at(bodyIndex);
   if (isForm(body) && body.calls("block")) {
     body.rest.forEach((entry) => {
@@ -378,10 +378,7 @@ const bindVar = (
   ctx: BindingContext,
   tracker: BinderScopeTracker,
 ): void => {
-  const assignment = ensureForm(
-    form.at(1),
-    "var statement expects an assignment",
-  );
+  const assignment = ensureForm(form.at(1), "var statement expects an assignment");
   if (!assignment.calls("=")) {
     throw new Error("var statement must be an assignment form");
   }

--- a/packages/compiler/src/semantics/binding/binders/expressions.ts
+++ b/packages/compiler/src/semantics/binding/binders/expressions.ts
@@ -20,6 +20,7 @@ import { declareValueOrParameter } from "../redefinitions.js";
 import type { BindingContext, BindingResult } from "../types.js";
 import type { ScopeId, SymbolId } from "../../ids.js";
 import { parseLambdaSignature } from "../../lambda.js";
+import { normalizeNestedFunctionTypeAnnotation } from "../../function-type-annotations.js";
 import { ensureForm } from "./utils.js";
 import type { BinderScopeTracker } from "./scope-tracker.js";
 import {
@@ -434,7 +435,11 @@ const bindLambda = (
       if (!isForm(param)) {
         return;
       }
-      bindTypeExpr(param.at(2), ctx, tracker);
+      bindTypeExpr(
+        normalizeNestedFunctionTypeAnnotation(param).typeExpr,
+        ctx,
+        tracker
+      );
     });
     bindTypeExpr(signature.returnType, ctx, tracker);
     bindTypeExpr(signature.effectType, ctx, tracker);
@@ -484,13 +489,13 @@ const declareLambdaParam = (
 
   if (isForm(param) && (param.calls(":") || param.calls("?:"))) {
     rememberSyntax(param, ctx);
-    const nameExpr = param.at(1);
+    const { nameExpr, typeExpr } = normalizeNestedFunctionTypeAnnotation(param);
     const { target, bindingKind } = unwrapMutablePattern(nameExpr);
     if (!isIdentifierAtom(target)) {
       throw new Error("lambda parameter name must be an identifier");
     }
     rememberSyntax(target, ctx);
-    rememberSyntax(param.at(2) as Syntax, ctx);
+    rememberSyntax(typeExpr as Syntax, ctx);
     declareValueOrParameter({
       name: target.value,
       kind: "parameter",

--- a/packages/compiler/src/semantics/binding/parsing.ts
+++ b/packages/compiler/src/semantics/binding/parsing.ts
@@ -1,6 +1,7 @@
 import {
   type Expr,
   Form,
+  IdentifierAtom as IdentifierAtomNode,
   type IdentifierAtom,
   type Syntax,
   formCallsInternal,
@@ -266,8 +267,9 @@ export const parseModuleLetDecl = (form: Form): ParsedModuleLetDecl | null => {
     return null;
   }
 
+  const rawAssignment = form.at(index + 1);
   const assignment = ensureForm(
-    form.at(index + 1),
+    rawAssignment,
     "module-level let declaration expects an assignment",
   );
   if (!assignment.calls("=")) {
@@ -455,8 +457,8 @@ export const parseImplDecl = (form: Form): ParsedImplDecl | null => {
 };
 
 const parseFunctionSignature = (form: Form): ParsedFunctionSignature => {
-  if (form.calls(":") && form.at(2) && isForm(form.at(2)) && (form.at(2) as Form).calls("->")) {
-    const effectTail = form.at(2) as Form;
+  const effectTail = form.calls(":") ? form.at(2) : undefined;
+  if (form.calls(":") && isForm(effectTail) && effectTail.calls("->")) {
     const head = parseFunctionHead(form.at(1));
     return {
       name: head.name,
@@ -763,6 +765,30 @@ const parseLabeledParameters = (form: Form): SignatureParam[] =>
 
 const parseSingleParam = (expr: Form): SignatureParam => {
   const nameExpr = expr.at(1);
+  const candidateTypeExpr = expr.at(2);
+  const effectTail =
+    isForm(candidateTypeExpr) && candidateTypeExpr.calls("->")
+      ? candidateTypeExpr
+      : undefined;
+  const nestedFunctionType =
+    isForm(nameExpr) &&
+    (nameExpr.calls(":") || nameExpr.calls("?:")) &&
+    effectTail
+      ? parseSingleParam(nameExpr)
+      : undefined;
+  if (nestedFunctionType?.typeExpr) {
+    return {
+      ...nestedFunctionType,
+      typeExpr: new Form([
+        new IdentifierAtomNode(":"),
+        nestedFunctionType.typeExpr,
+        effectTail!,
+      ]),
+      optional:
+        expr.calls("?:") || nestedFunctionType.optional ? true : undefined,
+    };
+  }
+
   const { name, ast, bindingKind } = parseParamName(nameExpr);
   return {
     name,
@@ -793,6 +819,30 @@ const parseDefaultedParam = (expr: Form): SignatureParam => {
     optional: true,
     defaultValue,
   };
+};
+
+const normalizeNestedFunctionTypeAnnotation = (
+  expr: Form
+): { nameExpr: Expr | undefined; typeExpr: Expr | undefined } => {
+  const nameExpr = expr.at(1);
+  const typeExpr = expr.at(2);
+  if (
+    isForm(nameExpr) &&
+    (nameExpr.calls(":") || nameExpr.calls("?:")) &&
+    isForm(typeExpr) &&
+    typeExpr.calls("->")
+  ) {
+    return {
+      nameExpr: nameExpr.at(1),
+      typeExpr: new Form([
+        new IdentifierAtomNode(":"),
+        nameExpr.at(2)!,
+        typeExpr,
+      ]),
+    };
+  }
+
+  return { nameExpr, typeExpr };
 };
 
 const parseParamName = (
@@ -835,8 +885,7 @@ const parseModuleLetPattern = (
   }
 
   if (isForm(target) && target.calls(":")) {
-    const nameExpr = target.at(1);
-    const typeExpr = target.at(2);
+    const { nameExpr, typeExpr } = normalizeNestedFunctionTypeAnnotation(target);
     if (!isIdentifierAtom(nameExpr)) {
       throw new Error(
         "module-level let declaration expects an identifier binding",

--- a/packages/compiler/src/semantics/binding/parsing.ts
+++ b/packages/compiler/src/semantics/binding/parsing.ts
@@ -18,6 +18,7 @@ import { isIdentifierWithValue } from "../utils.js";
 import type { EffectAttribute, IntrinsicAttribute } from "../../parser/attributes.js";
 import type { HirBindingKind } from "../hir/index.js";
 import { ensureForm } from "./binders/utils.js";
+import { normalizeNestedFunctionTypeAnnotation } from "../function-type-annotations.js";
 
 export interface ParsedFunctionDecl {
   form: Form;
@@ -819,30 +820,6 @@ const parseDefaultedParam = (expr: Form): SignatureParam => {
     optional: true,
     defaultValue,
   };
-};
-
-const normalizeNestedFunctionTypeAnnotation = (
-  expr: Form
-): { nameExpr: Expr | undefined; typeExpr: Expr | undefined } => {
-  const nameExpr = expr.at(1);
-  const typeExpr = expr.at(2);
-  if (
-    isForm(nameExpr) &&
-    (nameExpr.calls(":") || nameExpr.calls("?:")) &&
-    isForm(typeExpr) &&
-    typeExpr.calls("->")
-  ) {
-    return {
-      nameExpr: nameExpr.at(1),
-      typeExpr: new Form([
-        new IdentifierAtomNode(":"),
-        nameExpr.at(2)!,
-        typeExpr,
-      ]),
-    };
-  }
-
-  return { nameExpr, typeExpr };
 };
 
 const parseParamName = (

--- a/packages/compiler/src/semantics/effects/format.ts
+++ b/packages/compiler/src/semantics/effects/format.ts
@@ -11,12 +11,13 @@ export const formatEffectRow = (
   const desc = effects.getRow(row);
   const ops = desc.operations.map(formatEffectOp);
   if (ops.length === 0 && desc.tailVar) {
-    return "open effect row";
+    return "(open)";
   }
   if (ops.length === 0) {
     return "()";
   }
-  const suffix = desc.tailVar ? ", ..." : "";
-  return `${ops.join(", ")}${suffix}`;
+  if (!desc.tailVar) {
+    return ops.join(", ");
+  }
+  return `(${ops.join(", ")}, open)`;
 };
-

--- a/packages/compiler/src/semantics/function-type-annotations.ts
+++ b/packages/compiler/src/semantics/function-type-annotations.ts
@@ -1,0 +1,32 @@
+import {
+  type Expr,
+  Form,
+  IdentifierAtom,
+  isForm,
+} from "../parser/index.js";
+
+export const normalizeNestedFunctionTypeAnnotation = (
+  expr: Form
+): { nameExpr: Expr | undefined; typeExpr: Expr | undefined; optional?: true } => {
+  const nameExpr = expr.at(1);
+  const typeExpr = expr.at(2);
+  const optional = expr.calls("?:") ? true : undefined;
+  if (
+    isForm(nameExpr) &&
+    (nameExpr.calls(":") || nameExpr.calls("?:")) &&
+    isForm(typeExpr) &&
+    typeExpr.calls("->")
+  ) {
+    return {
+      nameExpr: nameExpr.at(1),
+      typeExpr: new Form([
+        new IdentifierAtom(":"),
+        nameExpr.at(2)!,
+        typeExpr,
+      ]),
+      optional: optional ?? (nameExpr.calls("?:") ? true : undefined),
+    };
+  }
+
+  return { nameExpr, typeExpr, optional };
+};

--- a/packages/compiler/src/semantics/hir/nodes.ts
+++ b/packages/compiler/src/semantics/hir/nodes.ts
@@ -584,7 +584,7 @@ export interface HirEffectHandlerExpr extends HirExpressionBase {
   exprKind: "effect-handler";
   body: HirExprId;
   handlers: readonly HirEffectHandlerClause[];
-  forwardUnhandled?: boolean;
+  openUnhandled?: boolean;
   finallyBranch?: HirExprId;
 }
 

--- a/packages/compiler/src/semantics/lambda.ts
+++ b/packages/compiler/src/semantics/lambda.ts
@@ -1,6 +1,6 @@
 import {
   type Expr,
-  type Form,
+  Form,
   type IdentifierAtom,
   formCallsInternal,
   isForm,
@@ -43,12 +43,12 @@ const parseSignatureParts = (
   }
 
   if (isForm(expr) && expr.calls(":")) {
-    const candidateTail = expr.at(2);
-    if (isForm(candidateTail) && candidateTail.calls("->")) {
+    const effectTail = expr.at(2);
+    if (isForm(effectTail) && effectTail.calls("->")) {
       return {
         paramsExpr: expr.at(1) ?? expr,
-        effectType: candidateTail.at(1),
-        returnType: candidateTail.at(2),
+        effectType: effectTail.at(1),
+        returnType: effectTail.at(2),
       };
     }
   }

--- a/packages/compiler/src/semantics/lowering/expressions/block.ts
+++ b/packages/compiler/src/semantics/lowering/expressions/block.ts
@@ -1,4 +1,8 @@
-import { type Form, type Syntax, isForm } from "../../../parser/index.js";
+import {
+  Form,
+  type Syntax,
+  isForm,
+} from "../../../parser/index.js";
 import { toSourceSpan } from "../../utils.js";
 import type { HirExprId, HirStmtId } from "../../ids.js";
 import { lowerPattern } from "./patterns.js";

--- a/packages/compiler/src/semantics/lowering/expressions/lambda.ts
+++ b/packages/compiler/src/semantics/lowering/expressions/lambda.ts
@@ -12,6 +12,7 @@ import {
   lowerTypeParameters,
   wrapInOptionalTypeExpr,
 } from "../type-expressions.js";
+import { normalizeNestedFunctionTypeAnnotation } from "../../function-type-annotations.js";
 import type { HirExprId } from "../../ids.js";
 import type { HirParameter } from "../../hir/index.js";
 import { unwrapMutablePattern } from "./patterns.js";
@@ -95,8 +96,9 @@ const lowerLambdaParameter = (
     };
   }
 
-  if (isForm(target) && target.calls(":")) {
-    const nameExpr = target.at(1);
+  if (isForm(target) && (target.calls(":") || target.calls("?:"))) {
+    const { nameExpr, typeExpr, optional } =
+      normalizeNestedFunctionTypeAnnotation(target);
     const { target: nameTarget, bindingKind: nameBinding } =
       unwrapMutablePattern(nameExpr);
     if (
@@ -106,35 +108,14 @@ const lowerLambdaParameter = (
       throw new Error("lambda parameter name must be an identifier");
     }
     const symbol = resolveSymbol(nameTarget.value, scopes.current(), ctx);
-    return {
-      symbol,
-      pattern: {
-        kind: "identifier",
-        symbol,
-        span: toSourceSpan(param),
-        bindingKind: nameBinding ?? bindingKind,
-      },
-      mutable: false,
-      span: toSourceSpan(param),
-      type: lowerTypeExpr(target.at(2), ctx, scopes.current()),
-    };
-  }
-
-  if (isForm(target) && target.calls("?:")) {
-    const nameExpr = target.at(1);
-    const { target: nameTarget, bindingKind: nameBinding } =
-      unwrapMutablePattern(nameExpr);
-    if (
-      !isIdentifierAtom(nameTarget) &&
-      !isInternalIdentifierAtom(nameTarget)
-    ) {
-      throw new Error("lambda parameter name must be an identifier");
-    }
-    const symbol = resolveSymbol(nameTarget.value, scopes.current(), ctx);
-    const lowered = lowerTypeExpr(target.at(2), ctx, scopes.current());
-    if (!lowered) {
+    const lowered = lowerTypeExpr(typeExpr, ctx, scopes.current());
+    if (optional && !lowered) {
       throw new Error("optional lambda parameter missing type");
     }
+    const type =
+      lowered && optional
+        ? wrapInOptionalTypeExpr({ inner: lowered, ctx, scope: scopes.current() })
+        : lowered;
     return {
       symbol,
       pattern: {
@@ -145,8 +126,8 @@ const lowerLambdaParameter = (
       },
       mutable: false,
       span: toSourceSpan(param),
-      optional: true,
-      type: wrapInOptionalTypeExpr({ inner: lowered, ctx, scope: scopes.current() }),
+      optional,
+      type,
     };
   }
 

--- a/packages/compiler/src/semantics/lowering/expressions/patterns.ts
+++ b/packages/compiler/src/semantics/lowering/expressions/patterns.ts
@@ -1,5 +1,7 @@
 import {
   type Expr,
+  Form,
+  IdentifierAtom,
   isForm,
   isIdentifierAtom,
 } from "../../../parser/index.js";
@@ -105,8 +107,10 @@ export const lowerPattern = (
   }
 
   if (isForm(target) && target.calls(":")) {
-    const nameExpr = target.at(1);
-    const typeExpr = target.at(2);
+    const {
+      nameExpr,
+      typeExpr,
+    } = normalizeNestedFunctionTypePattern(target);
     if (!typeExpr) {
       throw new Error("typed pattern is missing a type annotation");
     }
@@ -141,4 +145,28 @@ export const unwrapMutablePattern = (
   }
 
   return { target: pattern };
+};
+
+const normalizeNestedFunctionTypePattern = (
+  target: Form
+): { nameExpr: Expr | undefined; typeExpr: Expr | undefined } => {
+  const nameExpr = target.at(1);
+  const typeExpr = target.at(2);
+  if (
+    isForm(nameExpr) &&
+    (nameExpr.calls(":") || nameExpr.calls("?:")) &&
+    isForm(typeExpr) &&
+    typeExpr.calls("->")
+  ) {
+    return {
+      nameExpr: nameExpr.at(1),
+      typeExpr: new Form([
+        new IdentifierAtom(":"),
+        nameExpr.at(2)!,
+        typeExpr,
+      ]),
+    };
+  }
+
+  return { nameExpr, typeExpr };
 };

--- a/packages/compiler/src/semantics/lowering/expressions/patterns.ts
+++ b/packages/compiler/src/semantics/lowering/expressions/patterns.ts
@@ -1,10 +1,9 @@
 import {
   type Expr,
-  Form,
-  IdentifierAtom,
   isForm,
   isIdentifierAtom,
 } from "../../../parser/index.js";
+import { normalizeNestedFunctionTypeAnnotation } from "../../function-type-annotations.js";
 import { toSourceSpan } from "../../utils.js";
 import type { HirBindingKind, HirPattern } from "../../hir/index.js";
 import type { LowerContext, LowerScopeStack } from "../types.js";
@@ -110,7 +109,7 @@ export const lowerPattern = (
     const {
       nameExpr,
       typeExpr,
-    } = normalizeNestedFunctionTypePattern(target);
+    } = normalizeNestedFunctionTypeAnnotation(target);
     if (!typeExpr) {
       throw new Error("typed pattern is missing a type annotation");
     }
@@ -145,28 +144,4 @@ export const unwrapMutablePattern = (
   }
 
   return { target: pattern };
-};
-
-const normalizeNestedFunctionTypePattern = (
-  target: Form
-): { nameExpr: Expr | undefined; typeExpr: Expr | undefined } => {
-  const nameExpr = target.at(1);
-  const typeExpr = target.at(2);
-  if (
-    isForm(nameExpr) &&
-    (nameExpr.calls(":") || nameExpr.calls("?:")) &&
-    isForm(typeExpr) &&
-    typeExpr.calls("->")
-  ) {
-    return {
-      nameExpr: nameExpr.at(1),
-      typeExpr: new Form([
-        new IdentifierAtom(":"),
-        nameExpr.at(2)!,
-        typeExpr,
-      ]),
-    };
-  }
-
-  return { nameExpr, typeExpr };
 };

--- a/packages/compiler/src/semantics/lowering/expressions/try.ts
+++ b/packages/compiler/src/semantics/lowering/expressions/try.ts
@@ -66,9 +66,9 @@ export const lowerTry = ({
   lowerExpr,
 }: LoweringFormParams): number => {
   const markerExpr = form.at(1);
-  const hasForwardUnhandled =
-    isIdentifierAtom(markerExpr) && markerExpr.value === "forward";
-  const bodyIndex = hasForwardUnhandled ? 2 : 1;
+  const hasOpenUnhandled =
+    isIdentifierAtom(markerExpr) && markerExpr.value === "open";
+  const bodyIndex = hasOpenUnhandled ? 2 : 1;
   const bodyExpr = form.at(bodyIndex);
   if (!bodyExpr) {
     throw new Error("try expression missing body");
@@ -128,7 +128,7 @@ export const lowerTry = ({
     span: toSourceSpan(form),
     body,
     handlers,
-    ...(hasForwardUnhandled ? { forwardUnhandled: true } : {}),
+    ...(hasOpenUnhandled ? { openUnhandled: true } : {}),
   });
 
   return exprId;

--- a/packages/compiler/src/semantics/lowering/type-expressions.ts
+++ b/packages/compiler/src/semantics/lowering/type-expressions.ts
@@ -17,6 +17,7 @@ import { resolveNamedTypeTarget } from "./named-type-resolution.js";
 import type { LowerContext } from "./types.js";
 import type { ScopeId, SymbolId } from "../ids.js";
 import { parseLambdaSignature } from "../lambda.js";
+import { normalizeNestedFunctionTypeAnnotation } from "../function-type-annotations.js";
 
 export const wrapInOptionalTypeExpr = ({
   inner,
@@ -259,9 +260,12 @@ const lowerFunctionTypeExpr = (
   );
 
   const parameters = signature.parameters.map((param) => {
-    const isOptional = isForm(param) && param.calls("?:");
-    const paramTypeExpr =
-      isForm(param) && (param.calls(":") || isOptional) ? param.at(2) : param;
+    const normalized =
+      isForm(param) && (param.calls(":") || param.calls("?:"))
+        ? normalizeNestedFunctionTypeAnnotation(param)
+        : undefined;
+    const isOptional = normalized?.optional === true;
+    const paramTypeExpr = normalized?.typeExpr ?? param;
     const lowered = lowerTypeExpr(paramTypeExpr, ctx, scope);
     if (!lowered) {
       throw new Error("function type parameter missing type");

--- a/packages/compiler/src/semantics/typing/__tests__/effects-function-types.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/effects-function-types.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createEffectTable } from "../../effects/effect-table.js";
+import { formatEffectRow } from "../../effects/format.js";
+import { constrainFunctionEffectRows } from "../effects.js";
 import { createTypeArena } from "../type-arena.js";
 import { FunctionStore, type FunctionSignature } from "../types.js";
 
@@ -94,5 +96,79 @@ describe("function types carry effect rows", () => {
     expect(
       instantiatedDesc.kind === "function" ? instantiatedDesc.effectRow : -1
     ).toBe(tailRow);
+  });
+
+  it("formats explicit open rows with the open marker", () => {
+    const effects = createEffectTable();
+    const effectRow = effects.internRow({
+      operations: [{ name: "Async.await" }],
+      tailVar: effects.freshTailVar(),
+    });
+
+    expect(formatEffectRow(effectRow, effects)).toBe("(Async.await, open)");
+    expect(formatEffectRow(effects.unknownRow, effects)).toBe("(open)");
+  });
+
+  it("requires prefixed effects on closed rows but preserves open tails", () => {
+    const effects = createEffectTable();
+    const asyncOpen = effects.internRow({
+      operations: [{ name: "Async.await" }],
+      tailVar: effects.freshTailVar(),
+    });
+    const asyncLog = effects.internRow({
+      operations: [{ name: "Async.await" }, { name: "Log.write" }],
+    });
+    const logOnly = effects.internRow({
+      operations: [{ name: "Log.write" }],
+    });
+    const genericOpen = effects.internRow({
+      operations: [],
+      tailVar: effects.freshTailVar(),
+    });
+
+    const closedMatch = constrainFunctionEffectRows({
+      actual: asyncLog,
+      expected: asyncOpen,
+      effects,
+      ctx: {
+        location: 0,
+        reason: "test",
+      },
+    });
+    expect(closedMatch.ok).toBe(true);
+    if (closedMatch.ok) {
+      const tailRow = closedMatch.substitution.rows.get(
+        effects.getRow(asyncOpen).tailVar!.id
+      );
+      expect(typeof tailRow).toBe("number");
+      if (typeof tailRow === "number") {
+        expect(formatEffectRow(tailRow, effects)).toBe("Log.write");
+      }
+    }
+
+    const closedMismatch = constrainFunctionEffectRows({
+      actual: logOnly,
+      expected: asyncOpen,
+      effects,
+      ctx: {
+        location: 0,
+        reason: "test",
+      },
+    });
+    expect(closedMismatch.ok).toBe(false);
+    if (!closedMismatch.ok) {
+      expect(closedMismatch.conflict.message).toContain("missing required effects");
+    }
+
+    const polymorphicMatch = constrainFunctionEffectRows({
+      actual: genericOpen,
+      expected: asyncOpen,
+      effects,
+      ctx: {
+        location: 0,
+        reason: "test",
+      },
+    });
+    expect(polymorphicMatch.ok).toBe(true);
   });
 });

--- a/packages/compiler/src/semantics/typing/__tests__/effects-inference.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/effects-inference.test.ts
@@ -683,7 +683,7 @@ fn missing()
     expect(caught && (caught as any).diagnostic?.code).toBe("TY0013");
   });
 
-  it("forwards unhandled operations in try forward handlers", () => {
+  it("forwards unhandled operations in try open handlers", () => {
     const ast = parse(
       `
 eff Async
@@ -692,7 +692,7 @@ eff Log
   fn write(tail) -> void
 
 fn forward_partial()
-  try forward
+  try open
     let value = Async::await()
     Log::write()
     value
@@ -718,6 +718,121 @@ fn forward_partial()
     expect(effectOps(signature.effectRow, typing.effects)).toEqual(["Log.write"]);
   });
 
+  it("supports open callback rows with a required handled prefix", () => {
+    const ast = parse(
+      `
+eff Async
+  fn await(tail, value: i32) -> i32
+eff Log
+  fn write(tail) -> void
+
+fn call<T>(cb: fn() : (Async, open) -> T) -> T
+  try open
+    cb()
+  Async::await(tail, value):
+    tail(value + 1)
+
+fn main()
+  call(() =>
+    let value = Async::await(10)
+    Log::write()
+    value
+  )
+`,
+      "effects.voyd"
+    );
+
+    const semantics = semanticsPipeline(ast);
+    const { typing } = semantics;
+    const symbolTable = getSymbolTable(semantics);
+    const callSymbol = symbolTable.resolve("call", symbolTable.rootScope);
+    const mainSymbol = symbolTable.resolve("main", symbolTable.rootScope);
+    expect(typeof callSymbol).toBe("number");
+    expect(typeof mainSymbol).toBe("number");
+    if (typeof callSymbol !== "number" || typeof mainSymbol !== "number") {
+      return;
+    }
+
+    const callSig = typing.functions.getSignature(callSymbol);
+    const mainSig = typing.functions.getSignature(mainSymbol);
+    expect(callSig && mainSig).toBeTruthy();
+    if (!callSig || !mainSig) {
+      return;
+    }
+
+    expect(typing.effects.isOpen(callSig.effectRow)).toBe(true);
+    expect(effectOps(mainSig.effectRow, typing.effects)).toEqual(["Log.write"]);
+  });
+
+  it("rejects callback rows that miss a required known prefix", () => {
+    const ast = parse(
+      `
+eff Async
+  fn await(tail) -> i32
+eff Log
+  fn write(tail) -> void
+
+fn main()
+  let cb: fn() : (Async, open) -> i32 = () =>
+    Log::write()
+    1
+  cb()
+`,
+      "effects.voyd"
+    );
+
+    let caught: unknown;
+    try {
+      semanticsPipeline(ast);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect((caught as any)?.diagnostic?.code).toBe("TY0027");
+    expect((caught as any)?.diagnostic?.message).toContain("Async.await");
+    expect((caught as any)?.diagnostic?.message).not.toContain(
+      "expected 'function', received 'function'"
+    );
+  });
+
+  it("supports explicit open rows in callback params, function annotations, lets, and = declarations", () => {
+    const ast = parse(
+      `
+eff Async
+  fn await(tail) -> i32
+
+fn run(cb: fn() : (open) -> i32) -> i32
+  cb()
+
+fn main() : (open) -> i32 = run(() =>
+  Async::await()
+)
+`,
+      "effects.voyd"
+    );
+
+    const semantics = semanticsPipeline(ast);
+    const { typing } = semantics;
+    const symbolTable = getSymbolTable(semantics);
+    const runSymbol = symbolTable.resolve("run", symbolTable.rootScope);
+    const mainSymbol = symbolTable.resolve("main", symbolTable.rootScope);
+    expect(typeof runSymbol).toBe("number");
+    expect(typeof mainSymbol).toBe("number");
+    if (typeof runSymbol !== "number" || typeof mainSymbol !== "number") {
+      return;
+    }
+
+    const runSig = typing.functions.getSignature(runSymbol);
+    const mainSig = typing.functions.getSignature(mainSymbol);
+    expect(runSig && mainSig).toBeTruthy();
+    if (!runSig || !mainSig) {
+      return;
+    }
+
+    expect(typing.effects.isOpen(runSig.effectRow)).toBe(true);
+    expect(typing.effects.isOpen(mainSig.effectRow)).toBe(true);
+  });
+
   it("keeps nested case clauses inside try bodies out of handler matching", () => {
     const ast = parse(
       `
@@ -727,7 +842,7 @@ eff Log
   fn write(tail) -> void
 
 fn forward_nested(flag: bool)
-  try forward
+  try open
     if
       flag:
         Async::await()
@@ -764,7 +879,7 @@ eff Log
   fn write(tail) -> void
 
 fn forward_nested_branch(flag: bool)
-  try forward
+  try open
     if
       flag:
         Async::await()

--- a/packages/compiler/src/semantics/typing/__tests__/effects-inference.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/effects-inference.test.ts
@@ -833,6 +833,44 @@ fn main() : (open) -> i32 = run(() =>
     expect(typing.effects.isOpen(mainSig.effectRow)).toBe(true);
   });
 
+  it("supports explicit open rows in nested callback parameter types", () => {
+    const ast = parse(
+      `
+eff Async
+  fn await(tail) -> i32
+
+fn run(cb: fn(inner: fn() : (open) -> i32) -> i32) -> i32
+  cb(() => 1)
+
+fn main(): (open) -> i32
+  let f = (inner: fn() : (open) -> i32) -> i32 => inner()
+  run(f)
+`,
+      "effects.voyd"
+    );
+
+    const semantics = semanticsPipeline(ast);
+    const { typing } = semantics;
+    const symbolTable = getSymbolTable(semantics);
+    const runSymbol = symbolTable.resolve("run", symbolTable.rootScope);
+    const mainSymbol = symbolTable.resolve("main", symbolTable.rootScope);
+    expect(typeof runSymbol).toBe("number");
+    expect(typeof mainSymbol).toBe("number");
+    if (typeof runSymbol !== "number" || typeof mainSymbol !== "number") {
+      return;
+    }
+
+    const runSig = typing.functions.getSignature(runSymbol);
+    const mainSig = typing.functions.getSignature(mainSymbol);
+    expect(runSig && mainSig).toBeTruthy();
+    if (!runSig || !mainSig) {
+      return;
+    }
+
+    expect(typing.effects.isOpen(runSig.effectRow)).toBe(true);
+    expect(typing.effects.isOpen(mainSig.effectRow)).toBe(true);
+  });
+
   it("keeps nested case clauses inside try bodies out of handler matching", () => {
     const ast = parse(
       `

--- a/packages/compiler/src/semantics/typing/effects.ts
+++ b/packages/compiler/src/semantics/typing/effects.ts
@@ -14,6 +14,7 @@ import type {
 } from "../hir/index.js";
 import type { Expr } from "../../parser/index.js";
 import { formatTypeAnnotation } from "../utils.js";
+import type { UnificationContext, UnificationResult } from "../effects/effect-table.js";
 
 const pureEffectRow = (effects: EffectTable): EffectRowId => effects.emptyRow;
 
@@ -84,6 +85,130 @@ export const composeEffectRows = (
   rows: readonly EffectRowId[]
 ): EffectRowId =>
   rows.reduce((acc, row) => effects.compose(acc, row), pureEffectRow(effects));
+
+export const constrainFunctionEffectRows = ({
+  actual,
+  expected,
+  effects,
+  ctx,
+}: {
+  actual: EffectRowId;
+  expected: EffectRowId;
+  effects: EffectTable;
+  ctx: UnificationContext;
+}): UnificationResult => {
+  const actualRow = effects.getRow(actual);
+  const expectedRow = effects.getRow(expected);
+  const opKey = ({ name, region }: { name: string; region?: number }): string =>
+    `${name}#${typeof region === "number" ? region : ""}`;
+  const formatOps = (
+    ops: readonly { name: string; region?: number }[]
+  ): string =>
+    ops
+      .map((op) =>
+        typeof op.region === "number" ? `${op.name}@${op.region}` : op.name
+      )
+      .join(", ");
+
+  const actualOps = new Set(actualRow.operations.map(opKey));
+  const expectedOps = new Set(expectedRow.operations.map(opKey));
+  const missingRequired = expectedRow.operations.filter(
+    (op) => !actualOps.has(opKey(op))
+  );
+  const extraActual = actualRow.operations.filter(
+    (op) => !expectedOps.has(opKey(op))
+  );
+
+  const actualCanSpecialize = Boolean(
+    actualRow.tailVar && !actualRow.tailVar.rigid
+  );
+  const expectedAllowsExtra = Boolean(
+    expectedRow.tailVar && !expectedRow.tailVar.rigid
+  );
+  const substitution = new Map<number, EffectRowId>();
+
+  if (missingRequired.length > 0 && !actualCanSpecialize) {
+    return {
+      ok: false,
+      conflict: {
+        left: actual,
+        right: expected,
+        message: `missing required effects (${ctx.reason}): ${formatOps(missingRequired)}`,
+      },
+    };
+  }
+
+  if (extraActual.length > 0 && !expectedAllowsExtra) {
+    return {
+      ok: false,
+      conflict: {
+        left: actual,
+        right: expected,
+        message: `unexpected effects (${ctx.reason}): ${formatOps(extraActual)}`,
+      },
+    };
+  }
+
+  const needsSharedTail =
+    actualCanSpecialize &&
+    expectedAllowsExtra &&
+    (missingRequired.length > 0 || extraActual.length > 0);
+  const sharedTail = needsSharedTail ? effects.freshTailVar() : undefined;
+
+  if (actualCanSpecialize) {
+    if (
+      missingRequired.length > 0 ||
+      !expectedRow.tailVar ||
+      expectedRow.tailVar.rigid ||
+      sharedTail
+    ) {
+      substitution.set(
+        actualRow.tailVar!.id,
+        effects.internRow({
+          operations: missingRequired,
+          tailVar: sharedTail,
+        })
+      );
+    }
+  }
+
+  if (expectedAllowsExtra) {
+    substitution.set(
+      expectedRow.tailVar!.id,
+      extraActual.length > 0 || sharedTail
+        ? effects.internRow({
+            operations: extraActual,
+            tailVar:
+              sharedTail ??
+              (actualRow.tailVar &&
+              actualRow.tailVar.id !== expectedRow.tailVar?.id
+                ? actualRow.tailVar
+                : undefined),
+          })
+        : actualRow.tailVar
+          ? effects.internRow({ operations: [], tailVar: actualRow.tailVar })
+          : effects.emptyRow
+    );
+  }
+
+  if (actualRow.tailVar && (!expectedRow.tailVar || expectedRow.tailVar.rigid)) {
+    if (actualRow.tailVar.rigid) {
+      return {
+        ok: false,
+        conflict: {
+          left: actual,
+          right: expected,
+          message: `effect row is too open (${ctx.reason})`,
+        },
+      };
+    }
+    if (!substitution.has(actualRow.tailVar.id)) {
+      substitution.set(actualRow.tailVar.id, effects.emptyRow);
+    }
+  }
+
+  return { ok: true, substitution: { rows: substitution } };
+};
 
 export const getExprEffectRow = (
   expr: HirExprId,
@@ -159,6 +284,14 @@ const resolveNamedEffectRow = (
   expr: HirNamedTypeExpr,
   ctx: TypingContext
 ): EffectRowId => {
+  if (
+    expr.path.length === 1 &&
+    expr.path[0] === "open" &&
+    typeof expr.symbol !== "number"
+  ) {
+    return freshOpenEffectRow(ctx.effects);
+  }
+
   const symbol = resolveEffectAnnotationSymbol(expr, ctx);
   if (typeof symbol !== "number") {
     return pureEffectRow(ctx.effects);

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -34,6 +34,7 @@ import {
 } from "../optionals.js";
 import { emitDiagnostic, normalizeSpan } from "../../../diagnostics/index.js";
 import {
+  constrainFunctionEffectRows,
   composeEffectRows,
   freshOpenEffectRow,
   getExprEffectRow,
@@ -4071,9 +4072,14 @@ const collectEffectTailSubstitutionsFromTypes = ({
       variance === "covariant"
         ? expectedDesc.effectRow
         : actualDesc.effectRow;
-    const constrained = ctx.effects.constrain(subEffectRow, supEffectRow, {
-      location,
-      reason,
+    const constrained = constrainFunctionEffectRows({
+      actual: subEffectRow,
+      expected: supEffectRow,
+      effects: ctx.effects,
+      ctx: {
+        location,
+        reason,
+      },
     });
     if (constrained.ok) {
       mergeEffectTailSubstitutions({

--- a/packages/compiler/src/semantics/typing/expressions/effect-handler.ts
+++ b/packages/compiler/src/semantics/typing/expressions/effect-handler.ts
@@ -532,7 +532,7 @@ export const typeEffectHandlerExpr = (
   if (
     unhandled.length > 0 &&
     !remainingDesc.tailVar &&
-    expr.forwardUnhandled !== true
+    expr.openUnhandled !== true
   ) {
     const opList = unhandled.map((op) => op.name).join(", ");
     emitDiagnostic({

--- a/packages/compiler/src/semantics/typing/type-system.ts
+++ b/packages/compiler/src/semantics/typing/type-system.ts
@@ -17,7 +17,12 @@ import {
   type StructuralField,
   type TypeDescriptor,
 } from "./type-arena.js";
-import { freshOpenEffectRow, resolveEffectAnnotation } from "./effects.js";
+import {
+  constrainFunctionEffectRows,
+  freshOpenEffectRow,
+  resolveEffectAnnotation,
+} from "./effects.js";
+import { formatEffectRow } from "../effects/format.js";
 import {
   BASE_OBJECT_NAME,
   type TypingContext,
@@ -2872,9 +2877,14 @@ const functionTypeSatisfies = ({
     return false;
   }
 
-  return ctx.effects.constrain(actualDesc.effectRow, expectedDesc.effectRow, {
-    location: ctx.hir.module.ast,
-    reason: "function type effect compatibility",
+  return constrainFunctionEffectRows({
+    actual: actualDesc.effectRow,
+    expected: expectedDesc.effectRow,
+    effects: ctx.effects,
+    ctx: {
+      location: ctx.hir.module.ast,
+      reason: "function type effect compatibility",
+    },
   }).ok;
 };
 
@@ -3195,11 +3205,72 @@ export const ensureTypeMatches = (
     code: "TY0027",
     params: {
       kind: "type-mismatch",
-      actual: typeDescriptorToUserString(ctx.arena.get(actual), ctx.arena),
-      expected: typeDescriptorToUserString(ctx.arena.get(expected), ctx.arena),
+      actual: typeIdToDiagnosticString(actual, ctx),
+      expected: typeIdToDiagnosticString(expected, ctx),
     },
     span: span ?? ctx.hir.module.span,
   });
+};
+
+const typeIdToDiagnosticString = (
+  typeId: TypeId,
+  ctx: TypingContext,
+  active = new Set<TypeId>(),
+): string => {
+  if (active.has(typeId)) {
+    return "recursive";
+  }
+
+  active.add(typeId);
+  const desc = ctx.arena.get(typeId);
+  const formatted = (() => {
+    switch (desc.kind) {
+      case "function": {
+        const params = desc.parameters
+          .map((param) => {
+            const label = param.label ? `${param.label}: ` : "";
+            const optionalSuffix = param.optional ? "?" : "";
+            return `${label}${typeIdToDiagnosticString(param.type, ctx, active)}${optionalSuffix}`;
+          })
+          .join(", ");
+        const returnType = typeIdToDiagnosticString(desc.returnType, ctx, active);
+        const effects = formatEffectRow(desc.effectRow, ctx.effects);
+        return effects === "()"
+          ? `(${params}) -> ${returnType}`
+          : `(${params}) -> ${returnType} ! ${effects}`;
+      }
+      case "structural-object":
+        return `{ ${desc.fields
+          .map(
+            (field) =>
+              `${field.name}: ${typeIdToDiagnosticString(field.type, ctx, active)}`
+          )
+          .join(", ")} }`;
+      case "union":
+        return desc.members
+          .map((member) => typeIdToDiagnosticString(member, ctx, active))
+          .join(" | ");
+      case "intersection": {
+        const parts: string[] = [];
+        if (typeof desc.nominal === "number") {
+          parts.push(typeIdToDiagnosticString(desc.nominal, ctx, active));
+        }
+        if (desc.traits && desc.traits.length > 0) {
+          desc.traits.forEach((trait) =>
+            parts.push(typeIdToDiagnosticString(trait, ctx, active))
+          );
+        }
+        if (typeof desc.structural === "number") {
+          parts.push(typeIdToDiagnosticString(desc.structural, ctx, active));
+        }
+        return parts.join(" & ");
+      }
+      default:
+        return typeDescriptorToUserString(desc, ctx.arena);
+    }
+  })();
+  active.delete(typeId);
+  return formatted;
 };
 
 const nominalInstantiationMatches = (

--- a/packages/language-server/src/__tests__/project.test.ts
+++ b/packages/language-server/src/__tests__/project.test.ts
@@ -1416,7 +1416,7 @@ describe("language server project analysis", () => {
       });
       expect(hover?.contents).toEqual({
         kind: "markdown",
-        value: "```voyd\nreducer: (T, T) -> T ! open effect row\n```",
+        value: "```voyd\nreducer: (T, T) -> T ! (open)\n```",
       });
     } finally {
       await rm(project.rootDir, { recursive: true, force: true });

--- a/packages/lib/assets/voyd.tmLanguage.json
+++ b/packages/lib/assets/voyd.tmLanguage.json
@@ -178,7 +178,11 @@
       "patterns": [
         {
           "name": "keyword.control.voyd",
-          "match": "\\b(if|then|else|elif|while|for|return|break|do|tail|resume|try forward|try)\\b"
+          "match": "\\b(if|then|else|elif|while|for|return|break|do|tail|resume|try open|try)\\b"
+        },
+        {
+          "name": "keyword.other.effect-row.voyd",
+          "match": "\\bopen\\b(?=\\s*\\)\\s*->)"
         },
         {
           "name": "keyword.other.voyd",

--- a/packages/reference/docs/types/effects.md
+++ b/packages/reference/docs/types/effects.md
@@ -36,6 +36,13 @@ fn load_twice(value: i32): Async -> i32
 If an effect row is omitted, Voyd infers it locally. Exported APIs should spell
 effects out explicitly.
 
+Function types can also spell effect rows directly:
+
+```voyd
+fn load_with(cb: fn() : Async -> i32) -> i32
+  cb()
+```
+
 ## Handling effects
 
 ```voyd
@@ -46,7 +53,7 @@ fn load_default(value: i32): () -> i32
     resume(current + 1)
 ```
 
-`try forward` handles selected operations and forwards the rest to the caller.
+`try open` handles selected operations and leaves the rest open to the caller.
 
 ## Row polymorphism
 
@@ -57,8 +64,33 @@ fn repeat_twice<T>(cb: fn() -> T): Array<T>
   [cb(), cb()]
 ```
 
-The compiler infers an effect-row parameter for the callback when needed. You can also
-spell it out explicitly with `effects` parameters.
+The compiler infers an effect-row parameter for the callback when needed. You can
+also spell the row out explicitly when you need to distinguish between omitted,
+closed, and open callback effect rows:
+
+```voyd
+fn omitted<T>(cb: fn() -> T) -> T
+  cb()
+
+fn closed<T>(cb: fn() : Async -> T) -> T
+  cb()
+
+fn call_open<T>(cb: fn() : (Async, open) -> T) : (open) -> T
+  try open
+    cb()
+  Async::await(tail, value):
+    tail(value + 1)
+```
+
+- `fn() -> T` omits the callback row and leaves it effect-polymorphic.
+- `fn() : Async -> T` is a closed callback annotation with only `Async`.
+- `fn() : (Async, open) -> T` requires `Async` and keeps the remaining callback
+  effects open.
+- `fn() : (open) -> T` is the explicit spelling for a fully open callback row.
+
+`try open` composes with open callback rows. When a higher-order function
+handles `Async` from `fn() : (Async, open) -> T`, the remaining callback effects
+continue to bubble outward through the open tail row.
 
 ## Exported APIs
 

--- a/packages/reference/docs/types/effects.md
+++ b/packages/reference/docs/types/effects.md
@@ -80,6 +80,11 @@ fn call_open<T>(cb: fn() : (Async, open) -> T) : (open) -> T
     cb()
   Async::await(tail, value):
     tail(value + 1)
+
+fn with_nested_callback(
+  cb: fn(inner: fn() : (open) -> i32) -> i32
+) : (open) -> i32
+  cb(() => 1)
 ```
 
 - `fn() -> T` omits the callback row and leaves it effect-polymorphic.
@@ -91,6 +96,11 @@ fn call_open<T>(cb: fn() : (Async, open) -> T) : (open) -> T
 `try open` composes with open callback rows. When a higher-order function
 handles `Async` from `fn() : (Async, open) -> T`, the remaining callback effects
 continue to bubble outward through the open tail row.
+
+Nested callback parameters use the same spelling. In
+`fn(inner: fn() : (open) -> i32) -> i32`, the `inner` callback can perform any
+effects and the outer callback remains polymorphic over effects caused by
+calling it.
 
 ## Exported APIs
 


### PR DESCRIPTION
## Summary
- replace explicit open callback effect row syntax with `open` and remove the `...` normalization path used for function effect annotations
- BREAKING: rename `try forward` to `try open` across parser, lowering, typing, codegen-facing handler state, fixtures, docs, and syntax highlighting
- add regression coverage for parser, lowering, typing, language server hover, smoke execution, and VSCode grammar checks

## Testing
- `npx vitest packages/compiler/src/parser/__tests__/function-syntax.test.ts packages/compiler/src/semantics/__tests__/lowering.test.ts packages/compiler/src/semantics/__tests__/effects-lowering.test.ts packages/compiler/src/semantics/__tests__/try-handler-clauses.test.ts packages/compiler/src/semantics/__tests__/type-display.test.ts packages/compiler/src/semantics/typing/__tests__/effects-function-types.test.ts packages/compiler/src/semantics/typing/__tests__/effects-inference.test.ts packages/language-server/src/__tests__/project.test.ts apps/smoke/src/open-callback-effect-rows.test.ts`
- `node apps/vscode/scripts/test-grammar.mjs`
- `npm run typecheck`
- `npm test`