### PR TITLE
Refactor type relations, arena normalization, and effects IR boundaries

### DIFF
--- a/packages/compiler/src/codegen/__tests__/function-dependencies.test.ts
+++ b/packages/compiler/src/codegen/__tests__/function-dependencies.test.ts
@@ -66,6 +66,9 @@ const createDependencyContext = (
           handlerTails: new Map(),
           lambdas: new Map(),
         },
+        effectsIr: {
+          calls: new Map(),
+        },
       },
     ] as const;
   });

--- a/packages/compiler/src/codegen/__tests__/support/test-codegen-context.ts
+++ b/packages/compiler/src/codegen/__tests__/support/test-codegen-context.ts
@@ -52,6 +52,9 @@ export const createTestCodegenContext = (): {
       handlerTails: new Map(),
       lambdas: new Map(),
     },
+    effectsIr: {
+      calls: new Map(),
+    },
   } as const;
   const moduleContexts = new Map<string, CodegenContext>();
 

--- a/packages/compiler/src/codegen/effects/facade.ts
+++ b/packages/compiler/src/codegen/effects/facade.ts
@@ -4,11 +4,9 @@ import type {
   EffectsLoweringHandlerInfo,
 } from "../../semantics/effects/analysis.js";
 import { getEffectOpIds } from "./op-ids.js";
-import { buildEffectsIr } from "../../semantics/effects/ir/build.js";
 import type { EffectsIr, EffectsIrCallKind } from "../../semantics/effects/ir/types.js";
 
 const FACADE_KEY = Symbol("voyd.effects.facade");
-const IR_KEY = Symbol("voyd.effects.ir");
 
 export type FunctionAbiInfo = {
   effectRow: EffectRowId;
@@ -36,18 +34,10 @@ export const effectsFacade = (ctx: CodegenContext): EffectsFacade => {
   const existing = memo.get(FACADE_KEY) as EffectsFacade | undefined;
   if (existing) return existing;
 
-  const ensureIr = (): EffectsIr => {
-    const cached = memo.get(IR_KEY) as EffectsIr | undefined;
-    if (cached) return cached;
-    const built = buildEffectsIr({ hir: ctx.module.hir, info: ctx.module.effectsInfo });
-    memo.set(IR_KEY, built);
-    return built;
-  };
-
   const facade: EffectsFacade = {
-    getIr: () => ensureIr(),
+    getIr: () => ctx.module.effectsIr,
     functionAbi: (symbol) => {
-      const info = ctx.module.effectsInfo.functions.get(symbol);
+      const info = ctx.module.effectsIr.info.functions.get(symbol);
       if (!info) return undefined;
       return {
         effectRow: info.effectRow,
@@ -56,7 +46,7 @@ export const effectsFacade = (ctx: CodegenContext): EffectsFacade => {
       };
     },
     lambdaAbi: (exprId) => {
-      const info = ctx.module.effectsInfo.lambdas.get(exprId);
+      const info = ctx.module.effectsIr.info.lambdas.get(exprId);
       if (!info) return undefined;
       return {
         effectfulType: info.effectfulType,
@@ -64,8 +54,8 @@ export const effectsFacade = (ctx: CodegenContext): EffectsFacade => {
         shouldLower: info.shouldLower,
       };
     },
-    handler: (exprId) => ctx.module.effectsInfo.handlers.get(exprId),
-    callKind: (exprId) => ensureIr().calls.get(exprId)?.kind,
+    handler: (exprId) => ctx.module.effectsIr.info.handlers.get(exprId),
+    callKind: (exprId) => ctx.module.effectsIr.calls.get(exprId)?.kind,
     effectOpIds: (symbol) => getEffectOpIds(symbol, ctx),
   };
 

--- a/packages/compiler/src/optimize/pipeline.ts
+++ b/packages/compiler/src/optimize/pipeline.ts
@@ -7,6 +7,7 @@ import type {
   ProgramCodegenView,
 } from "../semantics/codegen-view/index.js";
 import { buildEffectsLoweringInfo } from "../semantics/effects/analysis.js";
+import { buildEffectsIr } from "../semantics/effects/ir/build.js";
 import { getSymbolTable } from "../semantics/_internal/symbol-table.js";
 import {
   analyzeLambdaCaptures,
@@ -259,6 +260,10 @@ const buildOptimizationIr = ({
       semantics,
       hir: cloneHir(moduleView.hir),
       effectsInfo: cloneHir(moduleView.effectsInfo),
+      effectsIr: buildEffectsIr({
+        hir: moduleView.hir,
+        info: moduleView.effectsInfo,
+      }),
     });
   });
 
@@ -1850,11 +1855,16 @@ const rebuildEffectsInfo = ({
 }: {
   moduleView: OptimizedModuleView;
 }): void => {
-  moduleView.effectsInfo = buildEffectsLoweringInfo({
+  const effectsInfo = buildEffectsLoweringInfo({
     binding: moduleView.semantics.binding,
     symbolTable: getSymbolTable(moduleView.semantics),
     hir: moduleView.hir,
     typing: moduleView.semantics.typing,
+  });
+  moduleView.effectsInfo = effectsInfo;
+  moduleView.effectsIr = buildEffectsIr({
+    hir: moduleView.hir,
+    info: effectsInfo,
   });
 };
 

--- a/packages/compiler/src/semantics/codegen-view/index.ts
+++ b/packages/compiler/src/semantics/codegen-view/index.ts
@@ -29,12 +29,15 @@ import type {
 import type { SemanticsPipelineResult } from "../pipeline.js";
 import { buildEffectsLoweringInfo } from "../effects/analysis.js";
 import type { EffectsLoweringInfo } from "../effects/analysis.js";
+import { buildEffectsIr } from "../effects/ir/build.js";
+import type { EffectsIr } from "../effects/ir/types.js";
 import { getSymbolTable } from "../_internal/symbol-table.js";
 import type { SymbolRef as TypingSymbolRef } from "../typing/symbol-ref.js";
 import type {
   CallArgumentPlanEntry,
   ObjectTemplate,
   ObjectTypeInfo,
+  ObjectField,
   SymbolRefKey,
   TraitImplInstance,
 } from "../typing/types.js";
@@ -282,6 +285,7 @@ export type ModuleCodegenView = {
   effects: EffectTable;
   types: ModuleTypeIndex;
   effectsInfo: EffectsLoweringInfo;
+  effectsIr: EffectsIr;
   functionLocations: ReadonlyMap<SymbolId, CodegenSourceLocation>;
 };
 
@@ -616,14 +620,16 @@ export const buildProgramCodegenView = (
     instantiationsByFunctionId.set(functionId, bucket);
   };
 
-  const toCodegenStructuralField = (field: StructuralField): CodegenStructuralField => ({
+  const toCodegenStructuralField = (
+    field: StructuralField | ObjectField,
+  ): CodegenStructuralField => ({
     name: field.name,
     type: field.type,
     optional: field.optional === true,
     declaringParams: field.declaringParams,
-    visibility: field.visibility,
-    owner: field.owner,
-    packageId: field.packageId,
+    visibility: "visibility" in field ? field.visibility : undefined,
+    owner: "owner" in field ? field.owner : undefined,
+    packageId: "packageId" in field ? field.packageId : undefined,
   });
 
   const toCodegenTypeDesc = (typeId: TypeId, desc: TypeDescriptor): CodegenTypeDesc => {
@@ -1794,6 +1800,12 @@ export const buildProgramCodegenView = (
         endColumn: location.endColumn,
       });
     });
+    const effectsInfo = buildEffectsLoweringInfo({
+      binding: mod.binding,
+      symbolTable: getSymbolTable(mod),
+      hir: mod.hir,
+      typing: mod.typing,
+    });
     moduleViews.set(mod.moduleId, {
       moduleId: mod.moduleId,
       meta,
@@ -1808,12 +1820,8 @@ export const buildProgramCodegenView = (
           moduleTyping.get(mod.moduleId)?.valueTypes.get(symbol),
         getTailResumption: (expr) => mod.typing.tailResumptions.get(expr),
       },
-      effectsInfo: buildEffectsLoweringInfo({
-        binding: mod.binding,
-        symbolTable: getSymbolTable(mod),
-        hir: mod.hir,
-        typing: mod.typing,
-      }),
+      effectsInfo,
+      effectsIr: buildEffectsIr({ hir: mod.hir, info: effectsInfo }),
       functionLocations,
     });
   });

--- a/packages/compiler/src/semantics/effects/__tests__/effects-ir.test.ts
+++ b/packages/compiler/src/semantics/effects/__tests__/effects-ir.test.ts
@@ -6,6 +6,7 @@ import { semanticsPipeline } from "../../pipeline.js";
 import { buildEffectsLoweringInfo } from "../analysis.js";
 import { buildEffectsIr } from "../ir/build.js";
 import { getSymbolTable } from "../../_internal/symbol-table.js";
+import { buildProgramCodegenView } from "../../codegen-view/index.js";
 
 const loadFixture = () => {
   const source = readFileSync(
@@ -27,6 +28,30 @@ describe("EffectsIR (overlay)", () => {
     const ir = buildEffectsIr({ hir: semantics.hir, info });
 
     const calls = Array.from(ir.calls.values()).map((call) => ({
+      kind: call.kind,
+      callee:
+        typeof call.calleeSymbol === "number"
+          ? getSymbolTable(semantics).getSymbol(call.calleeSymbol).name
+          : "<unknown>",
+      op: call.operation?.name,
+    }));
+
+    expect(calls.some((call) => call.kind === "perform" && call.op === "Async.await")).toBe(true);
+    expect(calls.some((call) => call.kind === "pure-call" && call.callee === "pure_add")).toBe(
+      true
+    );
+    expect(
+      calls.some((call) => call.kind === "effectful-call" && call.callee === "effectful")
+    ).toBe(true);
+  });
+
+  it("is exposed as a codegen-view module artifact", () => {
+    const semantics = loadFixture();
+    const program = buildProgramCodegenView([semantics]);
+    const module = program.modules.get(semantics.moduleId);
+    expect(module).toBeDefined();
+
+    const calls = Array.from(module!.effectsIr.calls.values()).map((call) => ({
       kind: call.kind,
       callee:
         typeof call.calleeSymbol === "number"

--- a/packages/compiler/src/semantics/typing/__tests__/type-arena.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/type-arena.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { HirVisibility } from "../../hir/index.js";
+import type { SymbolId } from "../../ids.js";
+import { createTypeArena } from "../type-arena.js";
+
+const moduleVisibility = (): HirVisibility => ({ level: "module", api: false });
+
+describe("TypeArena shape normalization", () => {
+  it("collapses singleton unions to their member", () => {
+    const arena = createTypeArena();
+    const bool = arena.internPrimitive("bool");
+
+    expect(arena.internUnion([bool])).toBe(bool);
+    expect(arena.internUnion([arena.internUnion([bool])])).toBe(bool);
+  });
+
+  it("deduplicates identical structural field shapes", () => {
+    const arena = createTypeArena();
+    const i32 = arena.internPrimitive("i32");
+    const structural = arena.internStructuralObject({
+      fields: [
+        { name: "value", type: i32 },
+        { name: "value", type: i32, optional: false },
+      ],
+    });
+
+    const desc = arena.get(structural);
+    if (desc.kind !== "structural-object") {
+      throw new Error(`expected structural object, got ${desc.kind}`);
+    }
+    expect(desc.fields).toEqual([{ name: "value", type: i32, optional: false }]);
+  });
+
+  it("keeps structural identity independent from field access metadata", () => {
+    const arena = createTypeArena();
+    const i32 = arena.internPrimitive("i32");
+    const publicShape = arena.internStructuralObject({
+      fields: [{ name: "value", type: i32 }],
+    });
+    const restrictedField = {
+      name: "value",
+      type: i32,
+      visibility: moduleVisibility(),
+      owner: 1 as SymbolId,
+      packageId: "pkg",
+    };
+    const restrictedShape = arena.internStructuralObject({
+      fields: [restrictedField],
+    });
+
+    expect(restrictedShape).toBe(publicShape);
+    const desc = arena.get(restrictedShape);
+    if (desc.kind !== "structural-object") {
+      throw new Error(`expected structural object, got ${desc.kind}`);
+    }
+    expect(desc.fields[0]).toEqual({
+      name: "value",
+      type: i32,
+      optional: false,
+    });
+  });
+});

--- a/packages/compiler/src/semantics/typing/expressions/block.ts
+++ b/packages/compiler/src/semantics/typing/expressions/block.ts
@@ -12,9 +12,9 @@ import { mergeBranchType } from "./branching.js";
 import {
   ensureTypeMatches,
   resolveTypeExpr,
-  typeSatisfies,
   getSymbolName,
 } from "../type-system.js";
+import { satisfies as typeSatisfies } from "../type-relations.js";
 import { DiagnosticError, emitDiagnostic } from "../../../diagnostics/index.js";
 import type { TypingContext, TypingState } from "../types.js";
 

--- a/packages/compiler/src/semantics/typing/expressions/branching.ts
+++ b/packages/compiler/src/semantics/typing/expressions/branching.ts
@@ -1,6 +1,7 @@
 import type { SourceSpan, TypeId } from "../../ids.js";
 import type { TypingContext, TypingState } from "../types.js";
-import { internCheckedUnion, typeSatisfies } from "../type-system.js";
+import { internCheckedUnion } from "../type-system.js";
+import { satisfies as typeSatisfies } from "../type-relations.js";
 import { emitDiagnostic, normalizeSpan } from "../../../diagnostics/index.js";
 
 export const mergeBranchType = ({

--- a/packages/compiler/src/semantics/typing/expressions/call-arg-context.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call-arg-context.ts
@@ -9,7 +9,7 @@ import type {
   TypingContext,
   TypingState,
 } from "../types.js";
-import { bindTypeParamsFromType } from "../type-system.js";
+import { bindTypeParams as bindTypeParamsFromType } from "../type-relations.js";
 import { typeExpression } from "../expressions.js";
 import { applyCurrentSubstitution } from "./shared.js";
 

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -15,7 +15,6 @@ import type {
 import type { ModuleExportEntry } from "../../modules.js";
 import { intrinsicValueMetadataFor } from "../../intrinsics.js";
 import {
-  bindTypeParamsFromType,
   disallowedValueTraitObjectWidening,
   ensureTypeMatches,
   getNominalComponent,
@@ -24,10 +23,13 @@ import {
   getStructuralFields,
   internCheckedUnion,
   resolveTypeExpr,
-  typeSatisfies,
   getSymbolName,
-  unifyWithBudget,
 } from "../type-system.js";
+import {
+  bindTypeParams as bindTypeParamsFromType,
+  satisfies as typeSatisfies,
+  unify as unifyWithBudget,
+} from "../type-relations.js";
 import {
   getOptionalInfo,
   optionalResolverContextForTypingContext,
@@ -59,6 +61,12 @@ import {
   filterCandidatesByExplicitTypeArguments,
   type ExpectedCallContext,
 } from "./overload-candidates.js";
+import {
+  applyExplicitTypeArguments,
+  enforceOverloadCandidateBudget,
+  findOverloadMatches,
+  selectHintedOverloadCandidates,
+} from "./overload-resolution.js";
 import { typeExpression } from "../expressions.js";
 import { applyCurrentSubstitution } from "./shared.js";
 import { getValueType } from "./identifier.js";
@@ -92,11 +100,6 @@ import { collectTraitOwnersFromTypeParams } from "../constraint-trait-owners.js"
 import { typeDefaultParameterValues } from "../default-parameters.js";
 
 type SymbolNameResolver = (symbol: SymbolId) => string;
-type OverloadCandidate = {
-  symbol: SymbolId;
-  signature: FunctionSignature;
-};
-
 type MethodCallCandidate = {
   symbol: SymbolId;
   signature: FunctionSignature;
@@ -954,39 +957,6 @@ const getExpectedCallParameters = ({
   };
 };
 
-const applyExplicitTypeArguments = ({
-  signature,
-  typeArguments,
-  calleeSymbol,
-  ctx,
-}: {
-  signature: FunctionSignature;
-  typeArguments: readonly TypeId[] | undefined;
-  calleeSymbol: SymbolId;
-  ctx: TypingContext;
-}): ReadonlyMap<TypeParamId, TypeId> | undefined => {
-  if (!typeArguments || typeArguments.length === 0) {
-    return undefined;
-  }
-  const params = signature.typeParams ?? [];
-  if (typeArguments.length > params.length) {
-    throw new Error(
-      `function ${getSymbolName(
-        calleeSymbol,
-        ctx,
-      )} received too many type arguments`,
-    );
-  }
-  const substitution = new Map<TypeParamId, TypeId>();
-  params.forEach((param, index) => {
-    const arg = typeArguments[index];
-    if (typeof arg === "number") {
-      substitution.set(param.typeParam, arg);
-    }
-  });
-  return substitution.size > 0 ? substitution : undefined;
-};
-
 const mergeExplicitTypeArgumentSubstitution = ({
   signature,
   typeArguments,
@@ -1049,33 +1019,6 @@ const findMatchingOverloadCandidates = <
       typeArguments,
     ),
   );
-
-const enforceOverloadCandidateBudget = ({
-  name,
-  candidateCount,
-  ctx,
-  span,
-}: {
-  name: string;
-  candidateCount: number;
-  ctx: TypingContext;
-  span?: SourceSpan;
-}): void => {
-  if (candidateCount <= ctx.typeCheckBudget.maxOverloadCandidates) {
-    return;
-  }
-  emitDiagnostic({
-    ctx,
-    code: "TY0041",
-    params: {
-      kind: "overload-candidate-budget-exceeded",
-      name,
-      candidates: candidateCount,
-      maxCandidates: ctx.typeCheckBudget.maxOverloadCandidates,
-    },
-    span: normalizeSpan(span, ctx.hir.module.span),
-  });
-};
 
 const expectedCalleeType = (args: readonly Arg[], ctx: TypingContext): TypeId =>
   ctx.arena.internFunction({
@@ -3465,7 +3408,7 @@ const typeOperatorOverloadCall = ({
           state,
         })
       : undefined;
-  let selected = traitDispatch;
+  let selected: MethodCallCandidate | undefined = traitDispatch;
 
   if (!selected) {
     if (matches.length === 0) {
@@ -5075,325 +5018,6 @@ const resolveIntrinsicFallbackForIdentifierCall = ({
   };
 };
 
-const selectHintedOverloadCandidates = ({
-  candidates,
-  typeArguments,
-  expectedReturnType,
-  expectedReturnCandidates,
-  ctx,
-  state,
-}: {
-  candidates: readonly OverloadCandidate[];
-  typeArguments: readonly TypeId[] | undefined;
-  expectedReturnType: TypeId | undefined;
-  expectedReturnCandidates: ReadonlySet<SymbolId> | undefined;
-  ctx: TypingContext;
-  state: TypingState;
-}): {
-  hintedCandidates: readonly OverloadCandidate[];
-  fallbackCandidates?: readonly OverloadCandidate[];
-} => {
-  const candidatesForBudget = filterCandidatesByExplicitTypeArguments({
-    candidates,
-    typeArguments,
-  });
-
-  const returnHintCandidates =
-    expectedReturnCandidates && expectedReturnCandidates.size > 0
-      ? candidatesForBudget.filter((candidate) =>
-          expectedReturnCandidates.has(candidate.symbol),
-        )
-      : filterCandidatesByExpectedReturnType({
-          candidates: candidatesForBudget,
-          expectedReturnType,
-          typeArguments,
-          ctx,
-          state,
-        });
-
-  if (
-    returnHintCandidates.length === 0 ||
-    returnHintCandidates.length === candidatesForBudget.length
-  ) {
-    return { hintedCandidates: candidatesForBudget };
-  }
-
-  return {
-    hintedCandidates: returnHintCandidates,
-    fallbackCandidates: candidatesForBudget,
-  };
-};
-
-const findOverloadMatches = ({
-  name,
-  candidates,
-  args,
-  typeArguments,
-  span,
-  ctx,
-  state,
-}: {
-  name: string;
-  candidates: readonly OverloadCandidate[];
-  args: readonly Arg[];
-  typeArguments: readonly TypeId[] | undefined;
-  span: SourceSpan;
-  ctx: TypingContext;
-  state: TypingState;
-}): readonly OverloadCandidate[] => {
-  enforceOverloadCandidateBudget({
-    name,
-    candidateCount: candidates.length,
-    ctx,
-    span,
-  });
-  return findMatchingOverloadCandidates({
-    candidates,
-    args,
-    ctx,
-    state,
-    typeArguments,
-  });
-};
-
-const applyExplicitTypeArgumentSubstitution = ({
-  symbol,
-  signature,
-  typeArguments,
-  ctx,
-}: {
-  symbol: SymbolId;
-  signature: FunctionSignature;
-  typeArguments?: readonly TypeId[];
-  ctx: TypingContext;
-}) =>
-  signature.typeParams && signature.typeParams.length > 0
-    ? applyExplicitTypeArguments({
-        signature,
-        typeArguments,
-        calleeSymbol: symbol,
-        ctx,
-      })
-    : undefined;
-
-const specializeOverloadParameters = ({
-  symbol,
-  signature,
-  typeArguments,
-  ctx,
-}: {
-  symbol: SymbolId;
-  signature: FunctionSignature;
-  typeArguments?: readonly TypeId[];
-  ctx: TypingContext;
-}): readonly ParamSignature[] => {
-  const explicitSubstitution = applyExplicitTypeArgumentSubstitution({
-    symbol,
-    signature,
-    typeArguments,
-    ctx,
-  });
-  if (!explicitSubstitution) {
-    return signature.parameters;
-  }
-
-  return signature.parameters.map((param) => ({
-    ...param,
-    type: ctx.arena.substitute(param.type, explicitSubstitution),
-  }));
-};
-
-const overloadDominates = ({
-  candidate,
-  other,
-  typeArguments,
-  ctx,
-  state,
-}: {
-  candidate: { symbol: SymbolId; signature: FunctionSignature };
-  other: { symbol: SymbolId; signature: FunctionSignature };
-  typeArguments: readonly TypeId[] | undefined;
-  ctx: TypingContext;
-  state: TypingState;
-}): boolean => {
-  const candidateParams = specializeOverloadParameters({
-    symbol: candidate.symbol,
-    signature: candidate.signature,
-    typeArguments,
-    ctx,
-  });
-  const otherParams = specializeOverloadParameters({
-    symbol: other.symbol,
-    signature: other.signature,
-    typeArguments,
-    ctx,
-  });
-  if (candidateParams.length !== otherParams.length) {
-    return false;
-  }
-
-  let strictlyMoreSpecific = false;
-  for (let index = 0; index < candidateParams.length; index += 1) {
-    const candidateParam = candidateParams[index]!;
-    const otherParam = otherParams[index]!;
-    if (
-      candidateParam.label !== otherParam.label ||
-      candidateParam.optional !== otherParam.optional
-    ) {
-      return false;
-    }
-    if (!typeSatisfies(candidateParam.type, otherParam.type, ctx, state)) {
-      return false;
-    }
-    if (!typeSatisfies(otherParam.type, candidateParam.type, ctx, state)) {
-      strictlyMoreSpecific = true;
-    }
-  }
-
-  return strictlyMoreSpecific;
-};
-
-const unresolvedTypeParamPenalty = ({
-  type,
-  ctx,
-  visiting = new Set<TypeId>(),
-}: {
-  type: TypeId;
-  ctx: TypingContext;
-  visiting?: Set<TypeId>;
-}): number => {
-  if (visiting.has(type)) {
-    return 0;
-  }
-  visiting.add(type);
-  const penalty = (() => {
-    const desc = ctx.arena.get(type);
-    switch (desc.kind) {
-      case "type-param-ref":
-        return 1;
-      case "primitive":
-        return 0;
-      case "recursive":
-        return unresolvedTypeParamPenalty({ type: desc.body, ctx, visiting });
-      case "fixed-array":
-        return unresolvedTypeParamPenalty({ type: desc.element, ctx, visiting });
-      case "union":
-        return desc.members.reduce(
-          (sum, member) => sum + unresolvedTypeParamPenalty({ type: member, ctx, visiting }),
-          0,
-        );
-      case "intersection":
-        return (
-          (typeof desc.nominal === "number"
-            ? unresolvedTypeParamPenalty({ type: desc.nominal, ctx, visiting })
-            : 0) +
-          (typeof desc.structural === "number"
-            ? unresolvedTypeParamPenalty({ type: desc.structural, ctx, visiting })
-            : 0) +
-          (desc.traits?.reduce(
-            (sum, trait) => sum + unresolvedTypeParamPenalty({ type: trait, ctx, visiting }),
-            0,
-          ) ?? 0)
-        );
-      case "trait":
-      case "nominal-object":
-      case "value-object":
-        return desc.typeArgs.reduce(
-          (sum, arg) => sum + unresolvedTypeParamPenalty({ type: arg, ctx, visiting }),
-          0,
-        );
-      case "structural-object":
-        return desc.fields.reduce(
-          (sum, field) => sum + unresolvedTypeParamPenalty({ type: field.type, ctx, visiting }),
-          0,
-        );
-      case "function":
-        return (
-          desc.parameters.reduce(
-            (sum, param) =>
-              sum + unresolvedTypeParamPenalty({ type: param.type, ctx, visiting }),
-            0,
-          ) + unresolvedTypeParamPenalty({ type: desc.returnType, ctx, visiting })
-        );
-    }
-  })();
-  visiting.delete(type);
-  return penalty;
-};
-
-const overloadGenericityPenalty = ({
-  candidate,
-  typeArguments,
-  ctx,
-}: {
-  candidate: { symbol: SymbolId; signature: FunctionSignature };
-  typeArguments: readonly TypeId[] | undefined;
-  ctx: TypingContext;
-}): number =>
-  specializeOverloadParameters({
-    symbol: candidate.symbol,
-    signature: candidate.signature,
-    typeArguments,
-    ctx,
-  }).reduce(
-    (sum, param) => sum + unresolvedTypeParamPenalty({ type: param.type, ctx }),
-    0,
-  );
-
-const narrowOverloadMatches = <T extends { symbol: SymbolId; signature: FunctionSignature }>({
-  matches,
-  typeArguments,
-  ctx,
-  state,
-}: {
-  matches: readonly T[];
-  typeArguments: readonly TypeId[] | undefined;
-  ctx: TypingContext;
-  state: TypingState;
-}): readonly T[] => {
-  if (matches.length <= 1) {
-    return matches;
-  }
-
-  const maximalMatches = matches.filter((candidate) =>
-    matches.every(
-      (other) =>
-        candidate === other ||
-        !overloadDominates({
-          candidate: other,
-          other: candidate,
-          typeArguments,
-          ctx,
-          state,
-        }),
-    ),
-  );
-
-  if (maximalMatches.length === 1) {
-    return maximalMatches;
-  }
-
-  const minPenalty = Math.min(
-    ...maximalMatches.map((candidate) =>
-      overloadGenericityPenalty({
-        candidate,
-        typeArguments,
-        ctx,
-      }),
-    ),
-  );
-  const leastGenericMatches = maximalMatches.filter(
-    (candidate) =>
-      overloadGenericityPenalty({
-        candidate,
-        typeArguments,
-        ctx,
-      }) === minPenalty,
-  );
-
-  return leastGenericMatches.length === 1 ? leastGenericMatches : matches;
-};
-
 const typeOverloadedCall = (
   call: HirCallExpr,
   callee: HirOverloadSetExpr,
@@ -5441,6 +5065,15 @@ const typeOverloadedCall = (
     span: call.span,
     ctx,
     state,
+    matchesCandidate: (candidate, argsForMatch) =>
+      matchesOverloadSignature(
+        candidate.symbol,
+        candidate.signature,
+        argsForMatch,
+        ctx,
+        state,
+        typeArguments,
+      ),
   });
   if (matches.length === 0 && fallbackCandidates) {
     // Expected-return narrowing is a hint. If it removes all valid matches,
@@ -5454,9 +5087,17 @@ const typeOverloadedCall = (
       span: call.span,
       ctx,
       state,
+      matchesCandidate: (candidate, argsForMatch) =>
+        matchesOverloadSignature(
+          candidate.symbol,
+          candidate.signature,
+          argsForMatch,
+          ctx,
+          state,
+          typeArguments,
+        ),
     });
   }
-  matches = [...narrowOverloadMatches({ matches, typeArguments, ctx, state })];
 
   const traitDispatch =
     matches.length === 0 && (!typeArguments || typeArguments.length === 0)

--- a/packages/compiler/src/semantics/typing/expressions/effect-handler.ts
+++ b/packages/compiler/src/semantics/typing/expressions/effect-handler.ts
@@ -8,8 +8,8 @@ import {
 import {
   ensureTypeMatches,
   resolveTypeExpr,
-  typeSatisfies,
 } from "../type-system.js";
+import { satisfies as typeSatisfies } from "../type-relations.js";
 import type { TypingContext, TypingState } from "../types.js";
 import {
   analyzeContinuationUsage,

--- a/packages/compiler/src/semantics/typing/expressions/lambda.ts
+++ b/packages/compiler/src/semantics/typing/expressions/lambda.ts
@@ -9,11 +9,11 @@ import type {
   TypeParamId,
 } from "../../ids.js";
 import {
-  bindTypeParamsFromType,
   ensureTypeMatches,
   resolveTypeExpr,
   getSymbolName,
 } from "../type-system.js";
+import { bindTypeParams as bindTypeParamsFromType } from "../type-relations.js";
 import { typeExpression } from "../expressions.js";
 import {
   enforceTypeParamConstraint,

--- a/packages/compiler/src/semantics/typing/expressions/match.ts
+++ b/packages/compiler/src/semantics/typing/expressions/match.ts
@@ -5,14 +5,15 @@ import { getExprEffectRow } from "../effects.js";
 import {
   getNominalComponent,
   matchedUnionMembers,
-  narrowTypeForPattern,
   ensureTypeMatches,
   resolveTypeExpr,
-  unfoldRecursiveType,
   getStructuralFields,
   getSymbolName,
-  unifyWithBudget,
 } from "../type-system.js";
+import {
+  narrowForPattern as narrowTypeForPattern,
+  unify as unifyWithBudget,
+} from "../type-relations.js";
 import {
   diagnosticFromCode,
   DiagnosticError,
@@ -36,7 +37,7 @@ export const typeMatchExpr = (
 ): TypeId => {
   const discardValue = options.discardValue === true;
   const rawDiscriminantType = typeExpression(expr.discriminant, ctx, state);
-  const discriminantType = unfoldRecursiveType(rawDiscriminantType, ctx);
+  const discriminantType = ctx.arena.unfoldRecursive(rawDiscriminantType);
   const discriminantExpr = ctx.hir.expressions.get(expr.discriminant);
   const discriminantSymbol =
     discriminantExpr?.exprKind === "identifier"
@@ -287,8 +288,7 @@ const narrowMatchPattern = (
         pattern.typeId = ctx.primitives.unknown;
         return ctx.primitives.unknown;
       }
-      const narrowed =
-        candidates.length === 1 ? candidates[0]! : ctx.arena.internUnion(candidates);
+      const narrowed = ctx.arena.internUnion(candidates);
       pattern.typeId = narrowed;
       return narrowed;
     }

--- a/packages/compiler/src/semantics/typing/expressions/object-literal.ts
+++ b/packages/compiler/src/semantics/typing/expressions/object-literal.ts
@@ -6,7 +6,6 @@ import type { SourceSpan, TypeId, TypeParamId } from "../../ids.js";
 import { typeExpression, withSpeculativeExprTyping } from "../expressions.js";
 import { composeEffectRows, getExprEffectRow } from "../effects.js";
 import {
-  bindTypeParamsFromType,
   ensureObjectType,
   ensureTypeMatches,
   getObjectTemplate,
@@ -14,11 +13,9 @@ import {
   getSymbolName,
   resolveTypeExpr,
 } from "../type-system.js";
-import {
-  typeDescriptorToUserString,
-  type StructuralField,
-} from "../type-arena.js";
-import type { TypingContext, TypingState } from "../types.js";
+import { bindTypeParams as bindTypeParamsFromType } from "../type-relations.js";
+import { typeDescriptorToUserString } from "../type-arena.js";
+import type { ObjectField, TypingContext, TypingState } from "../types.js";
 import {
   assertFieldAccess,
   canAccessField,
@@ -100,7 +97,7 @@ const typeNominalObjectLiteral = (
   }
 
   const typeName = getSymbolName(targetSymbol, ctx);
-  const templateFields = new Map<string, StructuralField>(
+  const templateFields = new Map<string, ObjectField>(
     template.fields.map((field) => [field.name, field])
   );
   const explicitTypeArgs =
@@ -145,7 +142,7 @@ const typeNominalObjectLiteral = (
     throw new Error("missing object type information for nominal literal");
   }
 
-  const declaredFields = new Map<string, StructuralField>(
+  const declaredFields = new Map<string, ObjectField>(
     objectInfo.fields.map((field) => [field.name, field])
   );
   const provided = new Set<string>();
@@ -206,7 +203,7 @@ const bindNominalObjectEntry = (
     typeName,
   }: {
     entry: HirObjectLiteralEntry;
-    declared: Map<string, StructuralField>;
+    declared: Map<string, ObjectField>;
     bindings: Map<TypeParamId, TypeId>;
     ctx: TypingContext;
     state: TypingState;
@@ -234,7 +231,7 @@ const mergeNominalObjectEntry = (
     typeName,
   }: {
     entry: HirObjectLiteralEntry;
-    declared: Map<string, StructuralField>;
+    declared: Map<string, ObjectField>;
     provided: Set<string>;
     ctx: TypingContext;
     state: TypingState;
@@ -265,7 +262,7 @@ const mergeNominalObjectEntry = (
 type NominalObjectEntryField = {
   fieldSpan: SourceSpan;
   name: string;
-  expectedField: StructuralField;
+  expectedField: ObjectField;
   valueType: TypeId;
   isSpread: boolean;
 };
@@ -279,7 +276,7 @@ const forEachNominalObjectEntryField = ({
   onField,
 }: {
   entry: HirObjectLiteralEntry;
-  declared: Map<string, StructuralField>;
+  declared: Map<string, ObjectField>;
   ctx: TypingContext;
   state: TypingState;
   typeName: string;
@@ -354,7 +351,7 @@ const resolveAccessibleObjectSpreadFields = ({
   ctx: TypingContext;
   state: TypingState;
   allowOwnerPrivate?: boolean;
-}): readonly StructuralField[] | undefined => {
+}): readonly ObjectField[] | undefined => {
   const spreadType = typeExpression(entry.value, ctx, state);
   if (spreadType === ctx.primitives.unknown) {
     return undefined;
@@ -385,12 +382,12 @@ const resolveExpectedNominalField = ({
   span,
   ctx,
 }: {
-  declared: Map<string, StructuralField>;
+  declared: Map<string, ObjectField>;
   name: string;
   typeName: string;
   span: SourceSpan;
   ctx: TypingContext;
-}): StructuralField => {
+}): ObjectField => {
   const expectedField = declared.get(name);
   if (expectedField) {
     return expectedField;

--- a/packages/compiler/src/semantics/typing/expressions/overload-candidates.ts
+++ b/packages/compiler/src/semantics/typing/expressions/overload-candidates.ts
@@ -1,5 +1,5 @@
 import type { SymbolId, TypeId, TypeParamId } from "../../ids.js";
-import { typeSatisfies } from "../type-system.js";
+import { satisfies as typeSatisfies } from "../type-relations.js";
 import type { FunctionSignature, TypingContext, TypingState } from "../types.js";
 
 export type ExpectedCallContext = {

--- a/packages/compiler/src/semantics/typing/expressions/overload-resolution.ts
+++ b/packages/compiler/src/semantics/typing/expressions/overload-resolution.ts
@@ -1,0 +1,408 @@
+import type { SourceSpan, SymbolId, TypeId, TypeParamId } from "../../ids.js";
+import { emitDiagnostic, normalizeSpan } from "../../../diagnostics/index.js";
+import type {
+  Arg,
+  FunctionSignature,
+  ParamSignature,
+  TypingContext,
+  TypingState,
+} from "../types.js";
+import { getSymbolName } from "../type-system.js";
+import { satisfies as typeSatisfies } from "../type-relations.js";
+import {
+  filterCandidatesByExpectedReturnType,
+  filterCandidatesByExplicitTypeArguments,
+} from "./overload-candidates.js";
+
+export type OverloadResolutionCandidate = {
+  symbol: SymbolId;
+  signature: FunctionSignature;
+};
+
+export const enforceOverloadCandidateBudget = ({
+  name,
+  candidateCount,
+  ctx,
+  span,
+}: {
+  name: string;
+  candidateCount: number;
+  ctx: TypingContext;
+  span?: SourceSpan;
+}): void => {
+  if (candidateCount <= ctx.typeCheckBudget.maxOverloadCandidates) {
+    return;
+  }
+  emitDiagnostic({
+    ctx,
+    code: "TY0041",
+    params: {
+      kind: "overload-candidate-budget-exceeded",
+      name,
+      candidates: candidateCount,
+      maxCandidates: ctx.typeCheckBudget.maxOverloadCandidates,
+    },
+    span: normalizeSpan(span, ctx.hir.module.span),
+  });
+};
+
+export const selectHintedOverloadCandidates = <T extends OverloadResolutionCandidate>({
+  candidates,
+  typeArguments,
+  expectedReturnType,
+  expectedReturnCandidates,
+  ctx,
+  state,
+}: {
+  candidates: readonly T[];
+  typeArguments: readonly TypeId[] | undefined;
+  expectedReturnType: TypeId | undefined;
+  expectedReturnCandidates: ReadonlySet<SymbolId> | undefined;
+  ctx: TypingContext;
+  state: TypingState;
+}): {
+  hintedCandidates: readonly T[];
+  fallbackCandidates?: readonly T[];
+} => {
+  const candidatesForBudget = filterCandidatesByExplicitTypeArguments({
+    candidates,
+    typeArguments,
+  });
+
+  const returnHintCandidates =
+    expectedReturnCandidates && expectedReturnCandidates.size > 0
+      ? candidatesForBudget.filter((candidate) =>
+          expectedReturnCandidates.has(candidate.symbol),
+        )
+      : filterCandidatesByExpectedReturnType({
+          candidates: candidatesForBudget,
+          expectedReturnType,
+          typeArguments,
+          ctx,
+          state,
+        });
+
+  if (
+    returnHintCandidates.length === 0 ||
+    returnHintCandidates.length === candidatesForBudget.length
+  ) {
+    return { hintedCandidates: candidatesForBudget };
+  }
+
+  return {
+    hintedCandidates: returnHintCandidates,
+    fallbackCandidates: candidatesForBudget,
+  };
+};
+
+export const findOverloadMatches = <T extends OverloadResolutionCandidate>({
+  name,
+  candidates,
+  args,
+  typeArguments,
+  span,
+  ctx,
+  state,
+  matchesCandidate,
+  argsForCandidate,
+}: {
+  name: string;
+  candidates: readonly T[];
+  args: readonly Arg[];
+  typeArguments: readonly TypeId[] | undefined;
+  span: SourceSpan;
+  ctx: TypingContext;
+  state: TypingState;
+  matchesCandidate: (candidate: T, args: readonly Arg[]) => boolean;
+  argsForCandidate?: (candidate: T) => readonly Arg[];
+}): readonly T[] => {
+  enforceOverloadCandidateBudget({
+    name,
+    candidateCount: candidates.length,
+    ctx,
+    span,
+  });
+  const matches = candidates.filter((candidate) =>
+    matchesCandidate(candidate, argsForCandidate ? argsForCandidate(candidate) : args),
+  );
+  return narrowOverloadMatches({ matches, typeArguments, ctx, state });
+};
+
+export const applyExplicitTypeArguments = ({
+  signature,
+  typeArguments,
+  calleeSymbol,
+  ctx,
+}: {
+  signature: FunctionSignature;
+  typeArguments: readonly TypeId[] | undefined;
+  calleeSymbol: SymbolId;
+  ctx: TypingContext;
+}): ReadonlyMap<TypeParamId, TypeId> | undefined => {
+  if (!typeArguments || typeArguments.length === 0) {
+    return undefined;
+  }
+  const params = signature.typeParams ?? [];
+  if (typeArguments.length > params.length) {
+    throw new Error(
+      `function ${getSymbolName(
+        calleeSymbol,
+        ctx,
+      )} received too many type arguments`,
+    );
+  }
+  const substitution = new Map<TypeParamId, TypeId>();
+  params.forEach((param, index) => {
+    const arg = typeArguments[index];
+    if (typeof arg === "number") {
+      substitution.set(param.typeParam, arg);
+    }
+  });
+  return substitution.size > 0 ? substitution : undefined;
+};
+
+export const applyExplicitTypeArgumentSubstitution = ({
+  symbol,
+  signature,
+  typeArguments,
+  ctx,
+}: {
+  symbol: SymbolId;
+  signature: FunctionSignature;
+  typeArguments?: readonly TypeId[];
+  ctx: TypingContext;
+}) =>
+  signature.typeParams && signature.typeParams.length > 0
+    ? applyExplicitTypeArguments({
+        signature,
+        typeArguments,
+        calleeSymbol: symbol,
+        ctx,
+      })
+    : undefined;
+
+export const specializeOverloadParameters = ({
+  symbol,
+  signature,
+  typeArguments,
+  ctx,
+}: {
+  symbol: SymbolId;
+  signature: FunctionSignature;
+  typeArguments?: readonly TypeId[];
+  ctx: TypingContext;
+}): readonly ParamSignature[] => {
+  const explicitSubstitution = applyExplicitTypeArgumentSubstitution({
+    symbol,
+    signature,
+    typeArguments,
+    ctx,
+  });
+  if (!explicitSubstitution) {
+    return signature.parameters;
+  }
+
+  return signature.parameters.map((param) => ({
+    ...param,
+    type: ctx.arena.substitute(param.type, explicitSubstitution),
+  }));
+};
+
+const overloadDominates = ({
+  candidate,
+  other,
+  typeArguments,
+  ctx,
+  state,
+}: {
+  candidate: OverloadResolutionCandidate;
+  other: OverloadResolutionCandidate;
+  typeArguments: readonly TypeId[] | undefined;
+  ctx: TypingContext;
+  state: TypingState;
+}): boolean => {
+  const candidateParams = specializeOverloadParameters({
+    symbol: candidate.symbol,
+    signature: candidate.signature,
+    typeArguments,
+    ctx,
+  });
+  const otherParams = specializeOverloadParameters({
+    symbol: other.symbol,
+    signature: other.signature,
+    typeArguments,
+    ctx,
+  });
+  if (candidateParams.length !== otherParams.length) {
+    return false;
+  }
+
+  let strictlyMoreSpecific = false;
+  for (let index = 0; index < candidateParams.length; index += 1) {
+    const candidateParam = candidateParams[index]!;
+    const otherParam = otherParams[index]!;
+    if (
+      candidateParam.label !== otherParam.label ||
+      candidateParam.optional !== otherParam.optional
+    ) {
+      return false;
+    }
+    if (!typeSatisfies(candidateParam.type, otherParam.type, ctx, state)) {
+      return false;
+    }
+    if (!typeSatisfies(otherParam.type, candidateParam.type, ctx, state)) {
+      strictlyMoreSpecific = true;
+    }
+  }
+
+  return strictlyMoreSpecific;
+};
+
+const unresolvedTypeParamPenalty = ({
+  type,
+  ctx,
+  visiting = new Set<TypeId>(),
+}: {
+  type: TypeId;
+  ctx: TypingContext;
+  visiting?: Set<TypeId>;
+}): number => {
+  if (visiting.has(type)) {
+    return 0;
+  }
+  visiting.add(type);
+  const penalty = (() => {
+    const desc = ctx.arena.get(type);
+    switch (desc.kind) {
+      case "type-param-ref":
+        return 1;
+      case "primitive":
+        return 0;
+      case "recursive":
+        return unresolvedTypeParamPenalty({ type: desc.body, ctx, visiting });
+      case "fixed-array":
+        return unresolvedTypeParamPenalty({ type: desc.element, ctx, visiting });
+      case "union":
+        return desc.members.reduce(
+          (sum, member) =>
+            sum + unresolvedTypeParamPenalty({ type: member, ctx, visiting }),
+          0,
+        );
+      case "intersection":
+        return (
+          (typeof desc.nominal === "number"
+            ? unresolvedTypeParamPenalty({ type: desc.nominal, ctx, visiting })
+            : 0) +
+          (typeof desc.structural === "number"
+            ? unresolvedTypeParamPenalty({
+                type: desc.structural,
+                ctx,
+                visiting,
+              })
+            : 0) +
+          (desc.traits?.reduce(
+            (sum, trait) =>
+              sum + unresolvedTypeParamPenalty({ type: trait, ctx, visiting }),
+            0,
+          ) ?? 0)
+        );
+      case "trait":
+      case "nominal-object":
+      case "value-object":
+        return desc.typeArgs.reduce(
+          (sum, arg) =>
+            sum + unresolvedTypeParamPenalty({ type: arg, ctx, visiting }),
+          0,
+        );
+      case "structural-object":
+        return desc.fields.reduce(
+          (sum, field) =>
+            sum + unresolvedTypeParamPenalty({ type: field.type, ctx, visiting }),
+          0,
+        );
+      case "function":
+        return (
+          desc.parameters.reduce(
+            (sum, param) =>
+              sum + unresolvedTypeParamPenalty({ type: param.type, ctx, visiting }),
+            0,
+          ) + unresolvedTypeParamPenalty({ type: desc.returnType, ctx, visiting })
+        );
+    }
+  })();
+  visiting.delete(type);
+  return penalty;
+};
+
+const overloadGenericityPenalty = ({
+  candidate,
+  typeArguments,
+  ctx,
+}: {
+  candidate: OverloadResolutionCandidate;
+  typeArguments: readonly TypeId[] | undefined;
+  ctx: TypingContext;
+}): number =>
+  specializeOverloadParameters({
+    symbol: candidate.symbol,
+    signature: candidate.signature,
+    typeArguments,
+    ctx,
+  }).reduce(
+    (sum, param) => sum + unresolvedTypeParamPenalty({ type: param.type, ctx }),
+    0,
+  );
+
+export const narrowOverloadMatches = <T extends OverloadResolutionCandidate>({
+  matches,
+  typeArguments,
+  ctx,
+  state,
+}: {
+  matches: readonly T[];
+  typeArguments: readonly TypeId[] | undefined;
+  ctx: TypingContext;
+  state: TypingState;
+}): readonly T[] => {
+  if (matches.length <= 1) {
+    return matches;
+  }
+
+  const maximalMatches = matches.filter((candidate) =>
+    matches.every(
+      (other) =>
+        candidate === other ||
+        !overloadDominates({
+          candidate: other,
+          other: candidate,
+          typeArguments,
+          ctx,
+          state,
+        }),
+    ),
+  );
+
+  if (maximalMatches.length === 1) {
+    return maximalMatches;
+  }
+
+  const minPenalty = Math.min(
+    ...maximalMatches.map((candidate) =>
+      overloadGenericityPenalty({
+        candidate,
+        typeArguments,
+        ctx,
+      }),
+    ),
+  );
+  const leastGenericMatches = maximalMatches.filter(
+    (candidate) =>
+      overloadGenericityPenalty({
+        candidate,
+        typeArguments,
+        ctx,
+      }) === minPenalty,
+  );
+
+  return leastGenericMatches.length === 1 ? leastGenericMatches : matches;
+};

--- a/packages/compiler/src/semantics/typing/import-type-translation.ts
+++ b/packages/compiler/src/semantics/typing/import-type-translation.ts
@@ -172,7 +172,6 @@ export const createTranslation = ({
   targetEffects,
   paramMap,
   cache,
-  mapSymbol,
 }: TranslationContext): ((id: TypeId) => TypeId) => {
   const translate = (type: TypeId): TypeId => {
     const cached = cache.get(type);
@@ -237,25 +236,12 @@ export const createTranslation = ({
         break;
       }
       case "structural-object": {
-        const mapOwnerSymbol = (
-          owner: number | undefined,
-        ): number | undefined => {
-          if (typeof owner !== "number") return owner;
-          try {
-            return mapSymbol(owner);
-          } catch {
-            return undefined;
-          }
-        };
         const fields = desc.fields.map((field) => ({
           name: field.name,
           type: translate(field.type),
           declaringParams: field.declaringParams?.map((param) =>
             mapTypeParam(param, paramMap, { arena: targetArena }),
           ),
-          visibility: field.visibility,
-          owner: mapOwnerSymbol(field.owner),
-          packageId: field.packageId,
         }));
         result = targetArena.internStructuralObject({ fields });
         break;

--- a/packages/compiler/src/semantics/typing/optionals.ts
+++ b/packages/compiler/src/semantics/typing/optionals.ts
@@ -72,28 +72,16 @@ const resolveStructuralTypeId = (
     return undefined;
   }
 
-  const desc = ctx.arena.get(type);
-  if (desc.kind === "structural-object") {
-    return type;
+  const structural = ctx.arena.structuralComponent(type);
+  if (typeof structural === "number") {
+    return structural;
   }
-  if (desc.kind === "intersection") {
-    if (typeof desc.structural === "number") {
-      return desc.structural;
-    }
-    if (
-      typeof desc.nominal === "number" &&
-      ctx.getObjectStructuralTypeId
-    ) {
-      return ctx.getObjectStructuralTypeId(desc.nominal);
-    }
-    return undefined;
+
+  const nominal = ctx.arena.nominalComponent(type);
+  if (typeof nominal === "number" && ctx.getObjectStructuralTypeId) {
+    return ctx.getObjectStructuralTypeId(nominal);
   }
-  if (
-    (desc.kind === "nominal-object" || desc.kind === "value-object") &&
-    ctx.getObjectStructuralTypeId
-  ) {
-    return ctx.getObjectStructuralTypeId(type);
-  }
+
   return undefined;
 };
 
@@ -105,21 +93,12 @@ const resolveNominalOwnerSymbol = (
     return undefined;
   }
 
-  const desc = ctx.arena.get(type);
+  const nominalComponent = ctx.arena.nominalComponent(type);
+  const desc = ctx.arena.get(nominalComponent ?? type);
   if (desc.kind === "nominal-object" || desc.kind === "value-object") {
     return ctx.localSymbolForSymbolRef
       ? ctx.localSymbolForSymbolRef(desc.owner)
       : undefined;
-  }
-  if (desc.kind === "intersection" && typeof desc.nominal === "number") {
-    const nominal = ctx.arena.get(desc.nominal);
-    if (
-      (nominal.kind !== "nominal-object" && nominal.kind !== "value-object") ||
-      !ctx.localSymbolForSymbolRef
-    ) {
-      return undefined;
-    }
-    return ctx.localSymbolForSymbolRef(nominal.owner);
   }
   return undefined;
 };

--- a/packages/compiler/src/semantics/typing/type-arena.ts
+++ b/packages/compiler/src/semantics/typing/type-arena.ts
@@ -1,12 +1,10 @@
 import type {
   EffectRowId,
   NodeId,
-  SymbolId,
   TypeId,
   TypeParamId,
   TypeSchemeId,
 } from "../ids.js";
-import type { HirVisibility } from "../hir/index.js";
 import { symbolRefEquals, type SymbolRef } from "./symbol-ref.js";
 
 export type Substitution = ReadonlyMap<TypeParamId, TypeId>;
@@ -61,9 +59,6 @@ export interface StructuralField {
   type: TypeId;
   optional?: boolean;
   declaringParams?: readonly TypeParamId[];
-  visibility?: HirVisibility;
-  owner?: SymbolId;
-  packageId?: string;
 }
 
 export interface StructuralObjectType {
@@ -170,6 +165,10 @@ export interface TypeArena {
   internIntersection(desc: Omit<IntersectionType, "kind">): TypeId;
   internFixedArray(element: TypeId): TypeId;
   internTypeParamRef(param: TypeParamId): TypeId;
+  unfoldRecursive(type: TypeId): TypeId;
+  nominalComponent(type: TypeId): TypeId | undefined;
+  structuralComponent(type: TypeId): TypeId | undefined;
+  isUnknownPrimitive(type: TypeId): boolean;
   freshTypeParam(): TypeParamId;
   newScheme(
     params: readonly TypeParamId[],
@@ -479,9 +478,6 @@ export const createTypeArena = (): TypeArena => {
                 type: cloneReplacingSelf(field.type),
                 optional: field.optional,
                 declaringParams: field.declaringParams,
-                visibility: field.visibility,
-                owner: field.owner,
-                packageId: field.packageId,
               })),
             });
           case "function":
@@ -551,24 +547,61 @@ export const createTypeArena = (): TypeArena => {
       typeArgs: [...desc.typeArgs],
     });
 
+  const fieldShapeKey = (field: StructuralField): string => {
+    const declaringParamsKey =
+      field.declaringParams && field.declaringParams.length > 0
+        ? field.declaringParams.join(",")
+        : "u";
+    const optionalKey = field.optional ? "1" : "0";
+    return `${jsonStringKey(field.name)}:${field.type}:${optionalKey}:${declaringParamsKey}`;
+  };
+
+  const normalizeStructuralFieldShapes = (
+    fields: readonly StructuralField[],
+  ): readonly StructuralField[] => {
+    const normalized = fields
+      .map((field) => ({
+        name: field.name,
+        type: field.type,
+        optional: field.optional ?? false,
+        declaringParams:
+          field.declaringParams && field.declaringParams.length > 0
+            ? Array.from(new Set(field.declaringParams)).sort((a, b) => a - b)
+            : undefined,
+      }))
+      .sort((a, b) => {
+        const byName = a.name.localeCompare(b.name, undefined, {
+          numeric: true,
+        });
+        if (byName !== 0) {
+          return byName;
+        }
+        if (a.type !== b.type) {
+          return a.type - b.type;
+        }
+        if ((a.optional ?? false) !== (b.optional ?? false)) {
+          return a.optional ? 1 : -1;
+        }
+        return fieldShapeKey(a).localeCompare(fieldShapeKey(b));
+      });
+
+    const seen = new Set<string>();
+    return normalized.filter((field) => {
+      const key = fieldShapeKey(field);
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
+  };
+
   const internStructuralObject = (
     desc: Omit<StructuralObjectType, "kind">,
   ): TypeId =>
     storeDescriptor({
       kind: "structural-object",
-      fields: desc.fields
-        .map((field) => ({
-          name: field.name,
-          type: field.type,
-          optional: field.optional ?? false,
-          declaringParams:
-            field.declaringParams && field.declaringParams.length > 0
-              ? Array.from(new Set(field.declaringParams)).sort((a, b) => a - b)
-              : undefined,
-        }))
-        .sort((a, b) =>
-          a.name.localeCompare(b.name, undefined, { numeric: true }),
-        ),
+      fields: normalizeStructuralFieldShapes(desc.fields),
     });
 
   const internFunction = (desc: Omit<FunctionType, "kind">): TypeId =>
@@ -595,6 +628,9 @@ export const createTypeArena = (): TypeArena => {
     });
 
     const canonical = [...new Set(flattened)].sort((a, b) => a - b);
+    if (canonical.length === 1) {
+      return canonical[0]!;
+    }
     return storeDescriptor({ kind: "union", members: canonical });
   };
 
@@ -649,6 +685,89 @@ export const createTypeArena = (): TypeArena => {
   const isUnknownPrimitive = (type: TypeId): boolean => {
     const desc = getDescriptor(type);
     return desc.kind === "primitive" && desc.name === "unknown";
+  };
+
+  const unfoldRecursiveOnce = (type: TypeId): TypeId => {
+    const desc = getDescriptor(type);
+    if (desc.kind !== "recursive") {
+      return type;
+    }
+    const cached = recursiveUnfoldCache.get(type);
+    if (typeof cached === "number") {
+      return cached;
+    }
+    const unfolded = substitute(desc.body, new Map([[desc.binder, type]]));
+    recursiveUnfoldCache.set(type, unfolded);
+    return unfolded;
+  };
+
+  const unfoldRecursive = (type: TypeId): TypeId => {
+    let current = type;
+    const seen = new Set<TypeId>();
+
+    while (!seen.has(current)) {
+      seen.add(current);
+      const unfolded = unfoldRecursiveOnce(current);
+      if (unfolded === current) {
+        return current;
+      }
+      current = unfolded;
+    }
+
+    return current;
+  };
+
+  const nominalComponent = (
+    type: TypeId,
+    seen: Set<TypeId> = new Set(),
+  ): TypeId | undefined => {
+    if (seen.has(type) || isUnknownPrimitive(type)) {
+      return undefined;
+    }
+    seen.add(type);
+
+    const unfolded = unfoldRecursive(type);
+    const desc = getDescriptor(unfolded);
+    switch (desc.kind) {
+      case "nominal-object":
+      case "value-object":
+        return unfolded;
+      case "intersection":
+        if (typeof desc.nominal === "number") {
+          return desc.nominal;
+        }
+        return typeof desc.structural === "number"
+          ? nominalComponent(desc.structural, seen)
+          : undefined;
+      default:
+        return undefined;
+    }
+  };
+
+  const structuralComponent = (
+    type: TypeId,
+    seen: Set<TypeId> = new Set(),
+  ): TypeId | undefined => {
+    if (seen.has(type) || isUnknownPrimitive(type)) {
+      return undefined;
+    }
+    seen.add(type);
+
+    const unfolded = unfoldRecursive(type);
+    const desc = getDescriptor(unfolded);
+    switch (desc.kind) {
+      case "structural-object":
+        return unfolded;
+      case "intersection":
+        if (typeof desc.structural === "number") {
+          return desc.structural;
+        }
+        return typeof desc.nominal === "number"
+          ? structuralComponent(desc.nominal, seen)
+          : undefined;
+      default:
+        return undefined;
+    }
   };
 
   const instantiate = (
@@ -1084,20 +1203,6 @@ export const createTypeArena = (): TypeArena => {
       const resolved = structuralResolver(type);
       // Returning undefined means no projection; the original type is preserved.
       return typeof resolved === "number" ? resolved : type;
-    };
-
-    const unfoldRecursiveOnce = (type: TypeId): TypeId => {
-      const desc = getDescriptor(type);
-      if (desc.kind !== "recursive") {
-        return type;
-      }
-      const cached = recursiveUnfoldCache.get(type);
-      if (typeof cached === "number") {
-        return cached;
-      }
-      const unfolded = substitute(desc.body, new Map([[desc.binder, type]]));
-      recursiveUnfoldCache.set(type, unfolded);
-      return unfolded;
     };
 
     const unifyInternal = (
@@ -1703,9 +1808,6 @@ export const createTypeArena = (): TypeArena => {
                       type: substituted,
                       optional: field.optional,
                       declaringParams: field.declaringParams,
-                      visibility: field.visibility,
-                      owner: field.owner,
-                      packageId: field.packageId,
                     };
               });
               return changed
@@ -1782,6 +1884,10 @@ export const createTypeArena = (): TypeArena => {
     internIntersection,
     internFixedArray,
     internTypeParamRef,
+    unfoldRecursive,
+    nominalComponent,
+    structuralComponent,
+    isUnknownPrimitive,
     freshTypeParam,
     newScheme,
     instantiate,

--- a/packages/compiler/src/semantics/typing/type-relations.ts
+++ b/packages/compiler/src/semantics/typing/type-relations.ts
@@ -1,0 +1,50 @@
+import type { SourceSpan, TypeId, TypeParamId } from "../ids.js";
+import type { UnificationResult } from "./type-arena.js";
+import type { TypingContext, TypingState } from "./types.js";
+import {
+  bindTypeParamsFromType,
+  narrowTypeForPattern,
+  typeSatisfies,
+  unifyWithBudget,
+} from "./type-system.js";
+
+export interface TypeRelations {
+  satisfies(
+    actual: TypeId,
+    expected: TypeId,
+    ctx: TypingContext,
+    state: TypingState,
+  ): boolean;
+  unify(args: {
+    actual: TypeId;
+    expected: TypeId;
+    options: Parameters<typeof unifyWithBudget>[0]["options"];
+    ctx: TypingContext;
+    span?: SourceSpan;
+  }): UnificationResult;
+  narrowForPattern(
+    discriminantType: TypeId,
+    patternType: TypeId,
+    ctx: TypingContext,
+    state: TypingState,
+  ): TypeId | undefined;
+  bindTypeParams(
+    expected: TypeId,
+    actual: TypeId,
+    bindings: Map<TypeParamId, TypeId>,
+    ctx: TypingContext,
+    state: TypingState,
+  ): void;
+}
+
+export const typeRelations: TypeRelations = {
+  satisfies: typeSatisfies,
+  unify: unifyWithBudget,
+  narrowForPattern: narrowTypeForPattern,
+  bindTypeParams: bindTypeParamsFromType,
+};
+
+export const satisfies = typeRelations.satisfies;
+export const unify = typeRelations.unify;
+export const narrowForPattern = typeRelations.narrowForPattern;
+export const bindTypeParams = typeRelations.bindTypeParams;

--- a/packages/compiler/src/semantics/typing/type-system.ts
+++ b/packages/compiler/src/semantics/typing/type-system.ts
@@ -14,7 +14,6 @@ import {
   type UnificationContext,
   type UnificationResult,
   typeDescriptorToUserString,
-  type StructuralField,
   type TypeDescriptor,
 } from "./type-arena.js";
 import {
@@ -28,6 +27,7 @@ import {
   type TypingContext,
   type ObjectTemplate,
   type ObjectTypeInfo,
+  type ObjectField,
   type TypingState,
   type TraitImplInstance,
 } from "./types.js";
@@ -626,7 +626,7 @@ const assertAliasContractive = ({
 };
 
 const ensureFieldsSubstituted = (
-  fields: readonly StructuralField[],
+  fields: readonly ObjectField[],
   ctx: TypingContext,
   context: string,
 ): void => {
@@ -799,24 +799,7 @@ export const getPrimitiveType = (ctx: TypingContext, name: string): TypeId => {
 export const unfoldRecursiveType = (
   type: TypeId,
   ctx: TypingContext,
-): TypeId => {
-  let current = type;
-  const seen = new Set<TypeId>();
-
-  while (!seen.has(current)) {
-    seen.add(current);
-    const desc = ctx.arena.get(current);
-    if (desc.kind !== "recursive") {
-      return current;
-    }
-    current = ctx.arena.substitute(
-      desc.body,
-      new Map([[desc.binder, current]]),
-    );
-  }
-
-  return current;
-};
+): TypeId => ctx.arena.unfoldRecursive(type);
 
 export const resolveTypeExpr = (
   expr: HirTypeExpr | undefined,
@@ -1455,11 +1438,11 @@ const resolveIntersectionTypeExpr = (
     resolveTypeExpr(member, ctx, state, ctx.primitives.unknown, typeParams),
   );
 
-  const mergedFields = new Map<string, StructuralField>();
+  const mergedFields = new Map<string, ObjectField>();
   const traits: TypeId[] = [];
   let nominal: TypeId | undefined;
 
-  const mergeField = (field: StructuralField): void => {
+  const mergeField = (field: ObjectField): void => {
     const existing = mergedFields.get(field.name);
     if (!existing) {
       mergedFields.set(field.name, field);
@@ -1760,10 +1743,10 @@ const substituteObjectFields = ({
   substitution,
   ctx,
 }: {
-  fields: readonly StructuralField[];
+  fields: readonly ObjectField[];
   substitution?: ReadonlyMap<TypeParamId, TypeId>;
   ctx: TypingContext;
-}): readonly StructuralField[] =>
+}): readonly ObjectField[] =>
   substitution && substitution.size > 0
     ? fields.map((field) => ({
         ...field,
@@ -2061,7 +2044,7 @@ const validateValueFields = ({
   span,
 }: {
   nominal: TypeId;
-  fields: readonly StructuralField[];
+  fields: readonly ObjectField[];
   valueTypeName: string;
   ctx: TypingContext;
   state: TypingState;
@@ -2563,10 +2546,10 @@ export const refreshTraitImplInstances = (
 };
 
 const mergeDeclaredFields = (
-  inherited: readonly StructuralField[],
-  own: readonly StructuralField[],
-): StructuralField[] => {
-  const fields = new Map<string, StructuralField>();
+  inherited: readonly ObjectField[],
+  own: readonly ObjectField[],
+): ObjectField[] => {
+  const fields = new Map<string, ObjectField>();
   inherited.forEach((field) => fields.set(field.name, field));
   own.forEach((field) => fields.set(field.name, field));
   return Array.from(fields.values());
@@ -2595,28 +2578,7 @@ export const getObjectInfoForNominal = (
 export const getNominalComponent = (
   type: TypeId,
   ctx: TypingContext,
-): TypeId | undefined => {
-  if (type === ctx.primitives.unknown) {
-    return undefined;
-  }
-
-  const desc = ctx.arena.get(type);
-  switch (desc.kind) {
-    case "nominal-object":
-    case "value-object":
-      return type;
-    case "intersection":
-      if (typeof desc.nominal === "number") {
-        return desc.nominal;
-      }
-      if (typeof desc.structural === "number") {
-        return getNominalComponent(desc.structural, ctx);
-      }
-      return undefined;
-    default:
-      return undefined;
-  }
-};
+): TypeId | undefined => ctx.arena.nominalComponent(type);
 
 export const nominalSatisfies = (
   actual: TypeId,
@@ -2694,7 +2656,7 @@ export const getStructuralFields = (
   ctx: TypingContext,
   state: TypingState,
   options: { includeInaccessible?: boolean; allowOwnerPrivate?: boolean } = {},
-): readonly StructuralField[] | undefined => {
+): readonly ObjectField[] | undefined => {
   if (type === ctx.primitives.unknown) {
     return undefined;
   }
@@ -2733,13 +2695,13 @@ export const getStructuralFields = (
 
   if (desc.kind === "intersection") {
     const merge = (
-      base: readonly StructuralField[],
-      extra: readonly StructuralField[],
-    ): StructuralField[] => {
+      base: readonly ObjectField[],
+      extra: readonly ObjectField[],
+    ): ObjectField[] => {
       if (extra.length === 0) {
         return [...base];
       }
-      const byName = new Map<string, StructuralField>(
+      const byName = new Map<string, ObjectField>(
         base.map((field) => [field.name, field]),
       );
       extra.forEach((field) => {
@@ -3372,7 +3334,7 @@ export const narrowTypeForPattern = (
     if (matches.length === 0) {
       return undefined;
     }
-    return matches.length === 1 ? matches[0] : ctx.arena.internUnion(matches);
+    return ctx.arena.internUnion(matches);
   }
   return unionMemberMatchesPattern(discriminantType, patternType, ctx, state)
     ? discriminantType
@@ -3705,8 +3667,7 @@ const bindTypeParamsFromUnion = ({
           return;
         }
       } else {
-        const remainderType =
-          remainder.length === 1 ? remainder[0]! : ctx.arena.internUnion(remainder);
+        const remainderType = ctx.arena.internUnion(remainder);
         bindTypeParamsFromType(
           remainderTarget,
           remainderType,

--- a/packages/compiler/src/semantics/typing/types.ts
+++ b/packages/compiler/src/semantics/typing/types.ts
@@ -592,6 +592,14 @@ export interface MemberMetadata {
   packageId?: string;
 }
 
+export interface ObjectFieldAccessMetadata {
+  owner?: SymbolId;
+  visibility?: HirVisibility;
+  packageId?: string;
+}
+
+export type ObjectField = StructuralField & ObjectFieldAccessMetadata;
+
 export interface TypingContext {
   symbolTable: SymbolTable;
   hir: HirGraph;
@@ -631,7 +639,7 @@ export interface ObjectTypeInfo {
   nominal: TypeId;
   structural: TypeId;
   type: TypeId;
-  fields: readonly StructuralField[];
+  fields: readonly ObjectField[];
   visibility?: HirVisibility;
   baseNominal?: TypeId;
   traitImpls?: readonly TraitImplInstance[];
@@ -648,7 +656,7 @@ export interface ObjectTemplate {
   nominal: TypeId;
   structural: TypeId;
   type: TypeId;
-  fields: readonly StructuralField[];
+  fields: readonly ObjectField[];
   visibility?: HirVisibility;
   baseNominal?: TypeId;
 }

--- a/packages/compiler/src/semantics/typing/validation.ts
+++ b/packages/compiler/src/semantics/typing/validation.ts
@@ -8,9 +8,8 @@ import type {
   HirTypeParameter,
 } from "../hir/index.js";
 import type { TypeId, TypeParamId } from "../ids.js";
-import type { StructuralField } from "./type-arena.js";
 import { getSymbolName } from "./type-system.js";
-import type { TypingContext } from "./types.js";
+import type { ObjectField, TypingContext } from "./types.js";
 
 type TypeValidator = (typeId: TypeId, context: string) => void;
 
@@ -162,7 +161,7 @@ const collectReferencedParams = (
 };
 
 const referencedTemplateParams = (
-  field: StructuralField,
+  field: ObjectField,
   templateParams: ReadonlySet<TypeParamId>,
   ctx: TypingContext
 ): Set<TypeParamId> => new Set(
@@ -179,7 +178,7 @@ const ensureFieldsSubstituted = ({
   requireSubstitution,
   validateType,
 }: {
-  fields: readonly StructuralField[];
+  fields: readonly ObjectField[];
   ctx: TypingContext;
   context: string;
   templateParams?: ReadonlySet<TypeParamId>;

--- a/packages/compiler/src/semantics/typing/visibility.ts
+++ b/packages/compiler/src/semantics/typing/visibility.ts
@@ -1,14 +1,15 @@
 import { emitDiagnostic, normalizeSpan } from "../../diagnostics/index.js";
 import type { SourceSpan } from "../ids.js";
-import type { StructuralField } from "./type-arena.js";
 import type {
   MemberMetadata,
+  ObjectField,
+  ObjectFieldAccessMetadata,
   TypingContext,
   TypingState,
 } from "./types.js";
 
 const visibilityLabel = (
-  visibility: StructuralField["visibility"] | MemberMetadata["visibility"]
+  visibility: ObjectFieldAccessMetadata["visibility"] | MemberMetadata["visibility"]
 ): string => {
   if (!visibility) {
     return "unknown";
@@ -23,7 +24,7 @@ const sharesPackage = (
 ): boolean => (packageId ?? ctx.packageId) === ctx.packageId;
 
 export const canAccessField = (
-  field: StructuralField,
+  field: ObjectField,
   ctx: TypingContext,
   state: TypingState,
   options: { allowOwnerPrivate?: boolean } = {}
@@ -53,11 +54,11 @@ export const canAccessField = (
 };
 
 export const filterAccessibleFields = (
-  fields: readonly StructuralField[],
+  fields: readonly ObjectField[],
   ctx: TypingContext,
   state: TypingState,
   options: { allowOwnerPrivate?: boolean } = {}
-): StructuralField[] =>
+): ObjectField[] =>
   fields.filter((field) => canAccessField(field, ctx, state, options));
 
 const canAccessMember = (
@@ -89,7 +90,7 @@ export const assertFieldAccess = ({
   context,
   allowOwnerPrivate,
 }: {
-  field: StructuralField;
+  field: ObjectField;
   ctx: TypingContext;
   state: TypingState;
   span?: SourceSpan;
@@ -153,7 +154,7 @@ export const reportInaccessibleFieldRequirement = ({
   span,
   allowOwnerPrivate,
 }: {
-  field: StructuralField;
+  field: ObjectField;
   typeName: string;
   ctx: TypingContext;
   state: TypingState;


### PR DESCRIPTION
**Summary**
- Moved pure type-shape normalization into `TypeArena`, including recursive unfolding, singleton-union collapse, and canonical structural field shapes.
- Split structural shape from access metadata by introducing typing-owned field metadata types.
- Extracted overload-selection helpers into a dedicated relation module and reduced `call.ts` ownership of overload policy.
- Promoted `EffectsIr` into the codegen view and updated optimized pipeline plumbing to rebuild it alongside lowering info.
- Added focused tests for arena normalization and effects IR exposure.

**Testing**
- `npm run typecheck` passed.
- Focused Vitest suites passed, including arena normalization, overload resolution, and effects IR coverage.
- Full affected test run passed.