### PR TITLE
Add scalar replacement for non-escaping object locals

### DIFF
--- a/packages/compiler/src/__tests__/optimize-pipeline.test.ts
+++ b/packages/compiler/src/__tests__/optimize-pipeline.test.ts
@@ -146,6 +146,15 @@ const getFunctionBodyValueExpr = ({
     : body;
 };
 
+const extractFunctionText = (wasmText: string, nameFragment: string): string => {
+  const start = wasmText.indexOf(`\n (func $${nameFragment}`);
+  if (start < 0) {
+    return "";
+  }
+  const next = wasmText.indexOf("\n (func $", start + 1);
+  return next < 0 ? wasmText.slice(start) : wasmText.slice(start, next);
+};
+
 describe("compiler optimization pipeline", () => {
   it("folds pure helper calls, prunes dead generic instances, and shrinks lambda captures", async () => {
     const { optimized } = await buildOptimized({
@@ -670,9 +679,12 @@ obj Vec2 {
   y: i32
 }
 
+fn read(vec: Vec2) -> i32
+  vec.x + vec.y
+
 pub fn main() -> i32
   let vec = Vec2 { x: 1, y: 2 }
-  vec.x + vec.y
+  read(vec)
 `,
       },
     });
@@ -750,5 +762,343 @@ pub fn main() -> i32
     expect(wasmText).toContain("call $src__main__run_");
     expect(wasmText).toContain("call $__has_type");
     expect(wasmText).not.toContain("call $__lookup_method_accessor");
+  });
+
+  it("scalar-replaces non-escaping object literal locals", async () => {
+    const { optimized, entryModuleId } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Pair {
+  left: i32,
+  right: i32
+}
+
+pub fn main() -> i32
+  let pair = Pair { left: 3, right: 4 }
+  pair.left + pair.right
+`,
+      },
+    });
+
+    const mainFn = findFunction({
+      moduleId: "src::main",
+      name: "main",
+      program: optimized.program,
+    });
+    expect(mainFn?.kind).toBe("function");
+    if (!mainFn || mainFn.kind !== "function") return;
+
+    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    const pairLet = Array.from(optimized.program.modules.get("src::main")?.hir.statements.values() ?? [])
+      .find((stmt) => stmt.kind === "let" && stmt.pattern.kind === "identifier");
+    expect(pairLet?.kind).toBe("let");
+    if (!pairLet || pairLet.kind !== "let" || pairLet.pattern.kind !== "identifier") return;
+    expect(scalarLocals?.has(pairLet.pattern.symbol)).toBe(true);
+
+    const { module } = codegenProgram({
+      program: optimized.program,
+      entryModuleId,
+      optimization: optimized.facts,
+      options: {
+        optimize: false,
+        validate: false,
+        runtimeDiagnostics: false,
+      },
+    });
+    const mainText = extractFunctionText(module.emitText(), "src__main__main_");
+    expect(mainText).not.toContain("struct.new");
+  });
+
+  it("does not scalar-replace object locals that escape as whole values", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Pair {
+  left: i32,
+  right: i32
+}
+
+fn identity(pair: Pair) -> Pair
+  pair
+
+pub fn main() -> i32
+  let pair = Pair { left: 3, right: 4 }
+  identity(pair).left
+`,
+      },
+    });
+
+    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    expect(scalarLocals?.size ?? 0).toBe(0);
+  });
+
+  it("scalar-replaces non-escaping object method receivers", async () => {
+    const { optimized, entryModuleId } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Pair {
+  left: i32,
+  right: i32
+}
+
+impl Pair
+  fn sum(self) -> i32
+    self.left + self.right
+
+pub fn main() -> i32
+  let pair = Pair { left: 3, right: 4 }
+  pair.sum()
+`,
+      },
+    });
+
+    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    expect(scalarLocals?.size).toBe(1);
+
+    const { module } = codegenProgram({
+      program: optimized.program,
+      entryModuleId,
+      optimization: optimized.facts,
+      options: {
+        optimize: false,
+        validate: false,
+        runtimeDiagnostics: false,
+      },
+    });
+    const mainText = extractFunctionText(module.emitText(), "src__main__main_");
+    expect(mainText).not.toContain("struct.new");
+    expect(mainText).not.toContain("call $src__main__sum_");
+  });
+
+  it("does not scalar-replace method receivers that cannot stay scalar", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+eff Log
+  info(resume) -> void
+
+obj Pair {
+  left: i32,
+  right: i32
+}
+
+impl Pair
+  fn sum(self): Log -> i32
+    Log::info()
+    self.left + self.right
+
+pub fn main(): Log -> i32
+  let pair = Pair { left: 3, right: 4 }
+  pair.sum()
+`,
+      },
+    });
+
+    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    expect(scalarLocals?.size ?? 0).toBe(0);
+  });
+
+  it("does not scalar-replace method receivers passed as whole values inside methods", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Pair {
+  left: i32,
+  right: i32
+}
+
+fn identity(pair: Pair) -> Pair
+  pair
+
+impl Pair
+  fn sum(self) -> i32
+    identity(self).left
+
+pub fn main() -> i32
+  let pair = Pair { left: 3, right: 4 }
+  pair.sum()
+`,
+      },
+    });
+
+    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    expect(scalarLocals?.size ?? 0).toBe(0);
+  });
+
+  it("does not scalar-replace recursive method receivers inside method bodies", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Pair {
+  left: i32,
+  right: i32
+}
+
+impl Pair
+  fn sum(self) -> i32
+    let other = Pair { left: 1, right: 2 }
+    if self.left > 0 then:
+      other.sum()
+    else:
+      self.right
+
+pub fn main() -> i32
+  let pair = Pair { left: 3, right: 4 }
+  pair.sum()
+`,
+      },
+    });
+
+    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    expect(scalarLocals?.size ?? 0).toBe(0);
+  });
+
+  it("does not scalar-replace method receivers with helper calls that can recurse", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Pair {
+  left: i32,
+  right: i32
+}
+
+fn helper() -> i32
+  let other = Pair { left: 1, right: 2 }
+  other.sum()
+
+impl Pair
+  fn sum(self) -> i32
+    if self.left > 0 then:
+      helper()
+    else:
+      self.right
+
+pub fn main() -> i32
+  let pair = Pair { left: 3, right: 4 }
+  pair.sum()
+`,
+      },
+    });
+
+    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    expect(scalarLocals?.size ?? 0).toBe(0);
+  });
+
+  it("preserves scalar object field initializer evaluation order", async () => {
+    const { optimized, entryModuleId } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Pair {
+  left: i32,
+  right: i32
+}
+
+pub fn main() -> i32
+  let pair = Pair { right: 1, left: 2 }
+  pair.left * 10 + pair.right
+`,
+      },
+    });
+
+    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    expect(scalarLocals?.size).toBe(1);
+
+    const { module } = codegenProgram({
+      program: optimized.program,
+      entryModuleId,
+      optimization: optimized.facts,
+      options: {
+        optimize: false,
+        validate: false,
+        runtimeDiagnostics: false,
+      },
+    });
+    const mainText = extractFunctionText(module.emitText(), "src__main__main_");
+    expect(mainText.indexOf("(i32.const 1)")).toBeLessThan(
+      mainText.indexOf("(i32.const 2)"),
+    );
+  });
+
+  it("does not scalar-replace locals that can be captured by effect continuations", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+eff Log
+  info(resume) -> void
+
+obj Pair {
+  left: i32,
+  right: i32
+}
+
+pub fn main(): Log -> i32
+  let pair = Pair { left: 3, right: 4 }
+  Log::info()
+  pair.left + pair.right
+`,
+      },
+    });
+
+    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    expect(scalarLocals?.size ?? 0).toBe(0);
+  });
+
+  it("scalar-replaces effectful function locals created after effect sites", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+eff Log
+  info(resume) -> void
+
+obj Pair {
+  left: i32,
+  right: i32
+}
+
+pub fn main(): Log -> i32
+  Log::info()
+  let pair = Pair { left: 3, right: 4 }
+  pair.left + pair.right
+`,
+      },
+    });
+
+    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    expect(scalarLocals?.size).toBe(1);
+  });
+
+  it("scalar-replaces non-escaping mutable object field updates", async () => {
+    const { optimized, entryModuleId } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Pair {
+  left: i32,
+  right: i32
+}
+
+pub fn main() -> i32
+  let ~pair = Pair { left: 3, right: 4 }
+  pair.left = 9
+  pair.left + pair.right
+`,
+      },
+    });
+
+    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    expect(scalarLocals?.size).toBe(1);
+
+    const { module } = codegenProgram({
+      program: optimized.program,
+      entryModuleId,
+      optimization: optimized.facts,
+      options: {
+        optimize: false,
+        validate: false,
+        runtimeDiagnostics: false,
+      },
+    });
+    const mainText = extractFunctionText(module.emitText(), "src__main__main_");
+    expect(mainText).not.toContain("struct.new");
+    expect(mainText).toContain("(i32.const 9)");
   });
 });

--- a/packages/compiler/src/codegen/context.ts
+++ b/packages/compiler/src/codegen/context.ts
@@ -265,11 +265,17 @@ export interface LocalBindingProjectedElement extends LocalBindingBase {
   arrayTypeId: TypeId;
 }
 
+export interface LocalBindingScalarObject extends LocalBindingBase {
+  kind: "scalar-object";
+  fields: ReadonlyMap<string, LocalBindingLocal>;
+}
+
 export type LocalBinding =
   | LocalBindingLocal
   | LocalBindingCapture
   | LocalBindingStorageRef
-  | LocalBindingProjectedElement;
+  | LocalBindingProjectedElement
+  | LocalBindingScalarObject;
 
 export interface HandlerScope {
   prevHandler: LocalBindingLocal;

--- a/packages/compiler/src/codegen/expressions/blocks.ts
+++ b/packages/compiler/src/codegen/expressions/blocks.ts
@@ -29,6 +29,7 @@ import { wrapValueInOutcome } from "../effects/outcome-values.js";
 import { handlerCleanupOps } from "../effects/handler-stack.js";
 import { tailResumptionExitChecks } from "../effects/tail-resumptions.js";
 import { boxSignatureSpillValue } from "../signature-spill.js";
+import { tryCompileScalarObjectBinding } from "../scalar-objects.js";
 
 const expressionUsesExpectedResultType = ({
   exprId,
@@ -410,6 +411,37 @@ const compileLetStatement = (
   fnCtx: FunctionContext,
   compileExpr: ExpressionCompiler
 ): binaryen.ExpressionRef => {
+  if (stmt.pattern.kind === "identifier") {
+    const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+    const targetTypeId = getDeclaredSymbolTypeId(
+      stmt.pattern.symbol,
+      ctx,
+      typeInstanceId,
+    );
+    const scalarReplacedSymbols = ctx.optimization?.scalarReplacedObjectLocals.get(
+      ctx.moduleId,
+    );
+    const initializer = ctx.module.hir.expressions.get(stmt.initializer);
+    if (
+      scalarReplacedSymbols?.has(stmt.pattern.symbol) &&
+      initializer?.exprKind === "object-literal"
+    ) {
+      const scalarOps = tryCompileScalarObjectBinding({
+        symbol: stmt.pattern.symbol,
+        initializer,
+        targetTypeId,
+        ctx,
+        fnCtx,
+        compileExpr,
+      });
+      if (scalarOps) {
+        return scalarOps.length === 0
+          ? ctx.mod.nop()
+          : ctx.mod.block(null, [...scalarOps], binaryen.none);
+      }
+    }
+  }
+
   if (stmt.pattern.kind === "identifier" && !stmt.mutable) {
     if (fnCtx.nonBorrowableProjectedSymbols?.has(stmt.pattern.symbol)) {
       return compileDefaultLetStatement(stmt, ctx, fnCtx, compileExpr);

--- a/packages/compiler/src/codegen/expressions/call/entrypoints.ts
+++ b/packages/compiler/src/codegen/expressions/call/entrypoints.ts
@@ -23,6 +23,7 @@ import { emitResolvedCall } from "./resolved-call.js";
 import { compileTraitDispatchCall } from "./trait-dispatch.js";
 import { compileCallArgExpressionsWithTemps } from "./shared.js";
 import { tryInlineResolvedCall } from "./inline.js";
+import { tryCompileScalarObjectMethodCall } from "../../scalar-objects.js";
 
 export const compileCallExpr = (
   expr: HirCallExpr,
@@ -308,6 +309,23 @@ export const compileMethodCallExpr = (
   });
   if (!meta) {
     throw new Error(`codegen cannot call symbol ${targetRef.moduleId}::${targetRef.symbol}`);
+  }
+
+  const scalarObjectCall = tryCompileScalarObjectMethodCall({
+    expr,
+    meta,
+    ctx,
+    fnCtx,
+    compileExpr,
+    options: {
+      tailPosition,
+      expectedResultTypeId,
+      typeInstanceId,
+      outResultStorageRef,
+    },
+  });
+  if (scalarObjectCall) {
+    return scalarObjectCall;
   }
 
   const args = compileCallArguments({

--- a/packages/compiler/src/codegen/expressions/call/inline.ts
+++ b/packages/compiler/src/codegen/expressions/call/inline.ts
@@ -7,6 +7,7 @@ import type {
   FunctionContext,
   FunctionMetadata,
   HirFunction,
+  LocalBinding,
 } from "../../context.js";
 import { allocateTempLocal } from "../../locals.js";
 import { walkHirExpression } from "../../hir-walk.js";
@@ -117,13 +118,15 @@ const isInlineCandidate = ({
 export const tryInlineResolvedCall = ({
   meta,
   args,
+  parameterBindings,
   ctx,
   fnCtx,
   compileExpr,
   options = {},
 }: {
   meta: FunctionMetadata;
-  args: readonly binaryen.ExpressionRef[];
+  args: readonly (binaryen.ExpressionRef | undefined)[];
+  parameterBindings?: ReadonlyMap<number, LocalBinding>;
   ctx: CodegenContext;
   fnCtx: FunctionContext;
   compileExpr: ExpressionCompiler;
@@ -158,7 +161,20 @@ export const tryInlineResolvedCall = ({
     effectful: false,
   };
 
-  const setupOps = args.map((arg, index) => {
+  const setupOps = meta.parameters.flatMap((_parameter, index) => {
+    const prebound = parameterBindings?.get(index);
+    if (prebound) {
+      inlineFnCtx.bindings.set(fn.parameters[index]!.symbol, {
+        ...prebound,
+        typeId: meta.paramTypeIds[index],
+      });
+      return [];
+    }
+
+    const arg = args[index];
+    if (arg === undefined) {
+      throw new Error("inline call argument was not compiled");
+    }
     const local = allocateTempLocal(
       meta.paramTypes[index] as binaryen.Type,
       inlineFnCtx,
@@ -169,7 +185,7 @@ export const tryInlineResolvedCall = ({
       kind: "local",
       typeId: meta.paramTypeIds[index],
     });
-    return ownerCtx.mod.local.set(local.index, arg);
+    return [ownerCtx.mod.local.set(local.index, arg)];
   });
 
   const body = compileExpr({

--- a/packages/compiler/src/codegen/expressions/mutations.ts
+++ b/packages/compiler/src/codegen/expressions/mutations.ts
@@ -36,6 +36,7 @@ import {
 } from "../types.js";
 import { refCast, structSetFieldValue } from "@voyd-lang/lib/binaryen-gc/index.js";
 import type { ProgramFunctionInstanceId } from "../../semantics/ids.js";
+import { tryCompileScalarObjectFieldAssignment } from "../scalar-objects.js";
 
 const storeIntoBinding = ({
   binding,
@@ -87,6 +88,9 @@ const storeIntoBinding = ({
   }
   if (binding.kind === "projected-element-ref") {
     throw new Error("cannot assign to a projected element binding");
+  }
+  if (binding.kind === "scalar-object") {
+    throw new Error("cannot assign to a scalar-replaced object binding");
   }
 
   return storeLocalValue({ binding, value: coerced, ctx, fnCtx });
@@ -382,6 +386,19 @@ export const compileAssignExpr = (
       ctx,
       fnCtx,
     });
+    const scalarObjectFieldStore = tryCompileScalarObjectFieldAssignment({
+      targetExpr,
+      value: coerced,
+      valueTypeId: targetTypeId,
+      ctx,
+      fnCtx,
+    });
+    if (scalarObjectFieldStore) {
+      return {
+        expr: scalarObjectFieldStore,
+        usedReturnCall: false,
+      };
+    }
     return {
       expr: compileFieldAssignment({
         targetExpr,
@@ -457,6 +474,9 @@ export const compileAssignExpr = (
   }
   if (binding.kind === "projected-element-ref") {
     throw new Error("cannot assign to a projected element binding");
+  }
+  if (binding.kind === "scalar-object") {
+    throw new Error("cannot assign to a scalar-replaced object binding");
   }
 
   return {

--- a/packages/compiler/src/codegen/expressions/objects.ts
+++ b/packages/compiler/src/codegen/expressions/objects.ts
@@ -42,6 +42,7 @@ import {
 import { coerceExprToWasmType } from "../wasm-type-coercions.js";
 import { maybeReportValueBoxingNote } from "../value-boxing-notes.js";
 import { tryCompileProjectedFieldAccess } from "../projected-element-views.js";
+import { tryCompileScalarObjectFieldAccess } from "../scalar-objects.js";
 
 export const compileObjectLiteralExpr = (
   expr: HirObjectLiteralExpr,
@@ -563,6 +564,15 @@ export const compileFieldAccessExpr = (
   fnCtx: FunctionContext,
   compileExpr: ExpressionCompiler
 ): CompiledExpression => {
+  const scalarObjectField = tryCompileScalarObjectFieldAccess({
+    expr,
+    ctx,
+    fnCtx,
+  });
+  if (scalarObjectField) {
+    return scalarObjectField;
+  }
+
   const projected = tryCompileProjectedFieldAccess({
     expr,
     ctx,

--- a/packages/compiler/src/codegen/expressions/primitives.ts
+++ b/packages/compiler/src/codegen/expressions/primitives.ts
@@ -18,6 +18,7 @@ import { resolveModuleLetGetter } from "../module-lets.js";
 import { materializeProjectedElementBinding } from "../projected-element-views.js";
 import { coerceValueToType } from "../structural.js";
 import { unboxSignatureSpillValue } from "../signature-spill.js";
+import { materializeScalarObjectBindingValue } from "../scalar-objects.js";
 
 const encoder = new TextEncoder();
 
@@ -122,6 +123,26 @@ export const compileIdentifierExpr = (
                 [...materialized.setup, exprValue],
                 binaryen.getExpressionType(exprValue),
               ),
+        usedReturnCall: false,
+      };
+    }
+    if (binding.kind === "scalar-object") {
+      const value = materializeScalarObjectBindingValue({
+        binding,
+        ctx,
+        fnCtx,
+      });
+      return {
+        expr:
+          typeof expectedResultTypeId === "number"
+            ? coerceValueToType({
+                value,
+                actualType: binding.typeId ?? expectedResultTypeId,
+                targetType: expectedResultTypeId,
+                ctx,
+                fnCtx,
+              })
+            : value,
         usedReturnCall: false,
       };
     }

--- a/packages/compiler/src/codegen/locals.ts
+++ b/packages/compiler/src/codegen/locals.ts
@@ -280,6 +280,9 @@ export const loadBindingValue = (
   if (binding.kind === "projected-element-ref") {
     return loadProjectedElementBindingValue(binding, ctx);
   }
+  if (binding.kind === "scalar-object") {
+    throw new Error("scalar object binding cannot be loaded without materialization");
+  }
   if (binding.kind === "local") {
     return loadLocalValue(binding, ctx);
   }
@@ -328,6 +331,9 @@ export const loadBindingStorageRef = (
   if (binding.kind === "projected-element-ref") {
     return loadProjectedElementBindingStorageRef(binding, ctx);
   }
+  if (binding.kind === "scalar-object") {
+    return undefined;
+  }
   if (binding.kind === "local") {
     if (
       typeof binding.typeId !== "number" ||
@@ -374,6 +380,9 @@ export const materializeOwnedBinding = ({
   }
   if (existing.kind === "capture") {
     throw new Error("cannot materialize capture binding into owned local storage");
+  }
+  if (existing.kind === "scalar-object") {
+    throw new Error("cannot materialize scalar object binding in locals");
   }
   const typeId = existing.typeId;
   if (typeof typeId !== "number") {

--- a/packages/compiler/src/codegen/patterns.ts
+++ b/packages/compiler/src/codegen/patterns.ts
@@ -104,6 +104,9 @@ const storeIntoBinding = ({
   if (binding.kind === "projected-element-ref") {
     throw new Error("cannot assign to a projected element binding");
   }
+  if (binding.kind === "scalar-object") {
+    throw new Error("cannot assign to a scalar-replaced object binding");
+  }
   return storeLocalValue({ binding, value: coerced, ctx, fnCtx });
 };
 

--- a/packages/compiler/src/codegen/scalar-objects.ts
+++ b/packages/compiler/src/codegen/scalar-objects.ts
@@ -1,0 +1,317 @@
+import binaryen from "binaryen";
+import type {
+  CodegenContext,
+  CompiledExpression,
+  CompileCallOptions,
+  ExpressionCompiler,
+  FunctionContext,
+  FunctionMetadata,
+  HirFieldAccessExpr,
+  HirMethodCallExpr,
+  HirObjectLiteralExpr,
+  LocalBindingScalarObject,
+  SymbolId,
+  TypeId,
+} from "./context.js";
+import {
+  compileCallArgumentsForParams,
+  resolveTypedCallArgumentPlan,
+  sliceTypedCallArgumentPlan,
+} from "./expressions/call/arguments.js";
+import { tryInlineResolvedCall } from "./expressions/call/inline.js";
+import {
+  allocateTempLocal,
+  loadLocalValue,
+  storeLocalValue,
+} from "./locals.js";
+import {
+  coerceValueToType,
+  initStructuralValue,
+  lowerValueForHeapField,
+} from "./structural.js";
+import {
+  getExprBinaryenType,
+  getRequiredExprType,
+  getStructuralTypeInfo,
+  wasmTypeFor,
+} from "./types.js";
+import { coerceExprToWasmType } from "./wasm-type-coercions.js";
+
+export const tryCompileScalarObjectBinding = ({
+  symbol,
+  initializer,
+  targetTypeId,
+  ctx,
+  fnCtx,
+  compileExpr,
+}: {
+  symbol: SymbolId;
+  initializer: HirObjectLiteralExpr;
+  targetTypeId: TypeId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+}): readonly binaryen.ExpressionRef[] | undefined => {
+  const structInfo = getStructuralTypeInfo(targetTypeId, ctx);
+  if (!structInfo || structInfo.layoutKind !== "heap-object") {
+    return undefined;
+  }
+
+  const entriesByName = new Map(
+    initializer.entries
+      .filter((entry) => entry.kind === "field")
+      .map((entry) => [entry.name, entry] as const),
+  );
+  if (
+    entriesByName.size !== initializer.entries.length ||
+    entriesByName.size !== structInfo.fields.length
+  ) {
+    return undefined;
+  }
+
+  const fields = new Map<string, ReturnType<typeof allocateTempLocal>>();
+  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+
+  for (const field of structInfo.fields) {
+    const local = allocateTempLocal(
+      wasmTypeFor(field.typeId, ctx),
+      fnCtx,
+      field.typeId,
+      ctx,
+    );
+    fields.set(field.name, local);
+  }
+
+  const ops = initializer.entries.map((entry) => {
+    if (entry.kind !== "field") {
+      throw new Error("scalar object binding only supports direct field initializers");
+    }
+    const field = structInfo.fieldMap.get(entry.name);
+    const local = fields.get(entry.name);
+    if (!field || !local) {
+      throw new Error(`scalar object binding cannot set unknown field ${entry.name}`);
+    }
+    const actualTypeId = getRequiredExprType(entry.value, ctx, typeInstanceId);
+    const value = compileExpr({
+      exprId: entry.value,
+      ctx,
+      fnCtx,
+      expectedResultTypeId: field.typeId,
+    });
+    return (
+      storeLocalValue({
+        binding: local,
+        value: coerceValueToType({
+          value: value.expr,
+          actualType: actualTypeId,
+          targetType: field.typeId,
+          ctx,
+          fnCtx,
+        }),
+        ctx,
+        fnCtx,
+      })
+    );
+  });
+
+  fnCtx.bindings.set(symbol, {
+    kind: "scalar-object",
+    type: wasmTypeFor(targetTypeId, ctx),
+    storageType: wasmTypeFor(targetTypeId, ctx),
+    typeId: targetTypeId,
+    fields,
+  });
+
+  return ops;
+};
+
+export const tryCompileScalarObjectFieldAccess = ({
+  expr,
+  ctx,
+  fnCtx,
+}: {
+  expr: HirFieldAccessExpr;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): CompiledExpression | undefined => {
+  const target = ctx.module.hir.expressions.get(expr.target);
+  if (target?.exprKind !== "identifier") {
+    return undefined;
+  }
+  const binding = fnCtx.bindings.get(target.symbol);
+  if (binding?.kind !== "scalar-object") {
+    return undefined;
+  }
+  const fieldBinding = binding.fields.get(expr.field);
+  if (!fieldBinding || typeof fieldBinding.typeId !== "number") {
+    return undefined;
+  }
+
+  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+  const expectedTypeId = getRequiredExprType(expr.id, ctx, typeInstanceId);
+  const expectedWasmType = getExprBinaryenType(expr.id, ctx, typeInstanceId);
+  const value = coerceValueToType({
+    value: loadLocalValue(fieldBinding, ctx),
+    actualType: fieldBinding.typeId,
+    targetType: expectedTypeId,
+    ctx,
+    fnCtx,
+  });
+  return {
+    expr: coerceExprToWasmType({
+      expr: value,
+      targetType: expectedWasmType,
+      ctx,
+    }),
+    usedReturnCall: false,
+  };
+};
+
+export const tryCompileScalarObjectFieldAssignment = ({
+  targetExpr,
+  value,
+  valueTypeId,
+  ctx,
+  fnCtx,
+}: {
+  targetExpr: HirFieldAccessExpr;
+  value: binaryen.ExpressionRef;
+  valueTypeId: TypeId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef | undefined => {
+  const target = ctx.module.hir.expressions.get(targetExpr.target);
+  if (target?.exprKind !== "identifier") {
+    return undefined;
+  }
+  const binding = fnCtx.bindings.get(target.symbol);
+  if (binding?.kind !== "scalar-object") {
+    return undefined;
+  }
+  const fieldBinding = binding.fields.get(targetExpr.field);
+  if (!fieldBinding || typeof fieldBinding.typeId !== "number") {
+    return undefined;
+  }
+  return storeLocalValue({
+    binding: fieldBinding,
+    value: coerceValueToType({
+      value,
+      actualType: valueTypeId,
+      targetType: fieldBinding.typeId,
+      ctx,
+      fnCtx,
+    }),
+    ctx,
+    fnCtx,
+  });
+};
+
+export const tryCompileScalarObjectMethodCall = ({
+  expr,
+  meta,
+  ctx,
+  fnCtx,
+  compileExpr,
+  options,
+}: {
+  expr: HirMethodCallExpr;
+  meta: FunctionMetadata;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+  options: CompileCallOptions;
+}): CompiledExpression | undefined => {
+  if (meta.parameters.length === 0 || meta.paramAbiKinds[0] !== "direct") {
+    return undefined;
+  }
+
+  const target = ctx.module.hir.expressions.get(expr.target);
+  if (target?.exprKind !== "identifier") {
+    return undefined;
+  }
+  const binding = fnCtx.bindings.get(target.symbol);
+  if (binding?.kind !== "scalar-object") {
+    return undefined;
+  }
+
+  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+  const typedPlan = resolveTypedCallArgumentPlan({
+    callId: expr.id,
+    typeInstanceId,
+    ctx,
+  });
+  const callWithoutReceiver = {
+    kind: "expr" as const,
+    exprKind: "call" as const,
+    id: expr.id,
+    ast: expr.ast,
+    span: expr.span,
+    callee: expr.target,
+    args: expr.args,
+    typeArguments: expr.typeArguments,
+  };
+  const args = compileCallArgumentsForParams({
+    call: callWithoutReceiver,
+    params: meta.parameters.slice(1),
+    paramAbiKinds: meta.paramAbiKinds.slice(1),
+    ctx,
+    fnCtx,
+    compileExpr,
+    options: {
+      typeInstanceId,
+      typedPlan: typedPlan
+        ? sliceTypedCallArgumentPlan({
+            typedPlan,
+            paramOffset: 1,
+            argOffset: 1,
+          })
+        : undefined,
+    },
+  });
+
+  return tryInlineResolvedCall({
+    meta,
+    args: [undefined, ...args],
+    parameterBindings: new Map([[0, binding]]),
+    ctx,
+    fnCtx,
+    compileExpr,
+    options,
+  });
+};
+
+export const materializeScalarObjectBindingValue = ({
+  binding,
+  ctx,
+  fnCtx,
+}: {
+  binding: LocalBindingScalarObject;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  if (typeof binding.typeId !== "number") {
+    throw new Error("scalar object binding is missing a type id");
+  }
+  const structInfo = getStructuralTypeInfo(binding.typeId, ctx);
+  if (!structInfo) {
+    throw new Error("scalar object binding is missing structural type information");
+  }
+
+  return initStructuralValue({
+    structInfo,
+    fieldValues: structInfo.fields.map((field) => {
+      const fieldBinding = binding.fields.get(field.name);
+      if (!fieldBinding) {
+        throw new Error(`scalar object binding missing field ${field.name}`);
+      }
+      return lowerValueForHeapField({
+        value: loadLocalValue(fieldBinding, ctx),
+        typeId: field.typeId,
+        targetType: field.heapWasmType,
+        ctx,
+        fnCtx,
+      });
+    }),
+    ctx,
+  });
+};

--- a/packages/compiler/src/optimize/ir.ts
+++ b/packages/compiler/src/optimize/ir.ts
@@ -27,6 +27,7 @@ export type ProgramOptimizationFacts = {
   reachableFunctionSymbols: ReadonlySet<ProgramSymbolId>;
   reachableModuleLets: ReadonlyMap<string, ReadonlySet<SymbolId>>;
   usedTraitDispatchSignatures: ReadonlySet<string>;
+  scalarReplacedObjectLocals: ReadonlyMap<string, ReadonlySet<SymbolId>>;
 };
 
 export type ProgramOptimizationIR = {

--- a/packages/compiler/src/optimize/pipeline.ts
+++ b/packages/compiler/src/optimize/pipeline.ts
@@ -1,4 +1,10 @@
-import type { HirExpression, HirFunction, HirModuleLet } from "../semantics/hir/index.js";
+import type {
+  HirExpression,
+  HirFunction,
+  HirLetStatement,
+  HirModuleLet,
+  HirObjectLiteralExpr,
+} from "../semantics/hir/index.js";
 import { walkExpression } from "../semantics/hir/index.js";
 import type {
   CallLoweringInfo,
@@ -56,6 +62,7 @@ type MutableOptimizationIr = {
     reachableFunctionSymbols: Set<ProgramSymbolId>;
     reachableModuleLets: Map<string, Set<SymbolId>>;
     usedTraitDispatchSignatures: Set<string>;
+    scalarReplacedObjectLocals: Map<string, Set<SymbolId>>;
   };
 };
 
@@ -284,6 +291,7 @@ const buildOptimizationIr = ({
       reachableFunctionSymbols: new Set(),
       reachableModuleLets: new Map(),
       usedTraitDispatchSignatures: new Set(),
+      scalarReplacedObjectLocals: new Map(),
     },
   };
 };
@@ -1386,11 +1394,736 @@ const continuationAndHandlerEnvironmentShrinkingPass: ProgramOptimizationPass = 
   },
 };
 
+type ExpressionParent =
+  | { kind: "expr"; exprId: HirExprId; role: string }
+  | { kind: "stmt"; stmtId: number; role: string };
+
+const expressionChildren = (expr: HirExpression): readonly { id: HirExprId; role: string }[] => {
+  switch (expr.exprKind) {
+    case "literal":
+    case "identifier":
+    case "overload-set":
+    case "continue":
+      return [];
+    case "break":
+      return typeof expr.value === "number" ? [{ id: expr.value, role: "value" }] : [];
+    case "lambda":
+      return [{ id: expr.body, role: "body" }];
+    case "effect-handler":
+      return [
+        { id: expr.body, role: "body" },
+        ...expr.handlers.map((handler, index) => ({
+          id: handler.body,
+          role: `handler:${index}`,
+        })),
+        ...(typeof expr.finallyBranch === "number"
+          ? [{ id: expr.finallyBranch, role: "finally" }]
+          : []),
+      ];
+    case "block":
+      return typeof expr.value === "number" ? [{ id: expr.value, role: "value" }] : [];
+    case "call":
+      return [
+        { id: expr.callee, role: "callee" },
+        ...expr.args.map((arg, index) => ({ id: arg.expr, role: `arg:${index}` })),
+      ];
+    case "method-call":
+      return [
+        { id: expr.target, role: "target" },
+        ...expr.args.map((arg, index) => ({ id: arg.expr, role: `arg:${index}` })),
+      ];
+    case "tuple":
+      return expr.elements.map((id, index) => ({ id, role: `element:${index}` }));
+    case "loop":
+      return [{ id: expr.body, role: "body" }];
+    case "while":
+      return [
+        { id: expr.condition, role: "condition" },
+        { id: expr.body, role: "body" },
+      ];
+    case "cond":
+    case "if":
+      return [
+        ...expr.branches.flatMap((branch, index) => [
+          { id: branch.condition, role: `branch:${index}:condition` },
+          { id: branch.value, role: `branch:${index}:value` },
+        ]),
+        ...(typeof expr.defaultBranch === "number"
+          ? [{ id: expr.defaultBranch, role: "default" }]
+          : []),
+      ];
+    case "match":
+      return [
+        { id: expr.discriminant, role: "discriminant" },
+        ...expr.arms.flatMap((arm, index) => [
+          ...(typeof arm.guard === "number"
+            ? [{ id: arm.guard, role: `arm:${index}:guard` }]
+            : []),
+          { id: arm.value, role: `arm:${index}:value` },
+        ]),
+      ];
+    case "object-literal":
+      return expr.entries.map((entry, index) => ({
+        id: entry.value,
+        role: `entry:${index}`,
+      }));
+    case "field-access":
+      return [{ id: expr.target, role: "target" }];
+    case "assign":
+      return [
+        ...(typeof expr.target === "number"
+          ? [{ id: expr.target, role: "target" }]
+          : []),
+        { id: expr.value, role: "value" },
+      ];
+  }
+};
+
+const buildExpressionParents = ({
+  moduleView,
+}: {
+  moduleView: ModuleCodegenView;
+}): Map<HirExprId, ExpressionParent> => {
+  const parents = new Map<HirExprId, ExpressionParent>();
+  moduleView.hir.expressions.forEach((expr, exprId) => {
+    expressionChildren(expr).forEach((child) => {
+      parents.set(child.id, { kind: "expr", exprId, role: child.role });
+    });
+  });
+  moduleView.hir.statements.forEach((stmt, stmtId) => {
+    if (stmt.kind === "let") {
+      parents.set(stmt.initializer, { kind: "stmt", stmtId, role: "initializer" });
+      return;
+    }
+    if (stmt.kind === "expr-stmt") {
+      parents.set(stmt.expr, { kind: "stmt", stmtId, role: "expr" });
+      return;
+    }
+    if (stmt.kind === "return" && typeof stmt.value === "number") {
+      parents.set(stmt.value, { kind: "stmt", stmtId, role: "value" });
+    }
+  });
+  return parents;
+};
+
+const expressionContainsSymbol = ({
+  exprId,
+  symbol,
+  moduleView,
+}: {
+  exprId: HirExprId;
+  symbol: SymbolId;
+  moduleView: ModuleCodegenView;
+}): boolean => {
+  let found = false;
+  walkExpression({
+    exprId,
+    hir: moduleView.hir,
+    options: {
+      skipLambdas: false,
+      visitHandlerBodies: true,
+    },
+    onEnterExpression: (_id, expr) => {
+      if (expr.exprKind === "identifier" && expr.symbol === symbol) {
+        found = true;
+        return { stop: true };
+      }
+      return undefined;
+    },
+  });
+  return found;
+};
+
+const expressionContainsEffectHandler = ({
+  exprId,
+  moduleView,
+}: {
+  exprId: HirExprId;
+  moduleView: ModuleCodegenView;
+}): boolean => {
+  let found = false;
+  walkExpression({
+    exprId,
+    hir: moduleView.hir,
+    options: {
+      skipLambdas: false,
+      visitHandlerBodies: true,
+    },
+    onEnterExpression: (_id, expr) => {
+      if (expr.exprKind === "effect-handler") {
+        found = true;
+        return { stop: true };
+      }
+      return undefined;
+    },
+  });
+  return found;
+};
+
+const expressionContainsEffectfulCall = ({
+  exprId,
+  moduleView,
+}: {
+  exprId: HirExprId;
+  moduleView: ModuleCodegenView;
+}): boolean => {
+  let found = false;
+  walkExpression({
+    exprId,
+    hir: moduleView.hir,
+    options: {
+      skipLambdas: true,
+      visitHandlerBodies: false,
+    },
+    onEnterExpression: (_id, expr) => {
+      if (
+        (expr.exprKind === "call" || expr.exprKind === "method-call") &&
+        moduleView.effectsIr.calls.get(expr.id)?.kind !== "pure-call"
+      ) {
+        found = true;
+        return { stop: true };
+      }
+      return undefined;
+    },
+  });
+  return found;
+};
+
+const expressionIsAssignmentTarget = ({
+  exprId,
+  parents,
+  moduleView,
+}: {
+  exprId: HirExprId;
+  parents: ReadonlyMap<HirExprId, ExpressionParent>;
+  moduleView: ModuleCodegenView;
+}): boolean => {
+  let current = exprId;
+  while (true) {
+    const parent = parents.get(current);
+    if (!parent || parent.kind !== "expr") {
+      return false;
+    }
+    const parentExpr = moduleView.hir.expressions.get(parent.exprId);
+    if (parentExpr?.exprKind === "assign" && parent.role === "target") {
+      return true;
+    }
+    if (parentExpr?.exprKind !== "field-access" || parent.role !== "target") {
+      return false;
+    }
+    current = parent.exprId;
+  }
+};
+
+const expressionIsDirectAssignmentTarget = ({
+  exprId,
+  parents,
+  moduleView,
+}: {
+  exprId: HirExprId;
+  parents: ReadonlyMap<HirExprId, ExpressionParent>;
+  moduleView: ModuleCodegenView;
+}): boolean => {
+  const parent = parents.get(exprId);
+  if (!parent || parent.kind !== "expr" || parent.role !== "target") {
+    return false;
+  }
+  return moduleView.hir.expressions.get(parent.exprId)?.exprKind === "assign";
+};
+
+const objectLiteralHasDirectFieldInitializers = ({
+  expr,
+  typeId,
+  program,
+}: {
+  expr: HirObjectLiteralExpr;
+  typeId: TypeId;
+  program: ProgramCodegenView;
+}): boolean => {
+  if (expr.literalKind !== "nominal") {
+    return false;
+  }
+  const nominalTypeId = exactNominalForType({ typeId, program });
+  if (typeof nominalTypeId !== "number") {
+    return false;
+  }
+  const desc = program.types.getTypeDesc(nominalTypeId);
+  if (desc.kind !== "nominal-object") {
+    return false;
+  }
+  const objectInfo = program.objects.getInfoByNominal(nominalTypeId);
+  if (!objectInfo) {
+    return false;
+  }
+  const fieldNames = new Set(objectInfo.fields.map((field) => field.name));
+  const entries = new Set<string>();
+  for (const entry of expr.entries) {
+    if (entry.kind !== "field" || !fieldNames.has(entry.name)) {
+      return false;
+    }
+    entries.add(entry.name);
+  }
+  return entries.size === fieldNames.size;
+};
+
+const symbolTypeFor = ({
+  symbol,
+  moduleView,
+}: {
+  symbol: SymbolId;
+  moduleView: OptimizedModuleView;
+}): TypeId | undefined => {
+  const schemeId = moduleView.semantics.typing.table.getSymbolScheme(symbol);
+  return typeof schemeId === "number"
+    ? moduleView.semantics.typing.arena.getScheme(schemeId).body
+    : undefined;
+};
+
+const SCALAR_METHOD_INLINE_EXPR_LIMIT = 24;
+const SCALAR_METHOD_INLINE_STMT_LIMIT = 8;
+
+const simpleDirectSignatureType = ({
+  typeId,
+  program,
+}: {
+  typeId: TypeId;
+  program: ProgramCodegenView;
+}): boolean => {
+  const desc = program.types.getTypeDesc(typeId);
+  return desc.kind === "primitive" || desc.kind === "function";
+};
+
+const singletonMethodTarget = ({
+  expr,
+  moduleId,
+  program,
+}: {
+  expr: Extract<HirExpression, { exprKind: "method-call" }>;
+  moduleId: string;
+  program: ProgramCodegenView;
+}): { moduleId: string; symbol: SymbolId } | undefined => {
+  const callInfo = program.calls.getCallInfo(moduleId, expr.id);
+  if (callInfo.traitDispatch || callInfo.targets?.size !== 1) {
+    return undefined;
+  }
+  const functionId = callInfo.targets.values().next().value;
+  return typeof functionId === "number"
+    ? program.functions.getFunctionRef(functionId)
+    : undefined;
+};
+
+const isScalarLeafIntrinsicCall = ({
+  expr,
+  moduleId,
+  ownerModule,
+  program,
+}: {
+  expr: Extract<HirExpression, { exprKind: "call" }>;
+  moduleId: string;
+  ownerModule: ModuleCodegenView;
+  program: ProgramCodegenView;
+}): boolean => {
+  const callee = ownerModule.hir.expressions.get(expr.callee);
+  if (callee?.exprKind === "identifier") {
+    const localId = program.symbols.tryIdOf({
+      moduleId,
+      symbol: callee.symbol,
+    });
+    if (
+      typeof localId === "number" &&
+      program.symbols.getIntrinsicFunctionFlags(localId).intrinsic === true
+    ) {
+      return true;
+    }
+  }
+
+  const targets = program.calls.getCallInfo(moduleId, expr.id).targets;
+  if (!targets || targets.size === 0) {
+    return false;
+  }
+  return Array.from(targets.values()).every((target) =>
+    program.symbols.getIntrinsicFunctionFlags(target as ProgramSymbolId).intrinsic === true
+  );
+};
+
+const scalarInlineableMethodReceiverUse = ({
+  expr,
+  moduleId,
+  program,
+}: {
+  expr: Extract<HirExpression, { exprKind: "method-call" }>;
+  moduleId: string;
+  program: ProgramCodegenView;
+}): boolean => {
+  const target = singletonMethodTarget({ expr, moduleId, program });
+  if (!target) {
+    return false;
+  }
+
+  const ownerModule = program.modules.get(target.moduleId);
+  if (!ownerModule) {
+    return false;
+  }
+  const fn = functionItemBySymbol({
+    moduleView: ownerModule,
+    symbol: target.symbol,
+  });
+  const signature = program.functions.getSignature(target.moduleId, target.symbol);
+  if (!fn || !signature || !program.effects.isEmpty(signature.effectRow)) {
+    return false;
+  }
+  if (fn.parameters.some((parameter) => typeof parameter.defaultValue === "number")) {
+    return false;
+  }
+  if (
+    signature.parameters.length === 0 ||
+    signature.parameters.some((parameter) => (parameter.bindingKind ?? "value") !== "value") ||
+    !signature.parameters.slice(1).every((parameter) =>
+      simpleDirectSignatureType({ typeId: parameter.typeId, program }),
+    ) ||
+    !simpleDirectSignatureType({ typeId: signature.returnType, program })
+  ) {
+    return false;
+  }
+
+  const receiverSymbol = fn.parameters[0]?.symbol;
+  if (typeof receiverSymbol !== "number") {
+    return false;
+  }
+  const parents = buildExpressionParents({ moduleView: ownerModule });
+  let exprCount = 0;
+  let stmtCount = 0;
+  let allowed = true;
+  walkExpression({
+    exprId: fn.body,
+    hir: ownerModule.hir,
+    options: {
+      skipLambdas: false,
+      visitHandlerBodies: true,
+    },
+    onEnterExpression: (exprId, bodyExpr) => {
+      exprCount += 1;
+      if (exprCount > SCALAR_METHOD_INLINE_EXPR_LIMIT) {
+        allowed = false;
+        return { stop: true };
+      }
+
+      if (bodyExpr.exprKind === "identifier" && bodyExpr.symbol === receiverSymbol) {
+        const parent = parents.get(exprId);
+        const parentExpr =
+          parent?.kind === "expr"
+            ? ownerModule.hir.expressions.get(parent.exprId)
+            : undefined;
+        if (
+          parent?.kind !== "expr" ||
+          parentExpr?.exprKind !== "field-access" ||
+          parent.role !== "target" ||
+          expressionIsAssignmentTarget({
+            exprId: parent.exprId,
+            parents,
+            moduleView: ownerModule,
+          })
+        ) {
+          allowed = false;
+          return { stop: true };
+        }
+      }
+
+      switch (bodyExpr.exprKind) {
+        case "literal":
+        case "identifier":
+          return undefined;
+        case "call":
+          if (
+            isScalarLeafIntrinsicCall({
+              expr: bodyExpr,
+              moduleId: target.moduleId,
+              ownerModule,
+              program,
+            })
+          ) {
+            return undefined;
+          }
+          allowed = false;
+          return { stop: true };
+        case "block":
+        case "tuple":
+        case "cond":
+        case "if":
+        case "object-literal":
+        case "field-access":
+          return undefined;
+        default:
+          allowed = false;
+          return { stop: true };
+      }
+    },
+    onEnterStatement: (_stmtId, stmt) => {
+      stmtCount += 1;
+      if (stmtCount > SCALAR_METHOD_INLINE_STMT_LIMIT || stmt.kind === "return") {
+        allowed = false;
+        return { stop: true };
+      }
+      return undefined;
+    },
+  });
+
+  return allowed;
+};
+
+const localIsLiveAcrossEffectfulExpression = ({
+  block,
+  stmtIndex,
+  symbol,
+  moduleView,
+}: {
+  block: Extract<HirExpression, { exprKind: "block" }>;
+  stmtIndex: number;
+  symbol: SymbolId;
+  moduleView: ModuleCodegenView;
+}): boolean => {
+  let seenEffectful = false;
+  const laterStatements = block.statements.slice(stmtIndex + 1);
+  for (const stmtId of laterStatements) {
+    const stmt = moduleView.hir.statements.get(stmtId);
+    const exprId =
+      stmt?.kind === "let"
+        ? stmt.initializer
+        : stmt?.kind === "expr-stmt"
+          ? stmt.expr
+          : stmt?.kind === "return" && typeof stmt.value === "number"
+            ? stmt.value
+            : undefined;
+    if (typeof exprId !== "number") {
+      continue;
+    }
+
+    const hasSymbol = expressionContainsSymbol({ exprId, symbol, moduleView });
+    const hasEffect = expressionContainsEffectfulCall({ exprId, moduleView });
+    if ((seenEffectful && hasSymbol) || (hasEffect && hasSymbol)) {
+      return true;
+    }
+    seenEffectful = seenEffectful || hasEffect;
+  }
+
+  if (typeof block.value !== "number") {
+    return false;
+  }
+  const valueHasSymbol = expressionContainsSymbol({
+    exprId: block.value,
+    symbol,
+    moduleView,
+  });
+  const valueHasEffect = expressionContainsEffectfulCall({
+    exprId: block.value,
+    moduleView,
+  });
+  return (seenEffectful && valueHasSymbol) || (valueHasEffect && valueHasSymbol);
+};
+
+const isScalarReplaceableLocal = ({
+  stmt,
+  block,
+  stmtIndex,
+  functionBody,
+  moduleId,
+  moduleView,
+  parents,
+  program,
+}: {
+  stmt: HirLetStatement;
+  block: Extract<HirExpression, { exprKind: "block" }>;
+  stmtIndex: number;
+  functionBody: HirExprId;
+  moduleId: string;
+  moduleView: OptimizedModuleView;
+  parents: ReadonlyMap<HirExprId, ExpressionParent>;
+  program: ProgramCodegenView;
+}): boolean => {
+  if (stmt.pattern.kind !== "identifier") {
+    return false;
+  }
+  const initializer = moduleView.hir.expressions.get(stmt.initializer);
+  if (!initializer || initializer.exprKind !== "object-literal") {
+    return false;
+  }
+  if (
+    expressionContainsEffectfulCall({
+      exprId: stmt.initializer,
+      moduleView,
+    }) ||
+    localIsLiveAcrossEffectfulExpression({
+      block,
+      stmtIndex,
+      symbol: stmt.pattern.symbol,
+      moduleView,
+    })
+  ) {
+    return false;
+  }
+  const typeId =
+    symbolTypeFor({
+      symbol: stmt.pattern.symbol,
+      moduleView,
+    }) ??
+    exprTypeFor({
+      moduleView,
+      exprId: stmt.initializer,
+    });
+  if (
+    typeof typeId !== "number" ||
+    !objectLiteralHasDirectFieldInitializers({
+      expr: initializer,
+      typeId,
+      program,
+    })
+  ) {
+    return false;
+  }
+
+  const symbol = stmt.pattern.symbol;
+  let allowed = true;
+  walkExpression({
+    exprId: functionBody,
+    hir: moduleView.hir,
+    options: {
+      skipLambdas: false,
+      visitHandlerBodies: true,
+    },
+    onEnterExpression: (exprId, expr) => {
+      if (expr.exprKind === "lambda" && expr.captures.some((capture) => capture.symbol === symbol)) {
+        allowed = false;
+        return { stop: true };
+      }
+      if (expr.exprKind === "effect-handler") {
+        const handlerUsesSymbol = expr.handlers.some((handler) =>
+          expressionContainsSymbol({
+            exprId: handler.body,
+            symbol,
+            moduleView,
+          }),
+        );
+        if (handlerUsesSymbol) {
+          allowed = false;
+          return { stop: true };
+        }
+      }
+      if (expr.exprKind !== "identifier" || expr.symbol !== symbol) {
+        return undefined;
+      }
+      const parent = parents.get(exprId);
+      const parentExpr =
+        parent?.kind === "expr"
+          ? moduleView.hir.expressions.get(parent.exprId)
+          : undefined;
+      const allowedFieldUse =
+        parent?.kind === "expr" &&
+        parentExpr?.exprKind === "field-access" &&
+        parent.role === "target" &&
+        (!expressionIsAssignmentTarget({
+          exprId: parent.exprId,
+          parents,
+          moduleView,
+        }) ||
+          expressionIsDirectAssignmentTarget({
+            exprId: parent.exprId,
+            parents,
+            moduleView,
+          }));
+      const allowedMethodReceiverUse =
+        parent?.kind === "expr" &&
+        parentExpr?.exprKind === "method-call" &&
+        parent.role === "target" &&
+        !expressionIsAssignmentTarget({
+          exprId: parent.exprId,
+          parents,
+          moduleView,
+        }) &&
+        scalarInlineableMethodReceiverUse({
+          expr: parentExpr,
+          moduleId,
+          program,
+        });
+      if (!allowedFieldUse && !allowedMethodReceiverUse) {
+        allowed = false;
+        return { stop: true };
+      }
+      return undefined;
+    },
+  });
+
+  return allowed;
+};
+
+const scalarReplacementOfObjectLocalsPass: ProgramOptimizationPass = {
+  name: "scalar-replacement-of-object-locals",
+  run(ctx) {
+    let changed = false;
+
+    ctx.ir.modules.forEach((moduleView, moduleId) => {
+      const parents = buildExpressionParents({ moduleView });
+      const symbols = new Set<SymbolId>();
+      moduleView.hir.items.forEach((item) => {
+        if (item.kind !== "function") {
+          return;
+        }
+        if (
+          expressionContainsEffectHandler({
+            exprId: item.body,
+            moduleView,
+          })
+        ) {
+          return;
+        }
+        collectPostOrderExprIds({
+          rootExprId: item.body,
+          moduleView,
+        }).forEach((exprId) => {
+          const expr = moduleView.hir.expressions.get(exprId);
+          if (!expr || expr.exprKind !== "block") {
+            return;
+          }
+          expr.statements.forEach((stmtId, stmtIndex) => {
+            const stmt = moduleView.hir.statements.get(stmtId);
+            if (
+              stmt?.kind === "let" &&
+              stmt.pattern.kind === "identifier" &&
+              isScalarReplaceableLocal({
+                stmt,
+                block: expr,
+                stmtIndex,
+                functionBody: item.body,
+                moduleId,
+                moduleView,
+                parents,
+                program: ctx.ir.baseProgram,
+              })
+            ) {
+              symbols.add(stmt.pattern.symbol);
+            }
+          });
+        });
+      });
+
+      const existing = ctx.ir.facts.scalarReplacedObjectLocals.get(moduleId);
+      if (!existing || !setEquals(existing, symbols)) {
+        (ctx.ir as MutableOptimizationIr).facts.scalarReplacedObjectLocals.set(
+          moduleId,
+          symbols,
+        );
+        changed = true;
+      }
+    });
+
+    return { changed };
+  },
+};
+
 const functionItemBySymbol = ({
   moduleView,
   symbol,
 }: {
-  moduleView: OptimizedModuleView;
+  moduleView: ModuleCodegenView;
   symbol: SymbolId;
 }): HirFunction | undefined =>
   Array.from(moduleView.hir.items.values()).find(
@@ -1944,6 +2677,12 @@ const finalizeOptimization = ({
         ]),
       ),
       usedTraitDispatchSignatures: new Set(ir.facts.usedTraitDispatchSignatures),
+      scalarReplacedObjectLocals: new Map(
+        Array.from(ir.facts.scalarReplacedObjectLocals.entries()).map(([moduleId, symbols]) => [
+          moduleId,
+          new Set(symbols),
+        ]),
+      ),
     },
   };
 };
@@ -1955,6 +2694,7 @@ const OPTIMIZATION_PASSES: readonly ProgramOptimizationPass[] = [
   effectFastPathEliminationPass,
   closureEnvironmentShrinkingPass,
   traitDispatchDevirtualizationPass,
+  scalarReplacementOfObjectLocalsPass,
   continuationAndHandlerEnvironmentShrinkingPass,
   wholeProgramSpecializationPruningPass,
 ];


### PR DESCRIPTION
## Summary
- Add escape-analysis-backed scalar replacement for non-escaping `obj` locals in the compiler pipeline
- Lower eligible object locals into per-field locals in codegen, with fallback materialization when a whole object value is needed
- Preserve field initializer order, handle safe mutable field updates, and keep effectful/control-flow cases conservative
- Expand optimization pipeline tests to cover reads, writes, method receivers, recursion, and effect continuation interactions

## Testing
- Added and updated compiler optimization pipeline unit tests for scalar replacement behavior
- `npx vitest packages/compiler/src/__tests__/optimize-pipeline.test.ts`
- `npm run typecheck`
- `npx turbo run test --affected --output-logs=errors-only --concurrency=1`