### PR TITLE
Refactor scalar replacement into an explicit codegen plan

### DIFF
--- a/packages/compiler/src/__tests__/optimize-pipeline.test.ts
+++ b/packages/compiler/src/__tests__/optimize-pipeline.test.ts
@@ -155,6 +155,11 @@ const extractFunctionText = (wasmText: string, nameFragment: string): string => 
   return next < 0 ? wasmText.slice(start) : wasmText.slice(start, next);
 };
 
+const scalarObjectPlansFor = (
+  optimized: ReturnType<typeof optimizeProgram>,
+  moduleId: string,
+) => optimized.facts.codegenPlan.representations.scalarObjectLocals.get(moduleId);
+
 describe("compiler optimization pipeline", () => {
   it("folds pure helper calls, prunes dead generic instances, and shrinks lambda captures", async () => {
     const { optimized } = await buildOptimized({
@@ -788,12 +793,52 @@ pub fn main() -> i32
     expect(mainFn?.kind).toBe("function");
     if (!mainFn || mainFn.kind !== "function") return;
 
-    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    const scalarLocals = scalarObjectPlansFor(optimized, "src::main");
     const pairLet = Array.from(optimized.program.modules.get("src::main")?.hir.statements.values() ?? [])
       .find((stmt) => stmt.kind === "let" && stmt.pattern.kind === "identifier");
     expect(pairLet?.kind).toBe("let");
     if (!pairLet || pairLet.kind !== "let" || pairLet.pattern.kind !== "identifier") return;
     expect(scalarLocals?.has(pairLet.pattern.symbol)).toBe(true);
+    const pairPlan = scalarLocals?.get(pairLet.pattern.symbol);
+    expect(pairPlan?.kind).toBe("scalar-object-local");
+    expect(pairPlan?.representation).toBe("field-locals");
+    expect(pairPlan?.fields.map((field) => field.name)).toEqual(["left", "right"]);
+    expect(pairPlan?.operations.wholeValueMaterialization.allowed).toBe(false);
+
+    const { module } = codegenProgram({
+      program: optimized.program,
+      entryModuleId,
+      optimization: optimized.facts,
+      options: {
+        optimize: false,
+        validate: false,
+        runtimeDiagnostics: false,
+      },
+    });
+    const mainText = extractFunctionText(module.emitText(), "src__main__main_");
+    expect(mainText).not.toContain("struct.new");
+  });
+
+  it("scalar-replaces generic object locals with instantiated field types", async () => {
+    const { optimized, entryModuleId } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Box<T> {
+  value: T
+}
+
+pub fn main() -> i32
+  let box = Box<i32> { value: 3 }
+  box.value
+`,
+      },
+    });
+
+    const scalarLocals = scalarObjectPlansFor(optimized, "src::main");
+    expect(scalarLocals?.size).toBe(1);
+    const boxPlan = Array.from(scalarLocals?.values() ?? [])[0];
+    const valueType = boxPlan?.fields.find((field) => field.name === "value")?.typeId;
+    expect(valueType).toBeTypeOf("number");
 
     const { module } = codegenProgram({
       program: optimized.program,
@@ -828,7 +873,7 @@ pub fn main() -> i32
       },
     });
 
-    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    const scalarLocals = scalarObjectPlansFor(optimized, "src::main");
     expect(scalarLocals?.size ?? 0).toBe(0);
   });
 
@@ -852,8 +897,10 @@ pub fn main() -> i32
       },
     });
 
-    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    const scalarLocals = scalarObjectPlansFor(optimized, "src::main");
     expect(scalarLocals?.size).toBe(1);
+    const pairPlan = Array.from(scalarLocals?.values() ?? [])[0];
+    expect(pairPlan?.operations.methodReceiverInline).toHaveLength(1);
 
     const { module } = codegenProgram({
       program: optimized.program,
@@ -894,7 +941,40 @@ pub fn main(): Log -> i32
       },
     });
 
-    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    const scalarLocals = scalarObjectPlansFor(optimized, "src::main");
+    expect(scalarLocals?.size ?? 0).toBe(0);
+  });
+
+  it("does not scalar-replace method receivers that exceed inline limits", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Pair {
+  left: i32,
+  right: i32
+}
+
+impl Pair
+  fn sum(self) -> i32
+    let a = 1
+    let b = 2
+    let c = 3
+    let d = 4
+    let e = 5
+    let f = 6
+    let g = 7
+    let h = 8
+    let i = 9
+    self.left + self.right + a + b + c + d + e + f + g + h + i
+
+pub fn main() -> i32
+  let pair = Pair { left: 3, right: 4 }
+  pair.sum()
+`,
+      },
+    });
+
+    const scalarLocals = scalarObjectPlansFor(optimized, "src::main");
     expect(scalarLocals?.size ?? 0).toBe(0);
   });
 
@@ -921,7 +1001,7 @@ pub fn main() -> i32
       },
     });
 
-    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    const scalarLocals = scalarObjectPlansFor(optimized, "src::main");
     expect(scalarLocals?.size ?? 0).toBe(0);
   });
 
@@ -949,7 +1029,7 @@ pub fn main() -> i32
       },
     });
 
-    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    const scalarLocals = scalarObjectPlansFor(optimized, "src::main");
     expect(scalarLocals?.size ?? 0).toBe(0);
   });
 
@@ -980,7 +1060,7 @@ pub fn main() -> i32
       },
     });
 
-    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    const scalarLocals = scalarObjectPlansFor(optimized, "src::main");
     expect(scalarLocals?.size ?? 0).toBe(0);
   });
 
@@ -1000,7 +1080,7 @@ pub fn main() -> i32
       },
     });
 
-    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    const scalarLocals = scalarObjectPlansFor(optimized, "src::main");
     expect(scalarLocals?.size).toBe(1);
 
     const { module } = codegenProgram({
@@ -1039,7 +1119,7 @@ pub fn main(): Log -> i32
       },
     });
 
-    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    const scalarLocals = scalarObjectPlansFor(optimized, "src::main");
     expect(scalarLocals?.size ?? 0).toBe(0);
   });
 
@@ -1063,7 +1143,7 @@ pub fn main(): Log -> i32
       },
     });
 
-    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    const scalarLocals = scalarObjectPlansFor(optimized, "src::main");
     expect(scalarLocals?.size).toBe(1);
   });
 
@@ -1084,7 +1164,7 @@ pub fn main() -> i32
       },
     });
 
-    const scalarLocals = optimized.facts.scalarReplacedObjectLocals.get("src::main");
+    const scalarLocals = scalarObjectPlansFor(optimized, "src::main");
     expect(scalarLocals?.size).toBe(1);
 
     const { module } = codegenProgram({

--- a/packages/compiler/src/__tests__/optimize-pipeline.test.ts
+++ b/packages/compiler/src/__tests__/optimize-pipeline.test.ts
@@ -854,6 +854,41 @@ pub fn main() -> i32
     expect(mainText).not.toContain("struct.new");
   });
 
+  it("scalar-replaces generic function object locals with instantiated field types", async () => {
+    const { optimized, entryModuleId } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Box<T> {
+  value: T
+}
+
+fn unwrap<T>(value: T) -> T
+  let box = Box<T> { value }
+  box.value
+
+pub fn main() -> i32
+  unwrap<i32>(3)
+`,
+      },
+    });
+
+    const scalarLocals = scalarObjectPlansFor(optimized, "src::main");
+    expect(scalarLocals?.size).toBe(1);
+
+    const { module } = codegenProgram({
+      program: optimized.program,
+      entryModuleId,
+      optimization: optimized.facts,
+      options: {
+        optimize: false,
+        validate: false,
+        runtimeDiagnostics: false,
+      },
+    });
+    const unwrapText = extractFunctionText(module.emitText(), "src__main__unwrap_");
+    expect(unwrapText).not.toContain("struct.new");
+  });
+
   it("does not scalar-replace object locals that escape as whole values", async () => {
     const { optimized } = await buildOptimized({
       files: {

--- a/packages/compiler/src/codegen/context.ts
+++ b/packages/compiler/src/codegen/context.ts
@@ -46,6 +46,7 @@ import type { ModuleCodegenView } from "../semantics/codegen-view/index.js";
 import type { Diagnostic, DiagnosticEmitter } from "../diagnostics/index.js";
 import type { ProgramHelperRegistry } from "./program-helpers.js";
 import type { ProgramOptimizationFacts } from "../optimize/ir.js";
+import type { ScalarObjectLocalRepresentationPlan } from "../optimize/codegen-plan.js";
 
 export interface CodegenOptions {
   optimize?: boolean;
@@ -267,6 +268,7 @@ export interface LocalBindingProjectedElement extends LocalBindingBase {
 
 export interface LocalBindingScalarObject extends LocalBindingBase {
   kind: "scalar-object";
+  plan: ScalarObjectLocalRepresentationPlan;
   fields: ReadonlyMap<string, LocalBindingLocal>;
 }
 

--- a/packages/compiler/src/codegen/expressions/blocks.ts
+++ b/packages/compiler/src/codegen/expressions/blocks.ts
@@ -30,6 +30,7 @@ import { handlerCleanupOps } from "../effects/handler-stack.js";
 import { tailResumptionExitChecks } from "../effects/tail-resumptions.js";
 import { boxSignatureSpillValue } from "../signature-spill.js";
 import { tryCompileScalarObjectBinding } from "../scalar-objects.js";
+import { getScalarObjectLocalPlan } from "../../optimize/codegen-plan.js";
 
 const expressionUsesExpectedResultType = ({
   exprId,
@@ -412,24 +413,14 @@ const compileLetStatement = (
   compileExpr: ExpressionCompiler
 ): binaryen.ExpressionRef => {
   if (stmt.pattern.kind === "identifier") {
-    const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
-    const targetTypeId = getDeclaredSymbolTypeId(
-      stmt.pattern.symbol,
-      ctx,
-      typeInstanceId,
-    );
-    const scalarReplacedSymbols = ctx.optimization?.scalarReplacedObjectLocals.get(
-      ctx.moduleId,
-    );
-    const initializer = ctx.module.hir.expressions.get(stmt.initializer);
-    if (
-      scalarReplacedSymbols?.has(stmt.pattern.symbol) &&
-      initializer?.exprKind === "object-literal"
-    ) {
+    const scalarObjectPlan = getScalarObjectLocalPlan({
+      plan: ctx.optimization?.codegenPlan,
+      moduleId: ctx.moduleId,
+      symbol: stmt.pattern.symbol,
+    });
+    if (scalarObjectPlan?.initializerExpr === stmt.initializer) {
       const scalarOps = tryCompileScalarObjectBinding({
-        symbol: stmt.pattern.symbol,
-        initializer,
-        targetTypeId,
+        plan: scalarObjectPlan,
         ctx,
         fnCtx,
         compileExpr,

--- a/packages/compiler/src/codegen/scalar-objects.ts
+++ b/packages/compiler/src/codegen/scalar-objects.ts
@@ -33,6 +33,7 @@ import {
   lowerValueForHeapField,
 } from "./structural.js";
 import {
+  getDeclaredSymbolTypeId,
   getExprBinaryenType,
   getRequiredExprType,
   getStructuralTypeInfo,
@@ -51,7 +52,13 @@ export const tryCompileScalarObjectBinding = ({
   fnCtx: FunctionContext;
   compileExpr: ExpressionCompiler;
 }): readonly binaryen.ExpressionRef[] | undefined => {
-  const structInfo = getStructuralTypeInfo(plan.typeId, ctx);
+  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+  const targetTypeId = getDeclaredSymbolTypeId(
+    plan.symbol,
+    ctx,
+    typeInstanceId,
+  );
+  const structInfo = getStructuralTypeInfo(targetTypeId, ctx);
   if (!structInfo || structInfo.layoutKind !== "heap-object") {
     return undefined;
   }
@@ -62,17 +69,16 @@ export const tryCompileScalarObjectBinding = ({
   }
 
   const fields = new Map<string, ReturnType<typeof allocateTempLocal>>();
-  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
 
   for (const field of plan.fields) {
     const structField = structInfo.fieldMap.get(field.name);
-    if (!structField || structField.typeId !== field.typeId) {
+    if (!structField) {
       return undefined;
     }
     const local = allocateTempLocal(
-      wasmTypeFor(field.typeId, ctx),
+      wasmTypeFor(structField.typeId, ctx),
       fnCtx,
-      field.typeId,
+      structField.typeId,
       ctx,
     );
     fields.set(field.name, local);
@@ -88,7 +94,8 @@ export const tryCompileScalarObjectBinding = ({
   const ops = plan.initializerFields.map((entry) => {
     const field = getScalarObjectFieldPlan({ plan, field: entry.name });
     const local = fields.get(entry.name);
-    if (!field || !local) {
+    const structField = structInfo.fieldMap.get(entry.name);
+    if (!field || !local || !structField) {
       throw new Error(`scalar object binding cannot set unknown field ${entry.name}`);
     }
     const actualTypeId = getRequiredExprType(entry.valueExpr, ctx, typeInstanceId);
@@ -96,7 +103,7 @@ export const tryCompileScalarObjectBinding = ({
       exprId: entry.valueExpr,
       ctx,
       fnCtx,
-      expectedResultTypeId: field.typeId,
+      expectedResultTypeId: structField.typeId,
     });
     return (
       storeLocalValue({
@@ -104,7 +111,7 @@ export const tryCompileScalarObjectBinding = ({
         value: coerceValueToType({
           value: value.expr,
           actualType: actualTypeId,
-          targetType: field.typeId,
+          targetType: structField.typeId,
           ctx,
           fnCtx,
         }),
@@ -117,9 +124,9 @@ export const tryCompileScalarObjectBinding = ({
   fnCtx.bindings.set(plan.symbol, {
     kind: "scalar-object",
     plan,
-    type: wasmTypeFor(plan.typeId, ctx),
-    storageType: wasmTypeFor(plan.typeId, ctx),
-    typeId: plan.typeId,
+    type: wasmTypeFor(targetTypeId, ctx),
+    storageType: wasmTypeFor(targetTypeId, ctx),
+    typeId: targetTypeId,
     fields,
   });
 

--- a/packages/compiler/src/codegen/scalar-objects.ts
+++ b/packages/compiler/src/codegen/scalar-objects.ts
@@ -8,11 +8,14 @@ import type {
   FunctionMetadata,
   HirFieldAccessExpr,
   HirMethodCallExpr,
-  HirObjectLiteralExpr,
   LocalBindingScalarObject,
-  SymbolId,
   TypeId,
 } from "./context.js";
+import type { ScalarObjectLocalRepresentationPlan } from "../optimize/codegen-plan.js";
+import {
+  allowsScalarObjectMethodReceiverInline,
+  getScalarObjectFieldPlan,
+} from "../optimize/codegen-plan.js";
 import {
   compileCallArgumentsForParams,
   resolveTypedCallArgumentPlan,
@@ -38,41 +41,34 @@ import {
 import { coerceExprToWasmType } from "./wasm-type-coercions.js";
 
 export const tryCompileScalarObjectBinding = ({
-  symbol,
-  initializer,
-  targetTypeId,
+  plan,
   ctx,
   fnCtx,
   compileExpr,
 }: {
-  symbol: SymbolId;
-  initializer: HirObjectLiteralExpr;
-  targetTypeId: TypeId;
+  plan: ScalarObjectLocalRepresentationPlan;
   ctx: CodegenContext;
   fnCtx: FunctionContext;
   compileExpr: ExpressionCompiler;
 }): readonly binaryen.ExpressionRef[] | undefined => {
-  const structInfo = getStructuralTypeInfo(targetTypeId, ctx);
+  const structInfo = getStructuralTypeInfo(plan.typeId, ctx);
   if (!structInfo || structInfo.layoutKind !== "heap-object") {
     return undefined;
   }
 
-  const entriesByName = new Map(
-    initializer.entries
-      .filter((entry) => entry.kind === "field")
-      .map((entry) => [entry.name, entry] as const),
-  );
-  if (
-    entriesByName.size !== initializer.entries.length ||
-    entriesByName.size !== structInfo.fields.length
-  ) {
+  const planFieldNames = new Set(plan.fields.map((field) => field.name));
+  if (plan.fields.length !== structInfo.fields.length) {
     return undefined;
   }
 
   const fields = new Map<string, ReturnType<typeof allocateTempLocal>>();
   const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
 
-  for (const field of structInfo.fields) {
+  for (const field of plan.fields) {
+    const structField = structInfo.fieldMap.get(field.name);
+    if (!structField || structField.typeId !== field.typeId) {
+      return undefined;
+    }
     const local = allocateTempLocal(
       wasmTypeFor(field.typeId, ctx),
       fnCtx,
@@ -82,18 +78,22 @@ export const tryCompileScalarObjectBinding = ({
     fields.set(field.name, local);
   }
 
-  const ops = initializer.entries.map((entry) => {
-    if (entry.kind !== "field") {
-      throw new Error("scalar object binding only supports direct field initializers");
-    }
-    const field = structInfo.fieldMap.get(entry.name);
+  if (
+    plan.initializerFields.length !== plan.fields.length ||
+    !plan.initializerFields.every((entry) => planFieldNames.has(entry.name))
+  ) {
+    return undefined;
+  }
+
+  const ops = plan.initializerFields.map((entry) => {
+    const field = getScalarObjectFieldPlan({ plan, field: entry.name });
     const local = fields.get(entry.name);
     if (!field || !local) {
       throw new Error(`scalar object binding cannot set unknown field ${entry.name}`);
     }
-    const actualTypeId = getRequiredExprType(entry.value, ctx, typeInstanceId);
+    const actualTypeId = getRequiredExprType(entry.valueExpr, ctx, typeInstanceId);
     const value = compileExpr({
-      exprId: entry.value,
+      exprId: entry.valueExpr,
       ctx,
       fnCtx,
       expectedResultTypeId: field.typeId,
@@ -114,11 +114,12 @@ export const tryCompileScalarObjectBinding = ({
     );
   });
 
-  fnCtx.bindings.set(symbol, {
+  fnCtx.bindings.set(plan.symbol, {
     kind: "scalar-object",
-    type: wasmTypeFor(targetTypeId, ctx),
-    storageType: wasmTypeFor(targetTypeId, ctx),
-    typeId: targetTypeId,
+    plan,
+    type: wasmTypeFor(plan.typeId, ctx),
+    storageType: wasmTypeFor(plan.typeId, ctx),
+    typeId: plan.typeId,
     fields,
   });
 
@@ -140,6 +141,10 @@ export const tryCompileScalarObjectFieldAccess = ({
   }
   const binding = fnCtx.bindings.get(target.symbol);
   if (binding?.kind !== "scalar-object") {
+    return undefined;
+  }
+  const fieldPlan = getScalarObjectFieldPlan({ plan: binding.plan, field: expr.field });
+  if (!fieldPlan) {
     return undefined;
   }
   const fieldBinding = binding.fields.get(expr.field);
@@ -188,6 +193,13 @@ export const tryCompileScalarObjectFieldAssignment = ({
   if (binding?.kind !== "scalar-object") {
     return undefined;
   }
+  const fieldPlan = getScalarObjectFieldPlan({
+    plan: binding.plan,
+    field: targetExpr.field,
+  });
+  if (!fieldPlan) {
+    return undefined;
+  }
   const fieldBinding = binding.fields.get(targetExpr.field);
   if (!fieldBinding || typeof fieldBinding.typeId !== "number") {
     return undefined;
@@ -233,6 +245,16 @@ export const tryCompileScalarObjectMethodCall = ({
   if (binding?.kind !== "scalar-object") {
     return undefined;
   }
+  if (
+    !allowsScalarObjectMethodReceiverInline({
+      plan: binding.plan,
+      callExpr: expr.id,
+      targetModuleId: meta.moduleId,
+      targetSymbol: meta.symbol,
+    })
+  ) {
+    return undefined;
+  }
 
   const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
   const typedPlan = resolveTypedCallArgumentPlan({
@@ -269,7 +291,7 @@ export const tryCompileScalarObjectMethodCall = ({
     },
   });
 
-  return tryInlineResolvedCall({
+  const inlined = tryInlineResolvedCall({
     meta,
     args: [undefined, ...args],
     parameterBindings: new Map([[0, binding]]),
@@ -278,6 +300,10 @@ export const tryCompileScalarObjectMethodCall = ({
     compileExpr,
     options,
   });
+  if (!inlined) {
+    throw new Error("scalar object method receiver plan could not be lowered");
+  }
+  return inlined;
 };
 
 export const materializeScalarObjectBindingValue = ({
@@ -289,6 +315,9 @@ export const materializeScalarObjectBindingValue = ({
   ctx: CodegenContext;
   fnCtx: FunctionContext;
 }): binaryen.ExpressionRef => {
+  if (!binding.plan.operations.wholeValueMaterialization.allowed) {
+    throw new Error("scalar object plan does not allow whole-value materialization");
+  }
   if (typeof binding.typeId !== "number") {
     throw new Error("scalar object binding is missing a type id");
   }

--- a/packages/compiler/src/optimize/codegen-plan.ts
+++ b/packages/compiler/src/optimize/codegen-plan.ts
@@ -1,0 +1,87 @@
+import type { HirExprId, SymbolId, TypeId } from "../semantics/ids.js";
+
+export type ScalarObjectFieldRepresentationPlan = {
+  name: string;
+  typeId: TypeId;
+};
+
+export type ScalarObjectInitializerFieldPlan = {
+  name: string;
+  valueExpr: HirExprId;
+};
+
+export type ScalarObjectMethodReceiverInlinePlan = {
+  callExpr: HirExprId;
+  targetModuleId: string;
+  targetSymbol: SymbolId;
+};
+
+export type ScalarObjectLocalRepresentationPlan = {
+  kind: "scalar-object-local";
+  moduleId: string;
+  symbol: SymbolId;
+  initializerExpr: HirExprId;
+  typeId: TypeId;
+  representation: "field-locals";
+  fields: readonly ScalarObjectFieldRepresentationPlan[];
+  initializerFields: readonly ScalarObjectInitializerFieldPlan[];
+  operations: {
+    fieldRead: "local";
+    fieldWrite: "local";
+    methodReceiverInline: readonly ScalarObjectMethodReceiverInlinePlan[];
+    wholeValueMaterialization: { allowed: false };
+  };
+  verified: {
+    directFieldInitializers: true;
+    noUnsafeEscapes: true;
+    noContinuationCapture: true;
+    sourceOrderInitializers: true;
+  };
+};
+
+export type ProgramCodegenOptimizationPlan = {
+  representations: {
+    scalarObjectLocals: ReadonlyMap<
+      string,
+      ReadonlyMap<SymbolId, ScalarObjectLocalRepresentationPlan>
+    >;
+  };
+};
+
+export const getScalarObjectLocalPlan = ({
+  plan,
+  moduleId,
+  symbol,
+}: {
+  plan: ProgramCodegenOptimizationPlan | undefined;
+  moduleId: string;
+  symbol: SymbolId;
+}): ScalarObjectLocalRepresentationPlan | undefined =>
+  plan?.representations.scalarObjectLocals.get(moduleId)?.get(symbol);
+
+export const getScalarObjectFieldPlan = ({
+  plan,
+  field,
+}: {
+  plan: ScalarObjectLocalRepresentationPlan;
+  field: string;
+}): ScalarObjectFieldRepresentationPlan | undefined =>
+  plan.fields.find((candidate) => candidate.name === field);
+
+export const allowsScalarObjectMethodReceiverInline = ({
+  plan,
+  callExpr,
+  targetModuleId,
+  targetSymbol,
+}: {
+  plan: ScalarObjectLocalRepresentationPlan;
+  callExpr: HirExprId;
+  targetModuleId: string;
+  targetSymbol: SymbolId;
+}): boolean =>
+  plan.operations.methodReceiverInline.some(
+    (candidate) =>
+      candidate.callExpr === callExpr &&
+      candidate.targetModuleId === targetModuleId &&
+      candidate.targetSymbol === targetSymbol,
+  );

--- a/packages/compiler/src/optimize/ir.ts
+++ b/packages/compiler/src/optimize/ir.ts
@@ -11,6 +11,7 @@ import type {
   SymbolId,
 } from "../semantics/ids.js";
 import type { SemanticsPipelineResult } from "../semantics/pipeline.js";
+import type { ProgramCodegenOptimizationPlan } from "./codegen-plan.js";
 
 export type OptimizedCallInfo = CallLoweringInfo;
 
@@ -27,7 +28,7 @@ export type ProgramOptimizationFacts = {
   reachableFunctionSymbols: ReadonlySet<ProgramSymbolId>;
   reachableModuleLets: ReadonlyMap<string, ReadonlySet<SymbolId>>;
   usedTraitDispatchSignatures: ReadonlySet<string>;
-  scalarReplacedObjectLocals: ReadonlyMap<string, ReadonlySet<SymbolId>>;
+  codegenPlan: ProgramCodegenOptimizationPlan;
 };
 
 export type ProgramOptimizationIR = {

--- a/packages/compiler/src/optimize/pipeline.ts
+++ b/packages/compiler/src/optimize/pipeline.ts
@@ -38,6 +38,11 @@ import type {
   OptimizedModuleView,
   ProgramOptimizationResult,
 } from "./ir.js";
+import type {
+  ProgramCodegenOptimizationPlan,
+  ScalarObjectLocalRepresentationPlan,
+  ScalarObjectMethodReceiverInlinePlan,
+} from "./codegen-plan.js";
 
 type MutableOptimizationIr = {
   baseProgram: ProgramCodegenView;
@@ -62,7 +67,11 @@ type MutableOptimizationIr = {
     reachableFunctionSymbols: Set<ProgramSymbolId>;
     reachableModuleLets: Map<string, Set<SymbolId>>;
     usedTraitDispatchSignatures: Set<string>;
-    scalarReplacedObjectLocals: Map<string, Set<SymbolId>>;
+    codegenPlan: {
+      representations: {
+        scalarObjectLocals: Map<string, Map<SymbolId, ScalarObjectLocalRepresentationPlan>>;
+      };
+    };
   };
 };
 
@@ -291,7 +300,11 @@ const buildOptimizationIr = ({
       reachableFunctionSymbols: new Set(),
       reachableModuleLets: new Map(),
       usedTraitDispatchSignatures: new Set(),
-      scalarReplacedObjectLocals: new Map(),
+      codegenPlan: {
+        representations: {
+          scalarObjectLocals: new Map(),
+        },
+      },
     },
   };
 };
@@ -1631,39 +1644,81 @@ const expressionIsDirectAssignmentTarget = ({
   return moduleView.hir.expressions.get(parent.exprId)?.exprKind === "assign";
 };
 
-const objectLiteralHasDirectFieldInitializers = ({
+const buildScalarObjectInitializerPlan = ({
+  moduleId,
+  symbol,
   expr,
   typeId,
   program,
 }: {
+  moduleId: string;
+  symbol: SymbolId;
   expr: HirObjectLiteralExpr;
   typeId: TypeId;
   program: ProgramCodegenView;
-}): boolean => {
+}): Pick<
+  ScalarObjectLocalRepresentationPlan,
+  | "kind"
+  | "moduleId"
+  | "symbol"
+  | "initializerExpr"
+  | "typeId"
+  | "representation"
+  | "fields"
+  | "initializerFields"
+> | undefined => {
   if (expr.literalKind !== "nominal") {
-    return false;
+    return undefined;
   }
   const nominalTypeId = exactNominalForType({ typeId, program });
   if (typeof nominalTypeId !== "number") {
-    return false;
+    return undefined;
   }
   const desc = program.types.getTypeDesc(nominalTypeId);
   if (desc.kind !== "nominal-object") {
-    return false;
+    return undefined;
   }
   const objectInfo = program.objects.getInfoByNominal(nominalTypeId);
   if (!objectInfo) {
-    return false;
+    return undefined;
   }
-  const fieldNames = new Set(objectInfo.fields.map((field) => field.name));
+  const structuralLayout = program.types.getStructuralLayout(objectInfo.structural);
+  if (structuralLayout?.kind !== "structural-object") {
+    return undefined;
+  }
+  const fieldNames = new Set(structuralLayout.fields.map((field) => field.name));
   const entries = new Set<string>();
   for (const entry of expr.entries) {
     if (entry.kind !== "field" || !fieldNames.has(entry.name)) {
-      return false;
+      return undefined;
     }
     entries.add(entry.name);
   }
-  return entries.size === fieldNames.size;
+  if (entries.size !== fieldNames.size) {
+    return undefined;
+  }
+
+  return {
+    kind: "scalar-object-local",
+    moduleId,
+    symbol,
+    initializerExpr: expr.id,
+    typeId,
+    representation: "field-locals",
+    fields: structuralLayout.fields.map((field) => ({
+      name: field.name,
+      typeId: field.typeId,
+    })),
+    initializerFields: expr.entries.map((entry) => {
+      if (entry.kind !== "field") {
+        throw new Error("scalar object plan cannot include spread initializers");
+      }
+      return {
+        name: entry.name,
+        valueExpr: entry.value,
+      };
+    }),
+  };
 };
 
 const symbolTypeFor = ({
@@ -1746,7 +1801,7 @@ const isScalarLeafIntrinsicCall = ({
   );
 };
 
-const scalarInlineableMethodReceiverUse = ({
+const scalarInlineableMethodReceiverPlan = ({
   expr,
   moduleId,
   program,
@@ -1754,15 +1809,15 @@ const scalarInlineableMethodReceiverUse = ({
   expr: Extract<HirExpression, { exprKind: "method-call" }>;
   moduleId: string;
   program: ProgramCodegenView;
-}): boolean => {
+}): ScalarObjectMethodReceiverInlinePlan | undefined => {
   const target = singletonMethodTarget({ expr, moduleId, program });
   if (!target) {
-    return false;
+    return undefined;
   }
 
   const ownerModule = program.modules.get(target.moduleId);
   if (!ownerModule) {
-    return false;
+    return undefined;
   }
   const fn = functionItemBySymbol({
     moduleView: ownerModule,
@@ -1770,10 +1825,10 @@ const scalarInlineableMethodReceiverUse = ({
   });
   const signature = program.functions.getSignature(target.moduleId, target.symbol);
   if (!fn || !signature || !program.effects.isEmpty(signature.effectRow)) {
-    return false;
+    return undefined;
   }
   if (fn.parameters.some((parameter) => typeof parameter.defaultValue === "number")) {
-    return false;
+    return undefined;
   }
   if (
     signature.parameters.length === 0 ||
@@ -1783,12 +1838,12 @@ const scalarInlineableMethodReceiverUse = ({
     ) ||
     !simpleDirectSignatureType({ typeId: signature.returnType, program })
   ) {
-    return false;
+    return undefined;
   }
 
   const receiverSymbol = fn.parameters[0]?.symbol;
   if (typeof receiverSymbol !== "number") {
-    return false;
+    return undefined;
   }
   const parents = buildExpressionParents({ moduleView: ownerModule });
   let exprCount = 0;
@@ -1868,7 +1923,13 @@ const scalarInlineableMethodReceiverUse = ({
     },
   });
 
-  return allowed;
+  return allowed
+    ? {
+        callExpr: expr.id,
+        targetModuleId: target.moduleId,
+        targetSymbol: target.symbol,
+      }
+    : undefined;
 };
 
 const localIsLiveAcrossEffectfulExpression = ({
@@ -1921,7 +1982,7 @@ const localIsLiveAcrossEffectfulExpression = ({
   return (seenEffectful && valueHasSymbol) || (valueHasEffect && valueHasSymbol);
 };
 
-const isScalarReplaceableLocal = ({
+const buildScalarObjectLocalRepresentationPlan = ({
   stmt,
   block,
   stmtIndex,
@@ -1939,13 +2000,13 @@ const isScalarReplaceableLocal = ({
   moduleView: OptimizedModuleView;
   parents: ReadonlyMap<HirExprId, ExpressionParent>;
   program: ProgramCodegenView;
-}): boolean => {
+}): ScalarObjectLocalRepresentationPlan | undefined => {
   if (stmt.pattern.kind !== "identifier") {
-    return false;
+    return undefined;
   }
   const initializer = moduleView.hir.expressions.get(stmt.initializer);
   if (!initializer || initializer.exprKind !== "object-literal") {
-    return false;
+    return undefined;
   }
   if (
     expressionContainsEffectfulCall({
@@ -1959,7 +2020,7 @@ const isScalarReplaceableLocal = ({
       moduleView,
     })
   ) {
-    return false;
+    return undefined;
   }
   const typeId =
     symbolTypeFor({
@@ -1970,18 +2031,22 @@ const isScalarReplaceableLocal = ({
       moduleView,
       exprId: stmt.initializer,
     });
-  if (
-    typeof typeId !== "number" ||
-    !objectLiteralHasDirectFieldInitializers({
-      expr: initializer,
-      typeId,
-      program,
-    })
-  ) {
-    return false;
+  if (typeof typeId !== "number") {
+    return undefined;
+  }
+  const initializerPlan = buildScalarObjectInitializerPlan({
+    moduleId,
+    symbol: stmt.pattern.symbol,
+    expr: initializer,
+    typeId,
+    program,
+  });
+  if (!initializerPlan) {
+    return undefined;
   }
 
   const symbol = stmt.pattern.symbol;
+  const methodReceiverInline: ScalarObjectMethodReceiverInlinePlan[] = [];
   let allowed = true;
   walkExpression({
     exprId: functionBody,
@@ -2030,7 +2095,7 @@ const isScalarReplaceableLocal = ({
             parents,
             moduleView,
           }));
-      const allowedMethodReceiverUse =
+      const methodReceiverPlan =
         parent?.kind === "expr" &&
         parentExpr?.exprKind === "method-call" &&
         parent.role === "target" &&
@@ -2038,21 +2103,43 @@ const isScalarReplaceableLocal = ({
           exprId: parent.exprId,
           parents,
           moduleView,
-        }) &&
-        scalarInlineableMethodReceiverUse({
+        })
+          ? scalarInlineableMethodReceiverPlan({
           expr: parentExpr,
           moduleId,
           program,
-        });
-      if (!allowedFieldUse && !allowedMethodReceiverUse) {
+            })
+          : undefined;
+      if (!allowedFieldUse && !methodReceiverPlan) {
         allowed = false;
         return { stop: true };
+      }
+      if (methodReceiverPlan) {
+        methodReceiverInline.push(methodReceiverPlan);
       }
       return undefined;
     },
   });
 
-  return allowed;
+  if (!allowed) {
+    return undefined;
+  }
+
+  return {
+    ...initializerPlan,
+    operations: {
+      fieldRead: "local",
+      fieldWrite: "local",
+      methodReceiverInline,
+      wholeValueMaterialization: { allowed: false },
+    },
+    verified: {
+      directFieldInitializers: true,
+      noUnsafeEscapes: true,
+      noContinuationCapture: true,
+      sourceOrderInitializers: true,
+    },
+  };
 };
 
 const scalarReplacementOfObjectLocalsPass: ProgramOptimizationPass = {
@@ -2062,7 +2149,7 @@ const scalarReplacementOfObjectLocalsPass: ProgramOptimizationPass = {
 
     ctx.ir.modules.forEach((moduleView, moduleId) => {
       const parents = buildExpressionParents({ moduleView });
-      const symbols = new Set<SymbolId>();
+      const plans = new Map<SymbolId, ScalarObjectLocalRepresentationPlan>();
       moduleView.hir.items.forEach((item) => {
         if (item.kind !== "function") {
           return;
@@ -2085,10 +2172,10 @@ const scalarReplacementOfObjectLocalsPass: ProgramOptimizationPass = {
           }
           expr.statements.forEach((stmtId, stmtIndex) => {
             const stmt = moduleView.hir.statements.get(stmtId);
-            if (
+            const plan =
               stmt?.kind === "let" &&
               stmt.pattern.kind === "identifier" &&
-              isScalarReplaceableLocal({
+              buildScalarObjectLocalRepresentationPlan({
                 stmt,
                 block: expr,
                 stmtIndex,
@@ -2097,19 +2184,20 @@ const scalarReplacementOfObjectLocalsPass: ProgramOptimizationPass = {
                 moduleView,
                 parents,
                 program: ctx.ir.baseProgram,
-              })
-            ) {
-              symbols.add(stmt.pattern.symbol);
+              });
+            if (plan) {
+              plans.set(plan.symbol, plan);
             }
           });
         });
       });
 
-      const existing = ctx.ir.facts.scalarReplacedObjectLocals.get(moduleId);
-      if (!existing || !setEquals(existing, symbols)) {
-        (ctx.ir as MutableOptimizationIr).facts.scalarReplacedObjectLocals.set(
+      const existing =
+        ctx.ir.facts.codegenPlan.representations.scalarObjectLocals.get(moduleId);
+      if (!existing || !scalarObjectPlanMapEquals(existing, plans)) {
+        (ctx.ir as MutableOptimizationIr).facts.codegenPlan.representations.scalarObjectLocals.set(
           moduleId,
-          symbols,
+          plans,
         );
         changed = true;
       }
@@ -2201,6 +2289,16 @@ const canonicalProgramSymbolIdOf = ({
 
 const setEquals = <T>(left: ReadonlySet<T>, right: ReadonlySet<T>): boolean =>
   left.size === right.size && Array.from(left).every((value) => right.has(value));
+
+const scalarObjectPlanMapEquals = (
+  left: ReadonlyMap<SymbolId, ScalarObjectLocalRepresentationPlan>,
+  right: ReadonlyMap<SymbolId, ScalarObjectLocalRepresentationPlan>,
+): boolean =>
+  left.size === right.size &&
+  Array.from(left.entries()).every(([symbol, plan]) => {
+    const other = right.get(symbol);
+    return other ? JSON.stringify(plan) === JSON.stringify(other) : false;
+  });
 
 const mapOfSetEquals = <K, V>(
   left: ReadonlyMap<K, ReadonlySet<V>>,
@@ -2654,6 +2752,16 @@ const finalizeOptimization = ({
     ),
   };
 
+  const codegenPlan: ProgramCodegenOptimizationPlan = {
+    representations: {
+      scalarObjectLocals: new Map(
+        Array.from(ir.facts.codegenPlan.representations.scalarObjectLocals.entries()).map(
+          ([moduleId, plans]) => [moduleId, new Map(plans)],
+        ),
+      ),
+    },
+  };
+
   return {
     program: optimizedProgram,
     facts: {
@@ -2677,12 +2785,7 @@ const finalizeOptimization = ({
         ]),
       ),
       usedTraitDispatchSignatures: new Set(ir.facts.usedTraitDispatchSignatures),
-      scalarReplacedObjectLocals: new Map(
-        Array.from(ir.facts.scalarReplacedObjectLocals.entries()).map(([moduleId, symbols]) => [
-          moduleId,
-          new Set(symbols),
-        ]),
-      ),
+      codegenPlan,
     },
   };
 };

--- a/packages/compiler/src/optimize/pipeline.ts
+++ b/packages/compiler/src/optimize/pipeline.ts
@@ -1654,7 +1654,7 @@ const buildScalarObjectInitializerPlan = ({
   moduleId: string;
   symbol: SymbolId;
   expr: HirObjectLiteralExpr;
-  typeId: TypeId;
+  typeId?: TypeId;
   program: ProgramCodegenView;
 }): Pick<
   ScalarObjectLocalRepresentationPlan,
@@ -1671,18 +1671,57 @@ const buildScalarObjectInitializerPlan = ({
     return undefined;
   }
   const nominalTypeId = exactNominalForType({ typeId, program });
-  if (typeof nominalTypeId !== "number") {
+  const desc =
+    typeof nominalTypeId === "number"
+      ? program.types.getTypeDesc(nominalTypeId)
+      : undefined;
+  if (desc && desc.kind !== "nominal-object") {
     return undefined;
   }
-  const desc = program.types.getTypeDesc(nominalTypeId);
-  if (desc.kind !== "nominal-object") {
+  const owner =
+    desc?.owner ??
+    (typeof expr.targetSymbol === "number"
+      ? program.symbols.canonicalIdOf(moduleId, expr.targetSymbol)
+      : undefined);
+  const objectInfo =
+    typeof nominalTypeId === "number"
+      ? program.objects.getInfoByNominal(nominalTypeId)
+      : undefined;
+  const objectTemplate =
+    !objectInfo && typeof owner === "number"
+      ? program.objects.getTemplate(owner)
+      : undefined;
+  if (!objectInfo && !objectTemplate) {
     return undefined;
   }
-  const objectInfo = program.objects.getInfoByNominal(nominalTypeId);
-  if (!objectInfo) {
+  const targetTypeArgs =
+    expr.target?.typeKind === "named"
+      ? expr.target.typeArguments?.map((arg) => arg.typeId)
+      : undefined;
+  const templateTypeArgs =
+    desc?.typeArgs ??
+    (targetTypeArgs?.every((arg): arg is TypeId => typeof arg === "number")
+      ? targetTypeArgs
+      : undefined);
+  const templateSubstitution =
+    objectTemplate &&
+    templateTypeArgs &&
+    objectTemplate.params.length === templateTypeArgs.length
+      ? new Map(
+          objectTemplate.params.map(
+            (param, index) => [param.typeParam, templateTypeArgs[index]!] as const,
+          ),
+        )
+      : undefined;
+  const structuralId = objectInfo
+    ? objectInfo.structural
+    : objectTemplate && templateSubstitution
+      ? program.types.substitute(objectTemplate.structural, templateSubstitution)
+      : objectTemplate?.structural;
+  if (typeof structuralId !== "number") {
     return undefined;
   }
-  const structuralLayout = program.types.getStructuralLayout(objectInfo.structural);
+  const structuralLayout = program.types.getStructuralLayout(structuralId);
   if (structuralLayout?.kind !== "structural-object") {
     return undefined;
   }
@@ -1697,13 +1736,22 @@ const buildScalarObjectInitializerPlan = ({
   if (entries.size !== fieldNames.size) {
     return undefined;
   }
+  const planTypeId =
+    typeof typeId === "number"
+      ? typeId
+      : objectTemplate && templateSubstitution
+        ? program.types.substitute(objectTemplate.nominal, templateSubstitution)
+        : objectTemplate?.nominal;
+  if (typeof planTypeId !== "number") {
+    return undefined;
+  }
 
   return {
     kind: "scalar-object-local",
     moduleId,
     symbol,
     initializerExpr: expr.id,
-    typeId,
+    typeId: planTypeId,
     representation: "field-locals",
     fields: structuralLayout.fields.map((field) => ({
       name: field.name,
@@ -2031,9 +2079,6 @@ const buildScalarObjectLocalRepresentationPlan = ({
       moduleView,
       exprId: stmt.initializer,
     });
-  if (typeof typeId !== "number") {
-    return undefined;
-  }
   const initializerPlan = buildScalarObjectInitializerPlan({
     moduleId,
     symbol: stmt.pattern.symbol,


### PR DESCRIPTION
## Summary
- Replaced the loose `scalarReplacedObjectLocals` fact with an explicit optimizer-owned `codegenPlan` contract for scalar object locals.
- Codegen now consumes that plan for bindings, field reads/writes, and method receiver inlining instead of inferring scalar-replacement behavior from ad hoc facts.
- Tightened the optimizer to emit concrete per-symbol representation plans, including instantiated field types and verified receiver call sites.
- Added regression coverage for field reads, mutable writes, escaping whole-value rejection, method receiver scalarization/rejection, initializer order, continuation safety, and generic object scalarization.

## Testing
- `npm run typecheck` passed.
- `npm test` passed.
- `npx vitest packages/compiler/src/__tests__/optimize-pipeline.test.ts` passed with the new and updated scalar replacement cases.