### PR TITLE
[codex] Fix object init signature hints

### DIFF
--- a/packages/compiler/src/semantics/type-display.ts
+++ b/packages/compiler/src/semantics/type-display.ts
@@ -375,6 +375,27 @@ export const typeSummaryForSymbol = ({
 
   const symbolName = displayName ?? semantics.binding.symbolTable.getSymbol(ref.symbol).name;
 
+  const constructors = semantics.binding.staticMethods.get(ref.symbol)?.get("init");
+  if (constructors && constructors.size > 0) {
+    const constructorSummaries = Array.from(constructors)
+      .map((symbol) => {
+        const signature = semantics.typing.functions.getSignature(symbol);
+        return signature
+          ? formatFunctionSignature({
+              ref,
+              semantics,
+              signature,
+              formatType,
+            })
+          : undefined;
+      })
+      .filter((summary): summary is string => summary !== undefined);
+
+    if (constructorSummaries.length > 0) {
+      return Array.from(new Set(constructorSummaries)).join("\n");
+    }
+  }
+
   const findParameterSummary = (): string | undefined => {
     const toLocalParameter = ({
       ownerSymbol,

--- a/packages/language-server/src/__tests__/project.test.ts
+++ b/packages/language-server/src/__tests__/project.test.ts
@@ -1388,6 +1388,47 @@ describe("language server project analysis", () => {
     }
   });
 
+  it("shows overloaded object init constructor signatures in hover before a target is selected", async () => {
+    const project = await createProject({
+      "src/main.voyd": `obj MyObj {\n  x: i32,\n}\n\nimpl MyObj\n  fn init(y: i32)\n    MyObj { x: y }\n\n  fn init(flag: bool)\n    MyObj { x: 0 }\n\nfn main() -> MyObj\n  MyObj()\n\nfn other() -> MyObj\n  My\n`,
+    });
+
+    try {
+      const entryPath = project.filePathFor("src/main.voyd");
+      const uri = toFileUri(entryPath);
+      const analysis = await analyzeProject({
+        entryPath,
+        roots: resolveModuleRoots(entryPath),
+        openDocuments: new Map(),
+      });
+
+      const hover = hoverAtPosition({
+        analysis,
+        uri,
+        position: { line: 12, character: 3 },
+      });
+      expect(hover?.contents).toEqual({
+        kind: "markdown",
+        value:
+          "```voyd\nfn MyObj(y: i32) -> MyObj\nfn MyObj(flag: bool) -> MyObj\n```",
+      });
+
+      const completion = completionsAtPosition({
+        analysis,
+        uri,
+        position: { line: 15, character: 4 },
+      });
+      const constructorCompletion = completion.items.find(
+        (item) => item.label === "MyObj",
+      );
+      expect(constructorCompletion?.detail).toBe(
+        "fn MyObj(y: i32) -> MyObj\nfn MyObj(flag: bool) -> MyObj",
+      );
+    } finally {
+      await rm(project.rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("uses external labels for label hover type summaries", async () => {
     const source = `fn reduce<T>(value: T, { start: T, reducer cb: (acc: T, current: T) -> T }) -> T\n  cb(start, value)\n\nfn main() -> i32\n  1.reduce start: 0 reducer: (acc, current) =>\n    acc + current\n`;
     const project = await createProject({

--- a/packages/language-server/src/project/symbol-index.ts
+++ b/packages/language-server/src/project/symbol-index.ts
@@ -761,6 +761,28 @@ export const buildSymbolIndex = async ({
     const syntaxById = collectSyntaxById(moduleNode.ast);
 
     const moduleRef = (symbol: SymbolId): SymbolRef => ({ moduleId, symbol });
+    const constructorOwnerForOverloadSet = (
+      overloadSetId: number,
+    ): SymbolRef | undefined => {
+      const overloadSet = entry.binding.overloads.get(overloadSetId);
+      if (!overloadSet) {
+        return undefined;
+      }
+
+      const overloadSymbols = new Set(overloadSet.functions.map((fn) => fn.symbol));
+      for (const [targetSymbol, methods] of entry.binding.staticMethods) {
+        const constructors = methods.get("init");
+        if (!constructors) {
+          continue;
+        }
+
+        if (Array.from(constructors).some((symbol) => overloadSymbols.has(symbol))) {
+          return moduleRef(targetSymbol);
+        }
+      }
+
+      return undefined;
+    };
 
     entry.binding.imports.forEach((imported) => {
       if (!imported.target || !imported.span) {
@@ -1037,6 +1059,18 @@ export const buildSymbolIndex = async ({
               symbol: selected.symbol,
             },
           });
+        } else {
+          const callee = entry.hir.expressions.get(expression.callee);
+          if (callee?.exprKind === "overload-set") {
+            const constructorOwner = constructorOwnerForOverloadSet(callee.set);
+            if (constructorOwner) {
+              addOccurrenceFromSpan({
+                symbolRef: constructorOwner,
+                span: callee.span,
+                kind: "reference",
+              });
+            }
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes V-306 by surfacing object constructor `init` signatures in language-server hovers and completion details when an overloaded object constructor call has not yet resolved to a specific overload.

## Root Cause

The navigation index only attached call-site metadata once overload resolution selected a target. For an incomplete overloaded object constructor call such as `MyObj()`, there is no selected `init` target, so the object callee had no hoverable symbol. Object symbols also did not render their static `init` overloads as callable signatures.

## Changes

- Map unresolved overloaded constructor callees back to the object symbol in the language-server symbol index.
- Render object `init` overloads as callable object signatures, for example `fn MyObj(y: i32) -> MyObj`.
- Add a regression test covering hover and completion detail before a constructor overload target is selected.

## Validation

- `npm --workspace @voyd-lang/language-server test -- -t "shows overloaded object init constructor signatures"`
- `npm --workspace @voyd-lang/language-server run typecheck`
- `npm --workspace @voyd-lang/language-server test`
- `npm test`
- `npm run typecheck`