### PR TITLE
Add one-command release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,30 @@ on:
         description: "VSCode release bump for voyd-vscode (patch/minor/major/version)"
         required: false
         type: string
+      github_release:
+        description: "Create a GitHub release after a successful non-dry-run publish"
+        required: true
+        default: false
+        type: boolean
+      github_tag:
+        description: "Git tag for the GitHub release; defaults to v<selected package version>"
+        required: false
+        type: string
+      github_release_title:
+        description: "GitHub release title; defaults to Voyd <selected package version>"
+        required: false
+        type: string
+      github_release_notes:
+        description: "Inline GitHub release notes; generated notes are used when empty"
+        required: false
+        type: string
 
 jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
@@ -47,13 +64,20 @@ jobs:
       - name: Publish selected targets
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          GH_TOKEN: ${{ github.token }}
+          VOYD_GITHUB_TAG: ${{ inputs.github_tag }}
+          VOYD_GITHUB_RELEASE_TITLE: ${{ inputs.github_release_title }}
+          VOYD_GITHUB_RELEASE_NOTES: ${{ inputs.github_release_notes }}
         run: |
           args=(--tag "${{ inputs.npm_tag }}")
+          target_args=()
 
           if [ "${{ inputs.targets }}" = "--all" ]; then
             args+=(--all)
+            target_args+=(--all)
           else
             args+=(--targets "${{ inputs.targets }}")
+            target_args+=(--targets "${{ inputs.targets }}")
           fi
 
           if [ "${{ inputs.dry_run }}" = "true" ]; then
@@ -62,6 +86,26 @@ jobs:
 
           if [ -n "${{ inputs.vscode_release }}" ]; then
             args+=(--vscode-release "${{ inputs.vscode_release }}")
+          else
+            args+=(--use-existing-vscode-version)
           fi
 
           npm run release:publish -- "${args[@]}"
+
+          if [ "${{ inputs.dry_run }}" = "false" ] && [ "${{ inputs.github_release }}" = "true" ]; then
+            github_args=("${target_args[@]}" --create-tag)
+
+            if [ -n "$VOYD_GITHUB_TAG" ]; then
+              github_args+=(--github-tag "$VOYD_GITHUB_TAG")
+            fi
+
+            if [ -n "$VOYD_GITHUB_RELEASE_TITLE" ]; then
+              github_args+=(--title "$VOYD_GITHUB_RELEASE_TITLE")
+            fi
+
+            if [ -n "$VOYD_GITHUB_RELEASE_NOTES" ]; then
+              github_args+=(--notes "$VOYD_GITHUB_RELEASE_NOTES")
+            fi
+
+            npm run release:github -- "${github_args[@]}"
+          fi

--- a/docs/release/publishing.md
+++ b/docs/release/publishing.md
@@ -28,6 +28,33 @@ Current supported targets:
 Use `--all` to select every supported target without listing them explicitly.
 The GitHub release workflow accepts the same `--all` value in its `targets` input.
 
+## Full Release
+
+Cut a full release from a clean, up-to-date `main` checkout:
+
+```sh
+npm run release:cut -- --all --version 0.2.0 --publish --github-release
+```
+
+That single command:
+
+- verifies the worktree is clean and `main` matches `origin/main`
+- versions selected packages and internal dependency ranges
+- updates `packages/std/src/version.voyd` when `@voyd-lang/std` is selected
+- refreshes `package-lock.json`
+- runs the release validation suite
+- commits the version changes
+- pushes `main`
+- dispatches the GitHub `Release` workflow
+- asks the workflow to publish packages and create a GitHub release
+
+Omit `--publish` to dispatch the workflow in dry-run mode after the release
+prep commit is pushed. Use `--skip-workflow` to stop after pushing the version
+commit.
+
+`release:cut` is the preferred full-release entrypoint. The lower-level
+commands below are useful for manual recovery, partial publishes, and debugging.
+
 ## Versioning
 
 Bump every supported target by one patch version:
@@ -52,7 +79,11 @@ Version updates:
 
 - rewrite the selected targets' own `version` fields
 - update internal workspace dependency ranges that point at those targets
+- update `packages/std/src/version.voyd` when `@voyd-lang/std` is selected
 - refresh `package-lock.json`
+
+Commit version updates before publishing. The GitHub release workflow publishes
+the checked-out commit; it does not create an uncommitted version bump for you.
 
 ## Validation
 
@@ -73,6 +104,7 @@ Release checks always:
 - run uncached Turbo builds for the selected targets and their dependency closure
 - run each selected target's own `typecheck` and `test` scripts
 - run shared boundary suites when needed:
+  - compiler codegen tests for compiler/runtime-facing packages
   - `@voyd-lang/smoke` for runtime-facing packages
   - CLI dist e2e for CLI/runtime packages
 - run `npm pack --dry-run` and verify the published tarball contains only the expected files
@@ -97,6 +129,33 @@ Notes:
 - npm trusted publishing only works after the package already exists on npm, so the first publish may still need a token-based/manual bootstrap
 - the workflow has `id-token: write` enabled so npm can verify the GitHub OIDC identity during publish
 - the VS Code extension does not have an equivalent trusted-publisher flow in this repo today; CI still uses `VSCE_PAT`
+- when `voyd-vscode` is selected without `vscode_release`, the workflow publishes the version already committed in `apps/vscode/package.json`
+
+### GitHub Releases
+
+Create a GitHub release after the package publish succeeds:
+
+```sh
+npm run release:github -- --all
+```
+
+That command infers `v<version>` from the selected targets, verifies the tag
+exists, and runs `gh release create`. To create and push the tag as part of the
+same step:
+
+```sh
+npm run release:github -- --all --create-tag
+```
+
+Use an explicit tag or notes when needed:
+
+```sh
+npm run release:github -- --all --github-tag v0.2.0 --notes-file release-notes.md
+```
+
+The GitHub Actions workflow has an optional `github_release` input. When enabled
+on a non-dry-run publish, it runs the same helper after publishing. Leave
+`github_tag` blank to use `v<version>` or pass one explicitly.
 
 Dry-run a publish:
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     "dev": "turbo run dev --affected --parallel",
     "clean": "turbo run clean --affected --parallel",
     "release:list": "node ./scripts/release/list.mjs",
+    "release:cut": "node ./scripts/release/cut.mjs",
     "release:version": "node ./scripts/release/version.mjs",
     "release:version:all": "node ./scripts/release/version.mjs --all",
     "release:check": "node ./scripts/release/check.mjs",
+    "release:github": "node ./scripts/release/github-release.mjs",
     "release:publish": "node ./scripts/release/publish.mjs",
     "release:publish:all": "node ./scripts/release/publish.mjs --all"
   },

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -30,7 +30,8 @@
     "bench:typing": "vitest bench --config ../../vitest.config.ts src/semantics/typing/__tests__/typing.bench.ts",
     "test:w": "vitest --config ../../vitest.config.ts src",
     "lint": "echo 'no lint configured'",
-    "prepack": "npm run clean && npm run build"
+    "prepack": "npm run clean && npm run build",
+    "prepublishOnly": "node ../../scripts/release/enforce-workspace-release.mjs"
   },
   "dependencies": {
     "@msgpack/msgpack": "^3.1.2",

--- a/packages/std/src/version.voyd
+++ b/packages/std/src/version.voyd
@@ -4,8 +4,8 @@ use std::string::new_string
 
 /// Returns the version of the standard library package.
 pub fn std_version() -> String
-  "0.9.0"
+  "0.1.0"
 
 /// Returns the language version this standard library targets.
 pub fn language_version() -> String
-  "0.9.0"
+  "0.1.0"

--- a/scripts/release/cut.mjs
+++ b/scripts/release/cut.mjs
@@ -1,0 +1,191 @@
+import { execFileSync } from "node:child_process";
+import {
+  parseTargetSelection,
+  repoRoot,
+} from "./manifest.mjs";
+import {
+  runCommand,
+  runReleaseCheck,
+  versionSelectedTargets,
+} from "./runner.mjs";
+
+const readStdout = ({ command, args }) =>
+  execFileSync(command, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["inherit", "pipe", "pipe"],
+  });
+
+const hasFlag = ({ argv, flag }) => argv.includes(flag);
+
+const readFlagValue = ({ argv, flag }) => {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === flag) {
+      return argv[index + 1];
+    }
+
+    if (arg.startsWith(`${flag}=`)) {
+      return arg.slice(flag.length + 1);
+    }
+  }
+
+  return undefined;
+};
+
+const assertCleanWorktreeForReleaseCut = () => {
+  const status = readStdout({
+    command: "git",
+    args: ["status", "--porcelain=v1"],
+  }).trim();
+
+  if (status.length > 0) {
+    throw new Error("release:cut requires a clean worktree before versioning.");
+  }
+};
+
+const assertOnMain = () => {
+  const branch = readStdout({
+    command: "git",
+    args: ["rev-parse", "--abbrev-ref", "HEAD"],
+  }).trim();
+
+  if (branch !== "main") {
+    throw new Error(`release:cut must run from main, currently on ${branch}.`);
+  }
+};
+
+const assertUpToDate = () => {
+  runCommand({ command: "git", args: ["fetch", "origin", "main", "--tags"] });
+
+  const local = readStdout({ command: "git", args: ["rev-parse", "HEAD"] }).trim();
+  const upstream = readStdout({ command: "git", args: ["rev-parse", "origin/main"] }).trim();
+
+  if (local !== upstream) {
+    throw new Error("release:cut requires local main to match origin/main.");
+  }
+};
+
+const changedPaths = () =>
+  readStdout({
+    command: "git",
+    args: ["status", "--porcelain=v1"],
+  })
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.slice(3).trim())
+    .map((path) => path.replace(/^"|"$/g, ""));
+
+const requireVersionPlan = ({ bump, version }) => {
+  if (bump && version) {
+    throw new Error("Use either --bump or --version, not both.");
+  }
+
+  if (!bump && !version) {
+    throw new Error("release:cut requires --bump patch|minor|major or --version <x.y.z>.");
+  }
+};
+
+const workflowTargetsInput = ({ argv, targetNames }) =>
+  hasFlag({ argv, flag: "--all" }) ? "--all" : targetNames.join(",");
+
+const githubWorkflowArgs = ({
+  targetInput,
+  publish,
+  npmTag,
+  githubRelease,
+  githubTag,
+  githubReleaseTitle,
+  githubReleaseNotes,
+  vscodeRelease,
+}) => {
+  const args = [
+    "workflow",
+    "run",
+    "release.yml",
+    "--ref",
+    "main",
+    "--raw-field",
+    `targets=${targetInput}`,
+    "--raw-field",
+    `dry_run=${publish ? "false" : "true"}`,
+    "--raw-field",
+    `npm_tag=${npmTag}`,
+    "--raw-field",
+    `github_release=${githubRelease ? "true" : "false"}`,
+  ];
+
+  if (vscodeRelease) {
+    args.push("--raw-field", `vscode_release=${vscodeRelease}`);
+  }
+
+  if (githubTag) {
+    args.push("--raw-field", `github_tag=${githubTag}`);
+  }
+
+  if (githubReleaseTitle) {
+    args.push("--raw-field", `github_release_title=${githubReleaseTitle}`);
+  }
+
+  if (githubReleaseNotes) {
+    args.push("--raw-field", `github_release_notes=${githubReleaseNotes}`);
+  }
+
+  return args;
+};
+
+const argv = process.argv.slice(2);
+const targetNames = parseTargetSelection(argv);
+const bump = readFlagValue({ argv, flag: "--bump" });
+const version = readFlagValue({ argv, flag: "--version" });
+const npmTag = readFlagValue({ argv, flag: "--tag" }) ?? "latest";
+const commitMessageInput = readFlagValue({ argv, flag: "--commit-message" });
+const publish = hasFlag({ argv, flag: "--publish" });
+const skipWorkflow = hasFlag({ argv, flag: "--skip-workflow" });
+const githubRelease = hasFlag({ argv, flag: "--github-release" });
+const githubTag = readFlagValue({ argv, flag: "--github-tag" });
+const githubReleaseTitle = readFlagValue({ argv, flag: "--github-release-title" });
+const githubReleaseNotes = readFlagValue({ argv, flag: "--github-release-notes" });
+const vscodeRelease = readFlagValue({ argv, flag: "--vscode-release" });
+
+requireVersionPlan({ bump, version });
+assertCleanWorktreeForReleaseCut();
+assertOnMain();
+assertUpToDate();
+
+const versionPlan = versionSelectedTargets({ targetNames, bump, version });
+const releaseVersions = Array.from(new Set(versionPlan.values()));
+const releaseName =
+  releaseVersions.length === 1 ? releaseVersions[0] : releaseVersions.join(", ");
+const commitMessage =
+  commitMessageInput ?? `Prepare Voyd ${releaseName} release`;
+
+const versionedPaths = changedPaths();
+if (versionedPaths.length === 0) {
+  throw new Error("Versioning did not change any files; refusing to create an empty release commit.");
+}
+
+runReleaseCheck({ targetNames });
+
+runCommand({ command: "git", args: ["add", "--", ...versionedPaths] });
+runCommand({ command: "git", args: ["commit", "-m", commitMessage] });
+runCommand({ command: "git", args: ["push", "origin", "main"] });
+
+if (skipWorkflow) {
+  process.stdout.write("[release] Skipped GitHub release workflow dispatch.\n");
+} else {
+  runCommand({
+    command: "gh",
+    args: githubWorkflowArgs({
+      targetInput: workflowTargetsInput({ argv, targetNames }),
+      publish,
+      npmTag,
+      githubRelease,
+      githubTag,
+      githubReleaseTitle,
+      githubReleaseNotes,
+      vscodeRelease,
+    }),
+  });
+}

--- a/scripts/release/github-release.mjs
+++ b/scripts/release/github-release.mjs
@@ -1,0 +1,119 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import {
+  getTarget,
+  parseTargetSelection,
+  readTargetPackageJson,
+  repoRoot,
+} from "./manifest.mjs";
+import { runCommand } from "./runner.mjs";
+
+const readStdout = ({ command, args }) =>
+  execFileSync(command, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["inherit", "pipe", "pipe"],
+  });
+
+const readFlagValue = ({ argv, flag }) => {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === flag) {
+      return argv[index + 1];
+    }
+
+    if (arg.startsWith(`${flag}=`)) {
+      return arg.slice(flag.length + 1);
+    }
+  }
+
+  return undefined;
+};
+
+const hasFlag = ({ argv, flag }) => argv.includes(flag);
+
+const inferVersion = (targetNames) => {
+  const versions = Array.from(
+    new Set(
+      targetNames.map((targetName) => {
+        getTarget(targetName);
+        return readTargetPackageJson(targetName).version;
+      }),
+    ),
+  );
+
+  if (versions.length !== 1) {
+    throw new Error(
+      `Cannot infer a GitHub release tag from mixed target versions: ${versions.join(", ")}. Pass --github-tag explicitly.`,
+    );
+  }
+
+  return versions[0];
+};
+
+const tagExists = (tagName) => {
+  try {
+    readStdout({
+      command: "git",
+      args: ["rev-parse", "--quiet", "--verify", `refs/tags/${tagName}`],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const buildReleaseArgs = ({ tagName, title, notes, notesFile }) => {
+  const args = ["release", "create", tagName, "--title", title];
+
+  if (notesFile) {
+    args.push("--notes-file", notesFile);
+    return args;
+  }
+
+  if (notes) {
+    args.push("--notes", notes);
+    return args;
+  }
+
+  args.push("--generate-notes");
+  return args;
+};
+
+const argv = process.argv.slice(2);
+const targetNames = parseTargetSelection(argv);
+const version = inferVersion(targetNames);
+const tagName = readFlagValue({ argv, flag: "--github-tag" }) ?? `v${version}`;
+const titleVersion = tagName.startsWith("v") ? tagName.slice(1) : version;
+const title = readFlagValue({ argv, flag: "--title" }) ?? `Voyd ${titleVersion}`;
+const notes = readFlagValue({ argv, flag: "--notes" });
+const notesFile = readFlagValue({ argv, flag: "--notes-file" });
+const dryRun = hasFlag({ argv, flag: "--dry-run" });
+const createTag = hasFlag({ argv, flag: "--create-tag" });
+
+if (notesFile && !fs.existsSync(notesFile)) {
+  throw new Error(`GitHub release notes file does not exist: ${notesFile}`);
+}
+
+if (!tagExists(tagName)) {
+  if (!createTag) {
+    throw new Error(
+      `Git tag ${tagName} does not exist. Create it first or pass --create-tag.`,
+    );
+  }
+
+  if (dryRun) {
+    process.stdout.write(`[release] Would create and push git tag ${tagName}\n`);
+  } else {
+    runCommand({ command: "git", args: ["tag", tagName] });
+    runCommand({ command: "git", args: ["push", "origin", tagName] });
+  }
+}
+
+const releaseArgs = buildReleaseArgs({ tagName, title, notes, notesFile });
+
+if (dryRun) {
+  process.stdout.write(`[release] Would run gh ${releaseArgs.join(" ")}\n`);
+} else {
+  runCommand({ command: "gh", args: releaseArgs });
+}

--- a/scripts/release/manifest.mjs
+++ b/scripts/release/manifest.mjs
@@ -26,7 +26,7 @@ export const releaseTargets = {
     cwd: "packages/std",
     description: "Voyd standard library source bundle",
     packRequiredFiles: ["package.json", "src/pkg.voyd", "dist/.placeholder"],
-    relatedTests: ["own", "smoke", "cli-dist"],
+    relatedTests: ["own", "compiler-codegen", "smoke", "cli-dist"],
   }),
   "@voyd-lang/lib": npmTarget({
     workspace: "@voyd-lang/lib",
@@ -40,7 +40,7 @@ export const releaseTargets = {
       "assets/voyd-markdown-injection.json",
     ],
     packForbiddenPatterns: [/^src\//, /^dist\/__tests__\//, /^dist\/.*\/src\//],
-    relatedTests: ["own", "smoke", "cli-dist"],
+    relatedTests: ["own", "compiler-codegen", "smoke", "cli-dist"],
   }),
   "@voyd-lang/compiler": npmTarget({
     workspace: "@voyd-lang/compiler",
@@ -53,7 +53,7 @@ export const releaseTargets = {
       /^dist\/.*\/__tests__\//,
       /\.test\.(d\.ts|d\.ts\.map|js|js\.map)$/,
     ],
-    relatedTests: ["own", "smoke", "cli-dist"],
+    relatedTests: ["own", "compiler-codegen", "smoke", "cli-dist"],
   }),
   "@voyd-lang/js-host": npmTarget({
     workspace: "@voyd-lang/js-host",
@@ -65,7 +65,7 @@ export const releaseTargets = {
       /^dist\/__tests__\//,
       /\.test\.(d\.ts|d\.ts\.map|js|js\.map)$/,
     ],
-    relatedTests: ["own", "smoke", "cli-dist"],
+    relatedTests: ["own", "compiler-codegen", "smoke", "cli-dist"],
   }),
   "@voyd-lang/sdk": npmTarget({
     workspace: "@voyd-lang/sdk",
@@ -85,7 +85,7 @@ export const releaseTargets = {
       /^dist\/.*\/src\//,
       /\.test\.(d\.ts|d\.ts\.map|js|js\.map)$/,
     ],
-    relatedTests: ["own", "smoke", "cli-dist"],
+    relatedTests: ["own", "compiler-codegen", "smoke", "cli-dist"],
   }),
   "@voyd-lang/language-server": npmTarget({
     workspace: "@voyd-lang/language-server",
@@ -126,7 +126,7 @@ export const releaseTargets = {
       "dist/test-runner.js",
     ],
     packForbiddenPatterns: [/^src\//, /^dist\/__tests__\//],
-    relatedTests: ["own", "smoke", "cli-dist"],
+    relatedTests: ["own", "compiler-codegen", "smoke", "cli-dist"],
   }),
   "voyd-vscode": {
     kind: "vscode",

--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -22,6 +22,6 @@ if (options.targetNames.includes("voyd-vscode")) {
   runVscodePublish({
     dryRun: options.dryRun,
     release: options.vscodeRelease,
-    useExistingVersion: Boolean(versionPlan),
+    useExistingVersion: Boolean(versionPlan) || options.useExistingVscodeVersion,
   });
 }

--- a/scripts/release/runner.mjs
+++ b/scripts/release/runner.mjs
@@ -1,4 +1,7 @@
 import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import {
   collectPublishDependencies,
   getTarget,
@@ -94,6 +97,9 @@ const validateExactVersion = (version) => {
   return version;
 };
 
+const stdVersionSourcePath = path.join(repoRoot, "packages/std/src/version.voyd");
+const releaseNpmCache = process.env.NPM_CONFIG_CACHE ?? path.join(os.tmpdir(), "voyd-release-npm-cache");
+
 const resolveVersionPlan = ({ targetNames, bump, version }) => {
   if (!bump && !version) {
     return null;
@@ -143,6 +149,26 @@ const syncInternalDependencyRanges = ({ packageJson, versionPlan }) => {
   return changed;
 };
 
+const syncStdSourceVersion = ({ versionPlan }) => {
+  const nextVersion = versionPlan.get("@voyd-lang/std");
+  if (!nextVersion) {
+    return false;
+  }
+
+  const source = fs.readFileSync(stdVersionSourcePath, "utf8");
+  const updated = source.replace(
+    /(pub fn (?:std_version|language_version)\(\) -> String\s+)"[^"]+"/g,
+    `$1"${nextVersion}"`,
+  );
+
+  if (updated === source) {
+    return false;
+  }
+
+  fs.writeFileSync(stdVersionSourcePath, updated);
+  return true;
+};
+
 export const versionSelectedTargets = ({ targetNames, bump, version }) => {
   const versionPlan = resolveVersionPlan({ targetNames, bump, version });
   if (!versionPlan) {
@@ -177,6 +203,13 @@ export const versionSelectedTargets = ({ targetNames, bump, version }) => {
       nextVersions.push(`${packageJson.name}@${nextOwnVersion}`);
     }
   });
+
+  if (syncStdSourceVersion({ versionPlan })) {
+    changedFiles += 1;
+    process.stdout.write(
+      `[release] Updated packages/std/src/version.voyd for @voyd-lang/std\n`,
+    );
+  }
 
   runCommand({
     command: "npm",
@@ -257,6 +290,9 @@ const validatePackContents = (targetName) => {
       "--workspace",
       target.workspace,
     ],
+    env: {
+      NPM_CONFIG_CACHE: releaseNpmCache,
+    },
   });
   const [packResult] = JSON.parse(raw);
   const filePaths = new Set(packResult.files.map((file) => file.path));
@@ -296,6 +332,14 @@ const runSmokeChecks = (targetNames) => {
   }
 
   npmRunWorkspaceScript({ workspace: "@voyd-lang/smoke", script: "test" });
+};
+
+const runCompilerCodegenChecks = (targetNames) => {
+  if (!needsRelatedTest(targetNames, "compiler-codegen")) {
+    return;
+  }
+
+  npmRunWorkspaceScript({ workspace: "@voyd-lang/compiler", script: "test:codegen" });
 };
 
 const runCliDistChecks = (targetNames) => {
@@ -341,6 +385,7 @@ export const runReleaseCheck = ({ targetNames }) => {
   runTurboClean(targetNames);
   runTurboBuild(targetNames);
   runOwnChecks(targetNames);
+  runCompilerCodegenChecks(targetNames);
   runSmokeChecks(targetNames);
   runCliDistChecks(targetNames);
   runVscodePackageCheck(targetNames);
@@ -358,6 +403,7 @@ export const parseSharedArgs = (argv) => {
     bump: undefined,
     version: undefined,
     vscodeRelease: undefined,
+    useExistingVscodeVersion: argv.includes("--use-existing-vscode-version"),
   };
 
   for (let index = 0; index < argv.length; index += 1) {


### PR DESCRIPTION
## Summary
- add release:cut to version, validate, commit, push, and dispatch the GitHub release workflow
- add GitHub release helper and optional workflow inputs for tag/release creation
- harden release checks with compiler codegen coverage, compiler publish guard, std source version syncing, and isolated npm pack cache
- document the full release path and lower-level recovery commands

## Validation
- npm run typecheck
- npm test
- npm run release:check -- --target @voyd-lang/compiler
- node --check scripts/release/cut.mjs
- node --check scripts/release/runner.mjs
- node --check scripts/release/github-release.mjs
- npm run release:github -- --targets @voyd-lang/std,@voyd-lang/lib --github-tag v0.2.0 --create-tag --dry-run