### PR TITLE
Fix docs anchor scrolling and sticky header offset

### DIFF
--- a/apps/site/app/app.css
+++ b/apps/site/app/app.css
@@ -345,6 +345,13 @@ body {
 }
 
 :root {
+  --site-header-logo-size: 1.75rem;
+  --site-header-block-padding: 0.75rem;
+  --site-anchor-gap: 2rem;
+  --site-header-height: calc(
+    var(--site-header-logo-size) + (var(--site-header-block-padding) * 2) + 1px
+  );
+  --site-anchor-offset: calc(var(--site-header-height) + var(--site-anchor-gap));
   --site-page-bg: #f6f7fb;
   --site-surface: #ffffff;
   --site-surface-soft: #f1f4f9;
@@ -358,6 +365,20 @@ body {
   --site-button-solid-bg: #131f38;
   --site-button-solid-fg: #f4f7ff;
   --site-button-ghost-border: rgba(15, 23, 42, 0.2);
+}
+
+@media (min-width: 640px) {
+  :root {
+    --site-header-block-padding: 1rem;
+  }
+}
+
+.site-header-shell {
+  padding-block: var(--site-header-block-padding);
+}
+
+.docs-article :is(h1, h2, h3, h4, h5, h6) {
+  scroll-margin-top: var(--site-anchor-offset);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/apps/site/app/root.tsx
+++ b/apps/site/app/root.tsx
@@ -174,7 +174,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
               "color-mix(in srgb, var(--site-surface) 86%, transparent)",
           }}
         >
-          <div className="mx-auto w-full max-w-6xl px-4 py-3 sm:py-4">
+          <div className="site-header-shell mx-auto w-full max-w-6xl px-4">
             <div className="flex items-center justify-between gap-3">
               <Link
                 to="/"

--- a/apps/site/app/routes/docs.tsx
+++ b/apps/site/app/routes/docs.tsx
@@ -18,7 +18,13 @@ import {
   type ChangeEvent,
   type ReactNode,
 } from "react";
-import { Link, useHref, useNavigate, useSearchParams } from "react-router";
+import {
+  Link,
+  useHref,
+  useLocation,
+  useNavigate,
+  useSearchParams,
+} from "react-router";
 
 export const prerender = true;
 
@@ -340,10 +346,29 @@ const buildDocHref = ({
   hash?: string;
 }) => `${slug ? `${docsPath}?p=${encodeURIComponent(slug)}` : docsPath}${hash}`;
 
+const safeDecodeHashId = (hash: string) => {
+  const rawId = hash.startsWith("#") ? hash.slice(1) : hash;
+
+  try {
+    return decodeURIComponent(rawId);
+  } catch {
+    return rawId;
+  }
+};
+
+const findHashTarget = (hash: string) => {
+  if (!hash) return null;
+
+  const rawId = hash.startsWith("#") ? hash.slice(1) : hash;
+  const decodedId = safeDecodeHashId(hash);
+  return document.getElementById(decodedId) ?? document.getElementById(rawId);
+};
+
 export default function Docs() {
   const [headings, setHeadings] = useState<Heading[]>([]);
   const navRef = useRef<HTMLDivElement>(null);
   const articleRef = useRef<HTMLDivElement>(null);
+  const location = useLocation();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const docsPath = useHref("/docs");
@@ -430,6 +455,22 @@ export default function Docs() {
       return next;
     });
   }, [doc.slug]);
+
+  useEffect(() => {
+    if (!location.hash) return;
+
+    const scrollToHashTarget = () => {
+      findHashTarget(location.hash)?.scrollIntoView();
+    };
+
+    const frameId = window.requestAnimationFrame(scrollToHashTarget);
+    const timeoutId = window.setTimeout(scrollToHashTarget, 0);
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      window.clearTimeout(timeoutId);
+    };
+  }, [doc.body, location.hash]);
 
   const components: Components = {
     code({ className, children }) {
@@ -720,7 +761,7 @@ export default function Docs() {
 
         <article
           ref={articleRef}
-          className="prose rounded-xl bg-[var(--site-surface)] p-6 max-w-3xl min-w-0 space-y-8 text-[var(--foreground)] prose-headings:text-[var(--foreground)] prose-p:text-[var(--foreground)] prose-li:text-[var(--foreground)] prose-strong:text-[var(--foreground)] prose-a:text-[var(--foreground)] prose-a:underline prose-a:decoration-[var(--site-text-muted)] prose-blockquote:text-[var(--site-text-muted)] prose-hr:border-[var(--site-border)] prose-code:text-[var(--foreground)] prose-code:before:content-none prose-code:after:content-none"
+          className="docs-article prose rounded-xl bg-[var(--site-surface)] p-6 max-w-3xl min-w-0 space-y-8 text-[var(--foreground)] prose-headings:text-[var(--foreground)] prose-p:text-[var(--foreground)] prose-li:text-[var(--foreground)] prose-strong:text-[var(--foreground)] prose-a:text-[var(--foreground)] prose-a:underline prose-a:decoration-[var(--site-text-muted)] prose-blockquote:text-[var(--site-text-muted)] prose-hr:border-[var(--site-border)] prose-code:text-[var(--foreground)] prose-code:before:content-none prose-code:after:content-none"
         >
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}


### PR DESCRIPTION
## Summary
- Restore hash-based scrolling on docs page load and after doc swaps
- Move docs heading offset to shared CSS variables so it tracks the sticky header spacing
- Apply the shared offset to docs headings to keep anchor targets visible below the top bar

## Testing
- `npm -w voyd.dev run typecheck`
- `npm test`
- `npm run typecheck`
- Verified the release anchor on desktop and mobile in the local browser, including the `?p=releases#voyd-v010---sagittarius-a` case