### PR TITLE
Fix npm trusted publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,12 @@ jobs:
           cache-dependency-path: package-lock.json
           registry-url: "https://registry.npmjs.org"
 
+      - name: Use npm trusted-publishing CLI
+        run: |
+          npm install -g npm@^11.5.1
+          node --version
+          npm --version
+
       - run: npm ci --include=optional
 
       - name: Publish selected targets

--- a/docs/release/publishing.md
+++ b/docs/release/publishing.md
@@ -210,6 +210,10 @@ npm view @voyd-lang/reference version
 Voyd uses npm trusted publishing from GitHub Actions. That avoids long-lived npm
 publish tokens for normal releases.
 
+The release workflow must use npm CLI `11.5.1` or newer so `npm publish` can
+authenticate through GitHub Actions OIDC. The workflow installs a compatible npm
+version before running `npm ci` or publishing.
+
 For each npm package, configure trusted publishing on `npmjs.com`:
 
 1. Open the package page while signed in as an owner/maintainer.
@@ -223,6 +227,10 @@ For each npm package, configure trusted publishing on `npmjs.com`:
    - **Environment name**: leave blank
    - **Allowed actions**: allow `npm publish`
 6. Save the trusted publisher.
+
+Only set an npm trusted-publisher environment if the GitHub Actions job declares
+the same `environment:` value. The Voyd release workflow does not currently use
+a GitHub Actions environment, so the npm environment field should stay blank.
 
 Configure these packages:
 


### PR DESCRIPTION
## Summary
- install npm 11.5.1+ in the release workflow before npm ci/publish
- document the npm CLI requirement for trusted publishing
- document that the npm trusted-publisher environment must match the GitHub Actions job environment

## Context
The 0.2.0 release workflow failed publishing @voyd-lang/std@0.2.0 with npm 404s even after package bootstrap and trusted publisher setup. npm trusted publishing requires a compatible npm CLI with OIDC support; the GitHub runner's default npm for Node 22 is not sufficient.

## Verification
- npm test
- npm run typecheck
- git diff --check