### PR TITLE
Install trusted-publishing npm after npm ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,13 +63,13 @@ jobs:
           cache-dependency-path: package-lock.json
           registry-url: "https://registry.npmjs.org"
 
+      - run: npm ci --include=optional
+
       - name: Use npm trusted-publishing CLI
         run: |
           npm install -g npm@^11.5.1
           node --version
           npm --version
-
-      - run: npm ci --include=optional
 
       - name: Publish selected targets
         env:

--- a/docs/release/publishing.md
+++ b/docs/release/publishing.md
@@ -212,7 +212,9 @@ publish tokens for normal releases.
 
 The release workflow must use npm CLI `11.5.1` or newer so `npm publish` can
 authenticate through GitHub Actions OIDC. The workflow installs a compatible npm
-version before running `npm ci` or publishing.
+version after `npm ci` and before publishing. Dependency installation still uses
+the runner's bundled npm so `npm ci` stays compatible with the committed
+lockfile.
 
 For each npm package, configure trusted publishing on `npmjs.com`:
 


### PR DESCRIPTION
## Summary
- keep dependency installation on the runner's bundled npm
- install npm 11.5.1+ only after npm ci, immediately before publishing
- clarify the release docs around npm ci vs trusted-publishing npm

## Context
The previous trusted-publishing hotfix installed npm 11 before npm ci. The next release attempt failed quickly because npm 11 enforced optional dependency entries missing from the current lockfile. We still need npm 11.5.1+ for trusted publishing, but only for npm publish.

## Verification
- npm test
- npm run typecheck
- git diff --check