### PR TITLE
Add npm provenance repository metadata

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,6 +4,10 @@
   "private": false,
   "description": "Voyd CLI",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyd-lang/voyd"
+  },
   "bin": {
     "voyd": "./bin/voyd.js",
     "vt": "./bin/vt.js"

--- a/docs/release/publishing.md
+++ b/docs/release/publishing.md
@@ -216,6 +216,10 @@ version after `npm ci` and before publishing. Dependency installation still uses
 the runner's bundled npm so `npm ci` stays compatible with the committed
 lockfile.
 
+Each published npm workspace must also set `repository.url` to
+`https://github.com/voyd-lang/voyd`. npm validates that package metadata against
+the GitHub Actions provenance bundle when trusted publishing is enabled.
+
 For each npm package, configure trusted publishing on `npmjs.com`:
 
 1. Open the package page while signed in as an owner/maintainer.

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -4,6 +4,10 @@
   "description": "Voyd compiler",
   "type": "module",
   "main": "./dist/pipeline.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyd-lang/voyd"
+  },
   "files": [
     "dist"
   ],

--- a/packages/js-host/package.json
+++ b/packages/js-host/package.json
@@ -4,6 +4,10 @@
   "description": "Voyd JS host runtime",
   "type": "module",
   "main": "./dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyd-lang/voyd"
+  },
   "files": [
     "dist"
   ],

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -4,6 +4,10 @@
   "description": "Voyd language server",
   "type": "module",
   "main": "./dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyd-lang/voyd"
+  },
   "files": [
     "dist"
   ],

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -3,6 +3,10 @@
   "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyd-lang/voyd"
+  },
   "files": [
     "dist",
     "assets"

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyd-lang/voyd"
+  },
   "files": [
     "dist",
     "index.d.ts"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -4,6 +4,10 @@
   "description": "Voyd SDK",
   "type": "module",
   "main": "./dist/node.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyd-lang/voyd"
+  },
   "files": [
     "dist"
   ],

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -3,6 +3,10 @@
   "version": "0.2.0",
   "private": false,
   "description": "Voyd standard library sources",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyd-lang/voyd"
+  },
   "files": [
     "src",
     "dist"

--- a/scripts/release/runner.mjs
+++ b/scripts/release/runner.mjs
@@ -99,6 +99,7 @@ const validateExactVersion = (version) => {
 
 const stdVersionSourcePath = path.join(repoRoot, "packages/std/src/version.voyd");
 const releaseNpmCache = process.env.NPM_CONFIG_CACHE ?? path.join(os.tmpdir(), "voyd-release-npm-cache");
+const provenanceRepositoryUrl = "https://github.com/voyd-lang/voyd";
 
 const resolveVersionPlan = ({ targetNames, bump, version }) => {
   if (!bump && !version) {
@@ -314,6 +315,30 @@ const validatePackContents = (targetName) => {
   }
 };
 
+const readRepositoryUrl = (packageJson) => {
+  if (typeof packageJson.repository === "string") {
+    return packageJson.repository;
+  }
+
+  return packageJson.repository?.url;
+};
+
+const validateNpmPackageMetadata = (targetName) => {
+  const target = getTarget(targetName);
+  if (target.kind !== "npm") {
+    return;
+  }
+
+  const packageJson = readTargetPackageJson(targetName);
+  const repositoryUrl = readRepositoryUrl(packageJson);
+
+  if (repositoryUrl !== provenanceRepositoryUrl) {
+    throw new Error(
+      `${targetName} package.json repository.url must be ${provenanceRepositoryUrl} for npm provenance publishing.`,
+    );
+  }
+};
+
 const runOwnChecks = (targetNames) => {
   targetNames.forEach((targetName) => {
     const target = getTarget(targetName);
@@ -382,6 +407,7 @@ const runVscodePackageCheck = (targetNames) => {
 };
 
 export const runReleaseCheck = ({ targetNames }) => {
+  targetNames.forEach(validateNpmPackageMetadata);
   runTurboClean(targetNames);
   runTurboBuild(targetNames);
   runOwnChecks(targetNames);


### PR DESCRIPTION
## Summary
- add repository metadata to every npm release target package.json
- add a release preflight check for the provenance repository URL
- document the npm provenance metadata requirement

## Context
The 0.2.0 release now reaches npm trusted publishing and signs provenance, but npm rejects @voyd-lang/std because package.json repository.url is empty. The registry expects package metadata to match the GitHub source repository from the provenance bundle: https://github.com/voyd-lang/voyd.

## Verification
- npm test
- npm run typecheck
- git diff --check
- NPM_CONFIG_CACHE=/private/tmp/voyd-release-npm-cache node ./scripts/release/publish-targets.mjs --targets @voyd-lang/std --dry-run --allow-dirty
- manifest sanity check for all npm release targets