### PR TITLE
Add typed boundary SDK exports

### DIFF
--- a/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export-collision.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export-collision.voyd
@@ -1,0 +1,13 @@
+obj Point {
+  x: i32,
+  y: i32
+}
+
+pub fn translate(point: Point, dx: i32, dy: i32) -> Point
+  Point {
+    x: point.x + dx,
+    y: point.y + dy
+  }
+
+pub fn __voyd_serialized_export_translate() -> i32
+  7

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export.voyd
@@ -1,0 +1,38 @@
+use std::array::Array
+use std::enums::{ enum }
+use std::string::type::String
+
+obj Point {
+  x: i32,
+  y: i32
+}
+
+enum LookupResult
+  Found { value: String }
+  Missing
+
+pub fn translate(point: Point, dx: i32, dy: i32) -> Point
+  Point {
+    x: point.x + dx,
+    y: point.y + dy
+  }
+
+pub fn get_point() -> { x: i32, y: i32 }
+  { x: 1, y: 2 }
+
+pub fn lookup(key: String) -> LookupResult
+  if key == "name" then:
+    LookupResult::Found { value: "Ada" }
+  else:
+    LookupResult::Missing {}
+
+pub fn sum_values(values: Array<i32>) -> i32
+  var index = 0
+  var total = 0
+  while index < values.len():
+    total = total + values.at(index)
+    index = index + 1
+  total
+
+pub fn call_callback(callback: fn() -> i32) -> i32
+  callback()

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-tag-collision.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-tag-collision.voyd
@@ -1,0 +1,9 @@
+use std::enums::{ enum }
+use std::string::type::String
+
+enum TaggedResult
+  Tagged { tag: String }
+  Other {}
+
+pub fn tagged_result() -> TaggedResult
+  TaggedResult::Tagged { tag: "payload" }

--- a/packages/compiler/src/codegen/__tests__/codegen.test.ts
+++ b/packages/compiler/src/codegen/__tests__/codegen.test.ts
@@ -139,6 +139,7 @@ const DEFAULT_OPTIONS = {
   effectsHostBoundary: "off",
   linearMemoryExport: "always",
   effectsMemoryExport: "auto",
+  boundaryExports: false,
   testScope: "all",
 } as const;
 

--- a/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
+++ b/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
@@ -75,6 +75,7 @@ const buildLoweringSnapshot = () => {
       effectsHostBoundary: "off",
       linearMemoryExport: "always",
       effectsMemoryExport: "auto",
+      boundaryExports: false,
       testScope: "all",
     },
     programHelpers,

--- a/packages/compiler/src/codegen/__tests__/export-abi.test.ts
+++ b/packages/compiler/src/codegen/__tests__/export-abi.test.ts
@@ -7,6 +7,10 @@ import { wasmBufferSource } from "./support/wasm-utils.js";
 import type { CodegenOptions } from "../context.js";
 
 const fixtureRoot = resolve(import.meta.dirname, "__fixtures__");
+const smokeFixtureRoot = resolve(
+  import.meta.dirname,
+  "../../../../../apps/smoke/fixtures",
+);
 const stdRoot = resolve(import.meta.dirname, "../../../../std/src");
 const buildModuleCache = new Map<string, Promise<Uint8Array>>();
 
@@ -128,5 +132,214 @@ describe("export abi metadata", { timeout: 60_000 }, () => {
     expect(abi.exports).toEqual([
       { name: "fetch", abi: "serialized", formatId: "msgpack" },
     ]);
+  });
+
+  it("emits schema metadata and distinct wrappers for automatic boundary exports", async () => {
+    const wasm = await buildModule({
+      entryFile: "boundary-export.voyd",
+      codegenOptions: { boundaryExports: "auto" },
+    });
+    const module = new WebAssembly.Module(wasmBufferSource(wasm));
+    const abi = parseExportAbi(module);
+    const exports = WebAssembly.Module.exports(module).map((entry) => entry.name);
+
+    expect(exports).toContain("translate");
+    expect(exports).toContain("__voyd_serialized_export_translate");
+    expect(abi.exports).not.toContainEqual(
+      expect.objectContaining({ name: "call_callback", abi: "serialized" }),
+    );
+    expect(abi.exports).toEqual([
+      expect.objectContaining({
+        name: "get_point",
+        abi: "serialized",
+        wrapperName: "__voyd_serialized_export_get_point",
+        params: [],
+        result: expect.objectContaining({ kind: "record" }),
+      }),
+      expect.objectContaining({
+        name: "lookup",
+        abi: "serialized",
+        wrapperName: "__voyd_serialized_export_lookup",
+        params: [expect.objectContaining({ kind: "string" })],
+        result: expect.objectContaining({ kind: "union" }),
+      }),
+      expect.objectContaining({
+        name: "sum_values",
+        abi: "serialized",
+        wrapperName: "__voyd_serialized_export_sum_values",
+        params: [expect.objectContaining({ kind: "array" })],
+        result: expect.objectContaining({ kind: "i32" }),
+      }),
+      expect.objectContaining({
+        name: "translate",
+        abi: "serialized",
+        wrapperName: "__voyd_serialized_export_translate",
+        params: [
+          expect.objectContaining({ kind: "record" }),
+          expect.objectContaining({ kind: "i32" }),
+          expect.objectContaining({ kind: "i32" }),
+        ],
+        result: expect.objectContaining({ kind: "record" }),
+      }),
+    ]);
+  });
+
+  it.each([false, "off"] as const)(
+    "leaves automatic boundary exports off when disabled with %s",
+    async (boundaryExports) => {
+      const wasm = await buildModule({
+        entryFile: "boundary-export.voyd",
+        codegenOptions: { boundaryExports },
+      });
+      const module = new WebAssembly.Module(wasmBufferSource(wasm));
+      const abi = parseExportAbi(module);
+      const exports = WebAssembly.Module.exports(module).map((entry) => entry.name);
+
+      expect(exports).toContain("translate");
+      expect(exports).not.toContain("__voyd_serialized_export_translate");
+      expect(abi.exports).toContainEqual({ name: "translate", abi: "direct" });
+    },
+  );
+
+  it("reports diagnostics for unsupported explicitly requested boundary exports", async () => {
+    const result = await compileProgram({
+      entryPath: resolve(fixtureRoot, "boundary-export.voyd"),
+      roots: { src: fixtureRoot, std: stdRoot },
+      host: createFsModuleHost(),
+      codegenOptions: {
+        boundaryExports: { mode: "only", include: ["call_callback"] },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected explicit boundary export compile failure");
+    }
+    expect(
+      result.diagnostics.some((diagnostic) =>
+        diagnostic.message.includes("typed boundary export call_callback"),
+      ),
+    ).toBe(true);
+  });
+
+  it("reports diagnostics for unsupported included exports in explicit auto mode", async () => {
+    const result = await compileProgram({
+      entryPath: resolve(fixtureRoot, "boundary-export.voyd"),
+      roots: { src: fixtureRoot, std: stdRoot },
+      host: createFsModuleHost(),
+      codegenOptions: {
+        boundaryExports: {
+          mode: "auto",
+          include: ["call_callback"],
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected included boundary export compile failure");
+    }
+    expect(
+      result.diagnostics.some((diagnostic) =>
+        diagnostic.message.includes(
+          "typed boundary export call_callback was requested but was not emitted",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("treats include-only boundary export options as explicit requests", async () => {
+    const result = await compileProgram({
+      entryPath: resolve(fixtureRoot, "boundary-export.voyd"),
+      roots: { src: fixtureRoot, std: stdRoot },
+      host: createFsModuleHost(),
+      codegenOptions: {
+        boundaryExports: { include: ["missing_export"] },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected include-only boundary export compile failure");
+    }
+    expect(
+      result.diagnostics.some((diagnostic) =>
+        diagnostic.message.includes(
+          "typed boundary export missing_export was requested but was not emitted",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("counts VX lifecycle special serialized exports as explicit boundary includes", async () => {
+    const result = await compileProgram({
+      entryPath: resolve(smokeFixtureRoot, "vx-typed-counter.voyd"),
+      roots: { src: smokeFixtureRoot, std: stdRoot },
+      host: createFsModuleHost(),
+      codegenOptions: {
+        boundaryExports: { include: ["view"] },
+      },
+    });
+
+    const compiled = expectCompileSuccess(result);
+    if (!compiled.wasm) {
+      throw new Error("missing wasm output");
+    }
+    const module = new WebAssembly.Module(wasmBufferSource(compiled.wasm));
+    const abi = parseExportAbi(module);
+    const view = abi.exports.find((entry) => entry.name === "view");
+
+    expect(view).toEqual(
+      expect.objectContaining({
+        name: "view",
+        abi: "serialized",
+        formatId: "msgpack",
+        params: [expect.objectContaining({ kind: "record" })],
+      }),
+    );
+  });
+
+  it("avoids wrapper export name collisions with user exports", async () => {
+    const wasm = await buildModule({
+      entryFile: "boundary-export-collision.voyd",
+      codegenOptions: { boundaryExports: "auto" },
+    });
+    const module = new WebAssembly.Module(wasmBufferSource(wasm));
+    const abi = parseExportAbi(module);
+    const exports = WebAssembly.Module.exports(module).map((entry) => entry.name);
+    const translate = abi.exports.find((entry) => entry.name === "translate");
+
+    expect(exports).toContain("translate");
+    expect(exports).toContain("__voyd_serialized_export_translate");
+    expect(exports).toContain("__voyd_serialized_export_translate_1");
+    expect(translate).toEqual(
+      expect.objectContaining({
+        abi: "serialized",
+        wrapperName: "__voyd_serialized_export_translate_1",
+      }),
+    );
+  });
+
+  it("reports diagnostics for variant payload fields that collide with the JS tag discriminator", async () => {
+    const result = await compileProgram({
+      entryPath: resolve(fixtureRoot, "boundary-tag-collision.voyd"),
+      roots: { src: fixtureRoot, std: stdRoot },
+      host: createFsModuleHost(),
+      codegenOptions: {
+        boundaryExports: { include: ["tagged_result"] },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected tag collision boundary export compile failure");
+    }
+    expect(
+      result.diagnostics.some((diagnostic) =>
+        diagnostic.message.includes(
+          'variant payload fields named "tag" conflict with the JS boundary discriminator',
+        ),
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/compiler/src/codegen/__tests__/support/test-codegen-context.ts
+++ b/packages/compiler/src/codegen/__tests__/support/test-codegen-context.ts
@@ -162,6 +162,7 @@ export const createTestCodegenContext = (): {
       effectsHostBoundary: "off",
       linearMemoryExport: "always",
       effectsMemoryExport: "auto",
+      boundaryExports: false,
       testScope: "all",
     },
     programHelpers,

--- a/packages/compiler/src/codegen/boundary/msgpack-codec.ts
+++ b/packages/compiler/src/codegen/boundary/msgpack-codec.ts
@@ -70,12 +70,18 @@ export const packBoundaryValueAsMsgPack = ({
       return ctx.mod.call(msgpack.makeF32.wasmName, [value], msgPackType);
     case "f64":
       return ctx.mod.call(msgpack.makeF64.wasmName, [value], msgPackType);
-    case "void":
+    case "void": {
+      const valueType = binaryen.getExpressionType(value);
+      const valueOp =
+        valueType === binaryen.none || valueType === binaryen.unreachable
+          ? value
+          : ctx.mod.drop(value);
       return ctx.mod.block(
         null,
-        [ctx.mod.drop(value), ctx.mod.call(msgpack.makeNull.wasmName, [], msgPackType)],
+        [valueOp, ctx.mod.call(msgpack.makeNull.wasmName, [], msgPackType)],
         msgPackType,
       );
+    }
     case "string":
       return ctx.mod.call(
         msgpack.makeString.wasmName,

--- a/packages/compiler/src/codegen/boundary/schema.ts
+++ b/packages/compiler/src/codegen/boundary/schema.ts
@@ -181,6 +181,8 @@ export const formatBoundaryType = ({
 const DTO_SUMMARY =
   "boundary-compatible DTO values are bool, i32, i64, f32, f64, String, Array<T>, records/objects with boundary-compatible non-private fields, and named enum/union variants with boundary-compatible fields";
 
+const RESERVED_VARIANT_FIELD_NAMES = new Set(["tag", "$variant"]);
+
 const deriveBoundarySchemaInternal = ({
   typeId,
   ctx,
@@ -332,6 +334,20 @@ const deriveRecordSchema = ({
       reason: "record/object layout is not available at the boundary",
     });
   }
+  const standaloneTag = options.tagStandaloneVariants
+    ? ctx.program.types.getStandaloneVariantTag(typeId)
+    : undefined;
+  const reservedStandaloneVariantField = standaloneTag
+    ? reservedVariantField(info.fields)
+    : undefined;
+  if (reservedStandaloneVariantField) {
+    unsupported({
+      typeId,
+      ctx,
+      path: `${path}.${reservedStandaloneVariantField.name}`,
+      reason: `variant payload fields named "${reservedStandaloneVariantField.name}" conflict with the JS boundary discriminator`,
+    });
+  }
   const fields = deriveBoundaryFields({
     ownerTypeId: typeId,
     fields: info.fields,
@@ -344,9 +360,7 @@ const deriveRecordSchema = ({
     kind: "record",
     typeId,
     name: formatBoundaryType({ typeId, ctx }),
-    tag: options.tagStandaloneVariants
-      ? ctx.program.types.getStandaloneVariantTag(typeId)
-      : undefined,
+    tag: standaloneTag,
     fields,
   };
 };
@@ -439,16 +453,26 @@ const deriveUnionSchema = ({
         reason: "union variant layout is not available at the boundary",
       });
     }
+    const name = variantName({ typeId: member, ctx });
+    const reservedField = reservedVariantField(info.fields);
+    if (reservedField) {
+      unsupported({
+        typeId: member,
+        ctx,
+        path: `${path}.${name}.${reservedField.name}`,
+        reason: `variant payload fields named "${reservedField.name}" conflict with the JS boundary discriminator`,
+      });
+    }
     return {
-      name: variantName({ typeId: member, ctx }),
+      name,
       typeId: member,
       fields: deriveBoundaryFields({
         ownerTypeId: member,
         fields: info.fields,
         ctx,
-        path: `${path}.${variantName({ typeId: member, ctx })}`,
+        path: `${path}.${name}`,
         active,
-        options: { tagStandaloneVariants: false },
+        options: { tagStandaloneVariants: true },
       }),
     };
   });
@@ -459,6 +483,11 @@ const deriveUnionSchema = ({
     variants,
   };
 };
+
+const reservedVariantField = (
+  fields: readonly StructuralFieldInfo[],
+): StructuralFieldInfo | undefined =>
+  fields.find((field) => RESERVED_VARIANT_FIELD_NAMES.has(field.name));
 
 const primitiveSchema = ({
   typeId,

--- a/packages/compiler/src/codegen/codegen.ts
+++ b/packages/compiler/src/codegen/codegen.ts
@@ -62,6 +62,7 @@ const DEFAULT_OPTIONS: Required<CodegenOptions> = {
   effectsHostBoundary: "msgpack",
   linearMemoryExport: "always",
   effectsMemoryExport: "auto",
+  boundaryExports: false,
   continuationBackend: {},
   testMode: false,
   testScope: "all",
@@ -310,6 +311,7 @@ const normalizeCodegenOptions = (
     options.linearMemoryExport ?? DEFAULT_OPTIONS.linearMemoryExport,
   effectsMemoryExport:
     options.effectsMemoryExport ?? DEFAULT_OPTIONS.effectsMemoryExport,
+  boundaryExports: options.boundaryExports ?? DEFAULT_OPTIONS.boundaryExports,
   continuationBackend: {
     ...DEFAULT_OPTIONS.continuationBackend,
     ...(options.continuationBackend ?? {}),

--- a/packages/compiler/src/codegen/context.ts
+++ b/packages/compiler/src/codegen/context.ts
@@ -57,10 +57,21 @@ export interface CodegenOptions {
   effectsHostBoundary?: "msgpack" | "off";
   linearMemoryExport?: "always" | "auto" | "off";
   effectsMemoryExport?: "auto" | "always" | "off";
+  boundaryExports?: BoundaryExportsOption;
   continuationBackend?: ContinuationBackendOptions;
   testMode?: boolean;
   testScope?: "all" | "entry";
 }
+
+export type BoundaryExportsOption =
+  | "auto"
+  | "off"
+  | false
+  | {
+      mode?: "auto" | "off" | "only";
+      include?: string[];
+      onUnsupported?: "skip" | "diagnostic";
+    };
 
 export interface CodegenResult {
   module: binaryen.Module;

--- a/packages/compiler/src/codegen/exports/export-abi.ts
+++ b/packages/compiler/src/codegen/exports/export-abi.ts
@@ -1,12 +1,21 @@
 import type binaryen from "binaryen";
+import type { BoundarySchema } from "../boundary/schema.js";
 
 export const EXPORT_ABI_SECTION = "voyd.export_abi";
 
-export type ExportAbiEntry = {
-  name: string;
-  abi: "direct" | "serialized";
-  formatId?: string;
-};
+export type ExportAbiEntry =
+  | {
+      name: string;
+      abi: "direct";
+    }
+  | {
+      name: string;
+      abi: "serialized";
+      formatId: "msgpack";
+      wrapperName?: string;
+      params?: readonly BoundarySchema[];
+      result?: BoundarySchema;
+    };
 
 export const emitExportAbiSection = ({
   mod,

--- a/packages/compiler/src/codegen/exports/serialized-abi.ts
+++ b/packages/compiler/src/codegen/exports/serialized-abi.ts
@@ -4,21 +4,17 @@ import type {
   CodegenContext,
   FunctionContext,
   FunctionMetadata,
-  StructuralFieldInfo,
   TypeId,
 } from "../context.js";
-import type { ProgramSymbolId } from "../../semantics/ids.js";
 import { findSerializerForType } from "../serializer.js";
 import {
   coerceValueToType,
   liftHeapValueToInline,
-  loadStructuralField,
   storeValueIntoStorageRef,
 } from "../structural.js";
 import {
   abiTypeFor,
   getSignatureSpillBoxType,
-  getStructuralTypeInfo,
   wasmTypeFor,
 } from "../types.js";
 import { ensureLinearMemoryExport } from "../memory-exports.js";
@@ -39,17 +35,35 @@ import {
   unboxSignatureSpillValue,
 } from "../signature-spill.js";
 
+export type SerializedExportTypeAdapter = {
+  acceptsType?: (params: {
+    typeId: TypeId;
+    ctx: CodegenContext;
+  }) => boolean;
+  packResultValue?: (params: {
+    value: binaryen.ExpressionRef;
+    typeId: TypeId;
+    ctx: CodegenContext;
+    fnCtx: FunctionContext;
+    exportName: string;
+  }) => binaryen.ExpressionRef | undefined;
+};
+
 export const emitSerializedExportWrapper = ({
   ctx,
   meta,
   exportName,
+  wrapperExportName = exportName,
+  typeAdapter,
 }: {
   ctx: CodegenContext;
   meta: FunctionMetadata;
   exportName: string;
+  wrapperExportName?: string;
+  typeAdapter?: SerializedExportTypeAdapter;
 }): { wrapperName: string; formatId: "msgpack" } => {
   ensureLinearMemoryExport(ctx);
-  validateExportTypes({ ctx, meta, exportName });
+  validateExportTypes({ ctx, meta, exportName, typeAdapter });
 
   const msgpack = ensureMsgPackFunctions(ctx);
   const msgPackType = wasmTypeFor(msgpack.msgPackTypeId, ctx);
@@ -172,6 +186,7 @@ export const emitSerializedExportWrapper = ({
     ctx,
     fnCtx,
     exportName,
+    typeAdapter,
   });
   const encodedLength = ctx.mod.call(
     msgpack.encodeValue.wasmName,
@@ -199,8 +214,8 @@ export const emitSerializedExportWrapper = ({
     ])
   );
 
-  ctx.mod.addFunctionExport(wrapperName, exportName);
-  return { wrapperName, formatId: "msgpack" };
+  ctx.mod.addFunctionExport(wrapperName, wrapperExportName);
+  return { wrapperName: wrapperExportName, formatId: "msgpack" };
 };
 
 const lowerSerializedExportCall = ({
@@ -433,10 +448,12 @@ const validateExportTypes = ({
   ctx,
   meta,
   exportName,
+  typeAdapter,
 }: {
   ctx: CodegenContext;
   meta: FunctionMetadata;
   exportName: string;
+  typeAdapter?: SerializedExportTypeAdapter;
 }): void => {
   const allTypes = [...meta.paramTypeIds, meta.resultTypeId];
   allTypes.forEach((typeId, index) => {
@@ -449,7 +466,7 @@ const validateExportTypes = ({
       }
       return;
     }
-    if (isVxMsgPackAlias(typeId, ctx) || vxPayloadField(typeId, ctx)) {
+    if (typeAdapter?.acceptsType?.({ typeId, ctx }) === true) {
       return;
     }
     const target = index < meta.paramTypeIds.length ? `parameter ${index + 1}` : "return";
@@ -467,12 +484,14 @@ const packSerializedResultValue = ({
   ctx,
   fnCtx,
   exportName,
+  typeAdapter,
 }: {
   value: binaryen.ExpressionRef;
   typeId: TypeId;
   ctx: CodegenContext;
   fnCtx: FunctionContext;
   exportName: string;
+  typeAdapter?: SerializedExportTypeAdapter;
 }): binaryen.ExpressionRef => {
   const msgpack = ensureMsgPackFunctions(ctx);
   const serializer = findSerializerForType(typeId, ctx);
@@ -490,21 +509,15 @@ const packSerializedResultValue = ({
       fnCtx,
     });
   }
-  if (isVxMsgPackAlias(typeId, ctx)) {
-    return value;
-  }
-  const payloadField = vxPayloadField(typeId, ctx);
-  if (payloadField) {
-    const info = getStructuralTypeInfo(typeId, ctx);
-    if (!info) {
-      throw new Error(`VX payload envelope ${typeId} is missing structural info`);
-    }
-    return loadStructuralField({
-      structInfo: info,
-      field: payloadField,
-      pointer: () => value,
-      ctx,
-    });
+  const adapted = typeAdapter?.packResultValue?.({
+    value,
+    typeId,
+    ctx,
+    fnCtx,
+    exportName,
+  });
+  if (adapted) {
+    return adapted;
   }
   return packBoundaryValueAsMsgPack({
     value,
@@ -516,69 +529,6 @@ const packSerializedResultValue = ({
     ctx,
     fnCtx,
   });
-};
-
-const VX_MSGPACK_ALIAS_NAMES = new Set(["Html", "Attr", "Program"]);
-const VX_PAYLOAD_ENVELOPE_NAMES = new Set(["Cmd", "Sub"]);
-const VX_STD_MODULE_ID = "std::vx";
-
-const isStdVxSymbolNamed = (
-  symbol: ProgramSymbolId,
-  names: ReadonlySet<string>,
-  ctx: CodegenContext,
-): boolean =>
-  ctx.program.symbols.refOf(symbol).moduleId === VX_STD_MODULE_ID &&
-  names.has(ctx.program.symbols.getName(symbol) ?? "");
-
-const isVxMsgPackAlias = (typeId: TypeId, ctx: CodegenContext): boolean =>
-  ctx.program.types
-    .getAliasSymbols(typeId)
-    .some((symbol) => isStdVxSymbolNamed(symbol, VX_MSGPACK_ALIAS_NAMES, ctx));
-
-const vxPayloadField = (
-  typeId: TypeId,
-  ctx: CodegenContext,
-): StructuralFieldInfo | undefined => {
-  if (!nominalTypeSymbolIsStdVxNamed(typeId, VX_PAYLOAD_ENVELOPE_NAMES, ctx)) {
-    return undefined;
-  }
-  const info = getStructuralTypeInfo(typeId, ctx);
-  const payload = info?.fieldMap.get("payload");
-  if (!payload) {
-    return undefined;
-  }
-  const serializer = findSerializerForType(payload.typeId, ctx);
-  return serializer?.formatId === "msgpack" ? payload : undefined;
-};
-
-const nominalTypeName = (
-  typeId: TypeId,
-  ctx: CodegenContext,
-): string | undefined => {
-  const desc = ctx.program.types.getTypeDesc(typeId);
-  if (desc.kind === "nominal-object" || desc.kind === "value-object") {
-    return desc.name;
-  }
-  if (desc.kind === "intersection" && typeof desc.nominal === "number") {
-    return nominalTypeName(desc.nominal, ctx);
-  }
-  return undefined;
-};
-
-const nominalTypeSymbolIsStdVxNamed = (
-  typeId: TypeId,
-  names: ReadonlySet<string>,
-  ctx: CodegenContext,
-): boolean => {
-  const desc = ctx.program.types.getTypeDesc(typeId);
-  const nominal =
-    desc.kind === "intersection" && typeof desc.nominal === "number"
-      ? ctx.program.types.getTypeDesc(desc.nominal)
-      : desc;
-  if (nominal.kind !== "nominal-object" && nominal.kind !== "value-object") {
-    return false;
-  }
-  return isStdVxSymbolNamed(nominal.owner, names, ctx);
 };
 
 const sanitizeIdentifier = (value: string): string =>

--- a/packages/compiler/src/codegen/expressions/call/entrypoints.ts
+++ b/packages/compiler/src/codegen/expressions/call/entrypoints.ts
@@ -540,7 +540,8 @@ const shouldCompileIntrinsicCall = ({
   intrinsicName: string;
   usesSignature: boolean;
 }): boolean =>
-  usesSignature !== true || intrinsicName === "__vx_retain_event_handler";
+  usesSignature !== true ||
+  intrinsicName === "__boundary_retain_callback";
 
 const resolveTargetFunctionId = ({
   targets,

--- a/packages/compiler/src/codegen/functions.ts
+++ b/packages/compiler/src/codegen/functions.ts
@@ -58,11 +58,17 @@ import {
   emitExportAbiSection,
   type ExportAbiEntry,
 } from "./exports/export-abi.js";
+import {
+  BoundarySchemaError,
+  deriveBoundarySchema,
+  type BoundarySchema,
+} from "./boundary/schema.js";
 import { resolveSerializerForTypes } from "./serializer.js";
 import type { EffectfulExportTarget } from "./effects/codegen-backend.js";
 import { walkHirExpression } from "./hir-walk.js";
 import { markDependencyFunctionReachable } from "./function-dependencies.js";
 import { boxSignatureSpillValue, unboxSignatureSpillValue } from "./signature-spill.js";
+import { createSerializedExportSpecialCaseResolver } from "./serialized-export-special-cases.js";
 
 const REACHABILITY_STATE = Symbol.for("voyd.codegen.reachabilityState");
 const FUNCTION_METADATA_REGISTRATION_STATE = Symbol.for(
@@ -75,6 +81,12 @@ type ReachabilityState = {
 
 type FunctionMetadataRegistrationState = {
   active?: boolean;
+};
+
+type ResolvedBoundaryExportOptions = {
+  mode: "auto" | "off" | "only";
+  include?: ReadonlySet<string>;
+  onUnsupported: "skip" | "diagnostic";
 };
 
 const debugEffects = (): boolean =>
@@ -129,97 +141,112 @@ const userParamOffsetFor = (meta: FunctionMetadata): number => meta.userParamOff
 const firstUserParamIndexFor = (meta: FunctionMetadata): number =>
   meta.firstUserParamIndex;
 
-const VX_BOUNDARY_EXPORT_NAMES = new Set([
-  "init",
-  "update",
-  "view",
-  "subscriptions",
-]);
-
-const isVxBoundaryExportName = (exportName: string): boolean =>
-  VX_BOUNDARY_EXPORT_NAMES.has(exportName);
-
-const VX_MSGPACK_ALIAS_NAMES = new Set(["Html", "Program"]);
-const VX_PAYLOAD_ENVELOPE_NAMES = new Set(["Sub"]);
-const VX_STD_MODULE_ID = "std::vx";
-
-const isStdVxSymbolNamed = (
-  symbol: ProgramSymbolId,
-  names: ReadonlySet<string>,
+const resolveBoundaryExportOptions = (
   ctx: CodegenContext,
-): boolean =>
-  ctx.program.symbols.refOf(symbol).moduleId === VX_STD_MODULE_ID &&
-  names.has(ctx.program.symbols.getName(symbol) ?? "");
-
-const hasTypeAliasNamed = (
-  typeId: TypeId,
-  names: ReadonlySet<string>,
-  ctx: CodegenContext,
-): boolean =>
-  ctx.program.types
-    .getAliasSymbols(typeId)
-    .some((symbol) => isStdVxSymbolNamed(symbol, names, ctx));
-
-const nominalTypeName = (
-  typeId: TypeId,
-  ctx: CodegenContext,
-): string | undefined => {
-  const desc = ctx.program.types.getTypeDesc(typeId);
-  if (desc.kind === "nominal-object" || desc.kind === "value-object") {
-    return desc.name;
+): ResolvedBoundaryExportOptions => {
+  const option = ctx.options.boundaryExports;
+  if (option === false || option === "off") {
+    return { mode: "off", onUnsupported: "skip" };
   }
-  if (desc.kind === "intersection" && typeof desc.nominal === "number") {
-    return nominalTypeName(desc.nominal, ctx);
+  if (option === "auto") {
+    return { mode: "auto", onUnsupported: "skip" };
   }
-  return undefined;
+  const mode = option.mode ?? (option.include ? "only" : "auto");
+  return {
+    mode,
+    include: option.include ? new Set(option.include) : undefined,
+    onUnsupported:
+      option.onUnsupported ??
+      (mode === "only" || option.include ? "diagnostic" : "skip"),
+  };
 };
 
-const nominalTypeSymbolIsStdVxNamed = (
-  typeId: TypeId,
-  names: ReadonlySet<string>,
-  ctx: CodegenContext,
-): boolean => {
-  const desc = ctx.program.types.getTypeDesc(typeId);
-  const nominal =
-    desc.kind === "intersection" && typeof desc.nominal === "number"
-      ? ctx.program.types.getTypeDesc(desc.nominal)
-      : desc;
-  if (nominal.kind !== "nominal-object" && nominal.kind !== "value-object") {
-    return false;
-  }
-  return isStdVxSymbolNamed(nominal.owner, names, ctx);
-};
-
-const isVxPayloadEnvelope = (typeId: TypeId, ctx: CodegenContext): boolean =>
-  nominalTypeSymbolIsStdVxNamed(typeId, VX_PAYLOAD_ENVELOPE_NAMES, ctx);
-
-const isVxViewBoundaryMeta = (meta: FunctionMetadata, ctx: CodegenContext): boolean =>
-  meta.paramTypeIds.length === 1 &&
-  hasTypeAliasNamed(meta.resultTypeId, VX_MSGPACK_ALIAS_NAMES, ctx);
-
-const isVxSubscriptionsBoundaryMeta = (
-  meta: FunctionMetadata,
-  ctx: CodegenContext,
-): boolean =>
-  meta.paramTypeIds.length === 1 && isVxPayloadEnvelope(meta.resultTypeId, ctx);
-
-const shouldEmitVxBoundaryWrapper = ({
+const shouldConsiderBoundaryExport = ({
   exportName,
-  meta,
-  moduleHasVxAppShape,
-  ctx,
+  options,
 }: {
   exportName: string;
-  meta: FunctionMetadata;
-  moduleHasVxAppShape: boolean;
-  ctx: CodegenContext;
+  options: ResolvedBoundaryExportOptions;
 }): boolean => {
-  if (!isVxBoundaryExportName(exportName)) return false;
-  if (exportName === "view") return isVxViewBoundaryMeta(meta, ctx);
-  if (exportName === "subscriptions") return isVxSubscriptionsBoundaryMeta(meta, ctx);
-  if (exportName === "init") return moduleHasVxAppShape && meta.paramTypeIds.length === 0;
-  if (exportName === "update") return moduleHasVxAppShape && meta.paramTypeIds.length === 2;
-  return false;
+  if (options.mode === "off") return false;
+  if (options.include && !options.include.has(exportName)) return false;
+  if (options.mode === "only") return options.include?.has(exportName) ?? false;
+  return true;
+};
+
+const boundarySchemasForExport = ({
+  ctx,
+  meta,
+  exportName,
+}: {
+  ctx: CodegenContext;
+  meta: FunctionMetadata;
+  exportName: string;
+}): { params: BoundarySchema[]; result: BoundarySchema } => ({
+  params: meta.paramTypeIds.map((typeId, index) =>
+    deriveBoundarySchema({
+      typeId,
+      ctx,
+      label: `${exportName} arg${index}`,
+      options: { tagStandaloneVariants: true },
+    }),
+  ),
+  result: deriveBoundarySchema({
+    typeId: meta.resultTypeId,
+    ctx,
+    label: `${exportName} result`,
+    options: { tagStandaloneVariants: true },
+  }),
+});
+
+const reportBoundaryExportUnsupported = ({
+  ctx,
+  entry,
+  exportName,
+  error,
+}: {
+  ctx: CodegenContext;
+  entry: HirExportEntry;
+  exportName: string;
+  error: unknown;
+}): void => {
+  const message =
+    error instanceof BoundarySchemaError || error instanceof Error
+      ? error.message
+      : String(error);
+  ctx.diagnostics.report(
+    diagnosticFromCode({
+      code: "CG0001",
+      params: {
+        kind: "codegen-error",
+        message: `typed boundary export ${exportName} is not supported: ${message}`,
+      },
+      span: entry.span,
+    }),
+  );
+};
+
+const allocateBoundaryWrapperExportName = ({
+  ctx,
+  exportName,
+  reservedExportNames,
+}: {
+  ctx: CodegenContext;
+  exportName: string;
+  reservedExportNames: ReadonlySet<string>;
+}): string => {
+  const baseName = `__voyd_serialized_export_${sanitizeIdentifier(exportName)}`;
+  let index = 0;
+  while (true) {
+    const candidate = index === 0 ? baseName : `${baseName}_${index}`;
+    index += 1;
+    if (reservedExportNames.has(candidate)) {
+      continue;
+    }
+    if (ctx.programHelpers.registerExportName(candidate)) {
+      return candidate;
+    }
+  }
 };
 
 const makeAbiValue = (
@@ -1206,6 +1233,8 @@ export const emitModuleExports = (
 ): void => {
   const effectfulExports: EffectfulExportTarget[] = [];
   const exportAbiEntries: ExportAbiEntry[] = [];
+  const boundaryExportOptions = resolveBoundaryExportOptions(ctx);
+  const emittedBoundaryExports = new Set<string>();
 
   const emitEffectfulWasmExportWrapper = ({
     ctx: exportCtx,
@@ -1239,8 +1268,21 @@ export const emitModuleExports = (
   const testScope = ctx.options.testScope ?? "all";
   const exportContexts =
     ctx.options.testMode && testScope === "all" ? contexts : [ctx];
+  const reservedExportNames = new Set<string>();
   exportContexts.forEach((exportCtx) => {
     const exportEntries = getModuleExportEntries(exportCtx);
+    exportEntries.forEach((entry) => {
+      const baseExportName =
+        entry.alias ?? symbolName(exportCtx, exportCtx.moduleId, entry.symbol);
+      reservedExportNames.add(
+        exportCtx.options.testMode
+          ? formatTestExportName({
+              moduleId: exportCtx.moduleId,
+              testId: baseExportName,
+            })
+          : baseExportName,
+      );
+    });
     const metaForEntry = (entry: HirExportEntry): FunctionMetadata | undefined => {
       const metas = getFunctionMetas(
         exportCtx,
@@ -1249,16 +1291,12 @@ export const emitModuleExports = (
       );
       return metas?.find((candidate) => candidate.typeArgs.length === 0) ?? metas?.[0];
     };
-    const moduleHasVxAppShape = exportEntries.some((entry) => {
-      const exportName =
-        entry.alias ?? symbolName(exportCtx, exportCtx.moduleId, entry.symbol);
-      const meta = metaForEntry(entry);
-      if (!meta) return false;
-      return (
-        (exportName === "view" && isVxViewBoundaryMeta(meta, exportCtx)) ||
-        (exportName === "subscriptions" &&
-          isVxSubscriptionsBoundaryMeta(meta, exportCtx))
-      );
+    const resolveSpecialSerializedExport = createSerializedExportSpecialCaseResolver({
+      entries: exportEntries,
+      exportNameForEntry: (entry) =>
+        entry.alias ?? symbolName(exportCtx, exportCtx.moduleId, entry.symbol),
+      metaForEntry,
+      ctx: exportCtx,
     });
 
     exportEntries.forEach((entry) => {
@@ -1346,24 +1384,36 @@ export const emitModuleExports = (
         return;
       }
 
-      const shouldUseVxBoundary = shouldEmitVxBoundaryWrapper({
+      const specialSerializedExport = resolveSpecialSerializedExport({
         exportName,
         meta,
-        moduleHasVxAppShape,
-        ctx: exportCtx,
       });
 
-      if (serializer || shouldUseVxBoundary) {
+      if (serializer || specialSerializedExport) {
         if (serializer) {
           markSerializerReachable({ ctx: exportCtx, serializer });
         }
         try {
-          emitSerializedExportWrapper({ ctx: exportCtx, meta, exportName });
+          emitSerializedExportWrapper({
+            ctx: exportCtx,
+            meta,
+            exportName,
+            typeAdapter: specialSerializedExport?.typeAdapter,
+          });
           exportAbiEntries.push({
             name: exportName,
             abi: "serialized",
             formatId: "msgpack",
+            ...(specialSerializedExport?.params
+              ? { params: specialSerializedExport.params }
+              : {}),
+            ...(specialSerializedExport?.result
+              ? { result: specialSerializedExport.result }
+              : {}),
           });
+          if (specialSerializedExport) {
+            emittedBoundaryExports.add(exportName);
+          }
         } catch (error) {
           exportCtx.diagnostics.report(
             diagnosticFromCode({
@@ -1380,9 +1430,73 @@ export const emitModuleExports = (
       }
 
       exportCtx.mod.addFunctionExport(meta.wasmName, exportName);
+      if (
+        !exportCtx.options.testMode &&
+        shouldConsiderBoundaryExport({
+          exportName,
+          options: boundaryExportOptions,
+        })
+      ) {
+        try {
+          const schemas = boundarySchemasForExport({
+            ctx: exportCtx,
+            meta,
+            exportName,
+          });
+          const wrapperExportName = allocateBoundaryWrapperExportName({
+            ctx: exportCtx,
+            exportName,
+            reservedExportNames,
+          });
+          const wrapper = emitSerializedExportWrapper({
+            ctx: exportCtx,
+            meta,
+            exportName,
+            wrapperExportName,
+          });
+          exportAbiEntries.push({
+            name: exportName,
+            abi: "serialized",
+            wrapperName: wrapper.wrapperName,
+            formatId: wrapper.formatId,
+            params: schemas.params,
+            result: schemas.result,
+          });
+          emittedBoundaryExports.add(exportName);
+          return;
+        } catch (error) {
+          if (
+            boundaryExportOptions.mode === "only" ||
+            boundaryExportOptions.onUnsupported === "diagnostic"
+          ) {
+            reportBoundaryExportUnsupported({
+              ctx: exportCtx,
+              entry,
+              exportName,
+              error,
+            });
+          }
+        }
+      }
       exportAbiEntries.push({ name: exportName, abi: "direct" });
     });
   });
+
+  if (boundaryExportOptions.include) {
+    boundaryExportOptions.include?.forEach((name) => {
+      if (emittedBoundaryExports.has(name)) return;
+      ctx.diagnostics.report(
+        diagnosticFromCode({
+          code: "CG0001",
+          params: {
+            kind: "codegen-error",
+            message: `typed boundary export ${name} was requested but was not emitted`,
+          },
+          span: ctx.module.hir.module.span,
+        }),
+      );
+    });
+  }
 
   if (exportAbiEntries.length > 0) {
     emitExportAbiSection({ mod: ctx.mod, entries: exportAbiEntries });

--- a/packages/compiler/src/codegen/intrinsics.ts
+++ b/packages/compiler/src/codegen/intrinsics.ts
@@ -104,9 +104,9 @@ const PANIC_SCRATCH_CAPACITY_GLOBAL = "__voyd_panic_scratch_capacity";
 const TASK_IMPORT_MODULE = "voyd.task";
 const TASK_IMPORTS_KEY = Symbol("voyd.task.imports");
 const TASK_STARTERS_KEY = Symbol("voyd.task.starters");
-const VX_CALLBACK_IMPORT_MODULE = "voyd.vx.callback";
-const VX_CALLBACK_IMPORTS_KEY = Symbol("voyd.vx.callback.imports");
-const VX_CALLBACK_HELPERS_KEY = Symbol("voyd.vx.callback.helpers");
+const BOUNDARY_CALLBACK_IMPORT_MODULE = "voyd.boundary.callback";
+const BOUNDARY_CALLBACK_IMPORTS_KEY = Symbol("voyd.boundary.callback.imports");
+const BOUNDARY_CALLBACK_HELPERS_KEY = Symbol("voyd.boundary.callback.helpers");
 
 const ensurePanicTrapGlobals = (ctx: CodegenContext): void => {
   if (ctx.mod.getGlobal(PANIC_TRAP_PTR_GLOBAL) === 0) {
@@ -179,7 +179,7 @@ const ensureTaskImport = ({
   return name;
 };
 
-const ensureVxCallbackImport = ({
+const ensureBoundaryCallbackImport = ({
   name,
   base,
   params,
@@ -193,7 +193,7 @@ const ensureVxCallbackImport = ({
   ctx: CodegenContext;
 }): string => {
   const imports = ctx.programHelpers.getHelperState(
-    VX_CALLBACK_IMPORTS_KEY,
+    BOUNDARY_CALLBACK_IMPORTS_KEY,
     () => new Set<string>()
   );
   if (imports.has(name)) {
@@ -201,7 +201,7 @@ const ensureVxCallbackImport = ({
   }
   ctx.mod.addFunctionImport(
     name,
-    VX_CALLBACK_IMPORT_MODULE,
+    BOUNDARY_CALLBACK_IMPORT_MODULE,
     base,
     binaryen.createType(params as number[]),
     result
@@ -295,7 +295,7 @@ const ensureTaskStarterHelper = ({
   return exportName;
 };
 
-const ensureVxEventCallbackHelper = ({
+const ensureBoundaryRetainedCallbackHelper = ({
   closureTypeId,
   ctx,
 }: {
@@ -303,7 +303,7 @@ const ensureVxEventCallbackHelper = ({
   ctx: CodegenContext;
 }): string => {
   const helpers = ctx.programHelpers.getHelperState(
-    VX_CALLBACK_HELPERS_KEY,
+    BOUNDARY_CALLBACK_HELPERS_KEY,
     () => new Map<number, string>()
   );
   const cached = helpers.get(closureTypeId);
@@ -313,10 +313,10 @@ const ensureVxEventCallbackHelper = ({
 
   const desc = ctx.program.types.getTypeDesc(closureTypeId);
   if (desc.kind !== "function") {
-    throw new Error("VX event handler retention requires a function value");
+    throw new Error("boundary callback retention requires a function value");
   }
   if (desc.parameters.length > 1) {
-    throw new Error("VX event handler retention supports fn() -> Msg or fn(Event) -> Msg");
+    throw new Error("boundary callback retention supports fn() -> Msg or fn(Event) -> Msg");
   }
   ensureLinearMemoryExport(ctx);
   const msgpack = ensureMsgPackFunctions(ctx);
@@ -327,7 +327,7 @@ const ensureVxEventCallbackHelper = ({
       : undefined;
   if (parameterSerializer && parameterSerializer.formatId !== "msgpack") {
     throw new Error(
-      `VX event handler parameter serializer format ${parameterSerializer.formatId} is not supported`
+      `boundary callback parameter serializer format ${parameterSerializer.formatId} is not supported`
     );
   }
   const parameterSchema =
@@ -335,7 +335,7 @@ const ensureVxEventCallbackHelper = ({
       ? deriveBoundarySchema({
           typeId: parameterTypeId,
           ctx,
-          label: "VX event handler parameter",
+          label: "boundary callback parameter",
         })
       : undefined;
   const returnWasmType = wasmTypeFor(desc.returnType, ctx);
@@ -345,7 +345,7 @@ const ensureVxEventCallbackHelper = ({
     : findSerializerForType(desc.returnType, ctx);
   if (returnSerializer && returnSerializer.formatId !== "msgpack") {
     throw new Error(
-      `VX event handler return serializer format ${returnSerializer.formatId} is not supported`
+      `boundary callback return serializer format ${returnSerializer.formatId} is not supported`
     );
   }
   const returnSchema = returnSerializer || returnsVoid
@@ -353,7 +353,7 @@ const ensureVxEventCallbackHelper = ({
     : deriveBoundarySchema({
         typeId: desc.returnType,
         ctx,
-        label: "VX event handler return",
+        label: "boundary callback return",
       });
   const effectful =
     typeof desc.effectRow === "number" &&
@@ -361,7 +361,7 @@ const ensureVxEventCallbackHelper = ({
 
   const msgPackType = wasmTypeFor(msgpack.msgPackTypeId, ctx);
   const base = getClosureTypeInfo(closureTypeId, ctx);
-  const exportName = `__voyd_vx_event_callback_${sanitizeTaskKey(base.key)}`;
+  const exportName = `__voyd_boundary_callback_${sanitizeTaskKey(base.key)}`;
   const locals: binaryen.Type[] = [];
   const helperFnCtx: FunctionContext = {
     bindings: new Map(),
@@ -1190,22 +1190,22 @@ export const compileIntrinsicCall = ({
         ctx,
       });
     }
-    case "__vx_retain_event_handler": {
+    case "__boundary_retain_callback": {
       assertArgCount(name, args, 1);
       const handlerTypeId = getRequiredExprType(call.args[0]!.expr, ctx, instanceId);
       const handlerType = ctx.program.types.getTypeDesc(handlerTypeId);
       if (handlerType.kind !== "function") {
-        throw new Error("__vx_retain_event_handler requires a function-typed value");
+        throw new Error(`${name} requires a function-typed value`);
       }
-      const helperExport = ensureVxEventCallbackHelper({
+      const helperExport = ensureBoundaryRetainedCallbackHelper({
         closureTypeId: handlerTypeId,
         ctx,
       });
       const closureInfo = getClosureTypeInfo(handlerTypeId, ctx);
-      const importName = `__voyd_vx_retain_event_handler_${sanitizeTaskKey(helperExport)}`;
-      const importFn = ensureVxCallbackImport({
+      const importName = `__voyd_boundary_retain_callback_${sanitizeTaskKey(helperExport)}`;
+      const importFn = ensureBoundaryCallbackImport({
         name: importName,
-        base: `retain_event__${helperExport}`,
+        base: `retain_callback__${helperExport}`,
         params: [closureInfo.interfaceType],
         result: binaryen.i32,
         ctx,

--- a/packages/compiler/src/codegen/serialized-export-special-cases.ts
+++ b/packages/compiler/src/codegen/serialized-export-special-cases.ts
@@ -1,0 +1,118 @@
+import type { CodegenContext, FunctionMetadata, TypeId } from "./context.js";
+import {
+  BoundarySchemaError,
+  deriveBoundarySchema,
+  type BoundarySchema,
+} from "./boundary/schema.js";
+import {
+  createVxLifecycleSerializedExportPredicate,
+  vxSerializedExportTypeAdapter,
+} from "./vx-boundary-contract.js";
+import { findSerializerForType } from "./serializer.js";
+import type { SerializedExportTypeAdapter } from "./exports/serialized-abi.js";
+
+export type SerializedExportSpecialCase = {
+  typeAdapter?: SerializedExportTypeAdapter;
+  params?: readonly BoundarySchema[];
+  result?: BoundarySchema;
+};
+
+export const createSerializedExportSpecialCaseResolver = <Entry>({
+  entries,
+  exportNameForEntry,
+  metaForEntry,
+  ctx,
+}: {
+  entries: readonly Entry[];
+  exportNameForEntry: (entry: Entry) => string;
+  metaForEntry: (entry: Entry) => FunctionMetadata | undefined;
+  ctx: CodegenContext;
+}): ((params: {
+  exportName: string;
+  meta: FunctionMetadata;
+}) => SerializedExportSpecialCase | undefined) => {
+  const isVxLifecycleExport = createVxLifecycleSerializedExportPredicate({
+    entries,
+    exportNameForEntry,
+    metaForEntry,
+    ctx,
+  });
+  return ({ exportName, meta }) => {
+    if (!isVxLifecycleExport({ exportName, meta })) {
+      return undefined;
+    }
+    return {
+      typeAdapter: vxSerializedExportTypeAdapter,
+      ...boundaryMetadataFor({
+        exportName,
+        meta,
+        ctx,
+        typeAdapter: vxSerializedExportTypeAdapter,
+      }),
+    };
+  };
+};
+
+const boundaryMetadataFor = ({
+  exportName,
+  meta,
+  ctx,
+  typeAdapter,
+}: {
+  exportName: string;
+  meta: FunctionMetadata;
+  ctx: CodegenContext;
+  typeAdapter?: SerializedExportTypeAdapter;
+}): Pick<SerializedExportSpecialCase, "params" | "result"> => {
+  const params = meta.paramTypeIds.map((typeId, index) =>
+    schemaForSpecialSerializedType({
+      typeId,
+      ctx,
+      typeAdapter,
+      label: `${exportName} arg${index}`,
+    }),
+  );
+  const result = schemaForSpecialSerializedType({
+    typeId: meta.resultTypeId,
+    ctx,
+    typeAdapter,
+    label: `${exportName} result`,
+  });
+  return {
+    ...(params.every((schema): schema is BoundarySchema => schema !== undefined)
+      ? { params }
+      : {}),
+    ...(result ? { result } : {}),
+  };
+};
+
+const schemaForSpecialSerializedType = ({
+  typeId,
+  ctx,
+  typeAdapter,
+  label,
+}: {
+  typeId: TypeId;
+  ctx: CodegenContext;
+  typeAdapter?: SerializedExportTypeAdapter;
+  label: string;
+}): BoundarySchema | undefined => {
+  if (findSerializerForType(typeId, ctx)) {
+    return undefined;
+  }
+  if (typeAdapter?.acceptsType?.({ typeId, ctx }) === true) {
+    return undefined;
+  }
+  try {
+    return deriveBoundarySchema({
+      typeId,
+      ctx,
+      label,
+    });
+  } catch (error) {
+    if (error instanceof BoundarySchemaError) {
+      return undefined;
+    }
+    throw error;
+  }
+};

--- a/packages/compiler/src/codegen/vx-boundary-contract.ts
+++ b/packages/compiler/src/codegen/vx-boundary-contract.ts
@@ -1,0 +1,181 @@
+import type {
+  CodegenContext,
+  FunctionMetadata,
+  StructuralFieldInfo,
+  TypeId,
+} from "./context.js";
+import type { ProgramSymbolId } from "../semantics/ids.js";
+import { loadStructuralField } from "./structural.js";
+import { getStructuralTypeInfo } from "./types.js";
+import { findSerializerForType } from "./serializer.js";
+import type { SerializedExportTypeAdapter } from "./exports/serialized-abi.js";
+
+const VX_BOUNDARY_EXPORT_NAMES = new Set([
+  "init",
+  "update",
+  "view",
+  "subscriptions",
+]);
+const VX_SERIALIZED_ALIAS_NAMES = new Set(["Html", "Attr", "Program"]);
+const VX_LIFECYCLE_ALIAS_NAMES = new Set(["Html", "Program"]);
+const VX_SERIALIZED_PAYLOAD_ENVELOPE_NAMES = new Set(["Cmd", "Sub"]);
+const VX_LIFECYCLE_PAYLOAD_ENVELOPE_NAMES = new Set(["Sub"]);
+const VX_STD_MODULE_ID = "std::vx";
+
+export const createVxLifecycleSerializedExportPredicate = <Entry>({
+  entries,
+  exportNameForEntry,
+  metaForEntry,
+  ctx,
+}: {
+  entries: readonly Entry[];
+  exportNameForEntry: (entry: Entry) => string;
+  metaForEntry: (entry: Entry) => FunctionMetadata | undefined;
+  ctx: CodegenContext;
+}): ((params: {
+  exportName: string;
+  meta: FunctionMetadata;
+}) => boolean) => {
+  const moduleHasVxAppShape = entries.some((entry) => {
+    const exportName = exportNameForEntry(entry);
+    const meta = metaForEntry(entry);
+    if (!meta) return false;
+    return isVxAppShapeExport({ exportName, meta, ctx });
+  });
+  return ({ exportName, meta }) =>
+    shouldEmitVxLifecycleSerializedWrapper({
+      exportName,
+      meta,
+      moduleHasVxAppShape,
+      ctx,
+    });
+};
+
+const shouldEmitVxLifecycleSerializedWrapper = ({
+  exportName,
+  meta,
+  moduleHasVxAppShape,
+  ctx,
+}: {
+  exportName: string;
+  meta: FunctionMetadata;
+  moduleHasVxAppShape: boolean;
+  ctx: CodegenContext;
+}): boolean => {
+  if (!VX_BOUNDARY_EXPORT_NAMES.has(exportName)) return false;
+  if (exportName === "view") return isVxViewLifecycleMeta(meta, ctx);
+  if (exportName === "subscriptions") {
+    return isVxSubscriptionsLifecycleMeta(meta, ctx);
+  }
+  if (exportName === "init") return moduleHasVxAppShape && meta.paramTypeIds.length === 0;
+  if (exportName === "update") return moduleHasVxAppShape && meta.paramTypeIds.length === 2;
+  return false;
+};
+
+const isVxAppShapeExport = ({
+  exportName,
+  meta,
+  ctx,
+}: {
+  exportName: string;
+  meta: FunctionMetadata;
+  ctx: CodegenContext;
+}): boolean =>
+  (exportName === "view" && isVxViewLifecycleMeta(meta, ctx)) ||
+  (exportName === "subscriptions" && isVxSubscriptionsLifecycleMeta(meta, ctx));
+
+const isVxViewLifecycleMeta = (
+  meta: FunctionMetadata,
+  ctx: CodegenContext,
+): boolean =>
+  meta.paramTypeIds.length === 1 &&
+  hasTypeAliasNamed(meta.resultTypeId, VX_LIFECYCLE_ALIAS_NAMES, ctx);
+
+const isVxSubscriptionsLifecycleMeta = (
+  meta: FunctionMetadata,
+  ctx: CodegenContext,
+): boolean =>
+  meta.paramTypeIds.length === 1 &&
+  isVxPayloadEnvelopeNamed(meta.resultTypeId, VX_LIFECYCLE_PAYLOAD_ENVELOPE_NAMES, ctx);
+
+export const vxSerializedExportTypeAdapter: SerializedExportTypeAdapter = {
+  acceptsType: ({ typeId, ctx }) =>
+    isVxSerializedAlias(typeId, ctx) || vxSerializedPayloadField(typeId, ctx) !== undefined,
+  packResultValue: ({ value, typeId, ctx }) => {
+    if (isVxSerializedAlias(typeId, ctx)) {
+      return value;
+    }
+    const payloadField = vxSerializedPayloadField(typeId, ctx);
+    if (!payloadField) {
+      return undefined;
+    }
+    const info = getStructuralTypeInfo(typeId, ctx);
+    if (!info) {
+      throw new Error(`VX payload envelope ${typeId} is missing structural info`);
+    }
+    return loadStructuralField({
+      structInfo: info,
+      field: payloadField,
+      pointer: () => value,
+      ctx,
+    });
+  },
+};
+
+const hasTypeAliasNamed = (
+  typeId: TypeId,
+  names: ReadonlySet<string>,
+  ctx: CodegenContext,
+): boolean =>
+  ctx.program.types
+    .getAliasSymbols(typeId)
+    .some((symbol) => isStdVxSymbolNamed(symbol, names, ctx));
+
+const isVxSerializedAlias = (typeId: TypeId, ctx: CodegenContext): boolean =>
+  hasTypeAliasNamed(typeId, VX_SERIALIZED_ALIAS_NAMES, ctx);
+
+const isVxPayloadEnvelopeNamed = (
+  typeId: TypeId,
+  names: ReadonlySet<string>,
+  ctx: CodegenContext,
+): boolean => nominalTypeSymbolIsStdVxNamed(typeId, names, ctx);
+
+const vxSerializedPayloadField = (
+  typeId: TypeId,
+  ctx: CodegenContext,
+): StructuralFieldInfo | undefined => {
+  if (!isVxPayloadEnvelopeNamed(typeId, VX_SERIALIZED_PAYLOAD_ENVELOPE_NAMES, ctx)) {
+    return undefined;
+  }
+  const info = getStructuralTypeInfo(typeId, ctx);
+  const payload = info?.fieldMap.get("payload");
+  if (!payload) {
+    return undefined;
+  }
+  const serializer = findSerializerForType(payload.typeId, ctx);
+  return serializer?.formatId === "msgpack" ? payload : undefined;
+};
+
+const isStdVxSymbolNamed = (
+  symbol: ProgramSymbolId,
+  names: ReadonlySet<string>,
+  ctx: CodegenContext,
+): boolean =>
+  ctx.program.symbols.refOf(symbol).moduleId === VX_STD_MODULE_ID &&
+  names.has(ctx.program.symbols.getName(symbol) ?? "");
+
+const nominalTypeSymbolIsStdVxNamed = (
+  typeId: TypeId,
+  names: ReadonlySet<string>,
+  ctx: CodegenContext,
+): boolean => {
+  const desc = ctx.program.types.getTypeDesc(typeId);
+  const nominal =
+    desc.kind === "intersection" && typeof desc.nominal === "number"
+      ? ctx.program.types.getTypeDesc(desc.nominal)
+      : desc;
+  if (nominal.kind !== "nominal-object" && nominal.kind !== "value-object") {
+    return false;
+  }
+  return isStdVxSymbolNamed(nominal.owner, names, ctx);
+};

--- a/packages/compiler/src/semantics/codegen-view/index.ts
+++ b/packages/compiler/src/semantics/codegen-view/index.ts
@@ -50,6 +50,7 @@ import { buildProgramSymbolArena } from "../program-symbol-arena.js";
 import type { ProgramSymbolArena, SymbolRef } from "../program-symbol-arena.js";
 import { createCanonicalSymbolRefResolver } from "../canonical-symbol-ref.js";
 import { parseSymbolRefKey } from "../typing/symbol-ref-utils.js";
+import { enumNamespaceMemberNamesFromMetadata } from "../enum-namespace.js";
 
 export type { SymbolRef } from "../program-symbol-arena.js";
 
@@ -511,6 +512,8 @@ export const buildProgramCodegenView = (
     TypeId,
     Set<ProgramSymbolId>
   >();
+  const standaloneVariantMemberTypes = new Set<TypeId>();
+  const standaloneVariantOwners = new Set<ProgramSymbolId>();
 
   const traitImplsByNominal = new Map<TypeId, CodegenTraitImplInstance[]>();
   const traitImplsByTrait = new Map<
@@ -602,22 +605,72 @@ export const buildProgramCodegenView = (
     standaloneVariantAliasesByType.set(typeId, bucket);
   };
 
+  const collectStandaloneVariantMembersForTarget = (typeId: TypeId): void => {
+    const desc = arena.get(typeId);
+    if (desc.kind !== "union") return;
+    desc.members.forEach((member) => {
+      const memberDesc = arena.get(member);
+      if (memberDesc.kind === "union") {
+        collectStandaloneVariantMembersForTarget(member);
+        return;
+      }
+      standaloneVariantMemberTypes.add(member);
+      if (
+        memberDesc.kind === "intersection" &&
+        typeof memberDesc.nominal === "number"
+      ) {
+        standaloneVariantMemberTypes.add(memberDesc.nominal);
+      }
+    });
+  };
+
   const addStandaloneVariantAliasForTarget = (
+    typeId: TypeId,
+    aliasSymbols: Iterable<ProgramSymbolId>,
+  ): void => {
+    const desc = arena.get(typeId);
+    if (desc.kind !== "union") {
+      if (standaloneVariantMemberTypes.has(typeId)) {
+        addStandaloneVariantAliasForUnionMember(typeId, aliasSymbols);
+      }
+      return;
+    }
+    desc.members.forEach((member) =>
+      addStandaloneVariantAliasForUnionMember(member, aliasSymbols),
+    );
+  };
+
+  const addStandaloneVariantAliasForUnionMember = (
     typeId: TypeId,
     aliasSymbols: Iterable<ProgramSymbolId>,
   ): void => {
     const desc = arena.get(typeId);
     if (desc.kind === "union") {
       desc.members.forEach((member) =>
-        addStandaloneVariantAliasForTarget(member, aliasSymbols),
+        addStandaloneVariantAliasForUnionMember(member, aliasSymbols),
       );
       return;
     }
+    standaloneVariantMemberTypes.add(typeId);
     if (desc.kind === "intersection" && typeof desc.nominal === "number") {
+      standaloneVariantMemberTypes.add(desc.nominal);
       addStandaloneVariantAlias(desc.nominal, aliasSymbols);
     }
     addStandaloneVariantAlias(typeId, aliasSymbols);
   };
+
+  aliasSymbolsByType.forEach((_, typeId) => {
+    collectStandaloneVariantMembersForTarget(typeId);
+  });
+
+  stableModules.forEach((mod) => {
+    for (const template of mod.typing.typeAliases.templates()) {
+      if (typeof template.target.typeId !== "number") {
+        continue;
+      }
+      collectStandaloneVariantMembersForTarget(template.target.typeId);
+    }
+  });
 
   aliasSymbolsByType.forEach((symbolSet, typeId) => {
     addStandaloneVariantAliasForTarget(typeId, symbolSet);
@@ -1112,6 +1165,80 @@ export const buildProgramCodegenView = (
     symbol: SymbolId,
   ): ProgramSymbolId => symbols.idOf(canonicalSymbolRef({ moduleId, symbol }));
 
+  const isObjectTypeRecord = (
+    record: ReturnType<ReturnType<typeof getSymbolTable>["getSymbol"]>,
+  ): boolean => {
+    const metadata = (record.metadata ?? {}) as { entity?: unknown };
+    return record.kind === "type" && metadata.entity === "object";
+  };
+
+  const addStandaloneVariantOwner = (
+    moduleId: string,
+    symbol: SymbolId,
+  ): void => {
+    standaloneVariantOwners.add(canonicalProgramSymbolIdOf(moduleId, symbol));
+  };
+
+  const addStandaloneVariantOwnersFromEnumAlias = (
+    mod: SemanticsPipelineResult,
+    aliasSymbol: SymbolId,
+    targetTypeId: TypeId | undefined,
+  ): void => {
+    if (typeof targetTypeId !== "number") {
+      return;
+    }
+    const targetDesc = arena.get(targetTypeId);
+    if (targetDesc.kind !== "union") {
+      return;
+    }
+    const symbolTable = getSymbolTable(mod);
+    const aliasRecord = symbolTable.getSymbol(aliasSymbol);
+    const metadata = (aliasRecord.metadata ?? {}) as Record<string, unknown>;
+    const memberNames = enumNamespaceMemberNamesFromMetadata(metadata);
+    if (!memberNames || memberNames.length === 0) {
+      return;
+    }
+
+    memberNames.forEach((name) => {
+      const local = symbolTable.resolveWhere(
+        name,
+        symbolTable.rootScope,
+        isObjectTypeRecord,
+      );
+      if (typeof local === "number") {
+        addStandaloneVariantOwner(mod.moduleId, local);
+      }
+    });
+
+    const importMetadata = metadata.import as
+      | { moduleId?: unknown; symbol?: unknown }
+      | undefined;
+    const importedModuleId = importMetadata?.moduleId;
+    if (typeof importedModuleId !== "string") {
+      return;
+    }
+    const importedModule = modulesById.get(importedModuleId);
+    if (!importedModule) {
+      return;
+    }
+    const importedSymbolTable = getSymbolTable(importedModule);
+    memberNames.forEach((name) => {
+      const exported = importedModule.exports.get(name)?.symbol;
+      if (typeof exported === "number") {
+        addStandaloneVariantOwner(importedModule.moduleId, exported);
+        return;
+      }
+      const local = importedSymbolTable.resolveWhere(
+        name,
+        importedSymbolTable.rootScope,
+        isObjectTypeRecord,
+      );
+      if (typeof local === "number") {
+        addStandaloneVariantOwner(importedModule.moduleId, local);
+      }
+    });
+  };
+
   const toCodegenTraitImplInstanceForModule = (
     impl: TraitImplInstance,
     moduleId: string,
@@ -1166,6 +1293,14 @@ export const buildProgramCodegenView = (
           toCodegenObjectTemplate({ template, symbol: ownerId }),
         );
       }
+    }
+
+    for (const template of mod.typing.typeAliases.templates()) {
+      addStandaloneVariantOwnersFromEnumAlias(
+        mod,
+        template.symbol,
+        template.target.typeId,
+      );
     }
 
     const objectInfos =
@@ -1873,17 +2008,14 @@ export const buildProgramCodegenView = (
       if (!nominalDesc.name) {
         return undefined;
       }
-      const aliases =
-        standaloneVariantAliasesByType.get(typeId) ??
-        standaloneVariantAliasesByType.get(nominalTypeId);
-      if (!aliases || aliases.size === 0) {
-        return undefined;
-      }
-      const hasDistinctAlias = Array.from(aliases).some((alias) => {
-        const aliasName = symbols.getName(alias);
-        return Boolean(aliasName && aliasName !== nominalDesc.name);
-      });
-      return hasDistinctAlias ? nominalDesc.name : undefined;
+      const owner = symbols.tryIdOf(canonicalSymbolRef(nominalDesc.owner));
+      const isEnumNamespaceMember =
+        typeof owner === "number" && standaloneVariantOwners.has(owner);
+      return isEnumNamespaceMember ||
+        standaloneVariantMemberTypes.has(typeId) ||
+        standaloneVariantMemberTypes.has(nominalTypeId)
+        ? nominalDesc.name
+        : undefined;
     },
   };
 

--- a/packages/compiler/src/semantics/enum-namespace.ts
+++ b/packages/compiler/src/semantics/enum-namespace.ts
@@ -185,6 +185,14 @@ export const enumVariantTypeNamesFromAliasTarget = (
   return dedupeEnumNamespaceMembers(collected).map((entry) => entry.name);
 };
 
+export const enumNamespaceMemberNamesFromMetadata = (
+  source?: Record<string, unknown>,
+): string[] | undefined => {
+  const meta = source as { enumNamespaceMembers?: unknown } | undefined;
+  const members = enumNamespaceMembersFromUnknown(meta?.enumNamespaceMembers);
+  return members?.map((entry) => entry.name);
+};
+
 const collectUnionNominalMembers = (
   expr: Expr | undefined,
 ): EnumNamespaceMember[] | undefined => {

--- a/packages/compiler/src/semantics/intrinsics.ts
+++ b/packages/compiler/src/semantics/intrinsics.ts
@@ -62,7 +62,7 @@ const VALUE_INTRINSICS = new Map<string, IntrinsicValueMetadata>([
     { intrinsicUsesSignature: false, access: "std-only" },
   ],
   [
-    "__vx_retain_event_handler",
+    "__boundary_retain_callback",
     { intrinsicUsesSignature: false, access: "std-only" },
   ],
   [

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -5552,8 +5552,9 @@ const typeIntrinsicCall = (
         typeArguments,
         expectedReturnType,
       });
-    case "__vx_retain_event_handler":
-      return typeVxRetainEventHandlerIntrinsic({
+    case "__boundary_retain_callback":
+      return typeBoundaryRetainCallbackIntrinsic({
+        name,
         args,
         ctx,
         typeArguments,
@@ -6350,26 +6351,28 @@ const typeTaskCancelIntrinsic = ({
   return ctx.primitives.bool;
 };
 
-const typeVxRetainEventHandlerIntrinsic = ({
+const typeBoundaryRetainCallbackIntrinsic = ({
+  name,
   args,
   ctx,
   typeArguments,
 }: {
+  name: string;
   args: readonly Arg[];
   ctx: TypingContext;
   typeArguments?: readonly TypeId[];
 }): TypeId => {
   assertIntrinsicArgCount({
-    name: "__vx_retain_event_handler",
+    name,
     args,
     expected: 1,
     detail: "handler function",
   });
-  assertNoIntrinsicTypeArgs("__vx_retain_event_handler", typeArguments);
+  assertNoIntrinsicTypeArgs(name, typeArguments);
   const handlerType = args[0]!.type;
   const desc = ctx.arena.get(handlerType);
   if (desc.kind !== "function") {
-    throw new Error("__vx_retain_event_handler expects a function argument");
+    throw new Error(`${name} expects a function argument`);
   }
   return getPrimitiveType(ctx, "i32");
 };

--- a/packages/compiler/src/semantics/typing/type-system.ts
+++ b/packages/compiler/src/semantics/typing/type-system.ts
@@ -889,9 +889,8 @@ export const resolveTypeAlias = (
         ctx,
       });
       ctx.typeAliases.markValidated(key);
-    } else {
-      recordAliasInstanceSymbol(cached, symbol, ctx);
     }
+    recordAliasInstanceSymbol(cached, symbol, ctx);
     return cached;
   }
 
@@ -1107,6 +1106,7 @@ export const resolveTypeAlias = (
       ctx.typeAliases.cacheInstance(key, resolved);
       ctx.typeAliases.markValidated(key);
     }
+    recordAliasInstanceSymbol(resolved, symbol, ctx);
     return resolved;
   } catch (error) {
     ctx.typeAliases.markFailed(key);

--- a/packages/js-host/src/boundary-values.ts
+++ b/packages/js-host/src/boundary-values.ts
@@ -1,0 +1,414 @@
+import type {
+  BoundaryFieldSchema,
+  BoundarySchema,
+  BoundaryUnionSchema,
+} from "./protocol/export-abi.js";
+
+const I32_MIN = -2147483648;
+const I32_MAX = 2147483647;
+const I64_MIN = -(1n << 63n);
+const I64_MAX = (1n << 63n) - 1n;
+
+export const encodeBoundaryArgs = ({
+  exportName,
+  schemas,
+  args,
+}: {
+  exportName: string;
+  schemas: readonly BoundarySchema[];
+  args: readonly unknown[];
+}): unknown[] => {
+  if (args.length !== schemas.length) {
+    throw new Error(
+      `typed export ${exportName} expected ${schemas.length} args, got ${args.length}`,
+    );
+  }
+  return schemas.map((schema, index) =>
+    encodeBoundaryValue({
+      exportName,
+      schema,
+      value: args[index],
+      path: `arg${index}`,
+    }),
+  );
+};
+
+export const decodeBoundaryResult = ({
+  exportName,
+  schema,
+  value,
+}: {
+  exportName: string;
+  schema: BoundarySchema;
+  value: unknown;
+}): unknown =>
+  decodeBoundaryValue({
+    exportName,
+    schema,
+    value,
+    path: "result",
+  });
+
+const encodeBoundaryValue = ({
+  exportName,
+  schema,
+  value,
+  path,
+}: {
+  exportName: string;
+  schema: BoundarySchema;
+  value: unknown;
+  path: string;
+}): unknown => {
+  switch (schema.kind) {
+    case "bool":
+      return expectType({ exportName, path, expected: "bool", value, guard: isBool });
+    case "i32":
+      return expectI32({ exportName, path, value });
+    case "i64":
+      return expectI64({ exportName, path, value });
+    case "f32":
+    case "f64":
+      return expectFloat({ exportName, path, value, expected: schema.kind });
+    case "void":
+      return null;
+    case "string":
+      return expectType({
+        exportName,
+        path,
+        expected: "String",
+        value,
+        guard: isString,
+      });
+    case "array":
+      if (!Array.isArray(value)) {
+        throw typeError({ exportName, path, expected: "array", value });
+      }
+      return value.map((item, index) =>
+        encodeBoundaryValue({
+          exportName,
+          schema: schema.element,
+          value: item,
+          path: `${path}[${index}]`,
+        }),
+      );
+    case "record":
+      return encodeRecord({
+        exportName,
+        fields: schema.fields,
+        tag: schema.tag,
+        value,
+        path,
+      });
+    case "union":
+      return encodeUnion({ exportName, schema, value, path });
+  }
+};
+
+const decodeBoundaryValue = ({
+  exportName,
+  schema,
+  value,
+  path,
+}: {
+  exportName: string;
+  schema: BoundarySchema;
+  value: unknown;
+  path: string;
+}): unknown => {
+  switch (schema.kind) {
+    case "void":
+      return undefined;
+    case "array":
+      if (!Array.isArray(value)) {
+        throw typeError({ exportName, path, expected: "array", value });
+      }
+      return value.map((item, index) =>
+        decodeBoundaryValue({
+          exportName,
+          schema: schema.element,
+          value: item,
+          path: `${path}[${index}]`,
+        }),
+      );
+    case "record":
+      return decodeRecord({
+        exportName,
+        fields: schema.fields,
+        tag: schema.tag,
+        value,
+        path,
+      });
+    case "union":
+      return decodeUnion({ exportName, schema, value, path });
+    default:
+      return encodeBoundaryValue({ exportName, schema, value, path });
+  }
+};
+
+const encodeRecord = ({
+  exportName,
+  fields,
+  tag,
+  value,
+  path,
+}: {
+  exportName: string;
+  fields: readonly BoundaryFieldSchema[];
+  tag?: string;
+  value: unknown;
+  path: string;
+}): Record<string, unknown> => {
+  const record = toRecord({ exportName, path, value });
+  if (tag) {
+    const actualTag = record.tag ?? record.$variant;
+    if (actualTag !== tag) {
+      throw new Error(
+        `typed export ${exportName} ${path} expected variant tag ${tag}`,
+      );
+    }
+  }
+  return Object.fromEntries(
+    fields.map((field) => [
+      field.name,
+      encodeBoundaryValue({
+        exportName,
+        schema: field.schema,
+        value: record[field.name],
+        path: `${path}.${field.name}`,
+      }),
+    ]),
+  );
+};
+
+const decodeRecord = ({
+  exportName,
+  fields,
+  tag,
+  value,
+  path,
+}: {
+  exportName: string;
+  fields: readonly BoundaryFieldSchema[];
+  tag?: string;
+  value: unknown;
+  path: string;
+}): Record<string, unknown> => {
+  const record = toRecord({ exportName, path, value });
+  return {
+    ...Object.fromEntries(
+      fields.map((field) => [
+        field.name,
+        decodeBoundaryValue({
+          exportName,
+          schema: field.schema,
+          value: record[field.name],
+          path: `${path}.${field.name}`,
+        }),
+      ]),
+    ),
+    ...(tag ? { tag } : {}),
+  };
+};
+
+const encodeUnion = ({
+  exportName,
+  schema,
+  value,
+  path,
+}: {
+  exportName: string;
+  schema: BoundaryUnionSchema;
+  value: unknown;
+  path: string;
+}): Record<string, unknown> => {
+  const record = toRecord({ exportName, path, value });
+  const tag = record.tag ?? record.$variant;
+  if (typeof tag !== "string") {
+    throw variantTagError({ exportName, path, schema });
+  }
+  const variant = schema.variants.find((candidate) => candidate.name === tag);
+  if (!variant) {
+    throw variantTagError({ exportName, path, schema });
+  }
+  return {
+    ...encodeRecord({
+      exportName,
+      fields: variant.fields,
+      value: record,
+      path,
+    }),
+    $variant: tag,
+  };
+};
+
+const decodeUnion = ({
+  exportName,
+  schema,
+  value,
+  path,
+}: {
+  exportName: string;
+  schema: BoundaryUnionSchema;
+  value: unknown;
+  path: string;
+}): Record<string, unknown> => {
+  const record = toRecord({ exportName, path, value });
+  const tag = record.$variant ?? record.tag;
+  if (typeof tag !== "string") {
+    throw variantTagError({ exportName, path, schema });
+  }
+  const variant = schema.variants.find((candidate) => candidate.name === tag);
+  if (!variant) {
+    throw variantTagError({ exportName, path, schema });
+  }
+  return {
+    ...decodeRecord({
+      exportName,
+      fields: variant.fields,
+      value: record,
+      path,
+    }),
+    tag,
+  };
+};
+
+const expectI32 = ({
+  exportName,
+  path,
+  value,
+}: {
+  exportName: string;
+  path: string;
+  value: unknown;
+}): number => {
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    !Number.isFinite(value) ||
+    value < I32_MIN ||
+    value > I32_MAX
+  ) {
+    throw typeError({ exportName, path, expected: "i32", value });
+  }
+  return value;
+};
+
+const expectI64 = ({
+  exportName,
+  path,
+  value,
+}: {
+  exportName: string;
+  path: string;
+  value: unknown;
+}): bigint | number => {
+  if (typeof value === "bigint") {
+    if (value < I64_MIN || value > I64_MAX) {
+      throw typeError({ exportName, path, expected: "i64", value });
+    }
+    return value;
+  }
+  if (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    Number.isFinite(value)
+  ) {
+    return value;
+  }
+  throw typeError({ exportName, path, expected: "i64", value });
+};
+
+const expectFloat = ({
+  exportName,
+  path,
+  value,
+  expected,
+}: {
+  exportName: string;
+  path: string;
+  value: unknown;
+  expected: "f32" | "f64";
+}): number => {
+  if (typeof value !== "number") {
+    throw typeError({ exportName, path, expected, value });
+  }
+  return value;
+};
+
+const expectType = <T>({
+  exportName,
+  path,
+  expected,
+  value,
+  guard,
+}: {
+  exportName: string;
+  path: string;
+  expected: string;
+  value: unknown;
+  guard: (value: unknown) => value is T;
+}): T => {
+  if (!guard(value)) {
+    throw typeError({ exportName, path, expected, value });
+  }
+  return value;
+};
+
+const toRecord = ({
+  exportName,
+  path,
+  value,
+}: {
+  exportName: string;
+  path: string;
+  value: unknown;
+}): Record<string, unknown> => {
+  if (value instanceof Map) {
+    return Object.fromEntries(value.entries());
+  }
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  throw typeError({ exportName, path, expected: "object", value });
+};
+
+const variantTagError = ({
+  exportName,
+  path,
+  schema,
+}: {
+  exportName: string;
+  path: string;
+  schema: BoundaryUnionSchema;
+}): Error =>
+  new Error(
+    `typed export ${exportName} ${path} expected variant tag ${schema.variants
+      .map((variant) => variant.name)
+      .join(" | ")}`,
+  );
+
+const typeError = ({
+  exportName,
+  path,
+  expected,
+  value,
+}: {
+  exportName: string;
+  path: string;
+  expected: string;
+  value: unknown;
+}): Error =>
+  new Error(
+    `typed export ${exportName} ${path} expected ${expected}, got ${actualType(value)}`,
+  );
+
+const actualType = (value: unknown): string => {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (typeof value === "number" && Number.isNaN(value)) return "NaN";
+  return typeof value;
+};
+
+const isBool = (value: unknown): value is boolean => typeof value === "boolean";
+const isString = (value: unknown): value is string => typeof value === "string";

--- a/packages/js-host/src/host.ts
+++ b/packages/js-host/src/host.ts
@@ -26,6 +26,11 @@ import type { ParsedEffectOp, ParsedEffectTable } from "./protocol/table.js";
 import { registerHandlersByLabelSuffix } from "./handlers.js";
 import { parseExportAbi } from "./protocol/export-abi.js";
 import {
+  decodeBoundaryResult,
+  encodeBoundaryArgs,
+} from "./boundary-values.js";
+import type { ExportAbiEntry } from "./protocol/export-abi.js";
+import {
   createRuntimeScheduler,
   type RuntimeSchedulerOptions,
   type RuntimeStepResult,
@@ -85,7 +90,8 @@ export type VoydHost = {
 
 const MSGPACK_OPTS = { useBigInt64: true } as const;
 const TASK_RUNTIME_IMPORT_MODULE = "voyd.task";
-const VX_CALLBACK_IMPORT_MODULE = "voyd.vx.callback";
+const BOUNDARY_CALLBACK_IMPORT_MODULE = "voyd.boundary.callback";
+const LEGACY_VX_CALLBACK_IMPORT_MODULE = "voyd.vx.callback";
 const TASK_RUNTIME_EFFECT_ID = "voyd.std.task.runtime";
 const TASK_RUNTIME_WAIT_OP_ID = 0;
 const TASK_RUNTIME_YIELD_OP_ID = 1;
@@ -227,7 +233,7 @@ const buildTaskRuntimeImportModule = ({
     };
 };
 
-const buildVxCallbackImportModule = ({
+const buildRetainedCallbackImportModules = ({
   importDescriptors,
   getInstance,
   registry,
@@ -242,19 +248,22 @@ const buildVxCallbackImportModule = ({
   annotateTrap: (error: unknown, opts?: VoydTrapAnnotation) => Error;
   runEffectfulRetainedCallback: RetainedEffectfulCallbackRunner;
 }): WebAssembly.Imports => {
-  const callbackImports: Record<string, CallableFunction> = {};
+  const callbackImportsByModule = new Map<string, Record<string, CallableFunction>>();
 
   importDescriptors
     .filter(
       (descriptor) =>
-        descriptor.module === VX_CALLBACK_IMPORT_MODULE &&
+        (descriptor.module === BOUNDARY_CALLBACK_IMPORT_MODULE ||
+          descriptor.module === LEGACY_VX_CALLBACK_IMPORT_MODULE) &&
         descriptor.kind === "function",
     )
     .forEach((descriptor) => {
-      if (!descriptor.name.startsWith("retain_event__")) {
+      const callbackExportName = retainedCallbackExportNameFrom(descriptor.name);
+      if (!callbackExportName) {
         return;
       }
-      const callbackExportName = descriptor.name.slice("retain_event__".length);
+      const callbackImports = callbackImportsByModule.get(descriptor.module) ?? {};
+      callbackImportsByModule.set(descriptor.module, callbackImports);
       callbackImports[descriptor.name] = ((handlerRef: unknown): number =>
         registry.retain((payload) => {
           const instance = getInstance();
@@ -287,7 +296,7 @@ const buildVxCallbackImportModule = ({
           });
           const encodedPayload = encode(payload, MSGPACK_OPTS) as Uint8Array;
           if (encodedPayload.length > bufferSize) {
-            throw new Error("VX retained event callback payload exceeds buffer size");
+            throw new Error("retained boundary callback payload exceeds buffer size");
           }
           ensureMemoryCapacity({
             memory: msgpackMemory,
@@ -319,10 +328,10 @@ const buildVxCallbackImportModule = ({
               return returnsVoid ? outcome.then(() => undefined) : outcome;
             }
             throw annotateTrap(error, {
-              transition: {
-                point: "vx_retained_event_callback",
-                direction: "host->vm",
-              },
+                transition: {
+                  point: "retained_boundary_callback",
+                  direction: "host->vm",
+                },
               fallbackFunctionName: callbackExportName,
             });
           }
@@ -330,21 +339,27 @@ const buildVxCallbackImportModule = ({
             return undefined;
           }
           if (written < 0) {
-            throw new Error("VX retained event callback encoding failed");
+            throw new Error("retained boundary callback encoding failed");
           }
           if (written > bufferSize) {
-            throw new Error("VX retained event callback payload exceeds buffer size");
+            throw new Error("retained boundary callback payload exceeds buffer size");
           }
           const bytes = new Uint8Array(msgpackMemory.buffer, outPtr, written);
           return decode(bytes, MSGPACK_OPTS);
         })) as CallableFunction;
     });
 
-  return Object.keys(callbackImports).length === 0
-    ? {}
-    : {
-        [VX_CALLBACK_IMPORT_MODULE]: callbackImports,
-      };
+  return Object.fromEntries(callbackImportsByModule.entries()) as WebAssembly.Imports;
+};
+
+const retainedCallbackExportNameFrom = (importName: string): string | undefined => {
+  if (importName.startsWith("retain_callback__")) {
+    return importName.slice("retain_callback__".length);
+  }
+  if (importName.startsWith("retain_event__")) {
+    return importName.slice("retain_event__".length);
+  }
+  return undefined;
 };
 
 const isImportModuleRecord = (
@@ -665,13 +680,13 @@ export const createVoydHost = async ({
   const callbackRegistry =
     retainedCallbacks ?? createRetainedEventHandlerRegistry();
   let runEffectfulRetainedCallback: RetainedEffectfulCallbackRunner = () => {
-    throw new Error("VX retained event callback called before host runtime initialization");
+    throw new Error("retained boundary callback called before host runtime initialization");
   };
-  const vxCallbackImports = buildVxCallbackImportModule({
+  const retainedCallbackImports = buildRetainedCallbackImportModules({
     importDescriptors: WebAssembly.Module.imports(module),
     getInstance: () => {
       if (!instanceRef) {
-        throw new Error("VX callback import called before host instance initialization");
+        throw new Error("retained boundary callback import called before host instance initialization");
       }
       return instanceRef;
     },
@@ -686,7 +701,7 @@ export const createVoydHost = async ({
       {
         ...defaultImports(),
         ...(taskRuntimeImports as Record<string, unknown>),
-        ...(vxCallbackImports as Record<string, unknown>),
+        ...(retainedCallbackImports as Record<string, unknown>),
       } as WebAssembly.Imports,
       imports
     )
@@ -761,9 +776,11 @@ export const createVoydHost = async ({
 
   const runSerialized = async <T = unknown>(
     entryName: string,
-    args: unknown[] = []
+    args: unknown[] = [],
+    abi?: Extract<ExportAbiEntry, { abi: "serialized" }>
   ): Promise<T> => {
-    const entry = requireExportedFunction({ instance, name: entryName });
+    const wrapperName = abi?.wrapperName ?? entryName;
+    const entry = requireExportedFunction({ instance, name: wrapperName });
     const msgpackMemory = requireExportedMemory({
       instance,
       name: LINEAR_MEMORY_EXPORT,
@@ -774,9 +791,18 @@ export const createVoydHost = async ({
       label: LINEAR_MEMORY_EXPORT,
     });
 
-    const encodedArgs = encode(args, MSGPACK_OPTS) as Uint8Array;
+    const boundaryArgs = abi?.params
+      ? encodeBoundaryArgs({
+          exportName: entryName,
+          schemas: abi.params,
+          args,
+        })
+      : args;
+    const encodedArgs = encode(boundaryArgs, MSGPACK_OPTS) as Uint8Array;
     if (encodedArgs.length > bufferSize) {
-      throw new Error("serialized args exceed buffer size");
+      throw new Error(
+        `serialized export ${entryName} args exceed buffer size (${encodedArgs.length} > ${bufferSize}); increase createVoydHost({ bufferSize }) or pass a smaller payload`,
+      );
     }
     const inPtr = 0;
     const outPtr = bufferSize;
@@ -801,13 +827,24 @@ export const createVoydHost = async ({
       });
     }
     if (written < 0) {
-      throw new Error("serialized export encoding failed");
+      throw new Error(
+        `serialized export ${entryName} result encoding failed (bufferSize=${bufferSize}); increase createVoydHost({ bufferSize }) or return a smaller payload`,
+      );
     }
     if (written > bufferSize) {
-      throw new Error("serialized export payload exceeds buffer size");
+      throw new Error(
+        `serialized export ${entryName} result exceeds buffer size (${written} > ${bufferSize}); increase createVoydHost({ bufferSize }) or return a smaller payload`,
+      );
     }
     const bytes = new Uint8Array(msgpackMemory.buffer, outPtr, written);
-    return decode(bytes, MSGPACK_OPTS) as T;
+    const decoded = decode(bytes, MSGPACK_OPTS);
+    return (abi?.result
+      ? decodeBoundaryResult({
+          exportName: entryName,
+          schema: abi.result,
+          value: decoded,
+        })
+      : decoded) as T;
   };
 
   const runPure = async <T = unknown>(
@@ -819,7 +856,7 @@ export const createVoydHost = async ({
       if (abi.formatId !== "msgpack") {
         throw new Error(`unsupported serializer format ${abi.formatId}`);
       }
-      return runSerialized<T>(entryName, args);
+      return runSerialized<T>(entryName, args, abi);
     }
     const entry = requireExportedFunction({ instance, name: entryName });
     try {
@@ -1857,7 +1894,7 @@ export const createVoydHost = async ({
     });
     const encodedPayload = encode(payload, MSGPACK_OPTS) as Uint8Array;
     if (encodedPayload.length > bufferSize) {
-      throw new Error("VX retained event callback payload exceeds buffer size");
+      throw new Error("retained boundary callback payload exceeds buffer size");
     }
     return unwrapRunOutcome(
       runEffectfulManaged(callbackExportName, [], ({ bufferPtr, bufferSize }) => {
@@ -1880,7 +1917,7 @@ export const createVoydHost = async ({
         } catch (error) {
           throw annotateTrap(error, {
             transition: {
-              point: "vx_retained_event_callback",
+              point: "retained_boundary_callback",
               direction: "host->vm",
             },
             fallbackFunctionName: rawCallbackExportName,

--- a/packages/js-host/src/protocol/export-abi.ts
+++ b/packages/js-host/src/protocol/export-abi.ts
@@ -1,8 +1,65 @@
-export type ExportAbiEntry = {
-  name: string;
-  abi: "direct" | "serialized";
-  formatId?: string;
+export type BoundaryPrimitiveSchema =
+  | { kind: "bool"; typeId?: number }
+  | { kind: "i32"; typeId?: number }
+  | { kind: "i64"; typeId?: number }
+  | { kind: "f32"; typeId?: number }
+  | { kind: "f64"; typeId?: number }
+  | { kind: "void"; typeId?: number }
+  | { kind: "string"; typeId?: number };
+
+export type BoundaryArraySchema = {
+  kind: "array";
+  typeId?: number;
+  elementTypeId?: number;
+  element: BoundarySchema;
 };
+
+export type BoundaryFieldSchema = {
+  name: string;
+  typeId?: number;
+  schema: BoundarySchema;
+};
+
+export type BoundaryRecordSchema = {
+  kind: "record";
+  typeId?: number;
+  name?: string;
+  tag?: string;
+  fields: readonly BoundaryFieldSchema[];
+};
+
+export type BoundaryVariantSchema = {
+  name: string;
+  typeId?: number;
+  fields: readonly BoundaryFieldSchema[];
+};
+
+export type BoundaryUnionSchema = {
+  kind: "union";
+  typeId?: number;
+  name?: string;
+  variants: readonly BoundaryVariantSchema[];
+};
+
+export type BoundarySchema =
+  | BoundaryPrimitiveSchema
+  | BoundaryArraySchema
+  | BoundaryRecordSchema
+  | BoundaryUnionSchema;
+
+export type ExportAbiEntry =
+  | {
+      name: string;
+      abi: "direct";
+    }
+  | {
+      name: string;
+      abi: "serialized";
+      formatId?: string;
+      wrapperName?: string;
+      params?: readonly BoundarySchema[];
+      result?: BoundarySchema;
+    };
 
 export type ParsedExportAbi = {
   version: number;

--- a/packages/js-host/src/runtime/trap-diagnostics.ts
+++ b/packages/js-host/src/runtime/trap-diagnostics.ts
@@ -484,7 +484,9 @@ const buildDiagnostics = ({
   const safeFallbackMetadata =
     !resolved?.metadata &&
     annotation?.fallbackFunctionName
-      ? annotation.panic || frames.length === 1
+      ? annotation.panic ||
+        frames.length === 1 ||
+        annotation.transition?.point === "run_serialized_entry"
         ? metadataByFunctionName.get(annotation.fallbackFunctionName)
         : undefined
       : undefined;

--- a/packages/reference/docs/sdk.md
+++ b/packages/reference/docs/sdk.md
@@ -49,6 +49,99 @@ In the SDK, `optimize: true` selects Voyd's aggressive validated optimization
 profile.
 Binaryen pass configuration is intentionally not exposed as public SDK API.
 
+## Typed JavaScript boundary exports
+
+SDK builds automatically expose boundary-compatible public Voyd functions
+through the existing host and compiled-result run APIs. JavaScript callers pass
+plain JS values; the host validates and encodes them at the Wasm boundary.
+
+```ts
+const result = await sdk.compile({
+  source: `use std::array::Array
+use std::enums::{ enum }
+use std::string::type::String
+
+obj Point {
+  x: i32,
+  y: i32
+}
+
+enum LookupResult
+  Found { value: String }
+  Missing
+
+pub fn translate(point: Point, dx: i32, dy: i32) -> Point
+  Point { x: point.x + dx, y: point.y + dy }
+
+pub fn get_point() -> { x: i32, y: i32 }
+  { x: 1, y: 2 }
+
+pub fn lookup(key: String) -> LookupResult
+  if key == "name" then:
+    LookupResult::Found { value: "Ada" }
+  else:
+    LookupResult::Missing {}
+
+pub fn sum_values(values: Array<i32>) -> i32
+  var index = 0
+  var total = 0
+  while index < values.len():
+    total = total + values.at(index)
+    index = index + 1
+  total
+`,
+});
+
+if (result.success) {
+  await result.run({ entryName: "translate", args: [{ x: 1, y: 2 }, 10, 20] });
+  // { x: 11, y: 22 }
+
+  await result.run({ entryName: "get_point" });
+  // { x: 1, y: 2 }
+
+  await result.run({ entryName: "lookup", args: ["name"] });
+  // { tag: "Found", value: "Ada" }
+
+  await result.run({ entryName: "sum_values", args: [[1, 2, 3]] });
+  // 6
+}
+```
+
+Supported DTO shapes include booleans, numeric primitives, strings, arrays,
+records/objects with public boundary-compatible fields, structural records, and
+named enum/union variants represented in JS as `{ tag: "Variant", ...fields }`.
+`f32` and `f64` values accept any JavaScript number, including `NaN` and
+`Infinity`; integer values must be finite and in range.
+Unsupported public functions are skipped in automatic mode. Explicit requests
+can surface diagnostics:
+
+```ts
+await sdk.compile({
+  source: `${source}
+pub fn call_callback(callback: fn() -> i32) -> i32
+  callback()
+`,
+  boundaryExports: {
+    mode: "only",
+    include: ["call_callback"],
+    onUnsupported: "diagnostic",
+  },
+});
+```
+
+Disable automatic wrappers when Wasm size or compile-time overhead matters.
+
+```ts
+const result = await sdk.compile({
+  source,
+  boundaryExports: false,
+});
+```
+
+Raw Wasm exports remain available through `host.instance.exports`. Existing
+raw MsgPack interop still works; MsgPack is an internal codec detail for typed
+boundary exports, not a stable WIT/component-model replacement.
+
 ## Module roots and package resolution
 
 `createSdk().compile(...)` accepts `roots` when you need to override module

--- a/packages/sdk/src/__tests__/sdk-node.test.ts
+++ b/packages/sdk/src/__tests__/sdk-node.test.ts
@@ -11,6 +11,7 @@ import {
   type EffectHandler,
 } from "@voyd-lang/sdk";
 import { createVoydHost } from "@voyd-lang/sdk/js-host";
+import { parseExportAbi } from "@voyd-lang/js-host";
 
 const EFFECT_SOURCE = `use std::msgpack::self as __std_msgpack
 use std::string::self as __std_string
@@ -22,6 +23,72 @@ eff Async
 pub fn main(): Async -> i32
   Async::await(2) + 1
 `;
+const BOUNDARY_EXPORTS_SOURCE = `use std::array::Array
+use std::enums::{ enum }
+use std::string::type::String
+
+obj Point {
+  x: i32,
+  y: i32
+}
+
+enum LookupResult
+  Found { value: String }
+  Missing
+
+enum NestedResult
+  Wrapped { inner: LookupResult::Found }
+  Empty {}
+
+pub fn primitive() -> i32
+  42
+
+pub fn translate(point: Point, dx: i32, dy: i32) -> Point
+  Point {
+    x: point.x + dx,
+    y: point.y + dy
+  }
+
+pub fn get_point() -> { x: i32, y: i32 }
+  { x: 1, y: 2 }
+
+pub fn lookup(key: String) -> LookupResult
+  if key == "name" then:
+    LookupResult::Found { value: "Ada" }
+  else:
+    LookupResult::Missing {}
+
+pub fn sum_values(values: Array<i32>) -> i32
+  var index = 0
+  var total = 0
+  while index < values.len():
+    total = total + values.at(index)
+    index = index + 1
+  total
+
+pub fn add_float(value: f64) -> f64
+  value + 1.0
+
+pub fn nan_value() -> f64
+  0.0 / 0.0
+
+pub fn found_only() -> LookupResult::Found
+  LookupResult::Found { value: "Ada" }
+
+pub fn found_value(found: LookupResult::Found) -> String
+  found.value
+
+pub fn nested_found() -> NestedResult
+  NestedResult::Wrapped {
+    inner: LookupResult::Found { value: "Ada" }
+  }
+
+pub fn nested_found_value(wrapped: NestedResult::Wrapped) -> String
+  wrapped.inner.value
+
+pub fn long_text() -> String
+  "this result is intentionally longer than a tiny host buffer"
+`;
 const ASYNC_EFFECT_ID = "com.example.async";
 const RUNTIME_DIAGNOSTICS_SECTION = "voyd.runtime_diagnostics";
 const sdkTestRoot = path.dirname(fileURLToPath(import.meta.url));
@@ -29,18 +96,25 @@ const repoRoot = path.resolve(sdkTestRoot, "../../../../");
 let effectCompileResult: Extract<CompileResult, { success: true }>;
 
 const hasRuntimeDiagnosticsSection = (wasm: Uint8Array): boolean => {
-  const buffer =
-    wasm.buffer instanceof ArrayBuffer &&
-    wasm.byteOffset === 0 &&
-    wasm.byteLength === wasm.buffer.byteLength
-      ? wasm.buffer
-      : wasm.slice().buffer;
-  const module = new WebAssembly.Module(buffer);
+  const module = new WebAssembly.Module(wasmBufferSource(wasm));
   const sections = WebAssembly.Module.customSections(
     module,
     RUNTIME_DIAGNOSTICS_SECTION
   );
   return sections.length > 0;
+};
+
+const wasmBufferSource = (wasm: Uint8Array): BufferSource => {
+  if (
+    wasm.buffer instanceof ArrayBuffer &&
+    wasm.byteOffset === 0 &&
+    wasm.byteLength === wasm.buffer.byteLength
+  ) {
+    return wasm.buffer;
+  }
+  const copy = new Uint8Array(wasm.byteLength);
+  copy.set(wasm);
+  return copy.buffer;
 };
 
 const expectCompileSuccess = (
@@ -122,6 +196,118 @@ describe("node sdk", () => {
 
     const output = await result.run<number>({ entryName: "main" });
     expect(output).toBe(42);
+  });
+
+  it("runs typed boundary exports through the existing host and sdk APIs", async () => {
+    const sdk = createSdk();
+    const result = expectCompileSuccess(
+      await sdk.compile({ source: BOUNDARY_EXPORTS_SOURCE }),
+    );
+    const host = await createVoydHost({ wasm: result.wasm });
+
+    await expect(host.run("primitive")).resolves.toBe(42);
+    await expect(
+      host.run("translate", [{ x: 1, y: 2 }, 10, 20]),
+    ).resolves.toEqual({ x: 11, y: 22 });
+    await expect(result.run({ entryName: "get_point" })).resolves.toEqual({
+      x: 1,
+      y: 2,
+    });
+    await expect(host.run("lookup", ["name"])).resolves.toEqual({
+      tag: "Found",
+      value: "Ada",
+    });
+    await expect(host.run("lookup", ["other"])).resolves.toEqual({
+      tag: "Missing",
+    });
+    await expect(host.run("sum_values", [[1, 2, 3]])).resolves.toBe(6);
+    await expect(host.run("add_float", [Number.POSITIVE_INFINITY])).resolves.toBe(
+      Number.POSITIVE_INFINITY,
+    );
+    const nanResult = await host.run<number>("nan_value");
+    expect(Number.isNaN(nanResult)).toBe(true);
+    await expect(host.run("found_only")).resolves.toEqual({
+      tag: "Found",
+      value: "Ada",
+    });
+    await expect(
+      host.run("found_value", [{ tag: "Found", value: "Grace" }]),
+    ).resolves.toBe("Grace");
+    await expect(
+      host.run("found_value", [{ tag: "Missing", value: "Grace" }]),
+    ).rejects.toThrow("typed export found_value arg0 expected variant tag Found");
+    await expect(host.run("nested_found")).resolves.toEqual({
+      tag: "Wrapped",
+      inner: { tag: "Found", value: "Ada" },
+    });
+    await expect(
+      host.run("nested_found_value", [
+        { tag: "Wrapped", inner: { tag: "Found", value: "Grace" } },
+      ]),
+    ).resolves.toBe("Grace");
+    await expect(
+      host.run("nested_found_value", [
+        { tag: "Wrapped", inner: { tag: "Missing", value: "Grace" } },
+      ]),
+    ).rejects.toThrow("typed export nested_found_value arg0.inner expected variant tag Found");
+    await expect(
+      host.run("translate", [{ x: "bad", y: 2 }, 10, 20]),
+    ).rejects.toThrow("typed export translate arg0.x expected i32, got string");
+
+    const tinyBufferHost = await createVoydHost({
+      wasm: result.wasm,
+      bufferSize: 8,
+    });
+    await expect(
+      tinyBufferHost.run(
+        "sum_values",
+        [Array.from({ length: 32 }, (_, index) => index)],
+      ),
+    ).rejects.toThrow("increase createVoydHost({ bufferSize })");
+    await expect(tinyBufferHost.run("long_text")).rejects.toThrow(
+      "increase createVoydHost({ bufferSize })",
+    );
+  });
+
+  it("does not treat ordinary DTO type aliases as standalone variants", async () => {
+    const sdk = createSdk();
+    const result = expectCompileSuccess(
+      await sdk.compile({
+        source: `obj Point {
+  x: i32,
+  y: i32
+}
+
+type AliasPoint = Point
+
+pub fn shift(point: AliasPoint) -> AliasPoint
+  point
+`,
+      }),
+    );
+    const host = await createVoydHost({ wasm: result.wasm });
+
+    await expect(host.run("shift", [{ x: 1, y: 2 }])).resolves.toEqual({
+      x: 1,
+      y: 2,
+    });
+  });
+
+  it("can opt out of typed boundary export wrappers", async () => {
+    const sdk = createSdk();
+    const result = expectCompileSuccess(
+      await sdk.compile({
+        source: BOUNDARY_EXPORTS_SOURCE,
+        boundaryExports: false,
+      }),
+    );
+    const module = new WebAssembly.Module(wasmBufferSource(result.wasm));
+    const abi = parseExportAbi(module);
+    const exports = WebAssembly.Module.exports(module).map((entry) => entry.name);
+
+    expect(exports).toContain("translate");
+    expect(exports).not.toContain("__voyd_serialized_export_translate");
+    expect(abi.exports).toContainEqual({ name: "translate", abi: "direct" });
   });
 
   it("compiles when entryPath is relative with subdirectories", async () => {

--- a/packages/sdk/src/__tests__/sdk-tests.test.ts
+++ b/packages/sdk/src/__tests__/sdk-tests.test.ts
@@ -12,6 +12,23 @@ const expectCompileSuccess = (
 };
 
 describe("sdk tests collection", { timeout: 120_000 }, () => {
+  it("keeps explicit boundary export includes scoped to the runnable module", async () => {
+    const sdk = createSdk();
+    const result = expectCompileSuccess(await sdk.compile({
+      includeTests: true,
+      boundaryExports: { include: ["main"] },
+      source: `pub fn main() -> i32
+  42
+
+test "passes":
+  1
+`,
+    }));
+
+    expect(result.tests?.cases.length).toBe(1);
+    await expect(result.run({ entryName: "main" })).resolves.toBe(42);
+  });
+
   it("discovers and runs tests", async () => {
     const sdk = createSdk();
     const result = expectCompileSuccess(await sdk.compile({

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -92,6 +92,7 @@ const compileSdk = async (options: CompileOptions): Promise<CompileResult> => {
       testScope: options.testScope ?? "entry",
       runtimeDiagnostics: options.runtimeDiagnostics,
       loadModuleGraph,
+      boundaryExports: options.boundaryExports,
     });
     if (!result.success) {
       return result;

--- a/packages/sdk/src/node.ts
+++ b/packages/sdk/src/node.ts
@@ -85,6 +85,7 @@ const compileSdk = async (options: CompileOptions): Promise<CompileResult> => {
       testScope,
       runtimeDiagnostics,
       loadModuleGraph,
+      boundaryExports: options.boundaryExports,
     });
 
     if (!result.success) {

--- a/packages/sdk/src/shared/compile.ts
+++ b/packages/sdk/src/shared/compile.ts
@@ -9,6 +9,7 @@ import {
   type LoadModuleGraphFn,
   type TestScope,
 } from "@voyd-lang/compiler/pipeline-shared.js";
+import type { BoundaryExportsOption } from "@voyd-lang/compiler/codegen/context.js";
 import type { TestCase } from "./types.js";
 import { diagnosticsFromUnknownError } from "./diagnostics.js";
 
@@ -39,6 +40,7 @@ export const compileWithLoader = async ({
   runtimeDiagnostics,
   loadModuleGraph,
   testScope,
+  boundaryExports,
 }: {
   entryPath: string;
   roots: ModuleRoots;
@@ -48,6 +50,7 @@ export const compileWithLoader = async ({
   runtimeDiagnostics?: boolean;
   loadModuleGraph: LoadModuleGraphFn;
   testScope?: TestScope;
+  boundaryExports?: BoundaryExportsOption;
 }): Promise<CompileArtifacts> => {
   const shouldIncludeTests = includeTests || testsOnly;
   const codegenLoadPromise = preloadCodegen();
@@ -75,6 +78,14 @@ export const compileWithLoader = async ({
     typeof runtimeDiagnostics === "boolean"
       ? { runtimeDiagnostics, emitEffectHelpers: true }
       : { emitEffectHelpers: true };
+  const codegenOption = {
+    ...runtimeDiagnosticsCodegenOption,
+    boundaryExports: boundaryExports ?? "auto",
+  } as const;
+  const testCodegenOption = {
+    ...runtimeDiagnosticsCodegenOption,
+    boundaryExports: false,
+  } as const;
   const { semantics, diagnostics: semanticDiagnostics, tests } = analyzeModules({
     graph,
     includeTests: shouldIncludeTests,
@@ -98,7 +109,7 @@ export const compileWithLoader = async ({
         codegenOptions: {
           testMode: true,
           testScope: scopedTestScope,
-          ...runtimeDiagnosticsCodegenOption,
+          ...testCodegenOption,
         },
       });
       const allDiagnostics = [...diagnostics, ...testResult.diagnostics];
@@ -117,7 +128,7 @@ export const compileWithLoader = async ({
     const wasmResult = await emitProgram({
       graph,
       semantics,
-      codegenOptions: runtimeDiagnosticsCodegenOption,
+      codegenOptions: codegenOption,
     });
     const baseDiagnostics = [...diagnostics, ...wasmResult.diagnostics];
     if (hasErrorDiagnostics(baseDiagnostics)) {
@@ -133,7 +144,7 @@ export const compileWithLoader = async ({
         codegenOptions: {
           testMode: true,
           testScope: scopedTestScope,
-          ...runtimeDiagnosticsCodegenOption,
+          ...testCodegenOption,
         },
       });
       const allDiagnostics = [...baseDiagnostics, ...testResult.diagnostics];

--- a/packages/sdk/src/shared/types.ts
+++ b/packages/sdk/src/shared/types.ts
@@ -1,4 +1,5 @@
 import type { Diagnostic } from "@voyd-lang/compiler/diagnostics/index.js";
+import type { BoundaryExportsOption } from "@voyd-lang/compiler/codegen/context.js";
 import type { ModuleRoots } from "@voyd-lang/compiler/modules/types.js";
 import type { TestCase as CompilerTestCase } from "@voyd-lang/compiler/pipeline-shared.js";
 import type {
@@ -6,6 +7,7 @@ import type {
   EffectContinuation,
   EffectContinuationCall,
   EffectHandler,
+  ExportAbiEntry,
   HostProtocolTable,
   SignatureHash,
   VoydRuntimeDiagnostics,
@@ -18,6 +20,7 @@ export type {
   EffectContinuation,
   EffectContinuationCall,
   EffectHandler,
+  ExportAbiEntry,
   HostProtocolTable,
   ModuleRoots,
   SignatureHash,
@@ -26,12 +29,6 @@ export type {
 };
 
 export type TestCase = CompilerTestCase;
-
-export type ExportAbiEntry = {
-  name: string;
-  abi: "direct" | "serialized";
-  formatId?: string;
-};
 
 export type ExportAbiMetadata = {
   version: number;
@@ -49,6 +46,7 @@ export type CompileOptions = {
   /** Control which modules contribute test cases. */
   testScope?: "all" | "entry";
   optimize?: boolean;
+  boundaryExports?: BoundaryExportsOption;
   /**
    * Emit runtime trap-to-source metadata.
    * Defaults to true for non-optimized builds and false for optimized builds.

--- a/packages/std/src/vx.voyd
+++ b/packages/std/src/vx.voyd
@@ -94,25 +94,25 @@ pub eff Component
 
   task_started(tail, key: MsgPack, task_id: i32) -> void
 
-@intrinsic(name: "__vx_retain_event_handler", uses_signature: true)
+@intrinsic(name: "__boundary_retain_callback", uses_signature: true)
 fn retain_event_handler_id(handler: fn() -> MsgPack): () -> i32
   0
 
-@intrinsic(name: "__vx_retain_event_handler", uses_signature: true)
+@intrinsic(name: "__boundary_retain_callback", uses_signature: true)
 fn retain_event_handler_void_id(handler: fn() -> void): () -> i32
   0
 
-@intrinsic(name: "__vx_retain_event_handler", uses_signature: true)
+@intrinsic(name: "__boundary_retain_callback", uses_signature: true)
 fn retain_event_handler_with_payload_id(handler: fn(MsgPack) -> MsgPack): () -> i32
   0
 
-@intrinsic(name: "__vx_retain_event_handler", uses_signature: true)
+@intrinsic(name: "__boundary_retain_callback", uses_signature: true)
 fn retain_typed_event_handler_id<Msg>(handler: fn() -> Msg): () -> i32
-  __vx_retain_event_handler(handler)
+  __boundary_retain_callback(handler)
 
-@intrinsic(name: "__vx_retain_event_handler", uses_signature: true)
+@intrinsic(name: "__boundary_retain_callback", uses_signature: true)
 fn retain_typed_event_handler_with_payload_id<Event, Msg>(handler: fn(Event) -> Msg): () -> i32
-  __vx_retain_event_handler(handler)
+  __boundary_retain_callback(handler)
 
 @intrinsic(name: "__boundary_value_to_msgpack")
 fn boundary_value_to_msgpack<Msg>(message: Msg): () -> MsgPack


### PR DESCRIPTION
## Summary

- Adds automatic typed boundary export wrappers through the existing SDK and JS host APIs.
- Extends export ABI metadata with serialized wrapper names and boundary schemas.
- Adds JS-side boundary validation/encoding/decoding for DTO values, including records, arrays, structural records, and enum/union tags.
- Keeps VX-specific lifecycle behavior isolated behind a boundary contract and generic special-case resolver.
- Generalizes boundary callback retention while preserving legacy host import compatibility.
- Updates SDK docs and adds compiler/SDK/smoke regression coverage.

## Architecture Notes

DTO schema and serialized ABI code stay generic. VX-specific shape detection and lifecycle behavior live in `vx-boundary-contract.ts` and are reached through `serialized-export-special-cases.ts`, so ordinary typed exports do not depend on VX naming.

The host now uses serialized metadata when present for `run` and `runPure`, while falling back to direct/raw exports when no typed metadata exists. `boundaryExports: false` disables general wrappers without removing VX special cases.

## Validation

- `npx vitest packages/compiler/src/codegen/__tests__/export-abi.test.ts packages/sdk/src/__tests__/sdk-node.test.ts packages/sdk/src/__tests__/sdk-tests.test.ts apps/smoke/src/vx-dom.test.ts` — 52 passed
- `npm run typecheck` — passed
- `npm test` — passed

## Review Loop

- Implementation gap reviewer: no tangible implementation gaps found.
- Correctness reviewer: no tangible correctness issues found.