### PR TITLE
Decouple VX state and app APIs from compiler internals

### DIFF
--- a/apps/site/app/components/VsxPlayground.tsx
+++ b/apps/site/app/components/VsxPlayground.tsx
@@ -126,8 +126,6 @@ export const VsxPlayground = ({ value }: { value: string }) => {
       });
       const app = createVoydVxAppRuntime({
         host,
-        exports: { view: "view" },
-        viewReceivesModel: viewReceivesModel(code),
       });
 
       rendererRef.current?.dispose();
@@ -169,6 +167,3 @@ export const VsxPlayground = ({ value }: { value: string }) => {
     </div>
   );
 };
-
-const viewReceivesModel = (source: string): boolean =>
-  /\bpub\s+fn\s+view\s*\(\s*[^)\s]/.test(source);

--- a/apps/site/app/routes/playground.tsx
+++ b/apps/site/app/routes/playground.tsx
@@ -27,10 +27,13 @@ enum Msg
 
 pub fn app() -> Program<Model, Msg>
   program<Model, Msg>(
-    init: () -> Model => Model { count: 0 },
-    update: (model: Model, message: Msg) -> Program<Model, Msg> => update(model, message),
-    view: (model: Model) -> Html<Msg> => view(model)
+    init: init,
+    update: update,
+    view: view
   )
+
+fn init() -> Model
+  Model { count: 0 }
 
 fn update(model: Model, message: Msg) -> Program<Model, Msg>
   match(message)

--- a/apps/site/app/routes/playground.tsx
+++ b/apps/site/app/routes/playground.tsx
@@ -15,11 +15,29 @@ export function meta({}: Route.MetaArgs) {
   ];
 }
 
-const PLAYGROUND_STARTER = `use std::vx::all
+const PLAYGROUND_STARTER = `use std::enums::{ enum }
+use std::vx::all
 
-pub fn view()
-  let (local_count, set_local_count) = state(id: 1, initial: 0)
+obj Model {
+  count: i32
+}
 
+enum Msg
+  Increment
+
+pub fn app() -> Program<Model, Msg>
+  program<Model, Msg>(
+    init: () -> Model => Model { count: 0 },
+    update: (model: Model, message: Msg) -> Program<Model, Msg> => update(model, message),
+    view: (model: Model) -> Html<Msg> => view(model)
+  )
+
+fn update(model: Model, message: Msg) -> Program<Model, Msg>
+  match(message)
+    Msg::Increment:
+      program<Model, Msg>(model: Model { count: model.count + 1 })
+
+fn view(model: Model) -> Html<Msg>
   <main style="
     margin: 8px;
     padding: 16px;
@@ -35,11 +53,11 @@ pub fn view()
       background: rgba(148, 163, 184, 0.12);
     ">
       <p>
-        Component-local state updates from a retained event closure.
+        Typed messages update the model in Voyd.
       </p>
       <button
         type="button"
-        on_click={() => set_local_count(local_count + 1)}
+        on_click={Msg::Increment {}}
         style="
           border: 1px solid rgba(125, 211, 252, 0.45);
           padding: 10px 14px;
@@ -49,7 +67,7 @@ pub fn view()
           cursor: pointer;
         "
       >
-        Local clicks: {count_label(local_count)}
+        Count: {count_label(model.count)}
       </button>
     </section>
   </main>
@@ -60,12 +78,7 @@ fn count_label(value: i32) -> String
     value == 1: "1"
     value == 2: "2"
     value == 3: "3"
-    else: "many"
-
-obj Model {}
-
-pub fn init() -> Model
-  Model {}`;
+    else: "many"`;
 
 export default function Playground() {
   return (

--- a/apps/site/app/routes/wiki.tsx
+++ b/apps/site/app/routes/wiki.tsx
@@ -72,7 +72,6 @@ export default function WikiDemoRoute() {
         });
         const app = createVoydVxAppRuntime({
           host,
-          exports: { subscriptions: "subscriptions" },
         });
         const componentStateApp = createVoydVxAppRuntime({
           host,

--- a/apps/site/examples/wiki/wiki.voyd
+++ b/apps/site/examples/wiki/wiki.voyd
@@ -33,7 +33,15 @@ type TextInputEvent = {
   checked: bool
 }
 
-pub fn init() -> WikiModel
+pub fn app() -> Program<WikiModel, WikiMsg>
+  program<WikiModel, WikiMsg>(
+    init: () -> WikiModel => init(),
+    update: (model: WikiModel, message: WikiMsg) -> Program<WikiModel, WikiMsg> => update(model, message),
+    view: (model: WikiModel) -> Html<WikiMsg> => view(model),
+    subscriptions: (model: WikiModel) -> Sub<WikiMsg> => subscriptions(model)
+  )
+
+fn init() -> WikiModel
   WikiModel {
     selected: "intro",
     query: String::init(),
@@ -45,7 +53,7 @@ pub fn init() -> WikiModel
     status: "Ready"
   }
 
-pub fn update(model: WikiModel, message: WikiMsg) -> Program<WikiModel, WikiMsg>
+fn update(model: WikiModel, message: WikiMsg) -> Program<WikiModel, WikiMsg>
   match(message)
     WikiMsg::Select { page }:
       next(WikiModel {
@@ -149,10 +157,10 @@ pub fn update(model: WikiModel, message: WikiMsg) -> Program<WikiModel, WikiMsg>
         panel: toggled_panel(model.panel),
         status: "Panel toggled"
       })
-pub fn subscriptions(model: WikiModel) -> Sub<WikiMsg>
+fn subscriptions(model: WikiModel) -> Sub<WikiMsg>
   keyboard_on_key_down<WikiMsg>(key: "Escape", value: WikiMsg::Cancel {})
 
-pub fn view(model: WikiModel) -> Html<WikiMsg>
+fn view(model: WikiModel) -> Html<WikiMsg>
   <main class="wiki-demo-shell" tabindex="0" data-vx-ref="wiki-shell">
     <Sidebar model={model} />
     <Editor model={model} />
@@ -168,7 +176,7 @@ pub fn component_state_update(model: MsgPack, message: MsgPack) -> MsgPack
   model
 
 pub fn component_state_view(): Component -> MsgPack
-  let (local_clicks, set_local_clicks) = state(id: 1, initial: 0)
+  let (local_clicks, set_local_clicks) = state(initial: 0)
 
   <section class="wiki-demo-inspector wiki-demo-component-state">
     <h3>Component state</h3>

--- a/apps/site/examples/wiki/wiki.voyd
+++ b/apps/site/examples/wiki/wiki.voyd
@@ -35,10 +35,10 @@ type TextInputEvent = {
 
 pub fn app() -> Program<WikiModel, WikiMsg>
   program<WikiModel, WikiMsg>(
-    init: () -> WikiModel => init(),
-    update: (model: WikiModel, message: WikiMsg) -> Program<WikiModel, WikiMsg> => update(model, message),
-    view: (model: WikiModel) -> Html<WikiMsg> => view(model),
-    subscriptions: (model: WikiModel) -> Sub<WikiMsg> => subscriptions(model)
+    init: init,
+    update: update,
+    view: view,
+    subscriptions: subscriptions
   )
 
 fn init() -> WikiModel

--- a/apps/smoke/fixtures/vx-effectful-component-event.voyd
+++ b/apps/smoke/fixtures/vx-effectful-component-event.voyd
@@ -10,7 +10,7 @@ pub fn update(model: MsgPack, message: MsgPack) -> MsgPack
   model
 
 pub fn view(): Component -> MsgPack
-  let (count, set_count) = state(id: 1, initial: 0)
+  let (count, set_count) = state(initial: 0)
   <button on_click={() =>
     set_count(count + 1)
   }>

--- a/apps/smoke/fixtures/vx-inline-aggregate-array.voyd
+++ b/apps/smoke/fixtures/vx-inline-aggregate-array.voyd
@@ -8,13 +8,20 @@ type Model = Array<{ x: i32, y: i32 }>
 enum Msg
   Shift
 
-pub fn init() -> Model
+pub fn app() -> Program<Model, Msg>
+  program<Model, Msg>(
+    init: () -> Model => init(),
+    update: (model: Model, msg: Msg) -> Program<Model, Msg> => update(model, msg),
+    view: (model: Model) -> Html<Msg> => view(model)
+  )
+
+fn init() -> Model
   let ~points = Array<Point>::with_capacity(2)
   points.push({ x: 1, y: 2 })
   points.push({ x: 3, y: 4 })
   points
 
-pub fn update(model: Model, msg: Msg) -> Model
+fn update(model: Model, msg: Msg) -> Program<Model, Msg>
   match(msg)
     Msg::Shift:
       let ~points = Array<Point>::with_capacity(2)
@@ -22,9 +29,9 @@ pub fn update(model: Model, msg: Msg) -> Model
       let second = model.at(1)
       points.push({ x: first.x + 10, y: first.y + 20 })
       points.push({ x: second.x + 10, y: second.y + 20 })
-      points
+      program<Model, Msg>(model: points)
 
-pub fn view(model: Model) -> Html<Msg>
+fn view(model: Model) -> Html<Msg>
   let first = model.at(0)
   <button on_click={Msg::Shift {}}>
     Point: {label(first.x)}

--- a/apps/smoke/fixtures/vx-inline-aggregate-array.voyd
+++ b/apps/smoke/fixtures/vx-inline-aggregate-array.voyd
@@ -10,9 +10,9 @@ enum Msg
 
 pub fn app() -> Program<Model, Msg>
   program<Model, Msg>(
-    init: () -> Model => init(),
-    update: (model: Model, msg: Msg) -> Program<Model, Msg> => update(model, msg),
-    view: (model: Model) -> Html<Msg> => view(model)
+    init: init,
+    update: update,
+    view: view
   )
 
 fn init() -> Model

--- a/apps/smoke/fixtures/vx-state-explicit-id-rejected.voyd
+++ b/apps/smoke/fixtures/vx-state-explicit-id-rejected.voyd
@@ -1,0 +1,13 @@
+use std::msgpack
+use std::msgpack::MsgPack
+use std::vx::all
+
+pub fn init() -> MsgPack
+  msgpack::make_null()
+
+pub fn update(model: MsgPack, message: MsgPack) -> MsgPack
+  model
+
+pub fn view(): Component -> MsgPack
+  let (count, set_count) = state({ id: 1, initial: 0 })
+  <button on_click={() => set_count(count + 1)}>Count</button>

--- a/apps/smoke/fixtures/vx-typed-counter.voyd
+++ b/apps/smoke/fixtures/vx-typed-counter.voyd
@@ -13,10 +13,10 @@ enum Msg
 
 pub fn app() -> Program<Model, Msg>
   program<Model, Msg>(
-    init: () -> Model => init(),
-    update: (model: Model, msg: Msg) -> Program<Model, Msg> => update(model, msg),
-    view: (model: Model) -> Html<Msg> => view(model),
-    subscriptions: (model: Model) -> Sub<Msg> => subscriptions(model)
+    init: init,
+    update: update,
+    view: view,
+    subscriptions: subscriptions
   )
 
 fn init() -> Model

--- a/apps/smoke/fixtures/vx-typed-counter.voyd
+++ b/apps/smoke/fixtures/vx-typed-counter.voyd
@@ -11,20 +11,25 @@ enum Msg
   Increment
   Rename { value: String }
 
-pub fn init() -> Program<Model, Msg>
+pub fn app() -> Program<Model, Msg>
   program<Model, Msg>(
-    model: Model { count: 0, title: "Ready" },
-    commands: Cmd<Msg>::message(Msg::Increment {})
+    init: () -> Model => init(),
+    update: (model: Model, msg: Msg) -> Program<Model, Msg> => update(model, msg),
+    view: (model: Model) -> Html<Msg> => view(model),
+    subscriptions: (model: Model) -> Sub<Msg> => subscriptions(model)
   )
 
-pub fn update(model: Model, msg: Msg) -> Model
+fn init() -> Model
+  Model { count: 1, title: "Ready" }
+
+fn update(model: Model, msg: Msg) -> Program<Model, Msg>
   match(msg)
     Msg::Increment:
-      Model { count: model.count + 1, title: model.title }
+      program<Model, Msg>(model: Model { count: model.count + 1, title: model.title })
     Msg::Rename { value }:
-      Model { count: model.count, title: value }
+      program<Model, Msg>(model: Model { count: model.count, title: value })
 
-pub fn view(model: Model) -> Html<Msg>
+fn view(model: Model) -> Html<Msg>
   <div>
     <button on_click={Msg::Increment {}}>
       Count: {count_label(model.count)}
@@ -42,7 +47,7 @@ pub fn program_command(model: Model) -> Program<Model, Msg>
 pub fn mapped_command() -> Cmd<Msg>
   Cmd<Msg>::message(Msg::Increment {}).map<Msg>((message: Msg) -> Msg => message)
 
-pub fn subscriptions(model: Model) -> Sub<Msg>
+fn subscriptions(model: Model) -> Sub<Msg>
   if
     model.count == 0:
       Sub<Msg>::every(key: "counter", millis: 1000i64, value: Msg::Increment {})

--- a/apps/smoke/fixtures/vx-typed-mouse-event.voyd
+++ b/apps/smoke/fixtures/vx-typed-mouse-event.voyd
@@ -9,15 +9,22 @@ obj Model {
 enum Msg
   Moved { x: f64 }
 
-pub fn init() -> Model
+pub fn app() -> Program<Model, Msg>
+  program<Model, Msg>(
+    init: () -> Model => init(),
+    update: (model: Model, msg: Msg) -> Program<Model, Msg> => update(model, msg),
+    view: (model: Model) -> Html<Msg> => view(model)
+  )
+
+fn init() -> Model
   Model { x: 0.0 }
 
-pub fn update(model: Model, msg: Msg) -> Model
+fn update(model: Model, msg: Msg) -> Program<Model, Msg>
   match(msg)
     Msg::Moved { x }:
-      Model { x: x }
+      program<Model, Msg>(model: Model { x: x })
 
-pub fn view(model: Model) -> Html<Msg>
+fn view(model: Model) -> Html<Msg>
   <button on_mouse_move={(event: MouseEvent) -> Msg => Msg::Moved { x: event.client_x }}>
     X: {label(model.x)}
   </button>

--- a/apps/smoke/fixtures/vx-typed-mouse-event.voyd
+++ b/apps/smoke/fixtures/vx-typed-mouse-event.voyd
@@ -11,9 +11,9 @@ enum Msg
 
 pub fn app() -> Program<Model, Msg>
   program<Model, Msg>(
-    init: () -> Model => init(),
-    update: (model: Model, msg: Msg) -> Program<Model, Msg> => update(model, msg),
-    view: (model: Model) -> Html<Msg> => view(model)
+    init: init,
+    update: update,
+    view: view
   )
 
 fn init() -> Model

--- a/apps/smoke/fixtures/vx-wide-value-model.voyd
+++ b/apps/smoke/fixtures/vx-wide-value-model.voyd
@@ -15,9 +15,9 @@ enum Msg
 
 pub fn app() -> Program<Model, Msg>
   program<Model, Msg>(
-    init: () -> Model => init(),
-    update: (model: Model, msg: Msg) -> Program<Model, Msg> => update(model, msg),
-    view: (model: Model) -> Html<Msg> => view(model)
+    init: init,
+    update: update,
+    view: view
   )
 
 fn init() -> Model

--- a/apps/smoke/src/vx-dom.test.ts
+++ b/apps/smoke/src/vx-dom.test.ts
@@ -18,6 +18,10 @@ const effectfulComponentEventEntryPath = path.join(
   fixtureRoot,
   "vx-effectful-component-event.voyd",
 );
+const explicitStateIdEntryPath = path.join(
+  fixtureRoot,
+  "vx-state-explicit-id-rejected.voyd",
+);
 const inlineAggregateArrayEntryPath = path.join(
   fixtureRoot,
   "vx-inline-aggregate-array.voyd",
@@ -37,6 +41,19 @@ const expectCompileSuccess = (
 };
 
 describe("smoke: compiled VX DOM rendering", () => {
+  it("rejects explicit component state ids", async () => {
+    const sdk = createSdk();
+    const result = await sdk.compile({ entryPath: explicitStateIdEntryPath });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain(
+      "{ id: i32, initial: i32 }",
+    );
+  });
+
   it("renders a compiled Voyd VX tree through vx-dom in a browser-like DOM", async () => {
     const sdk = createSdk();
     const entryPath = path.join(fixtureRoot, "vx.voyd");
@@ -135,10 +152,7 @@ describe("smoke: compiled VX DOM rendering", () => {
       wasm: result.wasm,
       bufferSize: 256 * 1024,
     });
-    const app = createVoydVxAppRuntime({
-      host,
-      exports: { subscriptions: "subscriptions" },
-    });
+    const app = createVoydVxAppRuntime({ host });
 
     const container = document.createElement("div");
     const mounted = await mountVxApp({ container, app });
@@ -286,13 +300,20 @@ obj Model { count: i32 }
 enum Msg
   Save { value?: String }
 
-pub fn init() -> Model
+pub fn app() -> Program<Model, Msg>
+  program<Model, Msg>(
+    init: () -> Model => init(),
+    update: (model: Model, msg: Msg) -> Program<Model, Msg> => update(model, msg),
+    view: (model: Model) -> Html<Msg> => view(model)
+  )
+
+fn init() -> Model
   Model { count: 0 }
 
-pub fn update(model: Model, msg: Msg) -> Model
-  model
+fn update(model: Model, msg: Msg) -> Program<Model, Msg>
+  program<Model, Msg>(model: model)
 
-pub fn view(model: Model) -> Html<Msg>
+fn view(model: Model) -> Html<Msg>
   <button on_click={Msg::Save {}}>Save</button>
 `,
       entryPath: "invalid-vx-message.voyd",
@@ -339,10 +360,7 @@ pub fn view(model: Model) -> Html<Msg>
       wasm: result.wasm,
       bufferSize: 256 * 1024,
     });
-    const app = createVoydVxAppRuntime({
-      host,
-      exports: { subscriptions: "subscriptions" },
-    });
+    const app = createVoydVxAppRuntime({ host });
     const componentStateApp = createVoydVxAppRuntime({
       host,
       exports: {

--- a/apps/smoke/src/vx-dom.test.ts
+++ b/apps/smoke/src/vx-dom.test.ts
@@ -302,9 +302,9 @@ enum Msg
 
 pub fn app() -> Program<Model, Msg>
   program<Model, Msg>(
-    init: () -> Model => init(),
-    update: (model: Model, msg: Msg) -> Program<Model, Msg> => update(model, msg),
-    view: (model: Model) -> Html<Msg> => view(model)
+    init: init,
+    update: update,
+    view: view
   )
 
 fn init() -> Model

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export-contract.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export-contract.voyd
@@ -10,9 +10,9 @@ enum Msg
 
 pub fn app() -> Program<Model, Msg>
   program<Model, Msg>(
-    init: () -> Model => init(),
-    update: (model: Model, msg: Msg) -> Program<Model, Msg> => update(model, msg),
-    view: (model: Model) -> Html<Msg> => view(model)
+    init: init,
+    update: update,
+    view: view
   )
 
 fn init() -> Model

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export-contract.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export-contract.voyd
@@ -1,13 +1,8 @@
 use std::enums::{ enum }
-use std::string::type::String
 use std::vx::all
 
 obj Model {
-  a: i32,
-  b: i32,
-  c: i32,
-  d: i32,
-  e: i32
+  count: i32
 }
 
 enum Msg
@@ -21,23 +16,20 @@ pub fn app() -> Program<Model, Msg>
   )
 
 fn init() -> Model
-  Model { a: 0, b: 1, c: 2, d: 3, e: 4 }
+  Model { count: 0 }
 
 fn update(model: Model, msg: Msg) -> Program<Model, Msg>
   match(msg)
     Msg::Increment:
-      program<Model, Msg>(
-        model: Model { a: model.a + 1, b: model.b, c: model.c, d: model.d, e: model.e }
-      )
+      program<Model, Msg>(model: Model { count: model.count + 1 })
 
 fn view(model: Model) -> Html<Msg>
   <button on_click={Msg::Increment {}}>
-    Wide: {label(model.a)}
+    Count
   </button>
 
-fn label(value: i32) -> String
-  if
-    value == 0: "0"
-    value == 1: "1"
-    value == 2: "2"
-    else: "many"
+pub fn echo_command(command: Cmd<Msg>) -> Cmd<Msg>
+  command
+
+pub fn add(a: i32, b: i32) -> i32
+  a + b

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export-unsupported.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export-unsupported.voyd
@@ -10,8 +10,16 @@ enum Msg
 
 pub fn app() -> Program<MaybeCount, Msg>
   program<MaybeCount, Msg>(
-    init: () -> MaybeCount => MaybeCount {},
-    update: (model: MaybeCount, _msg: Msg) -> Program<MaybeCount, Msg> =>
-      program<MaybeCount, Msg>(model: model),
-    view: (_model: MaybeCount) -> Html<Msg> => <div></div>
+    init: init,
+    update: update,
+    view: view
   )
+
+fn init() -> MaybeCount
+  MaybeCount {}
+
+fn update(model: MaybeCount, _msg: Msg) -> Program<MaybeCount, Msg>
+  program<MaybeCount, Msg>(model: model)
+
+fn view(_model: MaybeCount) -> Html<Msg>
+  <div></div>

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export-unsupported.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export-unsupported.voyd
@@ -1,0 +1,17 @@
+use std::enums::{ enum }
+use std::vx::all
+
+obj MaybeCount {
+  value?: i32
+}
+
+enum Msg
+  Noop
+
+pub fn app() -> Program<MaybeCount, Msg>
+  program<MaybeCount, Msg>(
+    init: () -> MaybeCount => MaybeCount {},
+    update: (model: MaybeCount, _msg: Msg) -> Program<MaybeCount, Msg> =>
+      program<MaybeCount, Msg>(model: model),
+    view: (_model: MaybeCount) -> Html<Msg> => <div></div>
+  )

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-preview-export-contract.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-preview-export-contract.voyd
@@ -1,0 +1,13 @@
+use std::enums::{ enum }
+use std::vx::all
+
+enum Msg
+  Clicked
+
+pub fn view() -> Html<Msg>
+  <button on_click={Msg::Clicked {}}>
+    Preview
+  </button>
+
+pub fn init(value: i32) -> i32
+  value + 1

--- a/packages/compiler/src/codegen/__tests__/export-abi.test.ts
+++ b/packages/compiler/src/codegen/__tests__/export-abi.test.ts
@@ -62,6 +62,63 @@ describe("export abi metadata", { timeout: 60_000 }, () => {
     ]);
   });
 
+  it("does not serialize unrelated DTO-compatible exports in boundary modules", async () => {
+    const wasm = await buildModule({ entryFile: "boundary-export-contract.voyd" });
+    const module = new WebAssembly.Module(wasmBufferSource(wasm));
+    const abi = parseExportAbi(module);
+
+    expect(abi.exports).toEqual(
+      expect.arrayContaining([
+        { name: "app", abi: "serialized", formatId: "msgpack" },
+        { name: "echo_command", abi: "serialized", formatId: "msgpack" },
+        { name: "add", abi: "direct" },
+      ]),
+    );
+  });
+
+  it("decodes boundary payload envelopes in serialized params", async () => {
+    const wasm = await buildModule({ entryFile: "boundary-export-contract.voyd" });
+    const host = await createVoydHost({ wasm });
+    const payload = {
+      type: "cmd",
+      kind: "message",
+      value: { Increment: {} },
+    };
+
+    const result = await host.runPure("echo_command", [payload]);
+
+    expect(result).toEqual(payload);
+  });
+
+  it("does not activate companion boundary exports from unrelated boundary helpers", async () => {
+    const wasm = await buildModule({
+      entryFile: "boundary-preview-export-contract.voyd",
+    });
+    const module = new WebAssembly.Module(wasmBufferSource(wasm));
+    const abi = parseExportAbi(module);
+
+    expect(abi.exports).toEqual(
+      expect.arrayContaining([
+        { name: "view", abi: "serialized", formatId: "msgpack" },
+        { name: "init", abi: "direct" },
+      ]),
+    );
+  });
+
+  it("reports unsupported explicit boundary export DTOs", async () => {
+    const result = await compileProgram({
+      entryPath: resolve(fixtureRoot, "boundary-export-unsupported.voyd"),
+      roots: { src: fixtureRoot, std: stdRoot },
+      host: createFsModuleHost(),
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain(
+      "boundary DTO incompatibility",
+    );
+  });
+
   it("round-trips msgpack values for serialized exports", async () => {
     const wasm = await buildModule();
     const host = await createVoydHost({ wasm });

--- a/packages/compiler/src/codegen/boundary-metadata.ts
+++ b/packages/compiler/src/codegen/boundary-metadata.ts
@@ -1,0 +1,54 @@
+import type {
+  CodegenContext,
+  StructuralFieldInfo,
+  TypeId,
+} from "./context.js";
+import { findSerializerForType } from "./serializer.js";
+import { getStructuralTypeInfo } from "./types.js";
+
+export const isBoundaryMsgPackValue = (
+  typeId: TypeId,
+  ctx: CodegenContext,
+): boolean =>
+  ctx.program.types
+    .getAliasSymbols(typeId)
+    .some(
+      (symbol) => ctx.program.symbols.getBoundary(symbol)?.type === "value",
+    );
+
+export const isBoundaryMsgPackPayload = (
+  typeId: TypeId,
+  ctx: CodegenContext,
+): boolean => Boolean(boundaryMsgPackPayloadField(typeId, ctx));
+
+export const boundaryMsgPackPayloadField = (
+  typeId: TypeId,
+  ctx: CodegenContext,
+): StructuralFieldInfo | undefined => {
+  const metadata = boundaryMetadataForNominalType(typeId, ctx);
+  if (metadata?.type !== "payload" || !metadata.field) {
+    return undefined;
+  }
+  const info = getStructuralTypeInfo(typeId, ctx);
+  const payload = info?.fieldMap.get(metadata.field);
+  if (!payload) {
+    return undefined;
+  }
+  const serializer = findSerializerForType(payload.typeId, ctx);
+  return serializer?.formatId === "msgpack" ? payload : undefined;
+};
+
+const boundaryMetadataForNominalType = (
+  typeId: TypeId,
+  ctx: CodegenContext,
+) => {
+  const desc = ctx.program.types.getTypeDesc(typeId);
+  const nominal =
+    desc.kind === "intersection" && typeof desc.nominal === "number"
+      ? ctx.program.types.getTypeDesc(desc.nominal)
+      : desc;
+  if (nominal.kind !== "nominal-object" && nominal.kind !== "value-object") {
+    return undefined;
+  }
+  return ctx.program.symbols.getBoundary(nominal.owner);
+};

--- a/packages/compiler/src/codegen/context.ts
+++ b/packages/compiler/src/codegen/context.ts
@@ -86,6 +86,7 @@ export interface FunctionMetadata {
     optional?: boolean;
     name?: string;
     bindingKind?: HirBindingKind;
+    synthetic?: "stable-callsite-id";
   }[];
   paramAbiKinds: readonly OptimizedValueAbiKind[];
   resultTypeId: TypeId;

--- a/packages/compiler/src/codegen/exports/serialized-abi.ts
+++ b/packages/compiler/src/codegen/exports/serialized-abi.ts
@@ -4,15 +4,15 @@ import type {
   CodegenContext,
   FunctionContext,
   FunctionMetadata,
-  StructuralFieldInfo,
   TypeId,
 } from "../context.js";
-import type { ProgramSymbolId } from "../../semantics/ids.js";
 import { findSerializerForType } from "../serializer.js";
 import {
   coerceValueToType,
+  initStructuralValue,
   liftHeapValueToInline,
   loadStructuralField,
+  lowerValueForHeapField,
   storeValueIntoStorageRef,
 } from "../structural.js";
 import {
@@ -38,6 +38,11 @@ import {
   boxSignatureSpillValue,
   unboxSignatureSpillValue,
 } from "../signature-spill.js";
+import {
+  boundaryMsgPackPayloadField,
+  isBoundaryMsgPackValue,
+} from "../boundary-metadata.js";
+import { compileOptionalNoneValue } from "../optionals.js";
 
 export const emitSerializedExportWrapper = ({
   ctx,
@@ -145,6 +150,17 @@ export const emitSerializedExportWrapper = ({
         fnCtx,
       });
     }
+    const payloadField = boundaryMsgPackPayloadField(typeId, ctx);
+    if (payloadField) {
+      return buildPayloadEnvelopeParamExpr({
+        value: element,
+        typeId,
+        payloadField,
+        ctx,
+        fnCtx,
+        label: `${exportName} arg${index}`,
+      });
+    }
     return unpackBoundaryValueFromMsgPack({
       ctx,
       value: element,
@@ -201,6 +217,71 @@ export const emitSerializedExportWrapper = ({
 
   ctx.mod.addFunctionExport(wrapperName, exportName);
   return { wrapperName, formatId: "msgpack" };
+};
+
+const buildPayloadEnvelopeParamExpr = ({
+  value,
+  typeId,
+  payloadField,
+  ctx,
+  fnCtx,
+  label,
+}: {
+  value: binaryen.ExpressionRef;
+  typeId: TypeId;
+  payloadField: NonNullable<ReturnType<typeof boundaryMsgPackPayloadField>>;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  label: string;
+}): binaryen.ExpressionRef => {
+  const msgpack = ensureMsgPackFunctions(ctx);
+  const structInfo = getStructuralTypeInfo(typeId, ctx);
+  if (!structInfo) {
+    throw new Error(`boundary payload envelope ${label} is missing structural info`);
+  }
+
+  const fieldValues = structInfo.fields.map((field) => {
+    if (field.name === payloadField.name) {
+      const payload = coerceValueToType({
+        value,
+        actualType: msgpack.msgPackTypeId,
+        targetType: field.typeId,
+        ctx,
+        fnCtx,
+      });
+      return structInfo.layoutKind === "value-object"
+        ? payload
+        : lowerValueForHeapField({
+            value: payload,
+            typeId: field.typeId,
+            targetType: field.heapWasmType,
+            ctx,
+            fnCtx,
+          });
+    }
+
+    if (!field.optional) {
+      throw new Error(
+        `boundary payload envelope ${label} has non-payload field ${field.name}`
+      );
+    }
+    const none = compileOptionalNoneValue({
+      targetTypeId: field.typeId,
+      ctx,
+      fnCtx,
+    });
+    return structInfo.layoutKind === "value-object"
+      ? none
+      : lowerValueForHeapField({
+          value: none,
+          typeId: field.typeId,
+          targetType: field.heapWasmType,
+          ctx,
+          fnCtx,
+        });
+  });
+
+  return initStructuralValue({ structInfo, fieldValues, ctx });
 };
 
 const lowerSerializedExportCall = ({
@@ -449,7 +530,7 @@ const validateExportTypes = ({
       }
       return;
     }
-    if (isVxMsgPackAlias(typeId, ctx) || vxPayloadField(typeId, ctx)) {
+    if (isBoundaryMsgPackValue(typeId, ctx) || boundaryMsgPackPayloadField(typeId, ctx)) {
       return;
     }
     const target = index < meta.paramTypeIds.length ? `parameter ${index + 1}` : "return";
@@ -490,14 +571,14 @@ const packSerializedResultValue = ({
       fnCtx,
     });
   }
-  if (isVxMsgPackAlias(typeId, ctx)) {
+  if (isBoundaryMsgPackValue(typeId, ctx)) {
     return value;
   }
-  const payloadField = vxPayloadField(typeId, ctx);
+  const payloadField = boundaryMsgPackPayloadField(typeId, ctx);
   if (payloadField) {
     const info = getStructuralTypeInfo(typeId, ctx);
     if (!info) {
-      throw new Error(`VX payload envelope ${typeId} is missing structural info`);
+      throw new Error(`boundary payload envelope ${typeId} is missing structural info`);
     }
     return loadStructuralField({
       structInfo: info,
@@ -516,69 +597,6 @@ const packSerializedResultValue = ({
     ctx,
     fnCtx,
   });
-};
-
-const VX_MSGPACK_ALIAS_NAMES = new Set(["Html", "Attr", "Program"]);
-const VX_PAYLOAD_ENVELOPE_NAMES = new Set(["Cmd", "Sub"]);
-const VX_STD_MODULE_ID = "std::vx";
-
-const isStdVxSymbolNamed = (
-  symbol: ProgramSymbolId,
-  names: ReadonlySet<string>,
-  ctx: CodegenContext,
-): boolean =>
-  ctx.program.symbols.refOf(symbol).moduleId === VX_STD_MODULE_ID &&
-  names.has(ctx.program.symbols.getName(symbol) ?? "");
-
-const isVxMsgPackAlias = (typeId: TypeId, ctx: CodegenContext): boolean =>
-  ctx.program.types
-    .getAliasSymbols(typeId)
-    .some((symbol) => isStdVxSymbolNamed(symbol, VX_MSGPACK_ALIAS_NAMES, ctx));
-
-const vxPayloadField = (
-  typeId: TypeId,
-  ctx: CodegenContext,
-): StructuralFieldInfo | undefined => {
-  if (!nominalTypeSymbolIsStdVxNamed(typeId, VX_PAYLOAD_ENVELOPE_NAMES, ctx)) {
-    return undefined;
-  }
-  const info = getStructuralTypeInfo(typeId, ctx);
-  const payload = info?.fieldMap.get("payload");
-  if (!payload) {
-    return undefined;
-  }
-  const serializer = findSerializerForType(payload.typeId, ctx);
-  return serializer?.formatId === "msgpack" ? payload : undefined;
-};
-
-const nominalTypeName = (
-  typeId: TypeId,
-  ctx: CodegenContext,
-): string | undefined => {
-  const desc = ctx.program.types.getTypeDesc(typeId);
-  if (desc.kind === "nominal-object" || desc.kind === "value-object") {
-    return desc.name;
-  }
-  if (desc.kind === "intersection" && typeof desc.nominal === "number") {
-    return nominalTypeName(desc.nominal, ctx);
-  }
-  return undefined;
-};
-
-const nominalTypeSymbolIsStdVxNamed = (
-  typeId: TypeId,
-  names: ReadonlySet<string>,
-  ctx: CodegenContext,
-): boolean => {
-  const desc = ctx.program.types.getTypeDesc(typeId);
-  const nominal =
-    desc.kind === "intersection" && typeof desc.nominal === "number"
-      ? ctx.program.types.getTypeDesc(desc.nominal)
-      : desc;
-  if (nominal.kind !== "nominal-object" && nominal.kind !== "value-object") {
-    return false;
-  }
-  return isStdVxSymbolNamed(nominal.owner, names, ctx);
 };
 
 const sanitizeIdentifier = (value: string): string =>

--- a/packages/compiler/src/codegen/expressions/call/arguments.ts
+++ b/packages/compiler/src/codegen/expressions/call/arguments.ts
@@ -15,7 +15,11 @@ import type {
 } from "../../context.js";
 import type { ProgramFunctionInstanceId } from "../../../semantics/ids.js";
 import type { CallArgumentPlanEntry } from "../../../semantics/typing/types.js";
-import { compileOptionalNoneValue } from "../../optionals.js";
+import {
+  compileOptionalNoneValue,
+  compileOptionalSomeValue,
+} from "../../optionals.js";
+import { stableCallsiteIdFor } from "../../../stable-callsite-id.js";
 import {
   coerceValueToType,
   loadStructuralField,
@@ -252,6 +256,14 @@ export const sliceTypedCallArgumentPlan = ({
       };
     }
 
+    if (entry.kind === "stable-callsite-id") {
+      return {
+        kind: "stable-callsite-id",
+        targetTypeId: entry.targetTypeId,
+        value: entry.value,
+      };
+    }
+
     return {
       kind: "missing",
       targetTypeId: entry.targetTypeId,
@@ -344,6 +356,17 @@ const planCallArgumentsForParamsFallback = ({
   const allowsOmittedArgument = (param: CallParam): boolean =>
     param.optional === true ||
     ctx.program.optionals.getOptionalInfo(ctx.moduleId, param.typeId) !== undefined;
+  const omittedArgumentPlanEntry = (
+    param: CallParam,
+    paramIndex: number,
+  ): CallArgumentPlanEntry =>
+    param.synthetic === "stable-callsite-id"
+      ? {
+          kind: "stable-callsite-id",
+          targetTypeId: param.typeId,
+          value: stableCallsiteIdFor(call.span, `${paramIndex}`),
+        }
+      : { kind: "missing", targetTypeId: param.typeId };
 
   const plan: CallArgumentPlanEntry[] = [];
   const expectedTypeByArgIndex = new Map<number, TypeId>();
@@ -356,7 +379,7 @@ const planCallArgumentsForParamsFallback = ({
 
     if (!arg) {
       if (allowsOmittedArgument(param)) {
-        plan.push({ kind: "missing", targetTypeId: param.typeId });
+        plan.push(omittedArgumentPlanEntry(param, paramIndex));
         paramIndex += 1;
         continue;
       }
@@ -387,7 +410,7 @@ const planCallArgumentsForParamsFallback = ({
           }
 
           if (allowsOmittedArgument(runParam)) {
-            plan.push({ kind: "missing", targetTypeId: runParam.typeId });
+            plan.push(omittedArgumentPlanEntry(runParam, cursor));
             cursor += 1;
             continue;
           }
@@ -412,7 +435,7 @@ const planCallArgumentsForParamsFallback = ({
     }
 
     if (allowsOmittedArgument(param)) {
-      plan.push({ kind: "missing", targetTypeId: param.typeId });
+      plan.push(omittedArgumentPlanEntry(param, paramIndex));
       paramIndex += 1;
       continue;
     }
@@ -473,6 +496,15 @@ const planCallArgumentsFromTypedPlan = ({
       plan.push({
         kind: "missing",
         targetTypeId: currentParam.typeId,
+      });
+      return;
+    }
+
+    if (entry.kind === "stable-callsite-id") {
+      plan.push({
+        kind: "stable-callsite-id",
+        targetTypeId: currentParam.typeId,
+        value: entry.value,
       });
       return;
     }
@@ -553,6 +585,23 @@ const materializeCallArgumentPlan = ({
       return lowerCallArgumentForAbi({
         argValue: compileOptionalNoneValue({
           targetTypeId: entry.targetTypeId,
+          ctx,
+          fnCtx,
+        }),
+        paramTypeId,
+        abiKind,
+        ctx,
+        fnCtx,
+        compileExpr,
+      });
+    }
+
+    if (entry.kind === "stable-callsite-id") {
+      return lowerCallArgumentForAbi({
+        argValue: compileOptionalSomeValue({
+          targetTypeId: entry.targetTypeId,
+          value: ctx.mod.i32.const(entry.value),
+          valueTypeId: ctx.program.primitives.i32,
           ctx,
           fnCtx,
         }),

--- a/packages/compiler/src/codegen/expressions/call/entrypoints.ts
+++ b/packages/compiler/src/codegen/expressions/call/entrypoints.ts
@@ -540,7 +540,7 @@ const shouldCompileIntrinsicCall = ({
   intrinsicName: string;
   usesSignature: boolean;
 }): boolean =>
-  usesSignature !== true || intrinsicName === "__vx_retain_event_handler";
+  usesSignature !== true || intrinsicName === "__retain_callback";
 
 const resolveTargetFunctionId = ({
   targets,

--- a/packages/compiler/src/codegen/expressions/call/types.ts
+++ b/packages/compiler/src/codegen/expressions/call/types.ts
@@ -12,6 +12,7 @@ export type CallParam = {
   label?: string;
   optional?: boolean;
   name?: string;
+  synthetic?: "stable-callsite-id";
 };
 
 export type CompileCallArgumentOptions = {

--- a/packages/compiler/src/codegen/expressions/lambdas.ts
+++ b/packages/compiler/src/codegen/expressions/lambdas.ts
@@ -9,6 +9,7 @@ import type {
   CodegenContext,
   CompiledExpression,
   ExpressionCompiler,
+  FunctionMetadata,
   FunctionContext,
   HirLambdaExpr,
 } from "../context.js";
@@ -103,6 +104,54 @@ const defineLambdaEnvType = ({
         mutable: capture.mutable,
       })),
     ],
+    supertype: binaryenTypeToHeapType(base.interfaceType),
+    final: true,
+  });
+
+const sameTypes = (
+  left: readonly binaryen.Type[],
+  right: readonly binaryen.Type[],
+): boolean =>
+  left.length === right.length && left.every((type, index) => type === right[index]);
+
+const namedFunctionClosureKey = ({
+  meta,
+  functionTypeId,
+}: {
+  meta: FunctionMetadata;
+  functionTypeId: number;
+}): string =>
+  `named-fn:${meta.moduleId}:${meta.symbol}:${meta.instanceId}:${functionTypeId}`;
+
+const makeNamedFunctionWrapperName = ({
+  meta,
+  key,
+  ctx,
+}: {
+  meta: FunctionMetadata;
+  key: string;
+  ctx: CodegenContext;
+}): string => {
+  const safeKey = key.replace(/[^a-zA-Z0-9_]/g, "_");
+  const symbolName =
+    ctx.program.symbols.getName(
+      ctx.program.symbols.idOf({ moduleId: meta.moduleId, symbol: meta.symbol }),
+    ) ?? `${meta.symbol}`;
+  return `${ctx.moduleLabel}__fnref_${symbolName}_${safeKey}`;
+};
+
+const defineNamedFunctionEnvType = ({
+  base,
+  wrapperName,
+  ctx,
+}: {
+  base: ReturnType<typeof getClosureTypeInfo>;
+  wrapperName: string;
+  ctx: CodegenContext;
+}): binaryen.Type =>
+  defineStructType(ctx.mod, {
+    name: `${wrapperName}__env`,
+    fields: [{ name: "__fn", type: binaryen.funcref, mutable: false }],
     supertype: binaryenTypeToHeapType(base.interfaceType),
     final: true,
   });
@@ -481,4 +530,62 @@ export const compileLambdaExpr = (
   ]);
 
   return { expr: closure, usedReturnCall: false };
+};
+
+export const compileNamedFunctionClosure = ({
+  meta,
+  functionTypeId,
+  ctx,
+}: {
+  meta: FunctionMetadata;
+  functionTypeId: number;
+  ctx: CodegenContext;
+}): CompiledExpression => {
+  const base = getClosureTypeInfo(functionTypeId, ctx);
+  if (
+    !sameTypes(meta.paramTypes, base.paramTypes) ||
+    !sameTypes(meta.resultAbiTypes, base.resultAbiTypes) ||
+    meta.resultType !== base.resultType
+  ) {
+    throw new Error(
+      `named function closure ABI mismatch for ${meta.wasmName}`,
+    );
+  }
+
+  const key = namedFunctionClosureKey({ meta, functionTypeId });
+  let wrapperName = ctx.lambdaFunctions.get(key);
+  if (!wrapperName) {
+    wrapperName = makeNamedFunctionWrapperName({ meta, key, ctx });
+    const params = [base.interfaceType, ...base.paramTypes];
+    const args = meta.paramTypes.map((type, index) =>
+      ctx.mod.local.get(index + 1, type),
+    );
+    ctx.mod.addFunction(
+      wrapperName,
+      binaryen.createType(params as number[]),
+      base.resultType,
+      [],
+      ctx.mod.call(meta.wasmName, args as number[], meta.resultType),
+    );
+    ctx.lambdaFunctions.set(key, wrapperName);
+  }
+
+  const envKey = `${key}:env`;
+  let envInfo = ctx.lambdaEnvs.get(envKey);
+  if (!envInfo) {
+    envInfo = {
+      envType: defineNamedFunctionEnvType({ base, wrapperName, ctx }),
+      captures: [],
+      base,
+      typeId: functionTypeId,
+    };
+    ctx.lambdaEnvs.set(envKey, envInfo);
+  }
+
+  return {
+    expr: initStruct(ctx.mod, envInfo.envType, [
+      refFunc(ctx.mod, wrapperName, base.fnRefType),
+    ]),
+    usedReturnCall: false,
+  };
 };

--- a/packages/compiler/src/codegen/expressions/primitives.ts
+++ b/packages/compiler/src/codegen/expressions/primitives.ts
@@ -2,6 +2,7 @@ import binaryen from "binaryen";
 import type {
   CodegenContext,
   CompiledExpression,
+  FunctionMetadata,
   FunctionContext,
   HirExpression,
   SymbolId,
@@ -12,15 +13,63 @@ import {
   loadLocalValue,
 } from "../locals.js";
 import { arrayNew, arrayNewFixed } from "@voyd-lang/lib/binaryen-gc/index.js";
-import { getFixedArrayWasmTypes, wasmTypeFor } from "../types.js";
+import {
+  getFixedArrayWasmTypes,
+  getRequiredExprType,
+  wasmTypeFor,
+} from "../types.js";
 import { requireDependencyFunctionMeta } from "../function-dependencies.js";
 import { resolveModuleLetGetter } from "../module-lets.js";
 import { materializeProjectedElementBinding } from "../projected-element-views.js";
 import { coerceValueToType } from "../structural.js";
 import { unboxSignatureSpillValue } from "../signature-spill.js";
 import { materializeScalarObjectBindingValue } from "../scalar-objects.js";
+import { compileNamedFunctionClosure } from "./lambdas.js";
 
 const encoder = new TextEncoder();
+
+const functionMetaMatchesType = ({
+  meta,
+  functionTypeId,
+  ctx,
+}: {
+  meta: FunctionMetadata;
+  functionTypeId: TypeId;
+  ctx: CodegenContext;
+}): boolean => {
+  const desc = ctx.program.types.getTypeDesc(functionTypeId);
+  if (desc.kind !== "function") {
+    return false;
+  }
+  return (
+    meta.resultTypeId === desc.returnType &&
+    meta.paramTypeIds.length === desc.parameters.length &&
+    meta.paramTypeIds.every((typeId, index) => typeId === desc.parameters[index]?.type)
+  );
+};
+
+const findFunctionMetaForIdentifier = ({
+  symbol,
+  functionTypeId,
+  ctx,
+}: {
+  symbol: SymbolId;
+  functionTypeId: TypeId;
+  ctx: CodegenContext;
+}): FunctionMetadata | undefined => {
+  const candidates = [{ moduleId: ctx.moduleId, symbol }];
+  const targetId = ctx.program.imports.getTarget(ctx.moduleId, symbol);
+  if (typeof targetId === "number") {
+    const targetRef = ctx.program.symbols.refOf(targetId);
+    candidates.push({ moduleId: targetRef.moduleId, symbol: targetRef.symbol });
+  }
+
+  return candidates
+    .flatMap(({ moduleId, symbol: candidateSymbol }) =>
+      ctx.functions.get(moduleId)?.get(candidateSymbol) ?? [],
+    )
+    .find((meta) => functionMetaMatchesType({ meta, functionTypeId, ctx }));
+};
 
 export const compileLiteralExpr = (
   expr: HirExpression & {
@@ -189,6 +238,24 @@ export const compileIdentifierExpr = (
           : value,
       usedReturnCall: false,
     };
+  }
+
+  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+  const functionTypeId =
+    expectedResultTypeId ?? getRequiredExprType(expr.id, ctx, typeInstanceId);
+  if (ctx.program.types.getTypeDesc(functionTypeId).kind === "function") {
+    const meta = findFunctionMetaForIdentifier({
+      symbol: expr.symbol,
+      functionTypeId,
+      ctx,
+    });
+    if (meta) {
+      return compileNamedFunctionClosure({
+        meta,
+        functionTypeId,
+        ctx,
+      });
+    }
   }
 
   const targetId = ctx.program.imports.getTarget(ctx.moduleId, expr.symbol);

--- a/packages/compiler/src/codegen/functions.ts
+++ b/packages/compiler/src/codegen/functions.ts
@@ -582,6 +582,14 @@ const collectReachableFunctionSymbols = ({
           }
           return;
         }
+        if (expr.exprKind === "identifier") {
+          enqueueReferencedFunctionIdentifier({
+            ctx: ownerCtx,
+            symbol: expr.symbol,
+            enqueue,
+          });
+          return;
+        }
         if (expr.exprKind !== "method-call") {
           return;
         }
@@ -656,6 +664,38 @@ const markStringLiteralCtorReachable = ({
     dependency: "string-literal-constructor",
     reachable,
   });
+};
+
+const enqueueReferencedFunctionIdentifier = ({
+  ctx,
+  symbol,
+  enqueue,
+}: {
+  ctx: CodegenContext;
+  symbol: number;
+  enqueue: (symbolId: ProgramSymbolId) => void;
+}): boolean => {
+  if (!ctx.program.functions.getSignature(ctx.moduleId, symbol)) {
+    return false;
+  }
+  const targetId = ctx.program.imports.getTarget(ctx.moduleId, symbol);
+  if (typeof targetId === "number") {
+    const targetRef = ctx.program.symbols.refOf(targetId);
+    enqueue(
+      ctx.program.symbols.canonicalIdOf(
+        targetRef.moduleId,
+        targetRef.symbol,
+      ) as ProgramSymbolId,
+    );
+    return true;
+  }
+  enqueue(
+    ctx.program.symbols.canonicalIdOf(
+      ctx.moduleId,
+      symbol,
+    ) as ProgramSymbolId,
+  );
+  return true;
 };
 
 const walkFunctionReachabilityExpressions = ({
@@ -970,6 +1010,14 @@ export const compileFunctions = ({
               ) as ProgramSymbolId,
             );
           }
+          return;
+        }
+        if (expr.exprKind === "identifier") {
+          enqueueReferencedFunctionIdentifier({
+            ctx,
+            symbol: expr.symbol,
+            enqueue: (symbolId) => reachableFunctions.add(symbolId),
+          });
           return;
         }
         if (expr.exprKind === "literal" && expr.literalKind === "string") {

--- a/packages/compiler/src/codegen/functions.ts
+++ b/packages/compiler/src/codegen/functions.ts
@@ -58,11 +58,16 @@ import {
   emitExportAbiSection,
   type ExportAbiEntry,
 } from "./exports/export-abi.js";
+import { deriveBoundarySchema } from "./boundary/schema.js";
 import { resolveSerializerForTypes } from "./serializer.js";
 import type { EffectfulExportTarget } from "./effects/codegen-backend.js";
 import { walkHirExpression } from "./hir-walk.js";
 import { markDependencyFunctionReachable } from "./function-dependencies.js";
 import { boxSignatureSpillValue, unboxSignatureSpillValue } from "./signature-spill.js";
+import {
+  isBoundaryMsgPackPayload,
+  isBoundaryMsgPackValue,
+} from "./boundary-metadata.js";
 
 const REACHABILITY_STATE = Symbol.for("voyd.codegen.reachabilityState");
 const FUNCTION_METADATA_REGISTRATION_STATE = Symbol.for(
@@ -129,97 +134,38 @@ const userParamOffsetFor = (meta: FunctionMetadata): number => meta.userParamOff
 const firstUserParamIndexFor = (meta: FunctionMetadata): number =>
   meta.firstUserParamIndex;
 
-const VX_BOUNDARY_EXPORT_NAMES = new Set([
-  "init",
-  "update",
-  "view",
-  "subscriptions",
-]);
-
-const isVxBoundaryExportName = (exportName: string): boolean =>
-  VX_BOUNDARY_EXPORT_NAMES.has(exportName);
-
-const VX_MSGPACK_ALIAS_NAMES = new Set(["Html", "Program"]);
-const VX_PAYLOAD_ENVELOPE_NAMES = new Set(["Sub"]);
-const VX_STD_MODULE_ID = "std::vx";
-
-const isStdVxSymbolNamed = (
-  symbol: ProgramSymbolId,
-  names: ReadonlySet<string>,
+const typeUsesBoundaryMsgPack = (
+  typeId: TypeId,
   ctx: CodegenContext,
 ): boolean =>
-  ctx.program.symbols.refOf(symbol).moduleId === VX_STD_MODULE_ID &&
-  names.has(ctx.program.symbols.getName(symbol) ?? "");
+  isBoundaryMsgPackValue(typeId, ctx) || isBoundaryMsgPackPayload(typeId, ctx);
 
-const hasTypeAliasNamed = (
-  typeId: TypeId,
-  names: ReadonlySet<string>,
-  ctx: CodegenContext,
-): boolean =>
-  ctx.program.types
-    .getAliasSymbols(typeId)
-    .some((symbol) => isStdVxSymbolNamed(symbol, names, ctx));
-
-const nominalTypeName = (
-  typeId: TypeId,
-  ctx: CodegenContext,
-): string | undefined => {
-  const desc = ctx.program.types.getTypeDesc(typeId);
-  if (desc.kind === "nominal-object" || desc.kind === "value-object") {
-    return desc.name;
-  }
-  if (desc.kind === "intersection" && typeof desc.nominal === "number") {
-    return nominalTypeName(desc.nominal, ctx);
-  }
-  return undefined;
-};
-
-const nominalTypeSymbolIsStdVxNamed = (
-  typeId: TypeId,
-  names: ReadonlySet<string>,
-  ctx: CodegenContext,
-): boolean => {
-  const desc = ctx.program.types.getTypeDesc(typeId);
-  const nominal =
-    desc.kind === "intersection" && typeof desc.nominal === "number"
-      ? ctx.program.types.getTypeDesc(desc.nominal)
-      : desc;
-  if (nominal.kind !== "nominal-object" && nominal.kind !== "value-object") {
-    return false;
-  }
-  return isStdVxSymbolNamed(nominal.owner, names, ctx);
-};
-
-const isVxPayloadEnvelope = (typeId: TypeId, ctx: CodegenContext): boolean =>
-  nominalTypeSymbolIsStdVxNamed(typeId, VX_PAYLOAD_ENVELOPE_NAMES, ctx);
-
-const isVxViewBoundaryMeta = (meta: FunctionMetadata, ctx: CodegenContext): boolean =>
-  meta.paramTypeIds.length === 1 &&
-  hasTypeAliasNamed(meta.resultTypeId, VX_MSGPACK_ALIAS_NAMES, ctx);
-
-const isVxSubscriptionsBoundaryMeta = (
+const functionUsesBoundaryMsgPack = (
   meta: FunctionMetadata,
   ctx: CodegenContext,
 ): boolean =>
-  meta.paramTypeIds.length === 1 && isVxPayloadEnvelope(meta.resultTypeId, ctx);
+  [...meta.paramTypeIds, meta.resultTypeId].some((typeId) =>
+    typeUsesBoundaryMsgPack(typeId, ctx),
+  );
 
-const shouldEmitVxBoundaryWrapper = ({
-  exportName,
+const assertTypesSupportSerializedBoundary = ({
   meta,
-  moduleHasVxAppShape,
   ctx,
 }: {
-  exportName: string;
   meta: FunctionMetadata;
-  moduleHasVxAppShape: boolean;
   ctx: CodegenContext;
 }): boolean => {
-  if (!isVxBoundaryExportName(exportName)) return false;
-  if (exportName === "view") return isVxViewBoundaryMeta(meta, ctx);
-  if (exportName === "subscriptions") return isVxSubscriptionsBoundaryMeta(meta, ctx);
-  if (exportName === "init") return moduleHasVxAppShape && meta.paramTypeIds.length === 0;
-  if (exportName === "update") return moduleHasVxAppShape && meta.paramTypeIds.length === 2;
-  return false;
+  [...meta.paramTypeIds, meta.resultTypeId].forEach((typeId) => {
+    if (typeUsesBoundaryMsgPack(typeId, ctx)) {
+      return;
+    }
+    deriveBoundarySchema({
+      typeId,
+      ctx,
+      label: "serialized boundary export",
+    });
+  });
+  return true;
 };
 
 const makeAbiValue = (
@@ -944,6 +890,7 @@ export const registerFunctionMetadata = (ctx: CodegenContext): void => {
                 ? symbolName(ctx, ctx.moduleId, item.parameters[index]!.symbol)
                 : undefined,
             bindingKind: signature.parameters[index]?.bindingKind,
+            synthetic: signature.parameters[index]?.synthetic,
           })),
           paramAbiKinds,
           resultTypeId: descriptor.returnType,
@@ -1182,6 +1129,7 @@ export const registerImportMetadata = (ctx: CodegenContext): void => {
           optional: param.optional,
           name: signature.parameters[index]?.name,
           bindingKind: signature.parameters[index]?.bindingKind,
+          synthetic: signature.parameters[index]?.synthetic,
         })),
         paramAbiKinds,
         resultTypeId: instantiatedTypeDesc.returnType,
@@ -1249,18 +1197,6 @@ export const emitModuleExports = (
       );
       return metas?.find((candidate) => candidate.typeArgs.length === 0) ?? metas?.[0];
     };
-    const moduleHasVxAppShape = exportEntries.some((entry) => {
-      const exportName =
-        entry.alias ?? symbolName(exportCtx, exportCtx.moduleId, entry.symbol);
-      const meta = metaForEntry(entry);
-      if (!meta) return false;
-      return (
-        (exportName === "view" && isVxViewBoundaryMeta(meta, exportCtx)) ||
-        (exportName === "subscriptions" &&
-          isVxSubscriptionsBoundaryMeta(meta, exportCtx))
-      );
-    });
-
     exportEntries.forEach((entry) => {
       const intrinsicMetadata =
         exportCtx.program.symbols.getIntrinsicFunctionFlags(
@@ -1346,14 +1282,31 @@ export const emitModuleExports = (
         return;
       }
 
-      const shouldUseVxBoundary = shouldEmitVxBoundaryWrapper({
-        exportName,
-        meta,
-        moduleHasVxAppShape,
-        ctx: exportCtx,
-      });
+      const shouldUseBoundarySerialization =
+        functionUsesBoundaryMsgPack(meta, exportCtx);
 
-      if (serializer || shouldUseVxBoundary) {
+      if (shouldUseBoundarySerialization) {
+        try {
+          assertTypesSupportSerializedBoundary({
+            meta,
+            ctx: exportCtx,
+          });
+        } catch (error) {
+          exportCtx.diagnostics.report(
+            diagnosticFromCode({
+              code: "CG0001",
+              params: {
+                kind: "codegen-error",
+                message: (error as Error).message,
+              },
+              span: entry.span,
+            }),
+          );
+          return;
+        }
+      }
+
+      if (serializer || shouldUseBoundarySerialization) {
         if (serializer) {
           markSerializerReachable({ ctx: exportCtx, serializer });
         }

--- a/packages/compiler/src/codegen/intrinsics.ts
+++ b/packages/compiler/src/codegen/intrinsics.ts
@@ -55,6 +55,11 @@ import {
   unpackBoundaryValueFromMsgPack,
 } from "./boundary/msgpack-codec.js";
 import { findSerializerForType } from "./serializer.js";
+import { stableCallsiteIdFor } from "../stable-callsite-id.js";
+import {
+  boundaryMsgPackPayloadField,
+  isBoundaryMsgPackValue,
+} from "./boundary-metadata.js";
 
 type NumericKind = "i32" | "i64" | "f32" | "f64";
 type EqualityKind = NumericKind | "bool";
@@ -104,9 +109,9 @@ const PANIC_SCRATCH_CAPACITY_GLOBAL = "__voyd_panic_scratch_capacity";
 const TASK_IMPORT_MODULE = "voyd.task";
 const TASK_IMPORTS_KEY = Symbol("voyd.task.imports");
 const TASK_STARTERS_KEY = Symbol("voyd.task.starters");
-const VX_CALLBACK_IMPORT_MODULE = "voyd.vx.callback";
-const VX_CALLBACK_IMPORTS_KEY = Symbol("voyd.vx.callback.imports");
-const VX_CALLBACK_HELPERS_KEY = Symbol("voyd.vx.callback.helpers");
+const CALLBACK_IMPORT_MODULE = "voyd.callback";
+const CALLBACK_IMPORTS_KEY = Symbol("voyd.callback.imports");
+const CALLBACK_HELPERS_KEY = Symbol("voyd.callback.helpers");
 
 const ensurePanicTrapGlobals = (ctx: CodegenContext): void => {
   if (ctx.mod.getGlobal(PANIC_TRAP_PTR_GLOBAL) === 0) {
@@ -179,7 +184,7 @@ const ensureTaskImport = ({
   return name;
 };
 
-const ensureVxCallbackImport = ({
+const ensureCallbackImport = ({
   name,
   base,
   params,
@@ -193,7 +198,7 @@ const ensureVxCallbackImport = ({
   ctx: CodegenContext;
 }): string => {
   const imports = ctx.programHelpers.getHelperState(
-    VX_CALLBACK_IMPORTS_KEY,
+    CALLBACK_IMPORTS_KEY,
     () => new Set<string>()
   );
   if (imports.has(name)) {
@@ -201,7 +206,7 @@ const ensureVxCallbackImport = ({
   }
   ctx.mod.addFunctionImport(
     name,
-    VX_CALLBACK_IMPORT_MODULE,
+    CALLBACK_IMPORT_MODULE,
     base,
     binaryen.createType(params as number[]),
     result
@@ -295,7 +300,7 @@ const ensureTaskStarterHelper = ({
   return exportName;
 };
 
-const ensureVxEventCallbackHelper = ({
+const ensureRetainedCallbackHelper = ({
   closureTypeId,
   ctx,
 }: {
@@ -303,7 +308,7 @@ const ensureVxEventCallbackHelper = ({
   ctx: CodegenContext;
 }): string => {
   const helpers = ctx.programHelpers.getHelperState(
-    VX_CALLBACK_HELPERS_KEY,
+    CALLBACK_HELPERS_KEY,
     () => new Map<number, string>()
   );
   const cached = helpers.get(closureTypeId);
@@ -313,31 +318,29 @@ const ensureVxEventCallbackHelper = ({
 
   const desc = ctx.program.types.getTypeDesc(closureTypeId);
   if (desc.kind !== "function") {
-    throw new Error("VX event handler retention requires a function value");
-  }
-  if (desc.parameters.length > 1) {
-    throw new Error("VX event handler retention supports fn() -> Msg or fn(Event) -> Msg");
+    throw new Error("callback retention requires a function value");
   }
   ensureLinearMemoryExport(ctx);
   const msgpack = ensureMsgPackFunctions(ctx);
-  const parameterTypeId = desc.parameters[0]?.type;
-  const parameterSerializer =
-    parameterTypeId !== undefined
-      ? findSerializerForType(parameterTypeId, ctx)
-      : undefined;
-  if (parameterSerializer && parameterSerializer.formatId !== "msgpack") {
-    throw new Error(
-      `VX event handler parameter serializer format ${parameterSerializer.formatId} is not supported`
-    );
-  }
-  const parameterSchema =
-    parameterTypeId !== undefined && !parameterSerializer
-      ? deriveBoundarySchema({
-          typeId: parameterTypeId,
-          ctx,
-          label: "VX event handler parameter",
-        })
-      : undefined;
+  const parameterCodecs = desc.parameters.map((parameter, index) => {
+    const serializer = findSerializerForType(parameter.type, ctx);
+    if (serializer && serializer.formatId !== "msgpack") {
+      throw new Error(
+        `callback parameter serializer format ${serializer.formatId} is not supported`
+      );
+    }
+    return {
+      typeId: parameter.type,
+      serializer,
+      schema: serializer
+        ? undefined
+        : deriveBoundarySchema({
+            typeId: parameter.type,
+            ctx,
+            label: `callback parameter ${index + 1}`,
+          }),
+    };
+  });
   const returnWasmType = wasmTypeFor(desc.returnType, ctx);
   const returnsVoid = returnWasmType === binaryen.none;
   const returnSerializer = returnsVoid
@@ -345,15 +348,18 @@ const ensureVxEventCallbackHelper = ({
     : findSerializerForType(desc.returnType, ctx);
   if (returnSerializer && returnSerializer.formatId !== "msgpack") {
     throw new Error(
-      `VX event handler return serializer format ${returnSerializer.formatId} is not supported`
+      `callback return serializer format ${returnSerializer.formatId} is not supported`
     );
   }
-  const returnSchema = returnSerializer || returnsVoid
+  const returnUsesBoundary =
+    isBoundaryMsgPackValue(desc.returnType, ctx) ||
+    Boolean(boundaryMsgPackPayloadField(desc.returnType, ctx));
+  const returnSchema = returnSerializer || returnsVoid || returnUsesBoundary
     ? undefined
     : deriveBoundarySchema({
         typeId: desc.returnType,
         ctx,
-        label: "VX event handler return",
+        label: "callback return",
       });
   const effectful =
     typeof desc.effectRow === "number" &&
@@ -361,7 +367,7 @@ const ensureVxEventCallbackHelper = ({
 
   const msgPackType = wasmTypeFor(msgpack.msgPackTypeId, ctx);
   const base = getClosureTypeInfo(closureTypeId, ctx);
-  const exportName = `__voyd_vx_event_callback_${sanitizeTaskKey(base.key)}`;
+  const exportName = `__voyd_callback_${sanitizeTaskKey(base.key)}`;
   const locals: binaryen.Type[] = [];
   const helperFnCtx: FunctionContext = {
     bindings: new Map(),
@@ -379,31 +385,51 @@ const ensureVxEventCallbackHelper = ({
     binaryen.i32,
   ]);
   const closureRef = ctx.mod.local.get(0, base.interfaceType);
-  const rawPayloadValue =
-    parameterTypeId !== undefined
-      ? ctx.mod.call(
-          msgpack.decodeValue.wasmName,
-          [ctx.mod.local.get(1, binaryen.i32), ctx.mod.local.get(2, binaryen.i32)],
-          msgPackType
-        )
-      : undefined;
-  const payloadValue =
-    rawPayloadValue === undefined || parameterTypeId === undefined
-      ? undefined
-      : parameterSerializer
-        ? coerceValueToType({
-            value: rawPayloadValue,
-            actualType: msgpack.msgPackTypeId,
-            targetType: parameterTypeId,
-            ctx,
-            fnCtx: helperFnCtx,
-          })
-        : unpackBoundaryValueFromMsgPack({
-            value: rawPayloadValue,
-            schema: parameterSchema!,
-            ctx,
-            fnCtx: helperFnCtx,
-          });
+  const decodedPayloadValue = (): binaryen.ExpressionRef =>
+    ctx.mod.call(
+      msgpack.decodeValue.wasmName,
+      [ctx.mod.local.get(1, binaryen.i32), ctx.mod.local.get(2, binaryen.i32)],
+      msgPackType,
+    );
+  const payloadElementValue = (index: number): binaryen.ExpressionRef => {
+    if (parameterCodecs.length === 1) {
+      return decodedPayloadValue();
+    }
+    const argsArray = ctx.mod.call(
+      msgpack.unpackArray.wasmName,
+      [decodedPayloadValue()],
+      msgpack.arrayWithCapacity.resultType,
+    );
+    const storage = ctx.mod.call(
+      msgpack.arrayRawStorage.wasmName,
+      [argsArray],
+      msgpack.arrayRawStorage.resultType,
+    );
+    return arrayGet(
+      ctx.mod,
+      storage,
+      ctx.mod.i32.const(index),
+      msgPackType,
+      false,
+    );
+  };
+  const payloadValues = parameterCodecs.map((codec, index) => {
+    const value = payloadElementValue(index);
+    return codec.serializer
+      ? coerceValueToType({
+          value,
+          actualType: msgpack.msgPackTypeId,
+          targetType: codec.typeId,
+          ctx,
+          fnCtx: helperFnCtx,
+        })
+      : unpackBoundaryValueFromMsgPack({
+          value,
+          schema: codec.schema!,
+          ctx,
+          fnCtx: helperFnCtx,
+        });
+  });
   const fnField = structGetFieldValue({
     mod: ctx.mod,
     fieldIndex: 0,
@@ -414,17 +440,17 @@ const ensureVxEventCallbackHelper = ({
     base.fnRefType === binaryen.funcref
       ? fnField
       : refCast(ctx.mod, fnField, base.fnRefType);
-  const loweredPayload = payloadValue
-    ? lowerSerializedAbiArg({
-        wasmName: exportName,
-        abiKind: "direct",
-        abiTypes: base.paramAbiTypes[0] ?? [binaryen.getExpressionType(payloadValue)],
-        typeId: parameterTypeId!,
-        value: payloadValue,
-        ctx,
-        fnCtx: helperFnCtx,
-      })
-    : undefined;
+  const loweredPayloads = payloadValues.map((payloadValue, index) =>
+    lowerSerializedAbiArg({
+      wasmName: exportName,
+      abiKind: "direct",
+      abiTypes: base.paramAbiTypes[index] ?? [binaryen.getExpressionType(payloadValue)],
+      typeId: parameterCodecs[index]!.typeId,
+      value: payloadValue,
+      ctx,
+      fnCtx: helperFnCtx,
+    }),
+  );
   const callExpr = callRef(
     ctx.mod,
     targetFn,
@@ -433,11 +459,11 @@ const ensureVxEventCallbackHelper = ({
       ...base.paramTypes
         .slice(0, base.userParamOffset)
         .map(() => ctx.effectsBackend.abi.hiddenHandlerValue(ctx)),
-      ...(loweredPayload?.args ?? []),
+      ...loweredPayloads.flatMap((payload) => payload.args),
     ] as number[],
     base.resultType
   );
-  const setup = loweredPayload?.setup ?? [];
+  const setup = loweredPayloads.flatMap((payload) => payload.setup);
   if (effectful) {
     const rawExportName = `${exportName}_effectful_raw`;
     const dispatched = ctx.mod.call(
@@ -483,6 +509,7 @@ const ensureVxEventCallbackHelper = ({
   const encodedLength = returnsVoid
     ? ctx.mod.block(null, [resultValue, ctx.mod.i32.const(-2)], binaryen.i32)
     : (() => {
+        const payloadField = boundaryMsgPackPayloadField(desc.returnType, ctx);
         const encodedResultValue = returnSerializer
           ? coerceValueToType({
               value: resultValue,
@@ -491,6 +518,23 @@ const ensureVxEventCallbackHelper = ({
               ctx,
               fnCtx: helperFnCtx,
             })
+          : isBoundaryMsgPackValue(desc.returnType, ctx)
+            ? resultValue
+          : payloadField
+            ? (() => {
+                const info = getStructuralTypeInfo(desc.returnType, ctx);
+                if (!info) {
+                  throw new Error(
+                    `boundary payload callback return ${desc.returnType} is missing structural info`,
+                  );
+                }
+                return loadStructuralField({
+                  structInfo: info,
+                  field: payloadField,
+                  pointer: () => resultValue,
+                  ctx,
+                });
+              })()
           : packBoundaryValueAsMsgPack({
               value: resultValue,
               schema: returnSchema!,
@@ -1190,27 +1234,31 @@ export const compileIntrinsicCall = ({
         ctx,
       });
     }
-    case "__vx_retain_event_handler": {
+    case "__retain_callback": {
       assertArgCount(name, args, 1);
       const handlerTypeId = getRequiredExprType(call.args[0]!.expr, ctx, instanceId);
       const handlerType = ctx.program.types.getTypeDesc(handlerTypeId);
       if (handlerType.kind !== "function") {
-        throw new Error("__vx_retain_event_handler requires a function-typed value");
+        throw new Error("__retain_callback requires a function-typed value");
       }
-      const helperExport = ensureVxEventCallbackHelper({
+      const helperExport = ensureRetainedCallbackHelper({
         closureTypeId: handlerTypeId,
         ctx,
       });
       const closureInfo = getClosureTypeInfo(handlerTypeId, ctx);
-      const importName = `__voyd_vx_retain_event_handler_${sanitizeTaskKey(helperExport)}`;
-      const importFn = ensureVxCallbackImport({
+      const importName = `__voyd_retain_callback_${sanitizeTaskKey(helperExport)}`;
+      const importFn = ensureCallbackImport({
         name: importName,
-        base: `retain_event__${helperExport}`,
+        base: `retain__${helperExport}`,
         params: [closureInfo.interfaceType],
         result: binaryen.i32,
         ctx,
       });
       return ctx.mod.call(importFn, [args[0]!], binaryen.i32);
+    }
+    case "__stable_callsite_id": {
+      assertArgCount(name, args, 0);
+      return ctx.mod.i32.const(stableCallsiteIdFor(call.span));
     }
     case "__boundary_value_to_msgpack": {
       assertArgCount(name, args, 1);

--- a/packages/compiler/src/codegen/optionals.ts
+++ b/packages/compiler/src/codegen/optionals.ts
@@ -2,6 +2,7 @@ import binaryen from "binaryen";
 import type { CodegenContext, FunctionContext, TypeId } from "./context.js";
 import { coerceValueToType, initStructuralValue } from "./structural.js";
 import { getStructuralTypeInfo } from "./types.js";
+import { coerceExprToWasmType } from "./wasm-type-coercions.js";
 
 export const compileOptionalNoneValue = ({
   targetTypeId,
@@ -33,6 +34,57 @@ export const compileOptionalNoneValue = ({
   return coerceValueToType({
     value: noneValue,
     actualType: optionalInfo.noneType,
+    targetType: targetTypeId,
+    ctx,
+    fnCtx,
+  });
+};
+
+export const compileOptionalSomeValue = ({
+  targetTypeId,
+  value,
+  valueTypeId,
+  ctx,
+  fnCtx,
+}: {
+  targetTypeId: TypeId;
+  value: binaryen.ExpressionRef;
+  valueTypeId: TypeId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  const optionalInfo = ctx.program.optionals.getOptionalInfo(ctx.moduleId, targetTypeId);
+  if (!optionalInfo) {
+    throw new Error("optional value requires an Optional type");
+  }
+
+  const someInfo = getStructuralTypeInfo(optionalInfo.someType, ctx);
+  if (!someInfo || someInfo.fields.length !== 1) {
+    throw new Error("optional Some type must declare one field");
+  }
+  const field = someInfo.fields[0]!;
+  const coerced = coerceValueToType({
+    value,
+    actualType: valueTypeId,
+    targetType: field.typeId,
+    ctx,
+    fnCtx,
+  });
+  const someValue = initStructuralValue({
+    structInfo: someInfo,
+    fieldValues: [
+      coerceExprToWasmType({
+        expr: coerced,
+        targetType:
+          someInfo.layoutKind === "value-object" ? field.wasmType : field.heapWasmType,
+        ctx,
+      }),
+    ],
+    ctx,
+  });
+  return coerceValueToType({
+    value: someValue,
+    actualType: optionalInfo.someType,
     targetType: targetTypeId,
     ctx,
     fnCtx,

--- a/packages/compiler/src/docs/documentation-view.ts
+++ b/packages/compiler/src/docs/documentation-view.ts
@@ -391,6 +391,7 @@ const normalizeParameter = (
 const normalizeFunction = (
   fn: {
     id: number;
+    symbol: number;
     name: string;
     visibility: { level?: string };
     implId?: number;
@@ -407,17 +408,42 @@ const normalizeFunction = (
     effectTypeExpr?: unknown;
     documentation?: string;
   },
+  semantic: SemanticsPipelineResult,
 ): DocumentationFunctionView => ({
   id: fn.id,
   name: fn.name,
   visibility: normalizeVisibility(fn.visibility),
   implId: fn.implId,
   typeParameters: normalizeTypeParameters(fn.typeParameters),
-  params: fn.params.map(normalizeParameter),
+  params: publicParamsForFunction(fn, semantic).map(normalizeParameter),
   returnTypeExpr: fn.returnTypeExpr,
   effectTypeExpr: fn.effectTypeExpr,
   documentation: fn.documentation,
 });
+
+const publicParamsForFunction = (
+  fn: {
+    symbol: number;
+    params: ReadonlyArray<{
+      name: string;
+      label?: string;
+      bindingKind?: string;
+      optional?: boolean;
+      typeExpr?: unknown;
+      documentation?: string;
+    }>;
+  },
+  semantic: SemanticsPipelineResult,
+) => {
+  const signature = semantic.typing.functions.getSignature(fn.symbol);
+  if (!signature) {
+    return fn.params;
+  }
+  return fn.params.filter(
+    (_param, index) =>
+      signature.parameters[index]?.synthetic !== "stable-callsite-id",
+  );
+};
 
 const normalizeMethod = (
   method: {
@@ -493,7 +519,7 @@ const normalizeModules = ({
             })),
           functions: semantic.binding.functions
             .filter((fn) => allowsName(fn.name))
-            .map(normalizeFunction),
+            .map((fn) => normalizeFunction(fn, semantic)),
           typeAliases: semantic.binding.typeAliases
             .filter((typeAlias) => allowsName(typeAlias.name))
             .map((typeAlias) => ({
@@ -557,7 +583,7 @@ const normalizeModules = ({
               typeParameters: normalizeTypeParameters(implDecl.typeParameters),
               methods: implDecl.methods
                 .filter((method) => method.memberVisibility?.api === true)
-                .map(normalizeFunction),
+                .map((method) => normalizeFunction(method, semantic)),
               documentation: implDecl.documentation,
             })),
           reexports: semantic.binding.uses.flatMap((useDecl) =>

--- a/packages/compiler/src/parser/__tests__/__snapshots__/parser.test.ts.snap
+++ b/packages/compiler/src/parser/__tests__/__snapshots__/parser.test.ts.snap
@@ -1130,7 +1130,7 @@ exports[`parser can parse a file into a syntax expanded ast 1`] = `
         [
           "block",
           [
-            "element",
+            "html_element",
             [
               ":",
               "tag",
@@ -1215,7 +1215,7 @@ exports[`parser can parse a file into a syntax expanded ast 1`] = `
                   [
                     "fixed_array_literal",
                     [
-                      "element",
+                      "html_element",
                       [
                         ":",
                         "tag",
@@ -1309,7 +1309,7 @@ exports[`parser can parse a file into a syntax expanded ast 1`] = `
                       ],
                     ],
                     [
-                      "element",
+                      "html_element",
                       [
                         ":",
                         "tag",

--- a/packages/compiler/src/parser/__tests__/boundary-attribute.test.ts
+++ b/packages/compiler/src/parser/__tests__/boundary-attribute.test.ts
@@ -1,0 +1,41 @@
+import { test } from "vitest";
+import type { BoundaryAttribute } from "../attributes.js";
+import { isForm, parse } from "../index.js";
+
+const parseFirstForm = (text: string) => {
+  const ast = parse(text);
+  const node = ast.rest[0];
+  if (!isForm(node)) {
+    throw new Error("expected a declaration form");
+  }
+  return node;
+};
+
+test("@boundary attaches metadata to type aliases", (t) => {
+  const alias = parseFirstForm(`@boundary(type: "value")
+type Html = MsgPack`);
+
+  t.expect(alias.attributes?.boundary as BoundaryAttribute | undefined).toEqual({
+    type: "value",
+  });
+});
+
+test("@boundary rejects unsupported target combinations", (t) => {
+  t.expect(() =>
+    parse(`@boundary(type: "payload", field: "payload")
+type Cmd = MsgPack`),
+  ).toThrow("@boundary on type aliases only supports type: \"value\"");
+
+  t.expect(() =>
+    parse(`@boundary(type: "value")
+fn encode() -> i32
+  0`),
+  ).toThrow("@boundary does not apply to functions");
+});
+
+test("@boundary rejects fields outside payload envelopes", (t) => {
+  t.expect(() =>
+    parse(`@boundary(type: "value", field: "payload")
+type Html = MsgPack`),
+  ).toThrow("@boundary value does not accept a 'field:' argument");
+});

--- a/packages/compiler/src/parser/__tests__/html-inline-lambda.test.ts
+++ b/packages/compiler/src/parser/__tests__/html-inline-lambda.test.ts
@@ -54,7 +54,7 @@ pub fn main() -> MsgPack
   t.expect(lambda[1]).toBe("f");
 });
 
-test("lowers built-in HTML elements to VX constructors", (t) => {
+test("lowers built-in HTML elements to HTML helpers", (t) => {
   const code = `
 use std::all
 use std::vx::all
@@ -64,15 +64,15 @@ pub fn main()
 `;
 
   const ast = toPlain(code);
-  t.expect(findFirstCall(ast, "element")).toBeDefined();
+  t.expect(findFirstCall(ast, "html_element")).toBeDefined();
   t.expect(findFirstCall(ast, "create_element")).toBeUndefined();
   t.expect(findFirstCall(ast, "class")).toBeDefined();
   t.expect(findFirstCall(ast, "disabled")).toBeDefined();
-  t.expect(findFirstCall(ast, "event_message")).toBeDefined();
-  t.expect(findFirstCall(ast, "event_handler")).toBeUndefined();
+  t.expect(findFirstCall(ast, "html_event_message")).toBeDefined();
+  t.expect(findFirstCall(ast, "html_event_handler")).toBeUndefined();
 });
 
-test("lowers closure-valued HTML events to retained VX event helpers", (t) => {
+test("lowers closure-valued HTML events to retained HTML event helpers", (t) => {
   const code = `
 use std::msgpack
 use std::msgpack::MsgPack
@@ -86,9 +86,9 @@ pub fn main() -> MsgPack
 `;
 
   const ast = toPlain(code);
-  t.expect(findFirstCall(ast, "event_payload_handler")).toBeDefined();
-  t.expect(findFirstCall(ast, "event_handler")).toBeUndefined();
-  t.expect(findFirstCall(ast, "event_message")).toBeUndefined();
+  t.expect(findFirstCall(ast, "html_event_payload_handler")).toBeDefined();
+  t.expect(findFirstCall(ast, "html_event_handler")).toBeUndefined();
+  t.expect(findFirstCall(ast, "html_event_message")).toBeUndefined();
 });
 
 test("lowers non-click HTML event values to message and payload helpers", (t) => {
@@ -104,12 +104,12 @@ pub fn main() -> MsgPack
 `;
 
   const ast = toPlain(code);
-  t.expect(findFirstCall(ast, "event_message")).toBeDefined();
-  t.expect(findFirstCall(ast, "event_handler")).toBeUndefined();
-  t.expect(findFirstCall(ast, "event_payload_handler")).toBeDefined();
+  t.expect(findFirstCall(ast, "html_event_message")).toBeDefined();
+  t.expect(findFirstCall(ast, "html_event_handler")).toBeUndefined();
+  t.expect(findFirstCall(ast, "html_event_payload_handler")).toBeDefined();
 });
 
-test("lowers empty built-in HTML children to a typed MsgPack array", (t) => {
+test("lowers empty built-in HTML children to a typed HTML node array", (t) => {
   const code = `
 use std::array::Array
 use std::msgpack::MsgPack
@@ -125,7 +125,7 @@ pub fn main() -> MsgPack
   const ast = toPlain(code);
   t.expect(containsNode(ast, [
     "::",
-    ["Array", ["generics", "MsgPack"]],
+    ["Array", ["generics", "HtmlNode"]],
     ["init"],
   ])).toBe(true);
 });

--- a/packages/compiler/src/parser/attributes.ts
+++ b/packages/compiler/src/parser/attributes.ts
@@ -11,6 +11,11 @@ export type SerializerAttribute = {
   decode: Expr;
 };
 
+export type BoundaryAttribute = {
+  type: "value" | "payload";
+  field?: string;
+};
+
 export type TestAttribute = {
   id: string;
   description?: string;

--- a/packages/compiler/src/parser/reader-macros/html/html-parser.ts
+++ b/packages/compiler/src/parser/reader-macros/html/html-parser.ts
@@ -97,9 +97,9 @@ export class HTMLParser {
 
     // Built-in element: element(tag: "div", attrs: [...], children: [...])
     const attributes = propsOrAttrs.map(({ name, value }) =>
-      this.lowerVxAttribute(name, value),
+      this.lowerHtmlAttribute(name, value),
     );
-    const children = selfClosing ? emptyVxChildren() : this.parseChildren(tagName);
+    const children = selfClosing ? emptyHtmlChildren() : this.parseChildren(tagName);
     const args = [label("tag", string(tagName))];
 
     if (attributes.length) {
@@ -108,7 +108,7 @@ export class HTMLParser {
 
     args.push(label("children", children));
 
-    return surfaceCall("element", ...args).setLocation(
+    return surfaceCall("html_element", ...args).setLocation(
       this.stream.currentSourceLocation(),
     );
   }
@@ -188,20 +188,20 @@ export class HTMLParser {
     return string(text);
   }
 
-  private lowerVxAttribute(name: string, value: Expr): Expr {
+  private lowerHtmlAttribute(name: string, value: Expr): Expr {
     if (name.startsWith("on_")) {
       const eventValue = unwrapInlineLambdaExpr(value);
-      const eventName = domEventNameForVxAttribute(name);
+      const eventName = domEventNameForHtmlAttribute(name);
       if (!isLambdaExpr(eventValue)) {
         return surfaceCall(
-          "event_message",
+          "html_event_message",
           label("name", string(eventName)),
           label("message", eventValue),
         ).setLocation(this.stream.currentSourceLocation());
       }
       const eventHelper = eventLambdaAcceptsPayload(eventValue)
-        ? "event_payload_handler"
-        : "event_handler";
+        ? "html_event_payload_handler"
+        : "html_event_handler";
       return surfaceCall(
         eventHelper,
         label("name", string(eventName)),
@@ -281,7 +281,7 @@ export class HTMLParser {
       });
     }
 
-    const result = children.length > 0 ? arrayLiteral(...children) : emptyVxChildren();
+    const result = children.length > 0 ? arrayLiteral(...children) : emptyHtmlChildren();
 
     // Restore mode on exiting children
     this.whitespaceMode = prevMode;
@@ -404,16 +404,16 @@ const eventLambdaAcceptsPayload = (expr: Expr): boolean => {
     );
 };
 
-const domEventNameForVxAttribute = (name: string): string => {
+const domEventNameForHtmlAttribute = (name: string): string => {
   const eventName = name.slice("on_".length);
   if (eventName === "double_click") return "dblclick";
   return eventName.replaceAll("_", "");
 };
 
-const emptyVxChildren = (): Expr =>
+const emptyHtmlChildren = (): Expr =>
   surfaceCall(
     "::",
-    surfaceCall("Array", call("generics", identifier("MsgPack"))),
+    surfaceCall("Array", call("generics", identifier("HtmlNode"))),
     surfaceCall("init"),
   );
 

--- a/packages/compiler/src/parser/syntax-macros/__tests__/__snapshots__/interpret-whitespace.test.ts.snap
+++ b/packages/compiler/src/parser/syntax-macros/__tests__/__snapshots__/interpret-whitespace.test.ts.snap
@@ -1011,7 +1011,7 @@ exports[`it correctly handles the kitchen sink 1`] = `
         [
           "block",
           [
-            "element",
+            "html_element",
             [
               ":",
               "tag",
@@ -1096,7 +1096,7 @@ exports[`it correctly handles the kitchen sink 1`] = `
                   [
                     "fixed_array_literal",
                     [
-                      "element",
+                      "html_element",
                       [
                         ":",
                         "tag",
@@ -1190,7 +1190,7 @@ exports[`it correctly handles the kitchen sink 1`] = `
                       ],
                     ],
                     [
-                      "element",
+                      "html_element",
                       [
                         ":",
                         "tag",

--- a/packages/compiler/src/parser/syntax-macros/boundary-attribute.ts
+++ b/packages/compiler/src/parser/syntax-macros/boundary-attribute.ts
@@ -1,0 +1,204 @@
+import {
+  type Expr,
+  type Form,
+  isForm,
+  isIdentifierAtom,
+} from "../ast/index.js";
+import { cloneAttributes } from "../ast/syntax.js";
+import type { BoundaryAttribute } from "../attributes.js";
+import { parseStringValue } from "../string-value.js";
+import { transformFormSequence } from "./sequence-transform.js";
+
+type PendingBoundaryAttribute = BoundaryAttribute & { source: Form };
+
+export const boundaryAttributeMacro = (form: Form): Form =>
+  transformFormSequence({ form, transform: processSequence });
+
+const processSequence = (
+  elements: readonly Expr[],
+  allowAttributes: boolean,
+): { elements: Expr[]; changed: boolean } => {
+  const result: Expr[] = [];
+  let pending: PendingBoundaryAttribute | null = null;
+  let changed = false;
+
+  for (const element of elements) {
+    const processed = isForm(element) ? boundaryAttributeMacro(element) : element;
+    if (processed !== element) {
+      changed = true;
+    }
+
+    if (allowAttributes && isBoundaryAttributeForm(processed)) {
+      if (pending) {
+        throw new Error("duplicate @boundary attribute");
+      }
+      pending = parseBoundaryAttribute(processed);
+      changed = true;
+      continue;
+    }
+
+    if (pending && allowAttributes) {
+      const kind = isForm(processed) ? getBoundaryTargetDeclKind(processed) : null;
+      if (kind) {
+        attachBoundaryAttribute(processed as Form, pending, kind);
+        changed = true;
+        pending = null;
+      } else {
+        throw new Error("@boundary attribute must precede a type or function");
+      }
+    }
+
+    result.push(processed);
+  }
+
+  if (pending && allowAttributes) {
+    throw new Error("@boundary attribute missing a type or function");
+  }
+
+  return { elements: result, changed };
+};
+
+const getBoundaryTargetDeclKind = (
+  form: Form,
+): "fn" | "obj" | "value" | "type" | null => {
+  const normalizeDeclKind = (
+    keyword: string,
+  ): "fn" | "obj" | "value" | "type" | null => {
+    if (keyword === "fn" || keyword === "obj" || keyword === "type") {
+      return keyword;
+    }
+    return keyword === "val" ? "value" : null;
+  };
+
+  const head = form.at(0);
+  if (!isIdentifierAtom(head)) {
+    return null;
+  }
+  if (head.value === "pub") {
+    const keyword = form.at(1);
+    return isIdentifierAtom(keyword) ? normalizeDeclKind(keyword.value) : null;
+  }
+  return normalizeDeclKind(head.value);
+};
+
+const isBoundaryAttributeForm = (expr: Expr): expr is Form =>
+  isForm(expr) && expr.calls("@") && isBoundaryHead(expr.at(1));
+
+const isBoundaryHead = (expr?: Expr): boolean => {
+  if (isIdentifierAtom(expr)) {
+    return expr.value === "boundary";
+  }
+  if (!isForm(expr)) {
+    return false;
+  }
+  const head = expr.at(0);
+  return isIdentifierAtom(head) && head.value === "boundary";
+};
+
+const parseBoundaryAttribute = (form: Form): PendingBoundaryAttribute => {
+  const target = form.at(1);
+  const attributeCall = getAttributeCall(target);
+  if (!attributeCall || attributeCall.name !== "boundary") {
+    throw new Error("unsupported attribute");
+  }
+  return { ...parseBoundaryArgs(attributeCall.args), source: form };
+};
+
+const getAttributeCall = (
+  expr?: Expr,
+): { name: string; args: readonly Expr[] } | null => {
+  if (!expr) {
+    return null;
+  }
+  if (isIdentifierAtom(expr)) {
+    return { name: expr.value, args: [] };
+  }
+  if (isForm(expr)) {
+    const head = expr.at(0);
+    if (isIdentifierAtom(head)) {
+      return { name: head.value, args: expr.rest };
+    }
+  }
+  return null;
+};
+
+const parseBoundaryArgs = (args: readonly Expr[]): BoundaryAttribute => {
+  let type: BoundaryAttribute["type"] | undefined;
+  let field: string | undefined;
+
+  args.forEach((arg) => {
+    if (!isForm(arg) || !arg.calls(":")) {
+      throw new Error("@boundary arguments must be labeled with ':'");
+    }
+
+    const label = arg.at(1);
+    if (!isIdentifierAtom(label)) {
+      throw new Error("@boundary argument labels must be identifiers");
+    }
+
+    const value = arg.at(2);
+    const parsed = parseStringValue(value);
+    if (parsed === null) {
+      throw new Error(`@boundary ${label.value} must be a string`);
+    }
+
+    if (label.value === "type") {
+      if (parsed !== "value" && parsed !== "payload") {
+        throw new Error(`unknown @boundary type '${parsed}'`);
+      }
+      type = parsed;
+      return;
+    }
+
+    if (label.value === "field") {
+      field = parsed;
+      return;
+    }
+
+    throw new Error(`unknown @boundary argument '${label.value}'`);
+  });
+
+  if (!type) {
+    throw new Error("@boundary requires a 'type:' argument");
+  }
+  if (type === "payload" && !field) {
+    throw new Error("@boundary payload requires a 'field:' argument");
+  }
+  if (type !== "payload" && field) {
+    throw new Error(`@boundary ${type} does not accept a 'field:' argument`);
+  }
+  return { type, ...(field ? { field } : {}) };
+};
+
+const attachBoundaryAttribute = (
+  form: Form,
+  attr: PendingBoundaryAttribute,
+  targetKind: "fn" | "obj" | "value" | "type",
+): void => {
+  validateBoundaryTarget(attr, targetKind);
+  const attributes = cloneAttributes(form.attributes) ?? {};
+  if ((attributes as { boundary?: unknown }).boundary) {
+    throw new Error("duplicate @boundary attribute");
+  }
+  (attributes as { boundary: BoundaryAttribute }).boundary = {
+    type: attr.type,
+    ...(attr.field ? { field: attr.field } : {}),
+  };
+  form.attributes = attributes;
+};
+
+const validateBoundaryTarget = (
+  attr: PendingBoundaryAttribute,
+  targetKind: "fn" | "obj" | "value" | "type",
+): void => {
+  if (targetKind === "fn") {
+    throw new Error("@boundary does not apply to functions");
+  }
+
+  if (targetKind === "type") {
+    if (attr.type !== "value") {
+      throw new Error("@boundary on type aliases only supports type: \"value\"");
+    }
+    return;
+  }
+};

--- a/packages/compiler/src/parser/syntax-macros/index.ts
+++ b/packages/compiler/src/parser/syntax-macros/index.ts
@@ -4,6 +4,7 @@ import { intrinsicAttributeMacro } from "./intrinsic-attribute.js";
 import { intrinsicTypeAttributeMacro } from "./intrinsic-type-attribute.js";
 import { effectAttributeMacro } from "./effect-attribute.js";
 import { serializerAttributeMacro } from "./serializer-attribute.js";
+import { boundaryAttributeMacro } from "./boundary-attribute.js";
 import { primary } from "./primary.js";
 import { attachColonClauses } from "./colon-clauses.js";
 import { constructorObjectLiteral } from "./constructor-object-literal.js";
@@ -22,6 +23,7 @@ export const BASE_SYNTAX_MACROS: SyntaxMacro[] = [
 export const POST_SYNTAX_MACROS: SyntaxMacro[] = [
   intrinsicAttributeMacro,
   intrinsicTypeAttributeMacro,
+  boundaryAttributeMacro,
   serializerAttributeMacro,
   effectAttributeMacro,
   testBlockMacro,

--- a/packages/compiler/src/semantics/binding/binders/function.ts
+++ b/packages/compiler/src/semantics/binding/binders/function.ts
@@ -35,9 +35,11 @@ export const bindFunctionDecl = (
   const declarationScope = options.declarationScope ?? tracker.current();
   rememberSyntax(decl.form, ctx);
   const intrinsicMetadata = decl.intrinsic;
+  const boundaryMetadata = boundaryMetadataFromAttribute(decl.form.attributes?.boundary);
   const symbolMetadata: Record<string, unknown> = {
     entity: "function",
     ...options.metadata,
+    ...(boundaryMetadata ? { boundary: boundaryMetadata } : {}),
   };
   if (decl.signature.name.isQuoted) {
     symbolMetadata.quotedName = true;
@@ -97,6 +99,10 @@ export const bindFunctionDecl = (
 
   recordFunctionOverload(fnDecl, declarationScope, ctx);
   return fnDecl;
+};
+
+const boundaryMetadataFromAttribute = (_value: unknown): unknown | undefined => {
+  return undefined;
 };
 
 const bindFunctionTypeParameters = (

--- a/packages/compiler/src/semantics/binding/binders/object.ts
+++ b/packages/compiler/src/semantics/binding/binders/object.ts
@@ -30,6 +30,7 @@ export const bindObjectDecl = (
   const intrinsicType = decl.form.attributes?.intrinsicType;
   const intrinsicTypeMetadata =
     typeof intrinsicType === "string" ? { intrinsicType } : undefined;
+  const boundaryMetadata = boundaryMetadataFromAttribute(decl.form.attributes?.boundary);
   reportOverloadNameCollision({
     name: decl.name.value,
     scope: tracker.current(),
@@ -41,7 +42,12 @@ export const bindObjectDecl = (
     name: decl.name.value,
     kind: "type",
     declaredAt: decl.form.syntaxId,
-    metadata: { entity: "object", objectKind: decl.objectKind, ...intrinsicTypeMetadata },
+    metadata: {
+      entity: "object",
+      objectKind: decl.objectKind,
+      ...intrinsicTypeMetadata,
+      ...(boundaryMetadata ? { boundary: boundaryMetadata } : {}),
+    },
   });
 
   const objectScope = ctx.symbolTable.createScope({
@@ -100,6 +106,20 @@ export const bindObjectDecl = (
     moduleIndex: ctx.nextModuleIndex++,
     documentation: declarationDocForSyntax(decl.name, ctx),
   });
+};
+
+const boundaryMetadataFromAttribute = (value: unknown): unknown | undefined => {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as { type?: unknown; field?: unknown };
+  if (record.type !== "value" && record.type !== "payload") {
+    return undefined;
+  }
+  return {
+    type: record.type,
+    ...(typeof record.field === "string" ? { field: record.field } : {}),
+  };
 };
 
 export const resolveObjectDecl = (

--- a/packages/compiler/src/semantics/binding/binders/type-alias.ts
+++ b/packages/compiler/src/semantics/binding/binders/type-alias.ts
@@ -42,6 +42,7 @@ export const bindTypeAlias = (
   const intrinsicType = decl.form.attributes?.intrinsicType;
   const intrinsicTypeMetadata =
     typeof intrinsicType === "string" ? { intrinsicType } : undefined;
+  const boundaryMetadata = boundaryMetadataFromAttribute(decl.form.attributes?.boundary);
   const enumNamespaceMetadata = enumNamespaceMetadataFromAliasTarget({
     target: decl.target,
     typeParameterNames: decl.typeParameters.map((entry) => entry.name.value),
@@ -70,6 +71,7 @@ export const bindTypeAlias = (
     metadata: {
       entity: "type-alias",
       ...intrinsicTypeMetadata,
+      ...(boundaryMetadata ? { boundary: boundaryMetadata } : {}),
       ...(enumNamespaceMetadata ?? {}),
       ...(nominalTargetMetadata ?? {}),
     },
@@ -101,6 +103,19 @@ export const bindTypeAlias = (
     moduleIndex: ctx.nextModuleIndex++,
     documentation: declarationDocForSyntax(decl.name, ctx),
   });
+};
+
+const boundaryMetadataFromAttribute = (value: unknown): unknown | undefined => {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as { type?: unknown; field?: unknown };
+  if (record.type !== "value") {
+    return undefined;
+  }
+  return {
+    type: record.type,
+  };
 };
 
 const reportDuplicateTypeAlias = ({

--- a/packages/compiler/src/semantics/codegen-view/index.ts
+++ b/packages/compiler/src/semantics/codegen-view/index.ts
@@ -178,6 +178,7 @@ export type CodegenFunctionSignature = {
     name?: string;
     symbol?: SymbolId;
     bindingKind?: HirBindingKind;
+    synthetic?: "stable-callsite-id";
   }[];
   returnType: TypeId;
   effectRow: number;
@@ -430,6 +431,32 @@ export type CodegenTraitImplInstance = {
     implMethod: ProgramSymbolId;
   }[];
   implSymbol: ProgramSymbolId;
+};
+
+const defaultValueIsStableCallsiteId = ({
+  exprId,
+  module,
+}: {
+  exprId: HirExprId | undefined;
+  module: SemanticsPipelineResult;
+}): boolean => {
+  if (typeof exprId !== "number") {
+    return false;
+  }
+  const expr = module.hir.expressions.get(exprId);
+  if (expr?.exprKind !== "call" || expr.args.length !== 0) {
+    return false;
+  }
+  const callee = module.hir.expressions.get(expr.callee);
+  if (callee?.exprKind !== "identifier") {
+    return false;
+  }
+  const symbol = getSymbolTable(module).getSymbol(callee.symbol);
+  const metadata = (symbol.metadata ?? {}) as {
+    intrinsic?: unknown;
+    intrinsicName?: unknown;
+  };
+  return metadata.intrinsic === true && metadata.intrinsicName === "__stable_callsite_id";
 };
 
 export const buildProgramCodegenView = (
@@ -1958,6 +1985,12 @@ export const buildProgramCodegenView = (
           name: param.name,
           symbol: param.symbol,
           bindingKind: param.bindingKind,
+          ...(defaultValueIsStableCallsiteId({
+            exprId: param.defaultValue,
+            module: mod,
+          })
+            ? { synthetic: "stable-callsite-id" as const }
+            : {}),
         })),
         returnType: signature.returnType,
         effectRow: signature.effectRow,

--- a/packages/compiler/src/semantics/imports/metadata.ts
+++ b/packages/compiler/src/semantics/imports/metadata.ts
@@ -8,6 +8,7 @@ const IMPORTABLE_KEYS = [
   "intrinsicUsesSignature",
   "intrinsicType",
   "serializer",
+  "boundary",
   "enumNamespaceMembers",
   "enumNamespaceTypeParameterNames",
   "nominalTargetTypeArguments",

--- a/packages/compiler/src/semantics/intrinsics.ts
+++ b/packages/compiler/src/semantics/intrinsics.ts
@@ -62,7 +62,11 @@ const VALUE_INTRINSICS = new Map<string, IntrinsicValueMetadata>([
     { intrinsicUsesSignature: false, access: "std-only" },
   ],
   [
-    "__vx_retain_event_handler",
+    "__retain_callback",
+    { intrinsicUsesSignature: false, access: "std-only" },
+  ],
+  [
+    "__stable_callsite_id",
     { intrinsicUsesSignature: false, access: "std-only" },
   ],
   [

--- a/packages/compiler/src/semantics/program-symbol-arena.ts
+++ b/packages/compiler/src/semantics/program-symbol-arena.ts
@@ -1,5 +1,9 @@
 import type { ProgramSymbolId, SymbolId } from "./ids.js";
-import type { IntrinsicFunctionFlags, SerializerMetadata } from "./symbol-index.js";
+import type {
+  BoundaryMetadata,
+  IntrinsicFunctionFlags,
+  SerializerMetadata,
+} from "./symbol-index.js";
 import type { SemanticsPipelineResult } from "./pipeline.js";
 import { getSymbolTable } from "./_internal/symbol-table.js";
 
@@ -18,6 +22,7 @@ export type ProgramSymbolArena = {
   getIntrinsicName(id: ProgramSymbolId): string | undefined;
   getIntrinsicFunctionFlags(id: ProgramSymbolId): IntrinsicFunctionFlags;
   getSerializer(id: ProgramSymbolId): SerializerMetadata | undefined;
+  getBoundary(id: ProgramSymbolId): BoundaryMetadata | undefined;
   isModuleScoped(id: ProgramSymbolId): boolean;
 };
 
@@ -46,6 +51,7 @@ export const buildProgramSymbolArena = (
   const intrinsicNamesById: (string | undefined)[] = [];
   const intrinsicFlagsById: IntrinsicFunctionFlags[] = [];
   const serializerById: (SerializerMetadata | undefined)[] = [];
+  const boundaryById: (BoundaryMetadata | undefined)[] = [];
   const moduleScopedById: boolean[] = [];
 
   let nextId = 0;
@@ -72,6 +78,7 @@ export const buildProgramSymbolArena = (
       intrinsicNamesById[id] = mod.symbols.getIntrinsicName(symbol);
       intrinsicFlagsById[id] = mod.symbols.getIntrinsicFunctionFlags(symbol);
       serializerById[id] = mod.symbols.getSerializer(symbol);
+      boundaryById[id] = mod.symbols.getBoundary(symbol);
       moduleScopedById[id] = mod.symbols.isModuleScoped(symbol);
     });
   });
@@ -119,6 +126,7 @@ export const buildProgramSymbolArena = (
         intrinsicUsesSignature: false,
       },
     getSerializer: (id) => serializerById[id],
+    getBoundary: (id) => boundaryById[id],
     isModuleScoped: (id) => moduleScopedById[id] === true,
   };
 };

--- a/packages/compiler/src/semantics/symbol-index.ts
+++ b/packages/compiler/src/semantics/symbol-index.ts
@@ -12,6 +12,11 @@ export type SerializerMetadata = {
   decode: { moduleId: string; symbol: SymbolId };
 };
 
+export type BoundaryMetadata = {
+  type: "value" | "payload";
+  field?: string;
+};
+
 export type ModuleSymbolIndex = {
   moduleId: string;
   packageId: string;
@@ -22,6 +27,7 @@ export type ModuleSymbolIndex = {
   getIntrinsicName(symbol: SymbolId): string | undefined;
   getIntrinsicFunctionFlags(symbol: SymbolId): IntrinsicFunctionFlags;
   getSerializer(symbol: SymbolId): SerializerMetadata | undefined;
+  getBoundary(symbol: SymbolId): BoundaryMetadata | undefined;
 };
 
 export const buildModuleSymbolIndex = ({
@@ -40,6 +46,7 @@ export const buildModuleSymbolIndex = ({
   const intrinsicNameBySymbol = new Map<SymbolId, string>();
   const intrinsicFlagsBySymbol = new Map<SymbolId, IntrinsicFunctionFlags>();
   const serializerBySymbol = new Map<SymbolId, SerializerMetadata>();
+  const boundaryBySymbol = new Map<SymbolId, BoundaryMetadata>();
 
   const snapshot = symbolTable.snapshot();
   snapshot.symbols.forEach((record) => {
@@ -57,6 +64,7 @@ export const buildModuleSymbolIndex = ({
       intrinsic?: unknown;
       intrinsicUsesSignature?: unknown;
       serializer?: unknown;
+      boundary?: unknown;
     };
 
     if (typeof metadata.intrinsicType === "string") {
@@ -74,6 +82,9 @@ export const buildModuleSymbolIndex = ({
     if (isSerializerMetadata(metadata.serializer)) {
       serializerBySymbol.set(symbol, metadata.serializer);
     }
+    if (isBoundaryMetadata(metadata.boundary)) {
+      boundaryBySymbol.set(symbol, metadata.boundary);
+    }
   });
 
   return {
@@ -90,6 +101,7 @@ export const buildModuleSymbolIndex = ({
         intrinsicUsesSignature: false,
       },
     getSerializer: (symbol) => serializerBySymbol.get(symbol),
+    getBoundary: (symbol) => boundaryBySymbol.get(symbol),
   };
 };
 
@@ -108,5 +120,16 @@ const isSerializerMetadata = (value: unknown): value is SerializerMetadata => {
     typeof record.encode?.symbol === "number" &&
     typeof record.decode?.moduleId === "string" &&
     typeof record.decode?.symbol === "number"
+  );
+};
+
+const isBoundaryMetadata = (value: unknown): value is BoundaryMetadata => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as { type?: unknown; field?: unknown };
+  return (
+    (record.type === "value" || record.type === "payload") &&
+    (record.field === undefined || typeof record.field === "string")
   );
 };

--- a/packages/compiler/src/semantics/type-display.ts
+++ b/packages/compiler/src/semantics/type-display.ts
@@ -111,6 +111,7 @@ const formatFunctionSignatureParameters = ({
   }) => TypeId;
 }): string =>
   signature.parameters
+    .filter((parameter) => parameter.synthetic !== "stable-callsite-id")
     .map((parameter) => {
       const label = parameter.label;
       const name = parameter.name;

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -98,6 +98,7 @@ import {
 import { hydrateImportedTraitMetadataForOwnerRef } from "../import-trait-impl-hydration.js";
 import { collectTraitOwnersFromTypeParams } from "../constraint-trait-owners.js";
 import { typeDefaultParameterValues } from "../default-parameters.js";
+import { stableCallsiteIdFor } from "../../../stable-callsite-id.js";
 
 type SymbolNameResolver = (symbol: SymbolId) => string;
 type MethodCallCandidate = {
@@ -927,7 +928,7 @@ const getExpectedCallParameters = ({
           })
         : undefined;
     return {
-      params: selected.signature.parameters.map((param) =>
+      params: publicCallParametersFor({ signature: selected.signature }).map((param) =>
         substitution ? ctx.arena.substitute(param.type, substitution) : param.type,
       ),
       expectedReturnCandidates,
@@ -951,7 +952,7 @@ const getExpectedCallParameters = ({
         })
       : undefined;
   return {
-    params: signature.parameters.map((param) =>
+    params: publicCallParametersFor({ signature }).map((param) =>
       substitution ? ctx.arena.substitute(param.type, substitution) : param.type,
     ),
   };
@@ -1353,6 +1354,32 @@ const walkCallArguments = ({
           if (!runParam.label) {
             break;
           }
+          if (isStableCallsiteIdParam(runParam)) {
+            const explicitSyntheticField = structuralFields.find(
+              (field) =>
+                field.name === runParam.label || field.name === runParam.name,
+            );
+            if (explicitSyntheticField) {
+              return {
+                kind: "error",
+                failure: { kind: "extra-arguments", extra: 1 },
+              };
+            }
+            if (
+              !onSkipOptionalParam({
+                param: runParam,
+                paramIndex: cursor,
+                reason: "structural-missing-field",
+              })
+            ) {
+              return {
+                kind: "error",
+                failure: { kind: "incompatible", paramIndex: cursor, argIndex },
+              };
+            }
+            cursor += 1;
+            continue;
+          }
           const match = structuralFields.find(
             (field) => field.name === runParam.label,
           );
@@ -1647,6 +1674,36 @@ const ensureOptionalParameterIsSkippable = ({
   );
 };
 
+const isStableCallsiteIdParam = (param: ParamSignature): boolean =>
+  param.synthetic === "stable-callsite-id";
+
+const argumentTargetsSyntheticParam = (
+  arg: Arg,
+  params: readonly ParamSignature[],
+): boolean =>
+  typeof arg.label === "string" &&
+  params.some(
+    (param) =>
+      isStableCallsiteIdParam(param) &&
+      (param.label === arg.label || param.name === arg.label),
+  );
+
+const publicCallParametersFor = ({
+  signature,
+}: {
+  signature: FunctionSignature;
+}): readonly ParamSignature[] =>
+  signature.parameters.filter((param) => !isStableCallsiteIdParam(param));
+
+const callPlanParametersFor = ({
+  signature,
+}: {
+  signature: FunctionSignature;
+}): readonly ParamSignature[] =>
+  signature.parameters.map((param) =>
+    isStableCallsiteIdParam(param) ? { ...param } : param,
+  );
+
 const validateCallArgs = (
   args: readonly Arg[],
   params: readonly ParamSignature[],
@@ -1655,6 +1712,21 @@ const validateCallArgs = (
   callSpan?: SourceSpan,
 ): { ok: true; plan: readonly CallArgumentPlanEntry[] } | { ok: false } => {
   const span = callSpan ?? ctx.hir.module.span;
+  const explicitSyntheticArg = args.find((arg) =>
+    argumentTargetsSyntheticParam(arg, params),
+  );
+  if (explicitSyntheticArg) {
+    emitDiagnostic({
+      ctx,
+      code: "TY0021",
+      params: {
+        kind: "call-extra-arguments",
+        extra: 1,
+      },
+      span,
+    });
+    return { ok: false };
+  }
   const plan: CallArgumentPlanEntry[] = [];
   const hasUnknownArgs = args.some((arg) => arg.type === ctx.primitives.unknown);
   const result = walkCallArguments({
@@ -1709,7 +1781,15 @@ const validateCallArgs = (
         callSpan,
         fallbackSpan: span,
       });
-      plan.push({ kind: "missing", targetTypeId: param.type });
+      plan.push(
+        isStableCallsiteIdParam(param)
+          ? {
+              kind: "stable-callsite-id",
+              targetTypeId: param.type,
+              value: stableCallsiteIdFor(callSpan ?? span, `${paramIndex}`),
+            }
+          : { kind: "missing", targetTypeId: param.type },
+      );
       return true;
     },
   });
@@ -1935,7 +2015,7 @@ const formatFunctionSignatureForDiagnostic = ({
   const typeParamSuffix =
     typeParams && typeParams.length > 0 ? `<${typeParams.join(", ")}>` : "";
 
-  const params = signature.parameters.map((param) => {
+  const params = publicCallParametersFor({ signature }).map((param) => {
     const typeLabel = formatTypeForDiagnostic({ type: param.type, ctx });
     const label = param.label ?? param.name;
     const labelPrefix = label ? `${label}: ` : "";
@@ -1992,11 +2072,11 @@ const overloadCandidateFailureReason = ({
         })
       : undefined;
   const params = explicitSubstitution
-    ? signature.parameters.map((param) => ({
+    ? publicCallParametersFor({ signature }).map((param) => ({
         ...param,
         type: ctx.arena.substitute(param.type, explicitSubstitution),
       }))
-    : signature.parameters;
+    : publicCallParametersFor({ signature });
 
   let mismatch:
     | {
@@ -4320,11 +4400,17 @@ const typeFunctionCall = ({
       calleeModuleId: resolvedModuleId,
       ctx,
     }) ?? instantiation.parameters;
+  const planParameters = callPlanParametersFor({
+    signature: {
+      ...signature,
+      parameters: adjustedParameters,
+    },
+  });
 
   const callSpan = ctx.hir.expressions.get(callId)?.span;
   const validation = validateCallArgs(
     args,
-    adjustedParameters,
+    planParameters,
     ctx,
     state,
     callSpan,
@@ -4346,7 +4432,12 @@ const typeFunctionCall = ({
   const specializedEffectRow = specializeCallEffectRow({
     effectRow: signature.effectRow,
     args,
-    params: adjustedParameters,
+    params: publicCallParametersFor({
+      signature: {
+        ...signature,
+        parameters: adjustedParameters,
+      },
+    }),
     callId,
     ctx,
   });
@@ -5430,11 +5521,11 @@ const matchesOverloadSignature = (
         })
       : undefined;
   const params = explicitSubstitution
-    ? signature.parameters.map((param) => ({
+    ? publicCallParametersFor({ signature }).map((param) => ({
         ...param,
         type: ctx.arena.substitute(param.type, explicitSubstitution),
       }))
-    : signature.parameters;
+    : publicCallParametersFor({ signature });
 
   if (!callArgumentsSatisfyParams({ args, params, ctx, state })) {
     return false;
@@ -5552,12 +5643,20 @@ const typeIntrinsicCall = (
         typeArguments,
         expectedReturnType,
       });
-    case "__vx_retain_event_handler":
-      return typeVxRetainEventHandlerIntrinsic({
+    case "__retain_callback":
+      return typeRetainCallbackIntrinsic({
         args,
         ctx,
         typeArguments,
       });
+    case "__stable_callsite_id":
+      assertIntrinsicArgCount({
+        name: "__stable_callsite_id",
+        args,
+        expected: 0,
+      });
+      assertNoIntrinsicTypeArgs("__stable_callsite_id", typeArguments);
+      return getPrimitiveType(ctx, "i32");
     case "__boundary_value_to_msgpack":
       return typeBoundaryValueToMsgPackIntrinsic({
         args,
@@ -6350,7 +6449,7 @@ const typeTaskCancelIntrinsic = ({
   return ctx.primitives.bool;
 };
 
-const typeVxRetainEventHandlerIntrinsic = ({
+const typeRetainCallbackIntrinsic = ({
   args,
   ctx,
   typeArguments,
@@ -6360,16 +6459,16 @@ const typeVxRetainEventHandlerIntrinsic = ({
   typeArguments?: readonly TypeId[];
 }): TypeId => {
   assertIntrinsicArgCount({
-    name: "__vx_retain_event_handler",
+    name: "__retain_callback",
     args,
     expected: 1,
     detail: "handler function",
   });
-  assertNoIntrinsicTypeArgs("__vx_retain_event_handler", typeArguments);
+  assertNoIntrinsicTypeArgs("__retain_callback", typeArguments);
   const handlerType = args[0]!.type;
   const desc = ctx.arena.get(handlerType);
   if (desc.kind !== "function") {
-    throw new Error("__vx_retain_event_handler expects a function argument");
+    throw new Error("__retain_callback expects a function argument");
   }
   return getPrimitiveType(ctx, "i32");
 };

--- a/packages/compiler/src/semantics/typing/import-type-translation.ts
+++ b/packages/compiler/src/semantics/typing/import-type-translation.ts
@@ -136,6 +136,8 @@ export const translateFunctionSignature = ({
     bindingKind: param.bindingKind,
     span: param.span,
     name: param.name,
+    optional: param.optional,
+    synthetic: param.synthetic,
   }));
 
   const returnType = translation(signature.returnType);

--- a/packages/compiler/src/semantics/typing/registry.ts
+++ b/packages/compiler/src/semantics/typing/registry.ts
@@ -46,6 +46,31 @@ import {
 } from "./trait-method-matcher.js";
 import { registerTraitMethodImplMapping } from "./trait-method-impl-mapping.js";
 
+const defaultValueIsStableCallsiteId = ({
+  exprId,
+  ctx,
+}: {
+  exprId: number | undefined;
+  ctx: TypingContext;
+}): boolean => {
+  if (typeof exprId !== "number") {
+    return false;
+  }
+  const expr = ctx.hir.expressions.get(exprId);
+  if (expr?.exprKind !== "call" || expr.args.length !== 0) {
+    return false;
+  }
+  const callee = ctx.hir.expressions.get(expr.callee);
+  if (callee?.exprKind !== "identifier") {
+    return false;
+  }
+  const metadata = (ctx.symbolTable.getSymbol(callee.symbol).metadata ?? {}) as {
+    intrinsic?: unknown;
+    intrinsicName?: unknown;
+  };
+  return metadata.intrinsic === true && metadata.intrinsicName === "__stable_callsite_id";
+};
+
 type ConstraintTypeParameterDecl = {
   symbol: SymbolId;
   constraint?: HirTypeExpr;
@@ -436,6 +461,9 @@ export const registerFunctionSignatures = (
         symbol: param.symbol,
         optional,
         defaultValue: param.defaultValue,
+        ...(defaultValueIsStableCallsiteId({ exprId: param.defaultValue, ctx })
+          ? { synthetic: "stable-callsite-id" as const }
+          : {}),
       };
     });
 

--- a/packages/compiler/src/semantics/typing/types.ts
+++ b/packages/compiler/src/semantics/typing/types.ts
@@ -131,6 +131,7 @@ export interface ParamSignature {
   symbol?: SymbolId;
   optional?: boolean;
   defaultValue?: HirExprId;
+  synthetic?: "stable-callsite-id";
 }
 
 export interface FunctionTypeParam {
@@ -149,6 +150,7 @@ export interface Arg {
 export type CallArgumentPlanEntry =
   | { kind: "direct"; argIndex: number }
   | { kind: "missing"; targetTypeId: TypeId }
+  | { kind: "stable-callsite-id"; targetTypeId: TypeId; value: number }
   | {
       kind: "container-field";
       containerArgIndex: number;

--- a/packages/compiler/src/stable-callsite-id.ts
+++ b/packages/compiler/src/stable-callsite-id.ts
@@ -1,0 +1,10 @@
+import { murmurHash3 } from "@voyd-lang/lib/murmur-hash.js";
+import type { SourceSpan } from "./semantics/ids.js";
+
+export const stableCallsiteIdFor = (
+  span: SourceSpan | undefined,
+  salt = "",
+): number =>
+  murmurHash3(
+    `${span?.file ?? "<unknown>"}:${span?.start ?? 0}:${span?.end ?? 0}:${salt}`,
+  );

--- a/packages/js-host/src/host.ts
+++ b/packages/js-host/src/host.ts
@@ -77,6 +77,7 @@ export type VoydHost = {
     entryName: string,
     args?: unknown[]
   ) => VoydRunHandle<T>;
+  hasExport: (entryName: string) => boolean;
   runManaged: <T = unknown>(entryName: string, args?: unknown[]) => VoydRunHandle<T>;
   runEffectful: <T = unknown>(entryName: string, args?: unknown[]) => Promise<T>;
   run: <T = unknown>(entryName: string, args?: unknown[]) => Promise<T>;
@@ -85,7 +86,7 @@ export type VoydHost = {
 
 const MSGPACK_OPTS = { useBigInt64: true } as const;
 const TASK_RUNTIME_IMPORT_MODULE = "voyd.task";
-const VX_CALLBACK_IMPORT_MODULE = "voyd.vx.callback";
+const CALLBACK_IMPORT_MODULE = "voyd.callback";
 const TASK_RUNTIME_EFFECT_ID = "voyd.std.task.runtime";
 const TASK_RUNTIME_WAIT_OP_ID = 0;
 const TASK_RUNTIME_YIELD_OP_ID = 1;
@@ -227,7 +228,7 @@ const buildTaskRuntimeImportModule = ({
     };
 };
 
-const buildVxCallbackImportModule = ({
+const buildCallbackImportModule = ({
   importDescriptors,
   getInstance,
   registry,
@@ -247,14 +248,14 @@ const buildVxCallbackImportModule = ({
   importDescriptors
     .filter(
       (descriptor) =>
-        descriptor.module === VX_CALLBACK_IMPORT_MODULE &&
+        descriptor.module === CALLBACK_IMPORT_MODULE &&
         descriptor.kind === "function",
     )
     .forEach((descriptor) => {
-      if (!descriptor.name.startsWith("retain_event__")) {
+      if (!descriptor.name.startsWith("retain__")) {
         return;
       }
-      const callbackExportName = descriptor.name.slice("retain_event__".length);
+      const callbackExportName = descriptor.name.slice("retain__".length);
       callbackImports[descriptor.name] = ((handlerRef: unknown): number =>
         registry.retain((payload) => {
           const instance = getInstance();
@@ -287,7 +288,7 @@ const buildVxCallbackImportModule = ({
           });
           const encodedPayload = encode(payload, MSGPACK_OPTS) as Uint8Array;
           if (encodedPayload.length > bufferSize) {
-            throw new Error("VX retained event callback payload exceeds buffer size");
+            throw new Error("retained callback payload exceeds buffer size");
           }
           ensureMemoryCapacity({
             memory: msgpackMemory,
@@ -320,7 +321,7 @@ const buildVxCallbackImportModule = ({
             }
             throw annotateTrap(error, {
               transition: {
-                point: "vx_retained_event_callback",
+                point: "retained_callback",
                 direction: "host->vm",
               },
               fallbackFunctionName: callbackExportName,
@@ -330,10 +331,10 @@ const buildVxCallbackImportModule = ({
             return undefined;
           }
           if (written < 0) {
-            throw new Error("VX retained event callback encoding failed");
+            throw new Error("retained callback encoding failed");
           }
           if (written > bufferSize) {
-            throw new Error("VX retained event callback payload exceeds buffer size");
+            throw new Error("retained callback payload exceeds buffer size");
           }
           const bytes = new Uint8Array(msgpackMemory.buffer, outPtr, written);
           return decode(bytes, MSGPACK_OPTS);
@@ -343,7 +344,7 @@ const buildVxCallbackImportModule = ({
   return Object.keys(callbackImports).length === 0
     ? {}
     : {
-        [VX_CALLBACK_IMPORT_MODULE]: callbackImports,
+        [CALLBACK_IMPORT_MODULE]: callbackImports,
       };
 };
 
@@ -665,13 +666,13 @@ export const createVoydHost = async ({
   const callbackRegistry =
     retainedCallbacks ?? createRetainedEventHandlerRegistry();
   let runEffectfulRetainedCallback: RetainedEffectfulCallbackRunner = () => {
-    throw new Error("VX retained event callback called before host runtime initialization");
+    throw new Error("retained callback called before host runtime initialization");
   };
-  const vxCallbackImports = buildVxCallbackImportModule({
+  const callbackImports = buildCallbackImportModule({
     importDescriptors: WebAssembly.Module.imports(module),
     getInstance: () => {
       if (!instanceRef) {
-        throw new Error("VX callback import called before host instance initialization");
+        throw new Error("callback import called before host instance initialization");
       }
       return instanceRef;
     },
@@ -686,7 +687,7 @@ export const createVoydHost = async ({
       {
         ...defaultImports(),
         ...(taskRuntimeImports as Record<string, unknown>),
-        ...(vxCallbackImports as Record<string, unknown>),
+        ...(callbackImports as Record<string, unknown>),
       } as WebAssembly.Imports,
       imports
     )
@@ -1857,7 +1858,7 @@ export const createVoydHost = async ({
     });
     const encodedPayload = encode(payload, MSGPACK_OPTS) as Uint8Array;
     if (encodedPayload.length > bufferSize) {
-      throw new Error("VX retained event callback payload exceeds buffer size");
+      throw new Error("retained callback payload exceeds buffer size");
     }
     return unwrapRunOutcome(
       runEffectfulManaged(callbackExportName, [], ({ bufferPtr, bufferSize }) => {
@@ -1880,7 +1881,7 @@ export const createVoydHost = async ({
         } catch (error) {
           throw annotateTrap(error, {
             transition: {
-              point: "vx_retained_event_callback",
+              point: "retained_callback",
               direction: "host->vm",
             },
             fallbackFunctionName: rawCallbackExportName,
@@ -1945,6 +1946,7 @@ export const createVoydHost = async ({
     initEffects,
     runPure,
     runEffectfulManaged,
+    hasExport: (entryName) => hasExportedFunction({ instance, name: entryName }),
     runManaged,
     runEffectful,
     run,

--- a/packages/reference/docs/vx.md
+++ b/packages/reference/docs/vx.md
@@ -45,9 +45,9 @@ type TextInput = {
 
 pub fn app() -> Program<Model, Msg>
   program<Model, Msg>(
-    init: () -> Model => init(),
-    update: (model: Model, message: Msg) -> Program<Model, Msg> => update(model, message),
-    view: (model: Model) -> Html<Msg> => view(model)
+    init: init,
+    update: update,
+    view: view
   )
 
 fn init() -> Model

--- a/packages/reference/docs/vx.md
+++ b/packages/reference/docs/vx.md
@@ -19,7 +19,8 @@ Use VX when you want:
 
 ## A Small App
 
-A VX app usually has three exported functions:
+A VX app exports an `app` value that wires ordinary lifecycle functions into
+VX:
 
 ```voyd
 use std::enums::{ enum }
@@ -42,19 +43,26 @@ type TextInput = {
   checked: bool
 }
 
-pub fn init() -> Model
+pub fn app() -> Program<Model, Msg>
+  program<Model, Msg>(
+    init: () -> Model => init(),
+    update: (model: Model, message: Msg) -> Program<Model, Msg> => update(model, message),
+    view: (model: Model) -> Html<Msg> => view(model)
+  )
+
+fn init() -> Model
   Model { title: "Draft", saved: false }
 
-pub fn update(model: Model, message: Msg) -> Model
+fn update(model: Model, message: Msg) -> Program<Model, Msg>
   match(message)
     Msg::Edit { value }:
-      Model { title: value, saved: false }
+      program<Model, Msg>(model: Model { title: value, saved: false })
     Msg::Save:
-      Model { title: model.title, saved: false }
+      program<Model, Msg>(model: Model { title: model.title, saved: false })
     Msg::Saved:
-      Model { title: model.title, saved: true }
+      program<Model, Msg>(model: Model { title: model.title, saved: true })
 
-pub fn view(model: Model) -> Html<Msg>
+fn view(model: Model) -> Html<Msg>
   <main>
     <input
       value={model.title}
@@ -68,9 +76,9 @@ fn save_label(saved: bool) -> String
   if saved then: "Saved" else: "Unsaved"
 ```
 
-`init` creates the first model. `view` turns the model into HTML. `update`
-receives messages from events, commands, and subscriptions and returns the next
-model.
+`app` is the public VX entrypoint. `init` creates the first model. `view` turns
+the model into HTML. `update` receives messages from events, commands, and
+subscriptions and returns the next model.
 
 Typed lifecycle values must be boundary-compatible DTOs: primitives, `String`,
 records/objects with public DTO fields, named message variants, and arrays of
@@ -120,7 +128,9 @@ fn Editor()
 Use `class`, `id`, `role`, `name`, `placeholder`, `input_type`, `value`,
 `checked`, `disabled`, `style`, and `styles` for common attributes and
 properties. Use `keyed(key:, child:)` when list items should keep their DOM
-identity while reordering.
+identity while reordering. If the keyed child creates component state, use
+`keyed(key:, body:)` so the state is scoped to that key before the child is
+evaluated.
 
 ## Events
 
@@ -173,7 +183,7 @@ VX also exposes component-local state for small UI details that do not belong in
 the app model:
 
 ```voyd
-let (panel, set_panel) = state(id: 1, initial: "closed")
+let (panel, set_panel) = state(initial: "closed")
 
 <button on_click={() => set_panel("open")}>Open</button>
 ```
@@ -185,7 +195,7 @@ read or update the same value.
 Use `state_handle` when you need the advanced handle API:
 
 ```voyd
-let panel_state = state_handle(id: 1, initial: "closed")
+let panel_state = state_handle(initial: "closed")
 
 <button on_click={() => panel_state.set("open")}>Open</button>
 ```
@@ -234,18 +244,14 @@ Sub<Msg>::every(key: "clock", millis: 1000i64, value: Msg::Tick {})
 
 ## Mounting
 
-In the browser, compile the Voyd module, create a host, adapt the Voyd exports,
-and mount:
+In the browser, compile the Voyd module, create a host, and mount:
 
 ```ts
 import { createVoydHost } from "@voyd-lang/js-host";
 import { createVoydVxAppRuntime, mountVxApp } from "@voyd-lang/vx-dom";
 
 const host = await createVoydHost({ wasm });
-const app = createVoydVxAppRuntime({
-  host,
-  exports: { subscriptions: "subscriptions" },
-});
+const app = createVoydVxAppRuntime({ host });
 
 await mountVxApp({
   container: document.getElementById("root")!,
@@ -253,10 +259,9 @@ await mountVxApp({
 });
 ```
 
-Typed apps should export lifecycle functions with the canonical names `init`,
-`update`, and `view`. Add `subscriptions` in the adapter when your app exports
-one. Custom lifecycle names are still available for raw interop exports, but
-typed lifecycle wrappers are generated for the canonical app surface.
+Typed apps should export `app() -> Program<Model, Msg>`. Custom lifecycle
+export names are still available for raw interop, but everyday VX apps do not
+need boundary annotations or export adapters.
 
 ## Server Rendering
 
@@ -297,7 +302,7 @@ explicit so ordinary app code can stay typed.
 - Event payload: `on_input={(event: TextInput) -> Msg => ...}`
 - Reusable component action: pass `fn() -> Msg` into a component
 - App state: keep it in the model and return the next model from `update`
-- Component-local UI state: use `let (value, set_value) = state(id:, initial:)`
+- Component-local UI state: use `let (value, set_value) = state(initial:)`
   inside component-runtime views for small `String` or `i32` values
 - Later work: return a `Cmd`
 - Outside events: return a `Sub`

--- a/packages/std/src/vx.test.voyd
+++ b/packages/std/src/vx.test.voyd
@@ -164,6 +164,19 @@ test "vx class prop styles and keyed helpers encode renderer fields":
     Err:
       assert(false, eq: true)
 
+  let ~seen_scopes = Array<String>::init()
+  try open
+    match(msgpack::unpack_map(keyed(key: "page-2", body: () -> MsgPack => text("Lazy"))))
+      Ok<Dict<String, MsgPack>> { value }:
+        assert_string_field(value, "key", "page-2")
+      Err:
+        assert(false, eq: true)
+  Component::state_scope(tail, key):
+    seen_scopes.push("scope".to_string())
+    assert_msgpack_string(key, "page-2")
+    tail()
+  assert(seen_scopes.len(), eq: 1)
+
   match(msgpack::unpack_map(map_html<MsgPack, MsgPack>(html: text("Child"), handler_id: 21)))
     Ok<Dict<String, MsgPack>> { value }:
       assert_string_field(value, "kind", "map")
@@ -450,11 +463,12 @@ test "vx component state and task APIs use component effect":
   let ~seen = Array<String>::init()
 
   try open
-    let handle = state_handle(id: 3, initial: msgpack::make_string("initial"))
+    let handle = state_handle(initial: msgpack::make_string("initial"))
     assert_msgpack_string(handle.value, "current")
+  Component::state_key(tail, id):
+    tail(id)
   Component::state_get(tail, id, initial):
     seen.push("get".to_string())
-    assert(id, eq: 3)
     assert_msgpack_string(initial, "initial")
     tail(msgpack::make_string("current"))
 
@@ -468,32 +482,32 @@ test "vx component state and task APIs use component effect":
     tail()
 
   try open
-    let (value, set_value) = state(id: 4, initial: 1)
+    let (value, set_value) = state(initial: 1)
     assert(value, eq: 7)
     set_value(value + 1)
+  Component::state_key(tail, id):
+    tail(id)
   Component::state_get(tail, id, initial):
     seen.push("state-get".to_string())
-    assert(id, eq: 4)
     assert_msgpack_i32(initial, 1)
     tail(msgpack::make_i32(7))
   Component::state_set(tail, id, value):
     seen.push("state-set".to_string())
-    assert(id, eq: 4)
     assert_msgpack_i32(value, 8)
     tail()
 
   try open
-    let (text_value, set_text) = state(id: 5, initial: "initial")
+    let (text_value, set_text) = state(initial: "initial")
     assert(text_value.equals("current".to_string()), eq: true)
     set_text(text_value)
+  Component::state_key(tail, id):
+    tail(id)
   Component::state_get(tail, id, initial):
     seen.push("text-get".to_string())
-    assert(id, eq: 5)
     assert_msgpack_string(initial, "initial")
     tail(msgpack::make_string("current"))
   Component::state_set(tail, id, value):
     seen.push("text-set".to_string())
-    assert(id, eq: 5)
     assert_msgpack_string(value, "current")
     tail()
 
@@ -527,25 +541,6 @@ test "vx program constructor encodes lifecycle handles":
           assert(true, eq: true)
         None:
           assert(false, eq: true)
-    Err:
-      assert(false, eq: true)
-
-  let app = program<MsgPack, MsgPack>(
-    init: msgpack::make_i32(1),
-    update: msgpack::make_i32(2),
-    view: msgpack::make_i32(3),
-    subscriptions: msgpack::make_i32(4),
-    decode_msg: msgpack::make_i32(5)
-  )
-
-  match(msgpack::unpack_map(app))
-    Ok<Dict<String, MsgPack>> { value }:
-      assert_string_field(value, "kind", "program")
-      assert_i32_field(value, "init", 1)
-      assert_i32_field(value, "update", 2)
-      assert_i32_field(value, "view", 3)
-      assert_i32_field(value, "subscriptions", 4)
-      assert_i32_field(value, "decode_msg", 5)
     Err:
       assert(false, eq: true)
 

--- a/packages/std/src/vx.voyd
+++ b/packages/std/src/vx.voyd
@@ -8,15 +8,22 @@ use std::string::type::{ String, StringSlice, new_string }
 use std::task::{ Task }
 pub use std::msgpack::MsgPack
 
+@boundary(type: "value")
 pub type Html<Msg> = MsgPack
+pub type HtmlNode = MsgPack
+@boundary(type: "value")
 pub type Attr<Msg> = MsgPack
+pub type HtmlAttr = MsgPack
+@boundary(type: "value")
 pub type Program<Model, Msg> = MsgPack
 pub type RenderKey = String
 
+@boundary(type: "payload", field: "payload")
 pub obj Cmd<Msg> {
   api payload: MsgPack
 }
 
+@boundary(type: "payload", field: "payload")
 pub obj Sub<Msg> {
   api payload: MsgPack
 }
@@ -88,31 +95,39 @@ pub eff Dom
 
 @effect(id: "voyd.std.vx.component")
 pub eff Component
+  state_scope(tail, key: MsgPack) -> void
+
+  state_key(tail, id: i32) -> i32
+
   state_get(tail, id: i32, initial: MsgPack) -> MsgPack
 
   state_set(tail, id: i32, value: MsgPack) -> void
 
   task_started(tail, key: MsgPack, task_id: i32) -> void
 
-@intrinsic(name: "__vx_retain_event_handler", uses_signature: true)
+@intrinsic(name: "__retain_callback", uses_signature: true)
 fn retain_event_handler_id(handler: fn() -> MsgPack): () -> i32
   0
 
-@intrinsic(name: "__vx_retain_event_handler", uses_signature: true)
+@intrinsic(name: "__retain_callback", uses_signature: true)
 fn retain_event_handler_void_id(handler: fn() -> void): () -> i32
   0
 
-@intrinsic(name: "__vx_retain_event_handler", uses_signature: true)
+@intrinsic(name: "__retain_callback", uses_signature: true)
 fn retain_event_handler_with_payload_id(handler: fn(MsgPack) -> MsgPack): () -> i32
   0
 
-@intrinsic(name: "__vx_retain_event_handler", uses_signature: true)
+@intrinsic(name: "__retain_callback", uses_signature: true)
 fn retain_typed_event_handler_id<Msg>(handler: fn() -> Msg): () -> i32
-  __vx_retain_event_handler(handler)
+  __retain_callback(handler)
 
-@intrinsic(name: "__vx_retain_event_handler", uses_signature: true)
+@intrinsic(name: "__retain_callback", uses_signature: true)
 fn retain_typed_event_handler_with_payload_id<Event, Msg>(handler: fn(Event) -> Msg): () -> i32
-  __vx_retain_event_handler(handler)
+  __retain_callback(handler)
+
+@intrinsic(name: "__stable_callsite_id")
+fn stable_callsite_id(): () -> i32
+  0
 
 @intrinsic(name: "__boundary_value_to_msgpack")
 fn boundary_value_to_msgpack<Msg>(message: Msg): () -> MsgPack
@@ -354,52 +369,88 @@ pub fn keyboard_on_key_up<Msg>({ key: StringSlice, value: Msg }) -> Sub<Msg>
   keyboard_on_key_up<Msg>(key: key.to_string(), value: value)
 
 /// Reads a component-local serialized state handle.
-pub fn state_handle({ id: i32, initial: MsgPack }): Component -> StateHandle<MsgPack>
+pub fn state_handle({
+  initial: MsgPack,
+  id: i32 = stable_callsite_id()
+}): Component -> StateHandle<MsgPack>
+  state_handle_at(id: id, initial: initial)
+
+fn state_handle_at({ id: i32, initial: MsgPack }): Component -> StateHandle<MsgPack>
+  let slot = Component::state_key(id)
   StateHandle<MsgPack> {
-    id: id,
-    value: Component::state_get(id, initial)
+    id: slot,
+    value: Component::state_get(slot, initial)
   }
 
 /// Reads a component-local text state handle.
-pub fn state_handle({ id: i32, initial: String }): Component -> StateHandle<String>
+pub fn state_handle({
+  initial: String,
+  id: i32 = stable_callsite_id()
+}): Component -> StateHandle<String>
+  state_handle_at(id: id, initial: initial)
+
+fn state_handle_at({ id: i32, initial: String }): Component -> StateHandle<String>
+  let slot = Component::state_key(id)
   StateHandle<String> {
-    id: id,
+    id: slot,
     value: component_string_state_value(
-      value: Component::state_get(id, msgpack::make_string(initial)),
+      value: Component::state_get(slot, msgpack::make_string(initial)),
       fallback: initial
     )
   }
 
-pub fn state_handle({ id: i32, initial: StringSlice }): Component -> StateHandle<String>
-  state_handle(id: id, initial: initial.to_string())
+pub fn state_handle({
+  initial: StringSlice,
+  id: i32 = stable_callsite_id()
+}): Component -> StateHandle<String>
+  state_handle_at(id: id, initial: initial.to_string())
 
 /// Reads a component-local integer state handle.
-pub fn state_handle({ id: i32, initial: i32 }): Component -> StateHandle<i32>
+pub fn state_handle({
+  initial: i32,
+  id: i32 = stable_callsite_id()
+}): Component -> StateHandle<i32>
+  state_handle_at(id: id, initial: initial)
+
+fn state_handle_at({ id: i32, initial: i32 }): Component -> StateHandle<i32>
+  let slot = Component::state_key(id)
   StateHandle<i32> {
-    id: id,
+    id: slot,
     value: component_i32_state_value(
-      value: Component::state_get(id, msgpack::make_i32(initial)),
+      value: Component::state_get(slot, msgpack::make_i32(initial)),
       fallback: initial
     )
   }
 
 /// Reads component-local serialized state as a `(value, setter)` pair.
-pub fn state({ id: i32, initial: MsgPack }): Component -> (MsgPack, fn(MsgPack) -> void)
-  let handle = state_handle(id: id, initial: initial)
+pub fn state({
+  initial: MsgPack,
+  id: i32 = stable_callsite_id()
+}): Component -> (MsgPack, fn(MsgPack) -> void)
+  let handle = state_handle_at(id: id, initial: initial)
   (handle.value, (value: MsgPack) -> void => handle.set_serialized(value))
 
 /// Reads component-local text state as a `(value, setter)` pair.
-pub fn state({ id: i32, initial: String }): Component -> (String, fn(String) -> void)
-  let handle = state_handle(id: id, initial: initial)
+pub fn state({
+  initial: String,
+  id: i32 = stable_callsite_id()
+}): Component -> (String, fn(String) -> void)
+  let handle = state_handle_at(id: id, initial: initial)
   (handle.value, (value: String) -> void => handle.set(value))
 
-pub fn state({ id: i32, initial: StringSlice }): Component -> (String, fn(String) -> void)
-  let handle = state_handle(id: id, initial: initial)
+pub fn state({
+  initial: StringSlice,
+  id: i32 = stable_callsite_id()
+}): Component -> (String, fn(String) -> void)
+  let handle = state_handle_at(id: id, initial: initial.to_string())
   (handle.value, (value: String) -> void => handle.set(value))
 
 /// Reads component-local integer state as a `(value, setter)` pair.
-pub fn state({ id: i32, initial: i32 }): Component -> (i32, fn(i32) -> void)
-  let handle = state_handle(id: id, initial: initial)
+pub fn state({
+  initial: i32,
+  id: i32 = stable_callsite_id()
+}): Component -> (i32, fn(i32) -> void)
+  let handle = state_handle_at(id: id, initial: initial)
   (handle.value, (value: i32) -> void => handle.set(value))
 
 fn component_string_state_value({ value: MsgPack, fallback: String }): () -> String
@@ -495,6 +546,13 @@ pub fn element({
     if normalized.events.len() > 0:
       out.set("events", normalized.events)
   msgpack::make_map(out)
+
+pub fn html_element({
+  tag: String,
+  attrs?: Array<HtmlAttr>,
+  children: Array<HtmlNode>
+}) -> HtmlNode
+  element(tag: tag, attrs: attrs, children: children)
 
 /// Creates a string-valued DOM attribute.
 pub fn attr({ name: String, value: String }): () -> MsgPack
@@ -641,6 +699,13 @@ pub fn keyed({ key: String, child: MsgPack }): () -> MsgPack
 pub fn keyed({ key: StringSlice, child: MsgPack }): () -> MsgPack
   keyed(key: key.to_string(), child: child)
 
+pub fn keyed({ key: String, body: fn() -> MsgPack }): Component -> MsgPack
+  Component::state_scope(msgpack::make_string(key))
+  keyed(key: key, child: body())
+
+pub fn keyed({ key: StringSlice, body: fn() -> MsgPack }): Component -> MsgPack
+  keyed(key: key.to_string(), body: body)
+
 /// Lifts child HTML through a retained message mapper.
 pub fn map_html<ChildMsg, ParentMsg>({ html: Html<ChildMsg>, handler_id: i32 }) -> Html<ParentMsg>
   let ~out = Dict<String, MsgPack>::init()
@@ -729,6 +794,29 @@ pub fn event_message<Msg>({ name: String, message: Msg, options?: EventOptions }
 
 pub fn event_message<Msg>({ name: StringSlice, message: Msg, options?: EventOptions }): () -> MsgPack
   event_message<Msg>(name: name.to_string(), message: message, options: options)
+
+pub fn html_event_message<Msg>({ name: String, message: fn() -> Msg, options?: EventOptions }): () -> HtmlAttr
+  event_message<Msg>(name: name, message: message, options: options)
+
+pub fn html_event_message<Event, Msg>({
+  name: String,
+  message: fn(Event) -> Msg,
+  options?: EventOptions
+}): () -> HtmlAttr
+  event_message<Event, Msg>(name: name, message: message, options: options)
+
+pub fn html_event_message<Msg>({ name: String, message: Msg, options?: EventOptions }): () -> HtmlAttr
+  event_message<Msg>(name: name, message: message, options: options)
+
+pub fn html_event_handler<Msg>({ name: String, handler: fn() -> Msg, options?: EventOptions }): () -> HtmlAttr
+  event_handler<Msg>(name: name, handler: handler, options: options)
+
+pub fn html_event_payload_handler<Event, Msg>({
+  name: String,
+  handler: fn(Event) -> Msg,
+  options?: EventOptions
+}): () -> HtmlAttr
+  event_payload_handler<Event, Msg>(name: name, handler: handler, options: options)
 
 pub fn on_click(handler: fn() -> MsgPack): () -> MsgPack
   event(name: "click", handler: handler)
@@ -1489,24 +1577,66 @@ pub fn program<Model, Msg>({
   msgpack::make_map(out)
 
 pub fn program<Model, Msg>({
-  init: MsgPack,
-  update: MsgPack,
-  view: MsgPack,
-  subscriptions?: MsgPack,
-  decode_msg?: MsgPack,
-  encode_msg?: MsgPack
+  init: fn() -> Model,
+  update: fn(Model, Msg) -> Program<Model, Msg>,
+  view: fn(Model) -> Html<Msg>
+}) -> Program<Model, Msg>
+  program_handlers<Model, Msg>(
+    init_id: __retain_callback(init),
+    update_id: __retain_callback(update),
+    view_id: __retain_callback(view)
+  )
+
+pub fn program<Model, Msg>({
+  init: fn() -> Program<Model, Msg>,
+  update: fn(Model, Msg) -> Program<Model, Msg>,
+  view: fn(Model) -> Html<Msg>
+}) -> Program<Model, Msg>
+  program_handlers<Model, Msg>(
+    init_id: __retain_callback(init),
+    update_id: __retain_callback(update),
+    view_id: __retain_callback(view)
+  )
+
+pub fn program<Model, Msg>({
+  init: fn() -> Model,
+  update: fn(Model, Msg) -> Program<Model, Msg>,
+  view: fn(Model) -> Html<Msg>,
+  subscriptions: fn(Model) -> Sub<Msg>
+}) -> Program<Model, Msg>
+  program_handlers<Model, Msg>(
+    init_id: __retain_callback(init),
+    update_id: __retain_callback(update),
+    view_id: __retain_callback(view),
+    subscriptions_id: __retain_callback(subscriptions)
+  )
+
+pub fn program<Model, Msg>({
+  init: fn() -> Program<Model, Msg>,
+  update: fn(Model, Msg) -> Program<Model, Msg>,
+  view: fn(Model) -> Html<Msg>,
+  subscriptions: fn(Model) -> Sub<Msg>
+}) -> Program<Model, Msg>
+  program_handlers<Model, Msg>(
+    init_id: __retain_callback(init),
+    update_id: __retain_callback(update),
+    view_id: __retain_callback(view),
+    subscriptions_id: __retain_callback(subscriptions)
+  )
+
+fn program_handlers<Model, Msg>({
+  init_id: i32,
+  update_id: i32,
+  view_id: i32,
+  subscriptions_id?: i32
 }) -> Program<Model, Msg>
   let ~out = Dict<String, MsgPack>::init()
   out.set("kind", "program")
-  out.set("init", init)
-  out.set("update", update)
-  out.set("view", view)
-  if subscriptions is Some:
-    out.set("subscriptions", subscriptions.value)
-  if decode_msg is Some:
-    out.set("decode_msg", decode_msg.value)
-  if encode_msg is Some:
-    out.set("encode_msg", encode_msg.value)
+  out.set("initHandlerId", msgpack::make_i32(init_id))
+  out.set("updateHandlerId", msgpack::make_i32(update_id))
+  out.set("viewHandlerId", msgpack::make_i32(view_id))
+  if subscriptions_id is Some:
+    out.set("subscriptionsHandlerId", msgpack::make_i32(subscriptions_id.value))
   msgpack::make_map(out)
 
 /// Creates a virtual DOM element payload for renderer consumption.

--- a/packages/vx-dom/src/__tests__/app-runtime.test.ts
+++ b/packages/vx-dom/src/__tests__/app-runtime.test.ts
@@ -179,6 +179,186 @@ describe("createVoydVxAppRuntime", () => {
       event: "click",
     });
   });
+
+  it("keeps repeated component state call-site occurrences in distinct slots", async () => {
+    let handlers: Record<string, (continuation: any, ...args: any[]) => unknown> = {};
+    let slots: number[] = [];
+    const callComponent = (name: string, ...args: unknown[]) =>
+      handlers[name]?.({ tail: (value?: unknown) => value }, ...args);
+    const host: VoydVxAppHost = {
+      registerHandlersByLabelSuffix: (nextHandlers) => {
+        handlers = nextHandlers;
+      },
+      run: async <T = unknown>(entryName: string): Promise<T> => {
+        if (entryName !== "view") {
+          throw new Error(`unexpected fake entry ${entryName}`);
+        }
+        const firstSlot = Number(callComponent("Component::state_key", 1234));
+        const first = callComponent("Component::state_get", firstSlot, 0);
+        const secondSlot = Number(callComponent("Component::state_key", 1234));
+        const second = callComponent("Component::state_get", secondSlot, 0);
+        slots = [firstSlot, secondSlot];
+        return { first, second } as T;
+      },
+    };
+    const app = createVoydVxAppRuntime({
+      host,
+      initialModel: undefined,
+      viewReceivesModel: false,
+    });
+
+    await expect(app.render()).resolves.toEqual({ first: 0, second: 0 });
+    expect(slots[0]).not.toBe(slots[1]);
+
+    callComponent("Component::state_set", slots[1], 1);
+
+    await expect(app.render()).resolves.toEqual({ first: 0, second: 1 });
+  });
+
+  it("keeps keyed component state with items after reorder", async () => {
+    let handlers: Record<string, (continuation: any, ...args: any[]) => unknown> = {};
+    let order = ["a", "b"];
+    const secondSlotsByKey = new Map<string, number>();
+    const callComponent = (name: string, ...args: unknown[]) =>
+      handlers[name]?.({ tail: (value?: unknown) => value }, ...args);
+    const withStateScope = <T>(key: unknown, body: () => T): T =>
+      handlers["Component::state_scope"]?.({ tail: body }, key) as T;
+    const host: VoydVxAppHost = {
+      registerHandlersByLabelSuffix: (nextHandlers) => {
+        handlers = nextHandlers;
+      },
+      run: async <T = unknown>(entryName: string): Promise<T> => {
+        if (entryName !== "view") {
+          throw new Error(`unexpected fake entry ${entryName}`);
+        }
+        const children = order.map((key) => withStateScope(key, () => {
+          const firstSlot = Number(callComponent("Component::state_key", 4321));
+          const first = callComponent("Component::state_get", firstSlot, 0);
+          const secondSlot = Number(callComponent("Component::state_key", 9876));
+          const second = callComponent("Component::state_get", secondSlot, 0);
+          secondSlotsByKey.set(key, secondSlot);
+          return {
+            kind: "element",
+            tag: "div",
+            key,
+            children: [
+              { kind: "text", key: `${key}-label`, value: `${key}:${String(first)}/${String(second)}` },
+            ],
+          };
+        }));
+        return { version: 1, root: { kind: "fragment", children } } as T;
+      },
+    };
+    const app = createVoydVxAppRuntime({
+      host,
+      initialModel: undefined,
+      viewReceivesModel: false,
+    });
+
+    await expect(app.render()).resolves.toEqual(frameWithChildren(["a:0/0", "b:0/0"]));
+    callComponent("Component::state_set", secondSlotsByKey.get("b"), 1);
+    order = ["b", "a"];
+
+    await expect(app.render()).resolves.toEqual(frameWithChildren(["b:0/1", "a:0/0"]));
+
+    order = ["x", "a", "b"];
+
+    await expect(app.render()).resolves.toEqual(
+      frameWithChildren(["x:0/0", "a:0/0", "b:0/1"]),
+    );
+  });
+
+  it("scopes duplicate child keys by keyed ancestors for component state", async () => {
+    let handlers: Record<string, (continuation: any, ...args: any[]) => unknown> = {};
+    const slotsByScope = new Map<string, number>();
+    const callComponent = (name: string, ...args: unknown[]) =>
+      handlers[name]?.({ tail: (value?: unknown) => value }, ...args);
+    const withStateScope = <T>(key: unknown, body: () => T): T =>
+      handlers["Component::state_scope"]?.({ tail: body }, key) as T;
+    const host: VoydVxAppHost = {
+      registerHandlersByLabelSuffix: (nextHandlers) => {
+        handlers = nextHandlers;
+      },
+      run: async <T = unknown>(entryName: string): Promise<T> => {
+        if (entryName !== "view") {
+          throw new Error(`unexpected fake entry ${entryName}`);
+        }
+        const children = ["left", "right"].map((scope) => withStateScope(scope, () => withStateScope("1", () => {
+          const slot = Number(callComponent("Component::state_key", 2468));
+          slotsByScope.set(scope, slot);
+          const value = callComponent("Component::state_get", slot, 0);
+          return {
+            kind: "element",
+            tag: "section",
+            key: scope,
+            children: [
+              {
+                kind: "element",
+                tag: "button",
+                key: "1",
+                children: [{ kind: "text", value: `${scope}:${String(value)}` }],
+              },
+            ],
+          };
+        })));
+        return { version: 1, root: { kind: "fragment", children } } as T;
+      },
+    };
+    const app = createVoydVxAppRuntime({
+      host,
+      initialModel: undefined,
+      viewReceivesModel: false,
+    });
+
+    await expect(app.render()).resolves.toEqual(frameWithScopedChildren(["left:0", "right:0"]));
+    callComponent("Component::state_set", slotsByScope.get("right"), 1);
+
+    await expect(app.render()).resolves.toEqual(frameWithScopedChildren(["left:0", "right:1"]));
+  });
+
+  it("does not assign parent component state to child row keys", async () => {
+    let handlers: Record<string, (continuation: any, ...args: any[]) => unknown> = {};
+    let order = ["a", "b"];
+    let parentSlot = 0;
+    const callComponent = (name: string, ...args: unknown[]) =>
+      handlers[name]?.({ tail: (value?: unknown) => value }, ...args);
+    const host: VoydVxAppHost = {
+      registerHandlersByLabelSuffix: (nextHandlers) => {
+        handlers = nextHandlers;
+      },
+      run: async <T = unknown>(entryName: string): Promise<T> => {
+        if (entryName !== "view") {
+          throw new Error(`unexpected fake entry ${entryName}`);
+        }
+        parentSlot = Number(callComponent("Component::state_key", 1357));
+        const parentValue = callComponent("Component::state_get", parentSlot, 0);
+        return {
+          version: 1,
+          root: {
+            kind: "element",
+            tag: "section",
+            children: [
+              { kind: "text", value: `parent:${String(parentValue)}` },
+              ...order.map((key) => ({ kind: "text", key, value: key })),
+            ],
+          },
+        } as T;
+      },
+    };
+    const app = createVoydVxAppRuntime({
+      host,
+      initialModel: undefined,
+      viewReceivesModel: false,
+    });
+
+    await expect(app.render()).resolves.toEqual(frameWithParentState("parent:0", ["a", "b"]));
+    callComponent("Component::state_set", parentSlot, 1);
+    order = ["x", "b", "a"];
+
+    await expect(app.render()).resolves.toEqual(
+      frameWithParentState("parent:1", ["x", "b", "a"]),
+    );
+  });
 });
 
 type FakeRun = (args: unknown[]) => Promise<unknown>;
@@ -197,5 +377,62 @@ function textFrame(value: string) {
   return {
     version: 1,
     root: { kind: "text", value },
+  };
+}
+
+function frameWithChildren(values: string[]) {
+  return {
+    version: 1,
+    root: {
+      kind: "fragment",
+      children: values.map((value) => {
+        const key = value.split(":")[0] ?? value;
+        return {
+          kind: "element",
+          tag: "div",
+          key,
+          children: [{ kind: "text", key: `${key}-label`, value }],
+        };
+      }),
+    },
+  };
+}
+
+function frameWithScopedChildren(values: string[]) {
+  return {
+    version: 1,
+    root: {
+      kind: "fragment",
+      children: values.map((value) => {
+        const scope = value.split(":")[0] ?? value;
+        return {
+          kind: "element",
+          tag: "section",
+          key: scope,
+          children: [
+            {
+              kind: "element",
+              tag: "button",
+              key: "1",
+              children: [{ kind: "text", value }],
+            },
+          ],
+        };
+      }),
+    },
+  };
+}
+
+function frameWithParentState(parent: string, keys: string[]) {
+  return {
+    version: 1,
+    root: {
+      kind: "element",
+      tag: "section",
+      children: [
+        { kind: "text", value: parent },
+        ...keys.map((key) => ({ kind: "text", key, value: key })),
+      ],
+    },
   };
 }

--- a/packages/vx-dom/src/app-runtime.ts
+++ b/packages/vx-dom/src/app-runtime.ts
@@ -10,6 +10,7 @@ import type {
 
 export type VoydVxAppHost = {
   run<T = unknown>(entryName: string, args?: unknown[]): Promise<T>;
+  hasExport?: (entryName: string) => boolean;
   registerHandlersByLabelSuffix?: (
     handlersByLabelSuffix: Record<string, ComponentEffectHandler>,
   ) => unknown;
@@ -30,6 +31,7 @@ export type VoydVxAppRuntimeExports = {
 export type CreateVoydVxAppRuntimeOptions = {
   host: VoydVxAppHost;
   initialModel?: unknown;
+  app?: string | false;
   exports?: VoydVxAppRuntimeExports;
   viewReceivesModel?: boolean;
 };
@@ -40,6 +42,13 @@ type RuntimeResult = Record<string, unknown> & {
   frame?: unknown;
   commands?: unknown;
   subscriptions?: unknown;
+};
+
+type ProgramDescriptor = {
+  initHandlerId: number;
+  updateHandlerId: number;
+  viewHandlerId: number;
+  subscriptionsHandlerId?: number;
 };
 
 const defaultExports = {
@@ -59,6 +68,12 @@ export function createVoydVxAppRuntime(
   options: CreateVoydVxAppRuntimeOptions,
 ): VxAppRuntime {
   const entryNames = { ...defaultExports, ...options.exports };
+  const appEntryName = options.app === false ? undefined : options.app ?? "app";
+  const shouldUseProgramDescriptor =
+    !options.exports &&
+    appEntryName !== undefined &&
+    options.host.hasExport?.(appEntryName) === true;
+  let programDescriptor: ProgramDescriptor | undefined;
   let model = options.initialModel;
   let initialized = Object.hasOwn(options, "initialModel");
   const componentState = createComponentStateRuntime(options.host);
@@ -70,23 +85,52 @@ export function createVoydVxAppRuntime(
     return model;
   };
 
+  const requireRetainedCallbacks = () => {
+    if (!options.host.retainedCallbacks) {
+      throw new Error("vx-dom: Program descriptors require retained callback support");
+    }
+    return options.host.retainedCallbacks;
+  };
+
+  const readProgramDescriptor = async (): Promise<ProgramDescriptor | undefined> => {
+    if (!shouldUseProgramDescriptor || !appEntryName) return undefined;
+    if (programDescriptor) return programDescriptor;
+    programDescriptor = parseProgramDescriptor(await options.host.run(appEntryName));
+    return programDescriptor;
+  };
+
+  const runProgramHandler = async <T = unknown>(
+    handlerId: number,
+    payload: unknown,
+  ): Promise<T> =>
+    await Promise.resolve(requireRetainedCallbacks().dispatch(handlerId, payload) as T);
+
   const render = async (): Promise<unknown> => {
     let frame: unknown;
     for (let pass = 0; pass < 5; pass += 1) {
       componentState.resetDirty();
-      frame = await options.host.run(
-        entryNames.view,
-        options.viewReceivesModel === false ? [] : [requireModel()],
-      );
+      componentState.beginRender();
+      const descriptor = await readProgramDescriptor();
+      frame = descriptor
+        ? await runProgramHandler(descriptor.viewHandlerId, requireModel())
+        : await options.host.run(
+            entryNames.view,
+            options.viewReceivesModel === false ? [] : [requireModel()],
+          );
+      componentState.finishRender(frame);
       if (!componentState.isDirty()) return frame;
     }
     return frame;
   };
 
   const readSubscriptions = async (): Promise<unknown> =>
-    entryNames.subscriptions
-      ? options.host.run(entryNames.subscriptions, [requireModel()])
-      : undefined;
+    readProgramDescriptor().then((descriptor) =>
+      descriptor?.subscriptionsHandlerId !== undefined
+        ? runProgramHandler(descriptor.subscriptionsHandlerId, requireModel())
+        : entryNames.subscriptions
+          ? options.host.run(entryNames.subscriptions, [requireModel()])
+          : undefined,
+    );
 
   const toRuntimeStep = async (
     result: unknown,
@@ -118,9 +162,12 @@ export function createVoydVxAppRuntime(
 
   return {
     init: async () => {
+      const descriptor = await readProgramDescriptor();
       const result = initialized
         ? runtimeResult({ model })
-        : await options.host.run(entryNames.init);
+        : descriptor
+          ? await runProgramHandler(descriptor.initHandlerId, undefined)
+          : await options.host.run(entryNames.init);
       return toRuntimeStep(result, true);
     },
     render,
@@ -129,10 +176,13 @@ export function createVoydVxAppRuntime(
       if (resolved === noRuntimeMessage) {
         return toRuntimeStep(runtimeResult({ model: requireModel() }), false);
       }
-      const result = await options.host.run(entryNames.update, [
-        requireModel(),
-        resolved,
-      ]);
+      const descriptor = await readProgramDescriptor();
+      const result = descriptor
+        ? await runProgramHandler(descriptor.updateHandlerId, [requireModel(), resolved])
+        : await options.host.run(entryNames.update, [
+            requireModel(),
+            resolved,
+          ]);
       return toRuntimeStep(result, true);
     },
     getSnapshot: () => model,
@@ -140,12 +190,53 @@ export function createVoydVxAppRuntime(
 }
 
 function createComponentStateRuntime(host: VoydVxAppHost): {
+  beginRender(): void;
+  finishRender(frame: unknown): void;
   isDirty(): boolean;
   resetDirty(): void;
 } {
   let dirty = false;
+  let nextSlotId = 1;
   const values = new Map<number, unknown>();
+  const slots = new Map<string, number>();
+  const renderOccurrences = new Map<string, number>();
+  const scopeStack: string[] = [];
+
+  const slotFor = (baseId: number, occurrence: number): number => {
+    const key = slotKey(baseId, scopeStack, occurrence);
+    const existing = slots.get(key);
+    if (existing !== undefined) return existing;
+    const slot = nextSlotId;
+    nextSlotId += 1;
+    slots.set(key, slot);
+    return slot;
+  };
+
   host.registerHandlersByLabelSuffix?.({
+    "Component::state_scope": ({ tail }, key) => {
+      scopeStack.push(scopePartFor(key));
+      try {
+        const result = tail();
+        if (result && typeof result === "object" && "finally" in result) {
+          return (result as Promise<unknown>).finally(() => {
+            scopeStack.pop();
+          });
+        }
+        scopeStack.pop();
+        return result;
+      } catch (error) {
+        scopeStack.pop();
+        throw error;
+      }
+    },
+    "Component::state_key": ({ tail }, id) => {
+      const baseId = Number(id);
+      const occurrenceKey = slotKey(baseId, scopeStack, -1);
+      const occurrence = renderOccurrences.get(occurrenceKey) ?? 0;
+      renderOccurrences.set(occurrenceKey, occurrence + 1);
+      const slot = slotFor(baseId, occurrence);
+      return tail(slot);
+    },
     "Component::state_get": ({ tail }, id, initial) => {
       const key = Number(id);
       if (!values.has(key)) values.set(key, initial);
@@ -160,12 +251,27 @@ function createComponentStateRuntime(host: VoydVxAppHost): {
   });
 
   return {
+    beginRender: () => {
+      renderOccurrences.clear();
+    },
+    finishRender: () => undefined,
     isDirty: () => dirty,
     resetDirty: () => {
       dirty = false;
     },
   };
 }
+
+const slotKey = (
+  baseId: number,
+  scopeStack: readonly string[],
+  occurrence: number,
+): string => `${baseId}:${JSON.stringify(scopeStack)}:${occurrence}`;
+
+const scopePartFor = (value: unknown): string =>
+  typeof value === "string" || typeof value === "number"
+    ? String(value)
+    : JSON.stringify(value);
 
 async function resolveRuntimeMessage(
   host: VoydVxAppHost,
@@ -218,4 +324,50 @@ function isRuntimeResult(input: unknown): input is RuntimeResult {
     !Array.isArray(input) &&
     (input as { $vx?: unknown }).$vx === "runtime_result"
   );
+}
+
+function parseProgramDescriptor(input: unknown): ProgramDescriptor {
+  if (readField(input, "kind") !== "program") {
+    throw new Error("vx-dom: app export did not return a VX program descriptor");
+  }
+  const initHandlerId = readNumberField(input, "initHandlerId");
+  const updateHandlerId = readNumberField(input, "updateHandlerId");
+  const viewHandlerId = readNumberField(input, "viewHandlerId");
+  const subscriptionsHandlerId = readOptionalNumberField(
+    input,
+    "subscriptionsHandlerId",
+  );
+  return {
+    initHandlerId,
+    updateHandlerId,
+    viewHandlerId,
+    ...(subscriptionsHandlerId !== undefined ? { subscriptionsHandlerId } : {}),
+  };
+}
+
+function readNumberField(input: unknown, name: string): number {
+  const value = readField(input, name);
+  if (typeof value !== "number") {
+    throw new Error(`vx-dom: program descriptor field ${name} must be a number`);
+  }
+  return value;
+}
+
+function readOptionalNumberField(input: unknown, name: string): number | undefined {
+  const value = readField(input, name);
+  if (value === undefined) return undefined;
+  if (typeof value !== "number") {
+    throw new Error(`vx-dom: program descriptor field ${name} must be a number`);
+  }
+  return value;
+}
+
+function readField(input: unknown, name: string): unknown {
+  if (input instanceof Map) {
+    return input.get(name);
+  }
+  if (input && typeof input === "object" && !Array.isArray(input)) {
+    return (input as Record<string, unknown>)[name];
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Summary
- Add a domain-neutral `__stable_callsite_id` intrinsic so VX state can derive stable ids without compiler VX special-casing.
- Remove user-supplied `state(id:)` and route state through hidden callsite ids instead.
- Move everyday VX apps to `app() -> Program<Model, Msg>` with transport-neutral boundary metadata and runtime auto-detection.
- Update site examples, smoke fixtures, and ABI coverage to match the new API shape.

## Testing
- `npm run typecheck`
- `npm test`
- Focused unit and integration test slices for compiler boundary ABI, parser boundary syntax, VX runtime, and smoke fixtures