### PR TITLE
Fix labeled object inference for VX program calls

### DIFF
--- a/apps/smoke/fixtures/vx-typed-counter.voyd
+++ b/apps/smoke/fixtures/vx-typed-counter.voyd
@@ -12,12 +12,10 @@ enum Msg
   Rename { value: String }
 
 pub fn app() -> Program<Model, Msg>
-  program<Model, Msg>(
-    init: init,
-    update: update,
-    view: view,
-    subscriptions: subscriptions
-  )
+  program({ init, update, view, subscriptions })
+
+pub fn app_explicit_config() -> Program<Model, Msg>
+  program<Model, Msg>({ init, update, view, subscriptions })
 
 fn init() -> Model
   Model { count: 1, title: "Ready" }

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/generic_labeled_function_object.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/generic_labeled_function_object.voyd
@@ -1,0 +1,41 @@
+obj Model {
+  value: i32
+}
+
+obj Msg {
+  value: i32
+}
+
+fn configure<T, U>({
+  init: fn() -> T,
+  update: fn(T, U) -> T,
+  view: fn(T) -> U
+}) -> i32
+  let model = init()
+  let message = view(model)
+  update(model, message)
+  7
+
+fn configure<T>({ model: T }) -> i32
+  99
+
+fn init() -> Model
+  Model { value: 1 }
+
+fn update(model: Model, message: Msg) -> Model
+  Model { value: model.value + message.value }
+
+fn view(model: Model) -> Msg
+  Msg { value: model.value + 1 }
+
+pub fn explicit_structural() -> i32
+  configure<Model, Msg>({ init, update, view })
+
+pub fn inferred_structural() -> i32
+  configure({ init, update, view })
+
+pub fn inferred_labeled() -> i32
+  configure(init: init, update: update, view: view)
+
+pub fn main() -> i32
+  explicit_structural() + inferred_structural() + inferred_labeled()

--- a/packages/compiler/src/codegen/__tests__/codegen.test.ts
+++ b/packages/compiler/src/codegen/__tests__/codegen.test.ts
@@ -483,7 +483,9 @@ describe("next codegen", () => {
 
     const infoNode = getStructuralTypeInfo(typeNode, ctx);
     if (!infoNode) {
-      throw new Error("missing structural type info for FixedArray recursion test");
+      throw new Error(
+        "missing structural type info for FixedArray recursion test",
+      );
     }
 
     const nextField = infoNode.fieldMap.get("next");
@@ -621,6 +623,17 @@ describe("next codegen", () => {
     expect((test9_closure_without_arg as () => number)()).toBe(1);
     expect((test10_optional_spread_wraps_some as () => number)()).toBe(5);
     expect((main as () => number)()).toBe(25);
+  });
+
+  it("infers generic labeled params from function-valued structural objects", () => {
+    const instance = loadWasmInstance("generic_labeled_function_object.voyd");
+    const { explicit_structural, inferred_structural, inferred_labeled, main } =
+      instance.exports as Record<string, unknown>;
+
+    expect((explicit_structural as () => number)()).toBe(7);
+    expect((inferred_structural as () => number)()).toBe(7);
+    expect((inferred_labeled as () => number)()).toBe(7);
+    expect((main as () => number)()).toBe(21);
   });
 
   it("supports default function parameters with and without annotations", () => {
@@ -846,7 +859,9 @@ describe("next codegen", () => {
   });
 
   it("emits wasm for trait object dispatch on generic impl instantiations", () => {
-    const instance = loadWasmInstance("trait_object_generic_impl_dispatch.voyd");
+    const instance = loadWasmInstance(
+      "trait_object_generic_impl_dispatch.voyd",
+    );
     const main = instance.exports.main;
     const mainF64 = instance.exports.main_f64;
     expect(typeof main).toBe("function");
@@ -1059,9 +1074,9 @@ describe("next codegen", () => {
       .split("\n")
       .map((line) => line.trim())
       .filter((line) => line.startsWith("(type"));
-    expect(
-      typeLines.some((line) => line.includes("voyd__closure_base_")),
-    ).toBe(true);
+    expect(typeLines.some((line) => line.includes("voyd__closure_base_"))).toBe(
+      true,
+    );
     expect(
       typeLines.some(
         (line) =>

--- a/packages/compiler/src/semantics/typing/expressions.ts
+++ b/packages/compiler/src/semantics/typing/expressions.ts
@@ -80,7 +80,7 @@ export const typeExpression = (
   exprId: HirExprId,
   ctx: TypingContext,
   state: TypingState,
-  options: TypeExpressionOptions = {}
+  options: TypeExpressionOptions = {},
 ): TypeId => {
   const expr = ctx.hir.expressions.get(exprId);
   if (!expr) {
@@ -102,10 +102,7 @@ export const typeExpression = (
     }
     const applied = applyCurrentSubstitution(cached.type, ctx, state);
     const span = normalizeSpan(ctx.hir.expressions.get(exprId)?.span);
-    if (
-      hasConcreteExpected &&
-      typeof appliedExpected === "number"
-    ) {
+    if (hasConcreteExpected && typeof appliedExpected === "number") {
       try {
         ensureTypeMatches(
           applied,
@@ -175,7 +172,7 @@ const resolveExpressionType = (
   expr: HirExpression,
   ctx: TypingContext,
   state: TypingState,
-  options: TypeExpressionOptions
+  options: TypeExpressionOptions,
 ): TypeId => {
   const expectedType = options.expectedType;
   switch (expr.exprKind) {
@@ -200,7 +197,7 @@ const resolveExpressionType = (
     case "tuple":
       return typeTupleExpr(expr, ctx, state);
     case "object-literal":
-      return typeObjectLiteralExpr(expr, ctx, state);
+      return typeObjectLiteralExpr(expr, ctx, state, expectedType);
     case "field-access":
       return typeFieldAccessExpr(expr, ctx, state);
     case "while":

--- a/packages/compiler/src/semantics/typing/expressions/call-arg-context.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call-arg-context.ts
@@ -1,15 +1,13 @@
-import type {
-  HirExprId,
-  TypeId,
-  TypeParamId,
-} from "../../ids.js";
+import type { HirExprId, TypeId, TypeParamId } from "../../ids.js";
 import type {
   Arg,
   FunctionSignature,
+  ParamSignature,
   TypingContext,
   TypingState,
 } from "../types.js";
 import { bindTypeParams as bindTypeParamsFromType } from "../type-relations.js";
+import { getStructuralFields } from "../type-system.js";
 import { typeExpression } from "../expressions.js";
 import { applyCurrentSubstitution } from "./shared.js";
 
@@ -39,13 +37,12 @@ export const buildCallArgumentHintSubstitution = ({
   }
 
   const merged = new Map<TypeParamId, TypeId>(seedSubstitution);
-  probeArgs.forEach((arg, index) => {
-    const param = signature.parameters[index];
-    if (!param) {
-      return;
-    }
-    const expected = ctx.arena.substitute(param.type, merged);
-    bindTypeParamsFromType(expected, arg.type, merged, ctx, state);
+  bindCallArgumentTypeParams({
+    signature,
+    args: probeArgs,
+    substitution: merged,
+    ctx,
+    state,
   });
 
   if (
@@ -83,9 +80,11 @@ export const typeCallArgsWithSignatureContext = ({
   args.map((arg, index) => ({
     label: arg.label,
     type: typeExpression(arg.expr, ctx, state, {
-      expectedType: expectedCallParamType({
-        signature,
+      expectedType: expectedCallArgType({
+        args,
         index: index + paramOffset,
+        argIndex: index,
+        params: signature.parameters,
         hintSubstitution,
         ctx,
       }),
@@ -93,22 +92,170 @@ export const typeCallArgsWithSignatureContext = ({
     exprId: arg.expr,
   }));
 
-const expectedCallParamType = ({
-  signature,
+export const expectedCallArgType = ({
+  args,
   index,
+  argIndex,
+  params,
   hintSubstitution,
   ctx,
 }: {
-  signature: FunctionSignature;
+  args: readonly CallArgInput[];
   index: number;
+  argIndex: number;
+  params: readonly ParamSignature[];
   hintSubstitution: ReadonlyMap<TypeParamId, TypeId> | undefined;
   ctx: TypingContext;
 }): TypeId | undefined => {
-  const param = signature.parameters[index];
+  const param = params[index];
   if (!param) {
     return undefined;
   }
-  return hintSubstitution
+  const directType = hintSubstitution
     ? ctx.arena.substitute(param.type, hintSubstitution)
     : param.type;
+  const arg = args[argIndex];
+  if (!arg || !param.label || arg.label !== undefined) {
+    return directType;
+  }
+
+  const expr = ctx.hir.expressions.get(arg.expr);
+  if (
+    expr?.exprKind !== "object-literal" ||
+    expr.literalKind !== "structural"
+  ) {
+    return directType;
+  }
+
+  const fields: { name: string; type: TypeId }[] = [];
+  let cursor = index;
+  while (cursor < params.length) {
+    const runParam = params[cursor]!;
+    if (!runParam.label) {
+      break;
+    }
+    fields.push({
+      name: runParam.label,
+      type: hintSubstitution
+        ? ctx.arena.substitute(runParam.type, hintSubstitution)
+        : runParam.type,
+    });
+    cursor += 1;
+  }
+
+  return fields.length > 0
+    ? ctx.arena.internStructuralObject({ fields })
+    : directType;
+};
+
+export const bindCallArgumentTypeParams = ({
+  signature,
+  args,
+  substitution,
+  ctx,
+  state,
+}: {
+  signature: FunctionSignature;
+  args: readonly Arg[];
+  substitution: Map<TypeParamId, TypeId>;
+  ctx: TypingContext;
+  state: TypingState;
+}): void => {
+  forEachCallArgumentMatch({
+    args,
+    params: signature.parameters,
+    ctx,
+    state,
+    onMatch: ({ param, actualType }) => {
+      const expectedType = ctx.arena.substitute(param.type, substitution);
+      bindTypeParamsFromType(
+        expectedType,
+        actualType,
+        substitution,
+        ctx,
+        state,
+      );
+    },
+  });
+};
+
+const forEachCallArgumentMatch = ({
+  args,
+  params,
+  ctx,
+  state,
+  onMatch,
+}: {
+  args: readonly Arg[];
+  params: readonly ParamSignature[];
+  ctx: TypingContext;
+  state: TypingState;
+  onMatch: (match: { param: ParamSignature; actualType: TypeId }) => void;
+}): void => {
+  if (
+    args.length > 0 &&
+    args.every((arg) => arg.label !== undefined) &&
+    params.length > 0 &&
+    params.every((param) => param.label !== undefined)
+  ) {
+    const byLabel = new Map(args.map((arg) => [arg.label, arg] as const));
+    params.forEach((param) => {
+      const arg = param.label ? byLabel.get(param.label) : undefined;
+      if (arg) {
+        onMatch({ param, actualType: arg.type });
+      }
+    });
+    return;
+  }
+
+  let argIndex = 0;
+  let paramIndex = 0;
+  while (paramIndex < params.length) {
+    const param = params[paramIndex]!;
+    const arg = args[argIndex];
+    if (!arg) {
+      paramIndex += 1;
+      continue;
+    }
+
+    if (param.label && arg.label === undefined) {
+      const structuralFields = getStructuralFields(arg.type, ctx, state);
+      if (structuralFields) {
+        let cursor = paramIndex;
+        while (cursor < params.length) {
+          const runParam = params[cursor]!;
+          if (!runParam.label) {
+            break;
+          }
+          const field = structuralFields.find(
+            (candidate) => candidate.name === runParam.label,
+          );
+          if (field) {
+            onMatch({ param: runParam, actualType: field.type });
+          }
+          cursor += 1;
+        }
+        if (cursor > paramIndex) {
+          paramIndex = cursor;
+          argIndex += 1;
+          continue;
+        }
+      }
+    }
+
+    if (param.label === arg.label) {
+      onMatch({ param, actualType: arg.type });
+      paramIndex += 1;
+      argIndex += 1;
+      continue;
+    }
+
+    if (param.optional) {
+      paramIndex += 1;
+      continue;
+    }
+
+    paramIndex += 1;
+    argIndex += 1;
+  }
 };

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -53,7 +53,9 @@ import {
   type CallArgumentShapeFailureEntry,
 } from "./call-argument-shape-classifier.js";
 import {
+  bindCallArgumentTypeParams,
   buildCallArgumentHintSubstitution,
+  expectedCallArgType,
   typeCallArgsWithSignatureContext,
 } from "./call-arg-context.js";
 import {
@@ -90,11 +92,12 @@ import {
   localSymbolForSymbolRef,
   symbolRefKey,
 } from "../symbol-ref-utils.js";
-import { createTranslation, translateFunctionSignature } from "../import-type-translation.js";
-import { typingContextsShareInterners } from "../shared-interners.js";
 import {
-  mapDependencySymbolToLocal,
-} from "../import-symbol-mapping.js";
+  createTranslation,
+  translateFunctionSignature,
+} from "../import-type-translation.js";
+import { typingContextsShareInterners } from "../shared-interners.js";
+import { mapDependencySymbolToLocal } from "../import-symbol-mapping.js";
 import { hydrateImportedTraitMetadataForOwnerRef } from "../import-trait-impl-hydration.js";
 import { collectTraitOwnersFromTypeParams } from "../constraint-trait-owners.js";
 import { typeDefaultParameterValues } from "../default-parameters.js";
@@ -261,7 +264,16 @@ export const typeCallExpr = (
   const shouldDeferLambdaProbeTyping = calleeExpr.exprKind === "overload-set";
 
   const args = expr.args.map((arg, index) => {
-    const expectedType = expectedParams?.[index];
+    const expectedType = expectedParams
+      ? expectedCallArgType({
+          args: expr.args,
+          index,
+          argIndex: index,
+          params: expectedParams,
+          hintSubstitution: undefined,
+          ctx,
+        })
+      : undefined;
     const shouldDeferLambdaArgTyping =
       shouldDeferLambdaProbeTyping &&
       ctx.hir.expressions.get(arg.expr)?.exprKind === "lambda" &&
@@ -413,7 +425,10 @@ export const typeCallExpr = (
           })
         : undefined;
     if (intrinsicFallbackForIdentifier) {
-      ctx.table.setExprType(calleeExpr.id, intrinsicFallbackForIdentifier.calleeType);
+      ctx.table.setExprType(
+        calleeExpr.id,
+        intrinsicFallbackForIdentifier.calleeType,
+      );
       ctx.resolvedExprTypes.set(
         calleeExpr.id,
         applyCurrentSubstitution(
@@ -432,8 +447,7 @@ export const typeCallExpr = (
     if (metadata.intrinsic && metadata.intrinsicUsesSignature === false) {
       const instantiation = signature
         ? (() => {
-            const hasTypeParams =
-              (signature.typeParams?.length ?? 0) > 0;
+            const hasTypeParams = (signature.typeParams?.length ?? 0) > 0;
             if (hasTypeParams) {
               return instantiateFunctionCall({
                 signature,
@@ -518,9 +532,7 @@ export const typeCallExpr = (
             effectRow: ctx.primitives.defaultEffectRow,
           });
         })()
-      : signature ||
-          !metadata.intrinsic ||
-          intrinsicSignatures.length > 0
+      : signature || !metadata.intrinsic || intrinsicSignatures.length > 0
         ? getValueType(calleeExpr.symbol, ctx, {
             span: calleeExpr.span ?? expr.span,
             mode: state.mode,
@@ -928,8 +940,11 @@ const getExpectedCallParameters = ({
           })
         : undefined;
     return {
-      params: publicCallParametersFor({ signature: selected.signature }).map((param) =>
-        substitution ? ctx.arena.substitute(param.type, substitution) : param.type,
+      params: publicCallParametersFor({ signature: selected.signature }).map(
+        (param) =>
+          substitution
+            ? { ...param, type: ctx.arena.substitute(param.type, substitution) }
+            : param,
       ),
       expectedReturnCandidates,
     };
@@ -953,7 +968,9 @@ const getExpectedCallParameters = ({
       : undefined;
   return {
     params: publicCallParametersFor({ signature }).map((param) =>
-      substitution ? ctx.arena.substitute(param.type, substitution) : param.type,
+      substitution
+        ? { ...param, type: ctx.arena.substitute(param.type, substitution) }
+        : param,
     ),
   };
 };
@@ -1342,7 +1359,10 @@ const walkCallArguments = ({
         paramIndex += 1;
         continue;
       }
-      return { kind: "error", failure: { kind: "missing-argument", paramIndex } };
+      return {
+        kind: "error",
+        failure: { kind: "missing-argument", paramIndex },
+      };
     }
 
     if (param.label && arg.label === undefined) {
@@ -1570,10 +1590,8 @@ const emitConsensusCallArgumentShapeDiagnostic = <
         state,
       }),
     )
-    .filter(
-      (
-        entry,
-      ): entry is CallArgumentShapeFailureEntry<ParamSignature> => Boolean(entry),
+    .filter((entry): entry is CallArgumentShapeFailureEntry<ParamSignature> =>
+      Boolean(entry),
     );
   if (entries.length !== candidates.length || entries.length === 0) {
     return false;
@@ -1728,7 +1746,9 @@ const validateCallArgs = (
     return { ok: false };
   }
   const plan: CallArgumentPlanEntry[] = [];
-  const hasUnknownArgs = args.some((arg) => arg.type === ctx.primitives.unknown);
+  const hasUnknownArgs = args.some(
+    (arg) => arg.type === ctx.primitives.unknown,
+  );
   const result = walkCallArguments({
     args,
     params,
@@ -1885,8 +1905,7 @@ const callArgumentsSatisfyParams = ({
             expected: match.param.type,
             ctx,
             state,
-          }) &&
-          typeSatisfies(match.matchedType, match.param.type, ctx, state),
+          }) && typeSatisfies(match.matchedType, match.param.type, ctx, state),
     onSkipOptionalParam: () => true,
   }).kind === "ok";
 
@@ -1983,7 +2002,10 @@ const signatureWithExplicitTypeArgumentsForDiagnostic = ({
       ...param,
       type: ctx.arena.substitute(param.type, explicitSubstitution),
     })),
-    returnType: ctx.arena.substitute(signature.returnType, explicitSubstitution),
+    returnType: ctx.arena.substitute(
+      signature.returnType,
+      explicitSubstitution,
+    ),
   };
 };
 
@@ -2022,7 +2044,10 @@ const formatFunctionSignatureForDiagnostic = ({
     const optionalSuffix = param.optional ? "?" : "";
     return `${labelPrefix}${typeLabel}${optionalSuffix}`;
   });
-  const returnType = formatTypeForDiagnostic({ type: signature.returnType, ctx });
+  const returnType = formatTypeForDiagnostic({
+    type: signature.returnType,
+    ctx,
+  });
   return `${name}${typeParamSuffix}(${params.join(", ")}) -> ${returnType}`;
 };
 
@@ -2038,7 +2063,10 @@ const formatIntrinsicSignatureForDiagnostic = ({
   const params = signature.parameters.map((param) =>
     formatTypeForDiagnostic({ type: param, ctx }),
   );
-  const returnType = formatTypeForDiagnostic({ type: signature.returnType, ctx });
+  const returnType = formatTypeForDiagnostic({
+    type: signature.returnType,
+    ctx,
+  });
   return `${name}(${params.join(", ")}) -> ${returnType}`;
 };
 
@@ -2138,7 +2166,10 @@ const overloadCandidateFailureReason = ({
           type: mismatch.expectedType,
           ctx,
         });
-        const actual = formatTypeForDiagnostic({ type: mismatch.actualType, ctx });
+        const actual = formatTypeForDiagnostic({
+          type: mismatch.actualType,
+          ctx,
+        });
         return `type incompatibility at argument ${mismatch.argIndex + 1}: expected ${expected}, got ${actual}`;
       }
 
@@ -2182,7 +2213,10 @@ const overloadDiagnosticCandidates = <
   argsForCandidate?: (candidate: T) => readonly Arg[];
   signatureForCandidate?: (candidate: T) => FunctionSignature;
 }): { signature: string; reason?: string }[] => {
-  const limitedCandidates = candidates.slice(0, MAX_OVERLOAD_DIAGNOSTIC_CANDIDATES);
+  const limitedCandidates = candidates.slice(
+    0,
+    MAX_OVERLOAD_DIAGNOSTIC_CANDIDATES,
+  );
   const details = limitedCandidates.map((candidate) => {
     const signatureForCandidateEntry = signatureForCandidate
       ? signatureForCandidate(candidate)
@@ -2331,7 +2365,9 @@ const intrinsicNoOverloadDiagnosticParams = ({
       }
       const mismatchIndex = signature.parameters.findIndex((param, index) => {
         const arg = args[index];
-        return Boolean(arg && arg.type !== ctx.primitives.unknown && arg.type !== param);
+        return Boolean(
+          arg && arg.type !== ctx.primitives.unknown && arg.type !== param,
+        );
       });
       if (mismatchIndex >= 0) {
         const expected = formatTypeForDiagnostic({
@@ -2380,7 +2416,11 @@ const intrinsicAmbiguousOverloadDiagnosticParams = ({
   candidates: matches
     .slice(0, MAX_OVERLOAD_DIAGNOSTIC_CANDIDATES)
     .map((signature) => ({
-      signature: formatIntrinsicSignatureForDiagnostic({ name, signature, ctx }),
+      signature: formatIntrinsicSignatureForDiagnostic({
+        name,
+        signature,
+        ctx,
+      }),
     })),
 });
 
@@ -2469,7 +2509,9 @@ const traitMethodImplMetadataFor = ({
   ctx: TypingContext;
 }):
   | {
-      metadata: NonNullable<ReturnType<TypingContext["traitMethodImpls"]["get"]>>;
+      metadata: NonNullable<
+        ReturnType<TypingContext["traitMethodImpls"]["get"]>
+      >;
       moduleId: string;
     }
   | undefined => {
@@ -2757,12 +2799,11 @@ const getTraitMethodTypeBindings = ({
     moduleId: methodMetadata.moduleId,
     ctx,
   });
-  const template = templates
-    .find(
-      (entry) =>
-        entry.methods.get(methodMetadata.metadata.traitMethodSymbol) ===
-        templateMethodSymbol,
-    );
+  const template = templates.find(
+    (entry) =>
+      entry.methods.get(methodMetadata.metadata.traitMethodSymbol) ===
+      templateMethodSymbol,
+  );
   if (!template) {
     return undefined;
   }
@@ -3016,14 +3057,18 @@ const resolveFreeFunctionFallbackCandidates = ({
   ctx: TypingContext;
 }): MethodCallCandidate[] => {
   const existingKeys = new Set(
-    existing.map((candidate) => canonicalMethodCandidateKey({ candidate, ctx })),
+    existing.map((candidate) =>
+      canonicalMethodCandidateKey({ candidate, ctx }),
+    ),
   );
   return resolveFreeFunctionCandidates({
     methodName,
     ctx,
   }).filter(
     (fallback) =>
-      !existingKeys.has(canonicalMethodCandidateKey({ candidate: fallback, ctx })),
+      !existingKeys.has(
+        canonicalMethodCandidateKey({ candidate: fallback, ctx }),
+      ),
   );
 };
 
@@ -3134,16 +3179,18 @@ const selectMethodCallCandidate = ({
     });
 
     if (fallbackCandidates.length > 0) {
-      const filteredFallbackCandidates = filterCandidatesByExplicitTypeArguments({
-        candidates: fallbackCandidates,
-        typeArguments,
-      });
+      const filteredFallbackCandidates =
+        filterCandidatesByExplicitTypeArguments({
+          candidates: fallbackCandidates,
+          typeArguments,
+        });
       candidates = filteredFallbackCandidates;
-      noOverloadDiagnosticCandidates = mergeCandidatesForMethodNoOverloadDiagnostic({
-        methodCandidates,
-        fallbackCandidates: filteredFallbackCandidates,
-        ctx,
-      });
+      noOverloadDiagnosticCandidates =
+        mergeCandidatesForMethodNoOverloadDiagnostic({
+          methodCandidates,
+          fallbackCandidates: filteredFallbackCandidates,
+          ctx,
+        });
       enforceOverloadCandidateBudget({
         name: expr.method,
         candidateCount: candidates.length,
@@ -3320,7 +3367,10 @@ const resolveQualifiedTraitMethodCallCandidates = ({
 }): MethodCallResolution => {
   const traitRecord = ctx.symbolTable.getSymbol(traitSymbol);
   const traitName = traitRecord.name;
-  const qualifiedTraitRef = canonicalSymbolRefForTypingContext(traitSymbol, ctx);
+  const qualifiedTraitRef = canonicalSymbolRefForTypingContext(
+    traitSymbol,
+    ctx,
+  );
 
   if (receiverType === ctx.primitives.unknown) {
     return { candidates: [], receiverName: traitName };
@@ -3370,24 +3420,22 @@ const resolveQualifiedTraitMethodCallCandidates = ({
     return { candidates: [], receiverName: traitName };
   }
 
-  const candidates = nominalResolution.candidates.filter(
-    (candidate) => {
-      const methodMetadata = traitMethodImplMetadataFor({
-        symbol: candidate.symbol,
-        moduleId: candidate.symbolRef.moduleId,
-        ctx,
-      });
-      if (!methodMetadata) {
-        return false;
-      }
-      const methodTraitRef = traitSymbolRefFor({
-        traitSymbol: methodMetadata.metadata.traitSymbol,
-        moduleId: methodMetadata.moduleId,
-        ctx,
-      });
-      return symbolRefEquals(methodTraitRef, qualifiedTraitRef);
-    },
-  );
+  const candidates = nominalResolution.candidates.filter((candidate) => {
+    const methodMetadata = traitMethodImplMetadataFor({
+      symbol: candidate.symbol,
+      moduleId: candidate.symbolRef.moduleId,
+      ctx,
+    });
+    if (!methodMetadata) {
+      return false;
+    }
+    const methodTraitRef = traitSymbolRefFor({
+      traitSymbol: methodMetadata.metadata.traitSymbol,
+      moduleId: methodMetadata.moduleId,
+      ctx,
+    });
+    return symbolRefEquals(methodTraitRef, qualifiedTraitRef);
+  });
 
   return { candidates, receiverName: traitName };
 };
@@ -3666,7 +3714,8 @@ const canonicalSymbolRefForModuleSymbol = ({
     return { moduleId, symbol };
   }
 
-  const metadata = (dependency.symbolTable.getSymbol(symbol).metadata ?? {}) as {
+  const metadata = (dependency.symbolTable.getSymbol(symbol).metadata ??
+    {}) as {
     import?: { moduleId?: unknown; symbol?: unknown };
   };
   if (
@@ -3915,7 +3964,8 @@ const findExportedMethodCandidates = ({
       return false;
     }
 
-    const metadata = (dependency.symbolTable.getSymbol(symbol).metadata ?? {}) as {
+    const metadata = (dependency.symbolTable.getSymbol(symbol).metadata ??
+      {}) as {
       static?: boolean;
     };
     return metadata.static !== true;
@@ -3980,7 +4030,13 @@ const resolveCurriedCallReturnType = ({
     }
 
     const segment = remainingArgs.slice(0, parameters.length);
-    const validation = validateCallArgs(segment, parameters, ctx, state, callSpan);
+    const validation = validateCallArgs(
+      segment,
+      parameters,
+      ctx,
+      state,
+      callSpan,
+    );
     if (!validation.ok) {
       return ctx.primitives.unknown;
     }
@@ -4088,13 +4144,9 @@ const collectEffectTailSubstitutionsFromTypes = ({
   const expectedDesc = ctx.arena.get(expectedType);
   if (actualDesc.kind === "function" && expectedDesc.kind === "function") {
     const subEffectRow =
-      variance === "covariant"
-        ? actualDesc.effectRow
-        : expectedDesc.effectRow;
+      variance === "covariant" ? actualDesc.effectRow : expectedDesc.effectRow;
     const supEffectRow =
-      variance === "covariant"
-        ? expectedDesc.effectRow
-        : actualDesc.effectRow;
+      variance === "covariant" ? expectedDesc.effectRow : actualDesc.effectRow;
     const constrained = constrainFunctionEffectRows({
       actual: subEffectRow,
       expected: supEffectRow,
@@ -4147,7 +4199,10 @@ const collectEffectTailSubstitutionsFromTypes = ({
     actualDesc.kind === expectedDesc.kind &&
     symbolRefEquals(actualDesc.owner, expectedDesc.owner)
   ) {
-    const count = Math.min(actualDesc.typeArgs.length, expectedDesc.typeArgs.length);
+    const count = Math.min(
+      actualDesc.typeArgs.length,
+      expectedDesc.typeArgs.length,
+    );
     for (let index = 0; index < count; index += 1) {
       collectEffectTailSubstitutionsFromTypes({
         actualType: actualDesc.typeArgs[index]!,
@@ -4168,7 +4223,10 @@ const collectEffectTailSubstitutionsFromTypes = ({
     expectedDesc.kind === "trait" &&
     symbolRefEquals(actualDesc.owner, expectedDesc.owner)
   ) {
-    const count = Math.min(actualDesc.typeArgs.length, expectedDesc.typeArgs.length);
+    const count = Math.min(
+      actualDesc.typeArgs.length,
+      expectedDesc.typeArgs.length,
+    );
     for (let index = 0; index < count; index += 1) {
       collectEffectTailSubstitutionsFromTypes({
         actualType: actualDesc.typeArgs[index]!,
@@ -4184,7 +4242,10 @@ const collectEffectTailSubstitutionsFromTypes = ({
     return;
   }
 
-  if (actualDesc.kind === "fixed-array" && expectedDesc.kind === "fixed-array") {
+  if (
+    actualDesc.kind === "fixed-array" &&
+    expectedDesc.kind === "fixed-array"
+  ) {
     collectEffectTailSubstitutionsFromTypes({
       actualType: actualDesc.element,
       expectedType: expectedDesc.element,
@@ -4224,7 +4285,10 @@ const collectEffectTailSubstitutionsFromTypes = ({
   }
 
   if (actualDesc.kind === "union" && expectedDesc.kind === "union") {
-    const count = Math.min(actualDesc.members.length, expectedDesc.members.length);
+    const count = Math.min(
+      actualDesc.members.length,
+      expectedDesc.members.length,
+    );
     for (let index = 0; index < count; index += 1) {
       collectEffectTailSubstitutionsFromTypes({
         actualType: actualDesc.members[index]!,
@@ -4594,13 +4658,12 @@ const instantiateFunctionCall = ({
     }
   });
 
-  args.forEach((arg, index) => {
-    const expected = signature.parameters[index];
-    if (!expected) {
-      return;
-    }
-    const expectedType = ctx.arena.substitute(expected.type, substitution);
-    bindTypeParamsFromType(expectedType, arg.type, substitution, ctx, state);
+  bindCallArgumentTypeParams({
+    signature,
+    args,
+    substitution,
+    ctx,
+    state,
   });
 
   if (
@@ -4657,7 +4720,10 @@ export const enforceTypeParamConstraint = (
   }
   const constraint = ctx.arena.substitute(param.constraint, substitution);
   if (!typeSatisfies(applied, constraint, ctx, state)) {
-    const appliedType = typeDescriptorToUserString(ctx.arena.get(applied), ctx.arena);
+    const appliedType = typeDescriptorToUserString(
+      ctx.arena.get(applied),
+      ctx.arena,
+    );
     const constraintType = typeDescriptorToUserString(
       ctx.arena.get(constraint),
       ctx.arena,
@@ -5005,7 +5071,9 @@ const typeIntrinsicFallbackCall = ({
   }
   const instanceKey = state.currentFunction?.instanceKey;
   if (!instanceKey) {
-    throw new Error(`missing function instance key for intrinsic fallback at call ${callId}`);
+    throw new Error(
+      `missing function instance key for intrinsic fallback at call ${callId}`,
+    );
   }
   const targets =
     ctx.callResolution.targets.get(callId) ?? new Map<string, SymbolRef>();
@@ -5138,14 +5206,15 @@ const typeOverloadedCall = (
     }
     return { symbol, signature };
   });
-  const { hintedCandidates, fallbackCandidates } = selectHintedOverloadCandidates({
-    candidates,
-    typeArguments,
-    expectedReturnType,
-    expectedReturnCandidates,
-    ctx,
-    state,
-  });
+  const { hintedCandidates, fallbackCandidates } =
+    selectHintedOverloadCandidates({
+      candidates,
+      typeArguments,
+      expectedReturnType,
+      expectedReturnCandidates,
+      ctx,
+      state,
+    });
 
   let candidatesForResolution = hintedCandidates;
   let matches = findOverloadMatches({
@@ -5384,9 +5453,7 @@ const resolveTraitDispatchOverload = <
         ? ctx.traitImplsByTrait.get(methodMetadata.metadata.traitSymbol)
         : ctx.dependencies
             .get(methodMetadata.moduleId)
-            ?.typing.traitImplsByTrait.get(
-              methodMetadata.metadata.traitSymbol,
-            );
+            ?.typing.traitImplsByTrait.get(methodMetadata.metadata.traitSymbol);
     const templates =
       methodMetadata.moduleId === ctx.moduleId
         ? ctx.traits.getImplTemplatesForTrait(
@@ -5428,7 +5495,10 @@ const resolveTraitDispatchOverload = <
     const toLocalType = (type: TypeId): TypeId =>
       translateDependencyType ? translateDependencyType(type) : type;
 
-    if ((!impls || impls.length === 0) && (!templates || templates.length === 0)) {
+    if (
+      (!impls || impls.length === 0) &&
+      (!templates || templates.length === 0)
+    ) {
       return false;
     }
 
@@ -5511,19 +5581,28 @@ const matchesOverloadSignature = (
   if (typeArguments && typeArguments.length > typeParamCount) {
     return false;
   }
-  const explicitSubstitution =
+  const substitution =
     signature.typeParams && signature.typeParams.length > 0
-      ? applyExplicitTypeArguments({
+      ? inferOverloadCandidateSubstitution({
           signature,
+          args,
           typeArguments,
           calleeSymbol: symbol,
           ctx,
+          state,
         })
       : undefined;
-  const params = explicitSubstitution
+  if (
+    signature.typeParams &&
+    signature.typeParams.length > 0 &&
+    !substitution
+  ) {
+    return false;
+  }
+  const params = substitution
     ? publicCallParametersFor({ signature }).map((param) => ({
         ...param,
-        type: ctx.arena.substitute(param.type, explicitSubstitution),
+        type: ctx.arena.substitute(param.type, substitution),
       }))
     : publicCallParametersFor({ signature });
 
@@ -5543,6 +5622,53 @@ const matchesOverloadSignature = (
   });
 
   return true;
+};
+
+const inferOverloadCandidateSubstitution = ({
+  signature,
+  args,
+  typeArguments,
+  calleeSymbol,
+  ctx,
+  state,
+}: {
+  signature: FunctionSignature;
+  args: readonly Arg[];
+  typeArguments?: readonly TypeId[];
+  calleeSymbol: SymbolId;
+  ctx: TypingContext;
+  state: TypingState;
+}): ReadonlyMap<TypeParamId, TypeId> | undefined => {
+  const typeParams = signature.typeParams ?? [];
+  if (typeParams.length === 0) {
+    return undefined;
+  }
+
+  const substitution = new Map<TypeParamId, TypeId>(
+    applyExplicitTypeArguments({
+      signature,
+      typeArguments,
+      calleeSymbol,
+      ctx,
+    }),
+  );
+  bindCallArgumentTypeParams({
+    signature,
+    args,
+    substitution,
+    ctx,
+    state,
+  });
+
+  try {
+    typeParams.forEach((param) =>
+      enforceTypeParamConstraint(param, substitution, ctx, state),
+    );
+  } catch {
+    return undefined;
+  }
+
+  return substitution;
 };
 
 const typeIntrinsicCall = (
@@ -6393,14 +6519,14 @@ const typePanicScratchSetIntrinsic = ({
     int32,
     ctx,
     state,
-    "__panic_scratch_set ptr"
+    "__panic_scratch_set ptr",
   );
   ensureTypeMatches(
     args[1]!.type,
     int32,
     ctx,
     state,
-    "__panic_scratch_set capacity"
+    "__panic_scratch_set capacity",
   );
   return ctx.primitives.void;
 };
@@ -6446,7 +6572,7 @@ const typeTaskCancelIntrinsic = ({
     getPrimitiveType(ctx, "i32"),
     ctx,
     state,
-    "__task_cancel task id"
+    "__task_cancel task id",
   );
   return ctx.primitives.bool;
 };
@@ -6518,7 +6644,7 @@ const typeTaskTakeValueIntrinsic = ({
     getPrimitiveType(ctx, "i32"),
     ctx,
     state,
-    "__task_take_value task id"
+    "__task_take_value task id",
   );
   return expectedReturnType ?? ctx.primitives.unknown;
 };

--- a/packages/compiler/src/semantics/typing/expressions/object-literal.ts
+++ b/packages/compiler/src/semantics/typing/expressions/object-literal.ts
@@ -27,15 +27,25 @@ import { emitDiagnostic, normalizeSpan } from "../../../diagnostics/index.js";
 export const typeObjectLiteralExpr = (
   expr: HirObjectLiteralExpr,
   ctx: TypingContext,
-  state: TypingState
+  state: TypingState,
+  expectedType?: TypeId,
 ): TypeId => {
   if (expr.literalKind === "nominal") {
     return typeNominalObjectLiteral(expr, ctx, state);
   }
 
+  const expectedFields =
+    typeof expectedType === "number" && expectedType !== ctx.primitives.unknown
+      ? new Map(
+          (getStructuralFields(expectedType, ctx, state) ?? []).map((field) => [
+            field.name,
+            field,
+          ]),
+        )
+      : undefined;
   const fields = new Map<string, TypeId>();
   expr.entries.forEach((entry) =>
-    mergeObjectLiteralEntry(entry, fields, ctx, state)
+    mergeObjectLiteralEntry(entry, fields, ctx, state, expectedFields),
   );
 
   const orderedFields = Array.from(fields.entries()).map(([name, type]) => ({
@@ -44,7 +54,7 @@ export const typeObjectLiteralExpr = (
   }));
   const effectRow = composeEffectRows(
     ctx.effects,
-    expr.entries.map((entry) => getExprEffectRow(entry.value, ctx))
+    expr.entries.map((entry) => getExprEffectRow(entry.value, ctx)),
   );
   ctx.effects.setExprEffect(expr.id, effectRow);
   return ctx.arena.internStructuralObject({ fields: orderedFields });
@@ -54,10 +64,14 @@ const mergeObjectLiteralEntry = (
   entry: HirObjectLiteralEntry,
   fields: Map<string, TypeId>,
   ctx: TypingContext,
-  state: TypingState
+  state: TypingState,
+  expectedFields?: ReadonlyMap<string, ObjectField>,
 ): void => {
   if (entry.kind === "field") {
-    const valueType = typeExpression(entry.value, ctx, state);
+    const expectedField = expectedFields?.get(entry.name);
+    const valueType = typeExpression(entry.value, ctx, state, {
+      expectedType: expectedField?.type,
+    });
     fields.set(entry.name, valueType);
     return;
   }
@@ -71,15 +85,13 @@ const mergeObjectLiteralEntry = (
     return;
   }
 
-  spreadFields.forEach((field) =>
-    fields.set(field.name, field.type)
-  );
+  spreadFields.forEach((field) => fields.set(field.name, field.type));
 };
 
 const typeNominalObjectLiteral = (
   expr: HirObjectLiteralExpr,
   ctx: TypingContext,
-  state: TypingState
+  state: TypingState,
 ): TypeId => {
   const namedTarget =
     expr.target?.typeKind === "named" ? expr.target : undefined;
@@ -98,18 +110,18 @@ const typeNominalObjectLiteral = (
 
   const typeName = getSymbolName(targetSymbol, ctx);
   const templateFields = new Map<string, ObjectField>(
-    template.fields.map((field) => [field.name, field])
+    template.fields.map((field) => [field.name, field]),
   );
   const explicitTypeArgs =
     namedTarget?.typeArguments?.map((arg) =>
-      resolveTypeExpr(arg, ctx, state, ctx.primitives.unknown)
+      resolveTypeExpr(arg, ctx, state, ctx.primitives.unknown),
     ) ?? [];
   const hasExplicitTypeArgsForAllParams =
     template.params.length > 0 &&
     template.params.every(
       (_, index) =>
         typeof explicitTypeArgs[index] === "number" &&
-        explicitTypeArgs[index] !== ctx.primitives.unknown
+        explicitTypeArgs[index] !== ctx.primitives.unknown,
     );
   const typeParamBindings = new Map<TypeParamId, TypeId>();
 
@@ -123,7 +135,7 @@ const typeNominalObjectLiteral = (
           ctx,
           state,
           typeName,
-        })
+        }),
       );
     });
   }
@@ -143,7 +155,7 @@ const typeNominalObjectLiteral = (
   }
 
   const declaredFields = new Map<string, ObjectField>(
-    objectInfo.fields.map((field) => [field.name, field])
+    objectInfo.fields.map((field) => [field.name, field]),
   );
   const provided = new Set<string>();
 
@@ -155,7 +167,7 @@ const typeNominalObjectLiteral = (
       ctx,
       state,
       typeName,
-    })
+    }),
   );
 
   declaredFields.forEach((field, name) => {
@@ -187,29 +199,27 @@ const typeNominalObjectLiteral = (
 
   const effectRow = composeEffectRows(
     ctx.effects,
-    expr.entries.map((entry) => getExprEffectRow(entry.value, ctx))
+    expr.entries.map((entry) => getExprEffectRow(entry.value, ctx)),
   );
   ctx.effects.setExprEffect(expr.id, effectRow);
   return objectInfo.type;
 };
 
-const bindNominalObjectEntry = (
-  {
-    entry,
-    declared,
-    bindings,
-    ctx,
-    state,
-    typeName,
-  }: {
-    entry: HirObjectLiteralEntry;
-    declared: Map<string, ObjectField>;
-    bindings: Map<TypeParamId, TypeId>;
-    ctx: TypingContext;
-    state: TypingState;
-    typeName: string;
-  }
-): void =>
+const bindNominalObjectEntry = ({
+  entry,
+  declared,
+  bindings,
+  ctx,
+  state,
+  typeName,
+}: {
+  entry: HirObjectLiteralEntry;
+  declared: Map<string, ObjectField>;
+  bindings: Map<TypeParamId, TypeId>;
+  ctx: TypingContext;
+  state: TypingState;
+  typeName: string;
+}): void =>
   forEachNominalObjectEntryField({
     entry,
     declared,
@@ -217,27 +227,31 @@ const bindNominalObjectEntry = (
     state,
     typeName,
     onField: ({ expectedField, valueType }) => {
-      bindTypeParamsFromType(expectedField.type, valueType, bindings, ctx, state);
+      bindTypeParamsFromType(
+        expectedField.type,
+        valueType,
+        bindings,
+        ctx,
+        state,
+      );
     },
   });
 
-const mergeNominalObjectEntry = (
-  {
-    entry,
-    declared,
-    provided,
-    ctx,
-    state,
-    typeName,
-  }: {
-    entry: HirObjectLiteralEntry;
-    declared: Map<string, ObjectField>;
-    provided: Set<string>;
-    ctx: TypingContext;
-    state: TypingState;
-    typeName: string;
-  }
-): void =>
+const mergeNominalObjectEntry = ({
+  entry,
+  declared,
+  provided,
+  ctx,
+  state,
+  typeName,
+}: {
+  entry: HirObjectLiteralEntry;
+  declared: Map<string, ObjectField>;
+  provided: Set<string>;
+  ctx: TypingContext;
+  state: TypingState;
+  typeName: string;
+}): void =>
   forEachNominalObjectEntryField({
     entry,
     declared,
@@ -290,8 +304,7 @@ const forEachNominalObjectEntryField = ({
       span: entry.span,
       ctx,
     });
-    const valueSpan =
-      ctx.hir.expressions.get(entry.value)?.span ?? entry.span;
+    const valueSpan = ctx.hir.expressions.get(entry.value)?.span ?? entry.span;
     assertFieldAccess({
       field: expectedField,
       ctx,
@@ -367,12 +380,17 @@ const resolveAccessibleObjectSpreadFields = ({
       params: {
         kind: "type-mismatch",
         expected: "structural object",
-        actual: typeDescriptorToUserString(ctx.arena.get(spreadType), ctx.arena),
+        actual: typeDescriptorToUserString(
+          ctx.arena.get(spreadType),
+          ctx.arena,
+        ),
       },
       span: normalizeSpan(entry.span),
     });
   }
-  return filterAccessibleFields(spreadFields, ctx, state, { allowOwnerPrivate });
+  return filterAccessibleFields(spreadFields, ctx, state, {
+    allowOwnerPrivate,
+  });
 };
 
 const resolveExpectedNominalField = ({

--- a/packages/compiler/src/semantics/typing/expressions/overload-candidates.ts
+++ b/packages/compiler/src/semantics/typing/expressions/overload-candidates.ts
@@ -1,9 +1,14 @@
 import type { SymbolId, TypeId, TypeParamId } from "../../ids.js";
 import { satisfies as typeSatisfies } from "../type-relations.js";
-import type { FunctionSignature, TypingContext, TypingState } from "../types.js";
+import type {
+  FunctionSignature,
+  ParamSignature,
+  TypingContext,
+  TypingState,
+} from "../types.js";
 
 export type ExpectedCallContext = {
-  params?: readonly TypeId[];
+  params?: readonly ParamSignature[];
   expectedReturnCandidates?: ReadonlySet<SymbolId>;
 };
 


### PR DESCRIPTION
## Summary
- Pass structural object literals through labeled-parameter expectations so field values are context-typed correctly
- Teach generic overload matching and instantiation to infer from matched labeled/object arguments instead of raw argument indexes
- Add regression coverage for function-valued structural objects and update the VX counter fixture to use the concise `program({ ... })` form

## Testing
- `packages/compiler/src/codegen/__tests__/codegen.test.ts` regression coverage passes
- `apps/smoke/src/vx-dom.test.ts` passes with the updated VX fixture
- Full `npm test` passed
- Full `npm run typecheck` passed