### PR TITLE
Fix recursive optional object resolution

### DIFF
--- a/apps/smoke/fixtures/std_optional_basic.voyd
+++ b/apps/smoke/fixtures/std_optional_basic.voyd
@@ -4,8 +4,18 @@ obj OptionalBox {
   v?: i32
 }
 
+obj Node {
+  val: i32,
+  l?: Node,
+  r?: Node
+}
+
 fn sum(v?: i32) -> i32
   unwrap_or(v, 0)
+
+fn recursive_optional_node_value() -> i32
+  let node = Node { val: 1 }
+  node.val
 
 pub fn main() -> i32
   let b1 = OptionalBox { v: 5 }
@@ -13,5 +23,4 @@ pub fn main() -> i32
   let s = { v: 7 }
   let b3 = OptionalBox { ...s }
 
-  sum(b1.v) + sum(b2.v) + sum() + sum(b3.v)
-
+  sum(b1.v) + sum(b2.v) + sum() + sum(b3.v) + recursive_optional_node_value()

--- a/apps/smoke/src/wasm-validation.test.ts
+++ b/apps/smoke/src/wasm-validation.test.ts
@@ -117,7 +117,7 @@ describe("smoke: wasm validation", { timeout: 120_000 }, () => {
     const wasm = assertRunnableWasm(module);
     const instance = getWasmInstance(wasm);
     const exports = instance.exports as Record<string, unknown>;
-    expect((exports.main as () => number)()).toBe(12);
+    expect((exports.main as () => number)()).toBe(13);
   });
 
   it("supports module-qualified return type annotations", async () => {

--- a/packages/compiler/src/semantics/typing/type-system.ts
+++ b/packages/compiler/src/semantics/typing/type-system.ts
@@ -2134,91 +2134,125 @@ export const getObjectTemplate = (
       });
     }
 
-    const baseType =
-      decl.objectKind === "value"
-        ? ctx.objects.base.type
-        : resolveTypeExpr(
-            decl.base,
-            ctx,
-            state,
-            ctx.objects.base.type,
-            paramMap,
-          );
-    const baseFields = (
-      decl.objectKind === "value"
-        ? []
-        : (getStructuralFields(baseType, ctx, state, {
-            includeInaccessible: true,
-            allowOwnerPrivate: true,
-          }) ?? [])
-    ).map((field) => ({
-      ...field,
-      declaringParams: declaringParamsForField(field.type, templateParams, ctx),
-      packageId: field.packageId ?? ctx.packageId,
-    }));
-    const baseNominal =
-      decl.objectKind === "value" ? undefined : getNominalComponent(baseType, ctx);
-
-    const ownFields = decl.fields.map((field) => {
-      const type = resolveTypeExpr(
-        field.type,
-        ctx,
-        state,
-        ctx.primitives.unknown,
-        paramMap,
-      );
-      return {
-        name: field.name,
-        type,
-        optional: field.optional,
-        declaringParams: declaringParamsForField(type, templateParams, ctx),
-        visibility: field.visibility,
-        owner: decl.symbol,
-        packageId: ctx.packageId,
-      };
-    });
-
-    if (baseFields.length > 0) {
-      const declaredFields = new Map(
-        ownFields.map((field) => [field.name, field]),
-      );
-      baseFields.forEach((baseField) => {
-        const declared = declaredFields.get(baseField.name);
-        if (!declared) {
-          throw new Error(
-            `object ${objectName} must redeclare inherited field ${baseField.name}`,
-          );
-        }
-        const compatibility = unifyWithBudget({
-          actual: declared.type,
-          expected: baseField.type,
-          options: {
-            location: ctx.hir.module.ast,
-            reason: `field ${baseField.name} compatibility with base object`,
-          },
-          ctx,
-          span: decl.span,
-        });
-        if (!compatibility.ok) {
-          throw new Error(
-            `field ${baseField.name} in object ${objectName} must match base object type`,
-          );
-        }
-      });
-    }
-
-    const fields = mergeDeclaredFields(baseFields, ownFields);
-    const structural = ctx.arena.internStructuralObject({ fields });
     const nominal = nominalObjectTypeFor({
       objectKind: decl.objectKind,
       symbol,
       ctx,
       typeArgs: params.map((param) => paramMap.get(param.symbol)!),
     });
-    const type = ctx.arena.internIntersection({
-      nominal,
-      structural,
+
+    let baseNominal: TypeId | undefined;
+    let fields: readonly ObjectField[] = [];
+    const activeKey = makeObjectInstanceKey(
+      symbol,
+      params.map((param) => paramMap.get(param.symbol)!),
+    );
+
+    const type = ctx.arena.createRecursiveType((self) => {
+      ctx.objects.beginActiveResolution(activeKey, {
+        objectKind: decl.objectKind,
+        nominal,
+        structural: ctx.primitives.unknown,
+        type: self,
+        fields: [],
+        visibility: decl.visibility,
+      });
+
+      try {
+        const baseType =
+          decl.objectKind === "value"
+            ? ctx.objects.base.type
+            : resolveTypeExpr(
+                decl.base,
+                ctx,
+                state,
+                ctx.objects.base.type,
+                paramMap,
+              );
+        const baseFields = (
+          decl.objectKind === "value"
+            ? []
+            : (getStructuralFields(baseType, ctx, state, {
+                includeInaccessible: true,
+                allowOwnerPrivate: true,
+              }) ?? [])
+        ).map((field) => ({
+          ...field,
+          declaringParams: declaringParamsForField(
+            field.type,
+            templateParams,
+            ctx,
+          ),
+          packageId: field.packageId ?? ctx.packageId,
+        }));
+        baseNominal =
+          decl.objectKind === "value"
+            ? undefined
+            : getNominalComponent(baseType, ctx);
+
+        const ownFields = decl.fields.map((field) => {
+          const type = resolveTypeExpr(
+            field.type,
+            ctx,
+            state,
+            ctx.primitives.unknown,
+            paramMap,
+          );
+          return {
+            name: field.name,
+            type,
+            optional: field.optional,
+            declaringParams: declaringParamsForField(type, templateParams, ctx),
+            visibility: field.visibility,
+            owner: decl.symbol,
+            packageId: ctx.packageId,
+          };
+        });
+
+        if (baseFields.length > 0) {
+          const declaredFields = new Map(
+            ownFields.map((field) => [field.name, field]),
+          );
+          baseFields.forEach((baseField) => {
+            const declared = declaredFields.get(baseField.name);
+            if (!declared) {
+              throw new Error(
+                `object ${objectName} must redeclare inherited field ${baseField.name}`,
+              );
+            }
+            const compatibility = unifyWithBudget({
+              actual: declared.type,
+              expected: baseField.type,
+              options: {
+                location: ctx.hir.module.ast,
+                reason: `field ${baseField.name} compatibility with base object`,
+              },
+              ctx,
+              span: decl.span,
+            });
+            if (!compatibility.ok) {
+              throw new Error(
+                `field ${baseField.name} in object ${objectName} must match base object type`,
+              );
+            }
+          });
+        }
+
+        fields = mergeDeclaredFields(baseFields, ownFields);
+        const structural = ctx.arena.internStructuralObject({ fields });
+        return {
+          kind: "intersection",
+          nominal,
+          structural,
+        };
+      } finally {
+        ctx.objects.endActiveResolution(activeKey);
+      }
     });
+    const structural = ctx.arena.structuralComponent(type);
+    if (typeof structural !== "number") {
+      throw new Error(`object ${objectName} missing structural type`);
+    }
 
     const template: ObjectTemplate = {
       symbol,
@@ -2255,7 +2289,9 @@ export const ensureObjectType = (
   typeArgs: readonly TypeId[] = [],
 ): ObjectTypeInfo | undefined => {
   if (ctx.objects.isResolving(symbol)) {
-    return undefined;
+    return ctx.objects.getActiveResolution(
+      makeObjectInstanceKey(symbol, typeArgs),
+    );
   }
 
   const template = getObjectTemplate(symbol, ctx, state);

--- a/packages/compiler/src/semantics/typing/types.ts
+++ b/packages/compiler/src/semantics/typing/types.ts
@@ -300,6 +300,7 @@ export interface BaseObjectInfo {
 export class ObjectStore {
   #templates = new Map<SymbolId, ObjectTemplate>();
   #instances = new Map<string, ObjectTypeInfo>();
+  #activeResolutions = new Map<string, ObjectTypeInfo>();
   #byName = new Map<string, SymbolId>();
   #byNominal = new Map<TypeId, ObjectTypeInfo>();
   #decls = new Map<SymbolId, HirObjectDecl>();
@@ -341,6 +342,18 @@ export class ObjectStore {
 
   getInstanceByNominal(nominal: TypeId): ObjectTypeInfo | undefined {
     return this.#byNominal.get(nominal);
+  }
+
+  beginActiveResolution(key: string, info: ObjectTypeInfo): void {
+    this.#activeResolutions.set(key, info);
+  }
+
+  getActiveResolution(key: string): ObjectTypeInfo | undefined {
+    return this.#activeResolutions.get(key);
+  }
+
+  endActiveResolution(key: string): void {
+    this.#activeResolutions.delete(key);
   }
 
   hasNominal(nominal: TypeId): boolean {


### PR DESCRIPTION
## Summary
- Preserve an active self type while building object templates so recursive object fields can resolve through `Optional<T>` instead of collapsing to `unknown`.
- Exercise the recursive optional object case in the std optional smoke fixture and keep the wasm validation expectation in sync.

## Testing
- `npm run typecheck`
- `npx vitest apps/smoke/src/wasm-validation.test.ts -t "std::optional"`
- `npx vitest packages/compiler/src/semantics/typing/__tests__/instantiation.test.ts`
- `npm test`