### PR TITLE
Remove standalone pure direct-call inlining

### DIFF
--- a/packages/compiler/src/__tests__/optimize-pipeline.test.ts
+++ b/packages/compiler/src/__tests__/optimize-pipeline.test.ts
@@ -645,36 +645,6 @@ test "reachable from export root":
     expect(codegen.module.emitText()).toContain(`(export "${utilTest.exportName}"`);
   });
 
-  it("inlines small pure direct calls during optimized codegen", async () => {
-    const { optimized, entryModuleId } = await buildOptimized({
-      files: {
-        "main.voyd": `
-fn double(value: i32) -> i32
-  value + value
-
-pub fn main() -> i32
-  double(21)
-`,
-      },
-    });
-
-    const optimizedCodegen = codegenProgram({
-      program: optimized.program,
-      entryModuleId,
-      optimization: optimized.facts,
-      options: {
-        optimize: false,
-        validate: false,
-        runtimeDiagnostics: false,
-      },
-    });
-    const wasmText = optimizedCodegen.module.emitText();
-
-    expect(wasmText).not.toContain("(func $src__main__double_");
-    expect(wasmText).not.toContain("call $src__main__double_");
-    expect(wasmText).toContain("(i32.const 42)");
-  });
-
   it("lowers exact nominal field reads to direct struct loads", async () => {
     const { optimized, entryModuleId } = await buildOptimized({
       files: {

--- a/packages/compiler/src/codegen/expressions/call/entrypoints.ts
+++ b/packages/compiler/src/codegen/expressions/call/entrypoints.ts
@@ -22,7 +22,6 @@ import { getFunctionMetadataForCall } from "./metadata.js";
 import { emitResolvedCall } from "./resolved-call.js";
 import { compileTraitDispatchCall } from "./trait-dispatch.js";
 import { compileCallArgExpressionsWithTemps } from "./shared.js";
-import { tryInlineResolvedCall } from "./inline.js";
 import { tryCompileScalarObjectMethodCall } from "../../scalar-objects.js";
 
 export const compileCallExpr = (
@@ -190,32 +189,16 @@ export const compileCallExpr = (
       typeInstanceId,
     });
     if (meta) {
-    const args = compileCallArguments({
-      call: expr,
-      meta,
-      ctx,
-      fnCtx,
-      compileExpr,
-    });
-    const inlined = tryInlineResolvedCall({
-      meta,
-      args,
-      ctx,
-      fnCtx,
-      compileExpr,
-      options: {
-        tailPosition,
-        expectedResultTypeId,
-        typeInstanceId,
-        outResultStorageRef,
-      },
-    });
-    if (inlined) {
-      return inlined;
-    }
-    return emitResolvedCall({
-      meta,
-      args,
+      const args = compileCallArguments({
+        call: expr,
+        meta,
+        ctx,
+        fnCtx,
+        compileExpr,
+      });
+      return emitResolvedCall({
+        meta,
+        args,
         callId: expr.id,
         ctx,
         fnCtx,
@@ -339,22 +322,6 @@ export const compileMethodCallExpr = (
     fnCtx,
     compileExpr,
   });
-  const inlined = tryInlineResolvedCall({
-    meta,
-    args,
-    ctx,
-    fnCtx,
-    compileExpr,
-    options: {
-      tailPosition,
-      expectedResultTypeId,
-      typeInstanceId,
-      outResultStorageRef,
-    },
-  });
-  if (inlined) {
-    return inlined;
-  }
   return emitResolvedCall({
     meta,
     args,
@@ -480,22 +447,6 @@ const compileResolvedSymbolCall = ({
     fnCtx,
     compileExpr,
   });
-  const inlined = tryInlineResolvedCall({
-    meta: targetMeta,
-    args,
-    ctx,
-    fnCtx,
-    compileExpr,
-    options: {
-      tailPosition,
-      expectedResultTypeId,
-      typeInstanceId,
-      outResultStorageRef,
-    },
-  });
-  if (inlined) {
-    return inlined;
-  }
   return emitResolvedCall({
     meta: targetMeta,
     args,

--- a/packages/compiler/src/codegen/expressions/call/inline.ts
+++ b/packages/compiler/src/codegen/expressions/call/inline.ts
@@ -126,7 +126,7 @@ export const tryInlineResolvedCall = ({
 }: {
   meta: FunctionMetadata;
   args: readonly (binaryen.ExpressionRef | undefined)[];
-  parameterBindings?: ReadonlyMap<number, LocalBinding>;
+  parameterBindings: ReadonlyMap<number, LocalBinding>;
   ctx: CodegenContext;
   fnCtx: FunctionContext;
   compileExpr: ExpressionCompiler;


### PR DESCRIPTION
## Summary
- remove standalone pure direct-call inlining from normal call lowering
- keep the inlining helper available for scalar-object receiver inlining, where prebound receivers serve a distinct optimization path
- remove the WAT-shape test that asserted standalone direct-call inlining

## Investigation
Linear: V-359

Targeted optimized benchmark stressing small pure helper calls in a hot loop:

- Enabled sample 1: wasmBytes=18199, compileMs=2619.77, median=5.42ms
- Enabled sample 2: wasmBytes=18199, compileMs=3078.17, median=5.63ms
- Disabled sample 1: wasmBytes=18199, compileMs=2770.87, median=5.51ms
- Disabled sample 2: wasmBytes=18199, compileMs=2729.63, median=5.88ms
- Final removal sample: wasmBytes=18199, compileMs=2854.97, median=5.62ms

Conclusion: standalone inlining produced no optimized Wasm size change and runtime stayed within noise, so the complexity was not justified.

## Verification
- ./node_modules/.bin/tsc --noEmit --pretty false -p packages/compiler/tsconfig.json
- ./node_modules/.bin/vitest packages/compiler/src/__tests__/optimize-pipeline.test.ts --run
- npm run typecheck
- npm test