### PR TITLE
Optimize local tail effect handlers

### DIFF
--- a/packages/compiler/src/codegen/__tests__/__fixtures__/effects-local-fast-path.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/effects-local-fast-path.voyd
@@ -1,0 +1,43 @@
+eff Local
+  next(tail) -> i32
+  next(tail, max: i32) -> i32
+
+fn helper(): Local -> i32
+  Local::next(4) + Local::next()
+
+fn big_helper(): Local -> i32
+  var total = 0
+  total = total + Local::next(0)
+  total = total + Local::next(1)
+  total = total + Local::next(2)
+  total = total + Local::next(3)
+  total = total + Local::next(4)
+  total = total + Local::next(5)
+  total = total + Local::next(6)
+  total = total + Local::next(7)
+  total = total + Local::next(8)
+  total
+
+pub fn direct_local(): () -> i32
+  try
+    Local::next()
+  Local::next(tail):
+    tail(7)
+  Local::next(tail, max: i32):
+    tail(max + 1)
+
+pub fn helper_local(): () -> i32
+  try
+    helper()
+  Local::next(tail):
+    tail(5)
+  Local::next(tail, max: i32):
+    tail(max + 1)
+
+pub fn big_local(): () -> i32
+  try
+    big_helper()
+  Local::next(tail):
+    tail(5)
+  Local::next(tail, max: i32):
+    tail(max + 1)

--- a/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
+++ b/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import binaryen from "binaryen";
+import { createVoydHost } from "@voyd-lang/js-host";
 import { parse } from "../../parser/parser.js";
 import { semanticsPipeline } from "../../semantics/pipeline.js";
 import { createRttContext } from "../rtt/index.js";
@@ -15,6 +16,8 @@ import {
   parseEffectTable,
 } from "./support/effects-harness.js";
 import { buildProgramCodegenView } from "../../semantics/codegen-view/index.js";
+import { monomorphizeProgram } from "../../semantics/linking.js";
+import { codegenProgram } from "../codegen.js";
 import { DiagnosticEmitter } from "../../diagnostics/index.js";
 import { createProgramHelperRegistry } from "../program-helpers.js";
 import type { TypeId } from "../../semantics/ids.js";
@@ -29,6 +32,50 @@ const guardFixturePath = resolve(
   "__fixtures__",
   "effects-perform-guard.voyd"
 );
+const localFastPathFixturePath = resolve(
+  import.meta.dirname,
+  "__fixtures__",
+  "effects-local-fast-path.voyd"
+);
+
+const compileEffectFixtureWithCompilerOptimization = async (
+  entryPath: string,
+) => {
+  const base = await compileEffectFixture({
+    entryPath,
+    codegenOptions: { effectsHostBoundary: "off" },
+  });
+  const modules = Array.from(base.semantics.values());
+  const monomorphized = monomorphizeProgram({
+    modules,
+    semantics: base.semantics,
+  });
+  const program = buildProgramCodegenView(modules, {
+    instances: monomorphized.instances,
+    moduleTyping: monomorphized.moduleTyping,
+  });
+  const result = codegenProgram({
+    program,
+    entryModuleId: base.entryModuleId,
+    options: { validate: true, effectsHostBoundary: "off" },
+    optimization: {
+      handlerClauseCaptures: new Map(),
+      reachableFunctionInstances: undefined as never,
+      reachableFunctionSymbols: undefined as never,
+      reachableModuleLets: new Map(),
+      usedTraitDispatchSignatures: new Set(),
+      codegenPlan: {
+        representations: {
+          scalarObjectLocals: new Map(),
+        },
+      },
+    },
+  });
+  if (!result.wasm) {
+    throw new Error("expected validated codegen to emit wasm bytes");
+  }
+  return { ...result, wasm: result.wasm };
+};
 
 const loadSemantics = () =>
   semanticsPipeline(parse(readFileSync(fixturePath, "utf8"), "/proj/src/effects-perform.voyd"));
@@ -170,6 +217,28 @@ describe("effect perform lowering", { timeout: 60_000 }, () => {
     },
     60_000,
   );
+
+  it("specializes simple locally handled tail effects in optimized builds", async () => {
+    const unoptimized = await compileEffectFixture({
+      entryPath: localFastPathFixturePath,
+      codegenOptions: { effectsHostBoundary: "off" },
+    });
+    const specialized = await compileEffectFixtureWithCompilerOptimization(
+      localFastPathFixturePath,
+    );
+
+    const unoptimizedText = unoptimized.module.emitText();
+    const specializedText = specialized.module.emitText();
+
+    expect(unoptimizedText).not.toContain("__handled_");
+    expect(specializedText).toContain("__handled_");
+    expect(specializedText).not.toContain("__handler_fast_");
+
+    const host = await createVoydHost({ wasm: specialized.wasm });
+    await expect(host.run<number>("direct_local")).resolves.toBe(7);
+    await expect(host.run<number>("helper_local")).resolves.toBe(10);
+    await expect(host.run<number>("big_local")).resolves.toBe(45);
+  });
 
   it("does not re-evaluate guards when resuming after a perform", async () => {
     const { module } = await compileEffectFixture({ entryPath: guardFixturePath });

--- a/packages/compiler/src/codegen/context.ts
+++ b/packages/compiler/src/codegen/context.ts
@@ -47,6 +47,7 @@ import type { Diagnostic, DiagnosticEmitter } from "../diagnostics/index.js";
 import type { ProgramHelperRegistry } from "./program-helpers.js";
 import type { ProgramOptimizationFacts } from "../optimize/ir.js";
 import type { ScalarObjectLocalRepresentationPlan } from "../optimize/codegen-plan.js";
+import type { ProgramSymbolId } from "../semantics/ids.js";
 
 export interface CodegenOptions {
   optimize?: boolean;
@@ -108,6 +109,28 @@ export interface FunctionMetadata {
   instanceId: ProgramFunctionInstanceId;
   effectful: boolean;
   effectRow?: EffectRowId;
+}
+
+export interface StaticEffectHandlerCapture {
+  symbol: SymbolId;
+  typeId: TypeId;
+  wasmType: binaryen.Type;
+  paramType: binaryen.Type;
+  mode: "value" | "storage-ref";
+  mutable: boolean;
+}
+
+export interface StaticEffectHandlerClause {
+  operation: ProgramSymbolId;
+  resumeValueExpr?: HirExprId;
+  paramSymbols: readonly SymbolId[];
+  returnTypeId: TypeId;
+}
+
+export interface StaticEffectHandlerContext {
+  key: string;
+  handlers: ReadonlyMap<ProgramSymbolId, StaticEffectHandlerClause>;
+  captures: readonly StaticEffectHandlerCapture[];
 }
 
 export interface ModuleLetGetterMetadata {
@@ -330,6 +353,7 @@ export interface FunctionContext {
   handlerStack?: HandlerScope[];
   loopStack?: LoopScope[];
   continuations?: Map<SymbolId, ContinuationBinding>;
+  staticEffectContext?: StaticEffectHandlerContext;
   continuation?: {
     cfg: GroupContinuationCfg;
     startedLocal: LocalBindingLocal;

--- a/packages/compiler/src/codegen/effects/gc-trampoline/perform.ts
+++ b/packages/compiler/src/codegen/effects/gc-trampoline/perform.ts
@@ -7,18 +7,21 @@ import type {
   HirCallExpr,
   SymbolId,
 } from "../../context.js";
+import type { ProgramFunctionInstanceId } from "../../../semantics/ids.js";
 import {
   initStruct,
   refFunc,
 } from "@voyd-lang/lib/binaryen-gc/index.js";
 import {
   allocateTempLocal,
+  storeLocalValue,
 } from "../../locals.js";
 import { coerceValueToType, lowerValueForHeapField } from "../../structural.js";
 import {
   getExprBinaryenType,
   getRequiredExprType,
   wasmHeapFieldTypeFor,
+  wasmTypeFor,
 } from "../../types.js";
 import { handlerCleanupOps } from "../handler-stack.js";
 import { captureContinuationEnvFieldValue } from "./shared.js";
@@ -33,6 +36,103 @@ import { ensureEffectsMemory } from "../host-boundary/imports.js";
 import { LINEAR_MEMORY_INTERNAL } from "../host-boundary/constants.js";
 import { ensureEffectHandleTable } from "../handle-table.js";
 import { tailResumptionExitChecks } from "../tail-resumptions.js";
+import { canonicalEffectOperation } from "../static-specialization.js";
+
+const tryCompileStaticHandledPerform = ({
+  expr,
+  calleeSymbol,
+  signatureTypes,
+  ctx,
+  fnCtx,
+  compileExpr,
+  typeInstanceId,
+}: {
+  expr: HirCallExpr;
+  calleeSymbol: SymbolId;
+  signatureTypes: { params: readonly number[]; returnType: number };
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+  typeInstanceId?: ProgramFunctionInstanceId;
+}): CompiledExpression | undefined => {
+  const staticContext = fnCtx.staticEffectContext;
+  const handled = staticContext?.handlers.get(
+    canonicalEffectOperation(ctx, calleeSymbol),
+  );
+  if (!handled) {
+    return undefined;
+  }
+
+  const savedBindings = new Map(
+    handled.paramSymbols.map((symbol) => [symbol, fnCtx.bindings.get(symbol)]),
+  );
+  const setup: binaryen.ExpressionRef[] = expr.args.map((arg, index) => {
+    const typeId = signatureTypes.params[index];
+    if (typeof typeId !== "number") {
+      throw new Error("static effect specialization missing argument type");
+    }
+    const actualTypeId = getRequiredExprType(arg.expr, ctx, typeInstanceId);
+    const value = compileExpr({ exprId: arg.expr, ctx, fnCtx });
+    const coerced = coerceValueToType({
+      value: value.expr,
+      actualType: actualTypeId,
+      targetType: typeId,
+      ctx,
+      fnCtx,
+    });
+    const local = allocateTempLocal(
+      wasmTypeFor(typeId, ctx),
+      fnCtx,
+      typeId,
+      ctx,
+    );
+    const symbol = handled.paramSymbols[index];
+    if (typeof symbol === "number") {
+      fnCtx.bindings.set(symbol, { ...local, kind: "local", typeId });
+    }
+    return storeLocalValue({ binding: local, value: coerced, ctx, fnCtx });
+  });
+
+  const value =
+    typeof handled.resumeValueExpr === "number"
+      ? compileExpr({
+          exprId: handled.resumeValueExpr,
+          ctx,
+          fnCtx,
+          expectedResultTypeId: signatureTypes.returnType,
+        }).expr
+      : ctx.mod.nop();
+  savedBindings.forEach((binding, symbol) => {
+    if (binding) {
+      fnCtx.bindings.set(symbol, binding);
+    } else {
+      fnCtx.bindings.delete(symbol);
+    }
+  });
+
+  const actualType =
+    typeof handled.resumeValueExpr === "number"
+      ? getRequiredExprType(handled.resumeValueExpr, ctx, typeInstanceId)
+      : ctx.program.primitives.void;
+  const coerced =
+    actualType === signatureTypes.returnType
+      ? value
+      : coerceValueToType({
+          value,
+          actualType,
+          targetType: signatureTypes.returnType,
+          ctx,
+          fnCtx,
+        });
+  return {
+    expr: ctx.mod.block(
+      null,
+      [...setup, coerced],
+      wasmTypeFor(signatureTypes.returnType, ctx),
+    ),
+    usedReturnCall: false,
+  };
+};
 
 export const compileEffectOpCall = ({
   expr,
@@ -74,8 +174,25 @@ export const compileEffectOpCall = ({
     typeInstanceId,
     registry,
   });
+  const signatureTypes = resolvePerformSignature({
+    site,
+    ctx,
+    typeInstanceId,
+  });
+  const staticHandled = tryCompileStaticHandledPerform({
+    expr,
+    calleeSymbol,
+    signatureTypes,
+    ctx,
+    fnCtx,
+    compileExpr,
+    typeInstanceId,
+  });
+  if (staticHandled) {
+    return staticHandled;
+  }
   const args = expr.args.map((arg, index) => {
-    const expectedTypeId = signature.parameters[index]?.typeId;
+    const expectedTypeId = signatureTypes.params[index] ?? signature.parameters[index]?.typeId;
     const actualTypeId = getRequiredExprType(arg.expr, ctx, typeInstanceId);
     const value = compileExpr({ exprId: arg.expr, ctx, fnCtx });
     return coerceValueToType({
@@ -108,11 +225,6 @@ export const compileEffectOpCall = ({
     fnRef: contRef,
     env,
     site: ctx.mod.i32.const(site.siteOrder),
-  });
-  const signatureTypes = resolvePerformSignature({
-    site,
-    ctx,
-    typeInstanceId,
   });
   const argsType = ensureEffectArgsType({
     ctx,

--- a/packages/compiler/src/codegen/effects/static-specialization.ts
+++ b/packages/compiler/src/codegen/effects/static-specialization.ts
@@ -1,0 +1,303 @@
+import type {
+  CodegenContext,
+  FunctionMetadata,
+  StaticEffectHandlerContext,
+} from "../context.js";
+import type { HirFunction } from "../../semantics/hir/index.js";
+import type { ProgramSymbolId } from "../../semantics/ids.js";
+import { effectsFacade } from "./facade.js";
+import {
+  getAbiTypesForSignature,
+  getSignatureWasmType,
+} from "../types.js";
+import { walkHirExpression } from "../hir-walk.js";
+
+export interface StaticEffectSpecialization {
+  base: FunctionMetadata;
+  meta: FunctionMetadata;
+  item: HirFunction;
+  context: StaticEffectHandlerContext;
+}
+
+type StaticEffectSpecializationState = {
+  byKey: Map<string, StaticEffectSpecialization>;
+  pending: StaticEffectSpecialization[];
+  compiled: Set<string>;
+};
+
+const STATIC_EFFECT_SPECIALIZATION_STATE = Symbol(
+  "voyd.effects.staticSpecializationState",
+);
+
+const stateOf = (ctx: CodegenContext): StaticEffectSpecializationState =>
+  ctx.programHelpers.getHelperState<StaticEffectSpecializationState>(
+    STATIC_EFFECT_SPECIALIZATION_STATE,
+    () => ({
+      byKey: new Map(),
+      pending: [],
+      compiled: new Set(),
+    }),
+  );
+
+const sanitize = (value: string): string =>
+  value.replace(/[^a-zA-Z0-9_]/g, "_");
+
+export const canonicalEffectOperation = (
+  ctx: CodegenContext,
+  symbol: number,
+): ProgramSymbolId =>
+  ctx.program.symbols.canonicalIdOf(ctx.moduleId, symbol) as ProgramSymbolId;
+
+const functionItemFor = ({
+  ctx,
+  symbol,
+}: {
+  ctx: CodegenContext;
+  symbol: number;
+}): HirFunction | undefined => {
+  for (const item of ctx.module.hir.items.values()) {
+    if (item.kind === "function" && item.symbol === symbol) {
+      return item;
+    }
+  }
+  return undefined;
+};
+
+const targetRequiresSpecialization = ({
+  ctx,
+  target,
+}: {
+  ctx: CodegenContext;
+  target: ProgramSymbolId;
+}): boolean => {
+  const targetRef = ctx.program.symbols.refOf(target);
+  const targetModule = ctx.program.modules.get(targetRef.moduleId);
+  const targetInfo = targetModule?.effectsIr.info.functions.get(targetRef.symbol);
+  return targetInfo?.abiEffectful === true || targetInfo?.pure === false;
+};
+
+const unresolvedCallRequiresSpecialization = ({
+  ctx,
+  expr,
+}: {
+  ctx: CodegenContext;
+  expr: { exprKind: "call" | "method-call"; callee?: number };
+}): boolean => {
+  if (expr.exprKind !== "call" || typeof expr.callee !== "number") {
+    return true;
+  }
+  const callee = ctx.module.hir.expressions.get(expr.callee);
+  if (callee?.exprKind !== "identifier") {
+    return true;
+  }
+  const calleeInfo = effectsFacade(ctx).functionAbi(callee.symbol);
+  return calleeInfo?.abiEffectful === true || calleeInfo?.typeEffectful === true;
+};
+
+const canSpecializeFunction = ({
+  ctx,
+  item,
+  context,
+  seen,
+}: {
+  ctx: CodegenContext;
+  item: HirFunction;
+  context: StaticEffectHandlerContext;
+  seen: Set<ProgramSymbolId>;
+}): boolean => {
+  const canonical = canonicalEffectOperation(ctx, item.symbol);
+  if (seen.has(canonical)) {
+    return true;
+  }
+  seen.add(canonical);
+
+  let supported = true;
+  walkHirExpression({
+    exprId: item.body,
+    ctx,
+    visitLambdaBodies: false,
+    visitHandlerBodies: false,
+    visitor: {
+      onExpr: (exprId, expr) => {
+        if (!supported) {
+          return "stop";
+        }
+        if (
+          expr.exprKind === "while" ||
+          expr.exprKind === "loop" ||
+          expr.exprKind === "match"
+        ) {
+          supported = false;
+          return "stop";
+        }
+        if (expr.exprKind !== "call" && expr.exprKind !== "method-call") {
+          return;
+        }
+        const callInfo = ctx.program.calls.getCallInfo(ctx.moduleId, exprId);
+        if (effectsFacade(ctx).callKind(exprId) === "perform") {
+          const site = ctx.effectLowering.sitesByExpr.get(exprId);
+          const operation =
+            site?.kind === "perform"
+              ? canonicalEffectOperation(ctx, site.effectSymbol)
+              : undefined;
+          if (typeof operation !== "number" || !context.handlers.has(operation)) {
+            supported = false;
+            return "stop";
+          }
+          return;
+        }
+        if (effectsFacade(ctx).callKind(exprId) !== "effectful-call") {
+          return;
+        }
+        const targets = callInfo.targets
+          ? Array.from(callInfo.targets.values())
+          : [];
+        if (targets.length === 0) {
+          if (
+            !unresolvedCallRequiresSpecialization({
+              ctx,
+              expr,
+            })
+          ) {
+            return;
+          }
+          supported = false;
+          return "stop";
+        }
+        const effectfulTargets = targets.filter((target) =>
+          targetRequiresSpecialization({
+            ctx,
+            target: target as ProgramSymbolId,
+          })
+        );
+        if (effectfulTargets.length === 0) {
+          return;
+        }
+        for (const target of effectfulTargets) {
+          const targetRef = ctx.program.symbols.refOf(target as ProgramSymbolId);
+          if (targetRef.moduleId !== ctx.moduleId) {
+            supported = false;
+            return "stop";
+          }
+          const targetItem = functionItemFor({ ctx, symbol: targetRef.symbol });
+          if (
+            !targetItem ||
+            !canSpecializeFunction({
+              ctx,
+              item: targetItem,
+              context,
+              seen,
+            })
+          ) {
+            supported = false;
+            return "stop";
+          }
+        }
+      },
+    },
+  });
+  return supported;
+};
+
+export const getOrCreateStaticEffectSpecialization = ({
+  ctx,
+  meta,
+  context,
+}: {
+  ctx: CodegenContext;
+  meta: FunctionMetadata;
+  context: StaticEffectHandlerContext;
+}): FunctionMetadata | undefined => {
+  const effectInfo = effectsFacade(ctx).functionAbi(meta.symbol);
+  const canSpecialize = meta.effectful || effectInfo?.abiEffectful === true;
+  if (!ctx.optimization || !canSpecialize || meta.moduleId !== ctx.moduleId) {
+    return undefined;
+  }
+  const item = functionItemFor({ ctx, symbol: meta.symbol });
+  if (!item) {
+    return undefined;
+  }
+  if (
+    !canSpecializeFunction({
+      ctx,
+      item,
+      context,
+      seen: new Set(),
+    })
+  ) {
+    return undefined;
+  }
+
+  const state = stateOf(ctx);
+  const key = `${meta.moduleId}:${meta.instanceId}:${context.key}`;
+  const existing = state.byKey.get(key);
+  if (existing) {
+    return existing.meta;
+  }
+
+  const captureParamTypes = context.captures.map((capture) => capture.paramType);
+  const captureTypeIds = context.captures.map((capture) => capture.typeId);
+  const resultAbiTypes = getAbiTypesForSignature(meta.resultTypeId, ctx);
+  const specializedMeta: FunctionMetadata = {
+    ...meta,
+    wasmName: `${meta.wasmName}__handled_${sanitize(context.key)}`,
+    paramTypes: [
+      ...meta.paramAbiTypes.flat(),
+      ...captureParamTypes,
+    ],
+    paramAbiTypes: [
+      ...meta.paramAbiTypes,
+      ...captureParamTypes.map((type) => [type] as const),
+    ],
+    userParamOffset: 0,
+    firstUserParamIndex: 0,
+    resultType: getSignatureWasmType(meta.resultTypeId, ctx),
+    resultAbiTypes,
+    paramTypeIds: [...meta.paramTypeIds, ...captureTypeIds],
+    parameters: [
+      ...meta.parameters,
+      ...context.captures.map((capture) => ({
+        typeId: capture.typeId,
+        name: `__handled_${capture.symbol}`,
+      })),
+    ],
+    paramAbiKinds: [
+      ...meta.paramAbiKinds,
+      ...context.captures.map(() => "direct" as const),
+    ],
+    resultAbiKind: "direct",
+    outParamType: undefined,
+    effectful: false,
+    effectRow: undefined,
+  };
+  const specialization: StaticEffectSpecialization = {
+    base: meta,
+    meta: specializedMeta,
+    item,
+    context,
+  };
+  state.byKey.set(key, specialization);
+  state.pending.push(specialization);
+  return specializedMeta;
+};
+
+export const takePendingStaticEffectSpecializations = (
+  ctx: CodegenContext,
+): StaticEffectSpecialization[] => {
+  const state = stateOf(ctx);
+  const pending = state.pending.filter(
+    (specialization) => !state.compiled.has(specialization.meta.wasmName),
+  );
+  state.pending = [];
+  return pending;
+};
+
+export const markStaticEffectSpecializationCompiled = ({
+  ctx,
+  wasmName,
+}: {
+  ctx: CodegenContext;
+  wasmName: string;
+}): void => {
+  stateOf(ctx).compiled.add(wasmName);
+};

--- a/packages/compiler/src/codegen/expressions/call/inline.ts
+++ b/packages/compiler/src/codegen/expressions/call/inline.ts
@@ -159,6 +159,7 @@ export const tryInlineResolvedCall = ({
     instanceId: meta.instanceId,
     typeInstanceId: meta.instanceId,
     effectful: false,
+    staticEffectContext: fnCtx.staticEffectContext,
   };
 
   const setupOps = meta.parameters.flatMap((_parameter, index) => {

--- a/packages/compiler/src/codegen/expressions/call/resolved-call.ts
+++ b/packages/compiler/src/codegen/expressions/call/resolved-call.ts
@@ -8,7 +8,13 @@ import type {
   FunctionMetadata,
   HirExprId,
 } from "../../context.js";
-import { allocateTempLocal, loadLocalValue, storeLocalValue } from "../../locals.js";
+import {
+  allocateTempLocal,
+  loadBindingStorageRef,
+  loadBindingValue,
+  loadLocalValue,
+  storeLocalValue,
+} from "../../locals.js";
 import {
   abiTypeFor,
   getExprBinaryenType,
@@ -28,6 +34,7 @@ import {
   boxSignatureSpillValue,
   unboxSignatureSpillValue,
 } from "../../signature-spill.js";
+import { getOrCreateStaticEffectSpecialization } from "../../effects/static-specialization.js";
 
 export const emitResolvedCall = ({
   meta,
@@ -139,33 +146,60 @@ export const emitResolvedCall = ({
   const callResultWasmType = wasmTypeFor(expectedTypeId, ctx);
   const callerReturnWasmType =
     fnCtx.returnWasmType ?? wasmTypeFor(fnCtx.returnTypeId, ctx);
+  const staticSpecializedMeta =
+    fnCtx.staticEffectContext
+      ? getOrCreateStaticEffectSpecialization({
+          ctx,
+          meta,
+          context: fnCtx.staticEffectContext,
+        })
+      : undefined;
+  const resolvedMeta = staticSpecializedMeta ?? meta;
+  const staticCaptureArgs =
+    staticSpecializedMeta && fnCtx.staticEffectContext
+      ? fnCtx.staticEffectContext.captures.map((capture) => {
+          const binding = fnCtx.bindings.get(capture.symbol);
+          if (!binding) {
+            throw new Error("missing static effect capture binding");
+          }
+          if (capture.mode === "storage-ref") {
+            const storageRef = loadBindingStorageRef(binding, ctx);
+            if (!storageRef) {
+              throw new Error("missing static effect capture storage ref");
+            }
+            return storageRef;
+          }
+          return loadBindingValue(binding, ctx);
+        })
+      : [];
 
   const argSetups: binaryen.ExpressionRef[] = [];
-  const userArgs = args.flatMap((arg, index) => {
+  const allArgs = [...args, ...staticCaptureArgs];
+  const userArgs = allArgs.flatMap((arg, index) => {
     const flattened = flattenAbiArgument(
       arg,
-      meta.paramAbiTypes[index] ?? [binaryen.getExpressionType(arg)],
-      meta.paramTypeIds[index],
+      resolvedMeta.paramAbiTypes[index] ?? [binaryen.getExpressionType(arg)],
+      resolvedMeta.paramTypeIds[index],
     );
     argSetups.push(...flattened.setup);
     return flattened.args;
   });
   const usingProvidedWideResultStorage =
-    !meta.effectful &&
-    meta.resultAbiKind === "out_ref" &&
+    !resolvedMeta.effectful &&
+    resolvedMeta.resultAbiKind === "out_ref" &&
     typeof outResultStorageRef === "number";
   const wideResultStorage =
-    meta.resultAbiKind === "out_ref"
+    resolvedMeta.resultAbiKind === "out_ref"
       ? (() => {
           if (usingProvidedWideResultStorage) {
             return undefined;
           }
-          if (typeof meta.outParamType !== "number") {
+          if (typeof resolvedMeta.outParamType !== "number") {
             throw new Error(
-              `codegen missing out param storage for ${meta.wasmName}`,
+              `codegen missing out param storage for ${resolvedMeta.wasmName}`,
             );
           }
-          return allocateTempLocal(meta.outParamType, fnCtx);
+          return allocateTempLocal(resolvedMeta.outParamType, fnCtx);
         })()
       : undefined;
   const initializedWideResultStorage = usingProvidedWideResultStorage
@@ -177,7 +211,7 @@ export const emitResolvedCall = ({
           wideResultStorage.type,
         )
       : undefined;
-  const callArgs = meta.effectful
+  const callArgs = resolvedMeta.effectful
     ? [
         currentHandlerValue(ctx, fnCtx),
         ...(initializedWideResultStorage
@@ -185,22 +219,26 @@ export const emitResolvedCall = ({
           : []),
         ...userArgs,
       ]
-    : [
+      : [
         ...(initializedWideResultStorage
           ? [initializedWideResultStorage]
           : []),
         ...userArgs,
       ];
 
-  if (meta.effectful) {
-    const rawCall = ctx.mod.call(meta.wasmName, callArgs as number[], meta.resultType);
+  if (resolvedMeta.effectful) {
+    const rawCall = ctx.mod.call(
+      resolvedMeta.wasmName,
+      callArgs as number[],
+      resolvedMeta.resultType,
+    );
     const callExpr =
       argSetups.length === 0
         ? rawCall
         : ctx.mod.block(
             null,
             [...argSetups, rawCall],
-            meta.resultType,
+            resolvedMeta.resultType,
           );
     return ctx.effectsBackend.lowerEffectfulCallResult({
       callExpr,
@@ -215,20 +253,20 @@ export const emitResolvedCall = ({
   }
 
   const allowReturnCall =
-    meta.resultAbiKind === "direct" &&
+    resolvedMeta.resultAbiKind === "direct" &&
     argSetups.length === 0 &&
     tailPosition &&
     !fnCtx.effectful &&
-    meta.resultTypeId === expectedTypeId &&
+    resolvedMeta.resultTypeId === expectedTypeId &&
     returnTypeId === expectedTypeId &&
-    meta.resultType === callerReturnWasmType &&
+    resolvedMeta.resultType === callerReturnWasmType &&
     intrinsicResultWasmType === callerReturnWasmType &&
     !requiresStructuralConversion(returnTypeId, expectedTypeId, ctx);
 
   if (allowReturnCall) {
     return {
       expr: ctx.mod.return_call(
-        meta.wasmName,
+        resolvedMeta.wasmName,
         callArgs as number[],
         intrinsicResultWasmType
       ),
@@ -236,7 +274,11 @@ export const emitResolvedCall = ({
     };
   }
 
-  const rawCall = ctx.mod.call(meta.wasmName, callArgs as number[], meta.resultType);
+  const rawCall = ctx.mod.call(
+    resolvedMeta.wasmName,
+    callArgs as number[],
+    resolvedMeta.resultType,
+  );
   if (usingProvidedWideResultStorage) {
     const ops =
       argSetups.length === 0
@@ -248,21 +290,21 @@ export const emitResolvedCall = ({
       usedOutResultStorageRef: true,
     };
   }
-  if (meta.resultAbiKind === "out_ref" && wideResultStorage) {
+  if (resolvedMeta.resultAbiKind === "out_ref" && wideResultStorage) {
     const reloaded = liftHeapValueToInline({
       value: ctx.mod.local.get(
         wideResultStorage.index,
         wideResultStorage.type,
       ),
-      typeId: meta.resultTypeId,
+      typeId: resolvedMeta.resultTypeId,
       ctx,
     });
     const coerced =
-      meta.resultTypeId === expectedTypeId
+      resolvedMeta.resultTypeId === expectedTypeId
         ? reloaded
         : coerceValueToType({
             value: reloaded,
-            actualType: meta.resultTypeId,
+            actualType: resolvedMeta.resultTypeId,
             targetType: expectedTypeId,
             ctx,
             fnCtx,
@@ -282,13 +324,14 @@ export const emitResolvedCall = ({
   }
   const stabilizedCall = stabilizeMultivalueResult(
     rawCall,
-    meta.resultAbiTypes,
+    resolvedMeta.resultAbiTypes,
   );
   const decodedCall =
-    getSignatureSpillBoxType({ typeId: meta.resultTypeId, ctx }) === meta.resultType
+    getSignatureSpillBoxType({ typeId: resolvedMeta.resultTypeId, ctx }) ===
+    resolvedMeta.resultType
       ? unboxSignatureSpillValue({
           value: stabilizedCall,
-          typeId: meta.resultTypeId,
+          typeId: resolvedMeta.resultTypeId,
           ctx,
         })
       : stabilizedCall;
@@ -301,11 +344,11 @@ export const emitResolvedCall = ({
           binaryen.getExpressionType(decodedCall),
         );
   const coercedCall =
-    meta.resultTypeId === expectedTypeId
+    resolvedMeta.resultTypeId === expectedTypeId
       ? callExpr
       : coerceValueToType({
           value: callExpr,
-          actualType: meta.resultTypeId,
+          actualType: resolvedMeta.resultTypeId,
           targetType: expectedTypeId,
           ctx,
           fnCtx,

--- a/packages/compiler/src/codegen/expressions/effect-handler.ts
+++ b/packages/compiler/src/codegen/expressions/effect-handler.ts
@@ -14,6 +14,9 @@ import type {
   CompiledExpression,
   ExpressionCompiler,
   FunctionContext,
+  StaticEffectHandlerCapture,
+  StaticEffectHandlerClause,
+  StaticEffectHandlerContext,
 } from "../context.js";
 import { effectsFacade } from "../effects/facade.js";
 import { ensureEffectArgsType } from "../effects/args-type.js";
@@ -41,7 +44,11 @@ import {
 } from "../effects/outcome-values.js";
 import { RESUME_KIND, type ResumeKind } from "../effects/runtime-abi.js";
 import type { HirEffectHandlerExpr } from "../../semantics/hir/index.js";
-import type { ProgramFunctionInstanceId, TypeId } from "../../semantics/ids.js";
+import type {
+  ProgramFunctionInstanceId,
+  ProgramSymbolId,
+  TypeId,
+} from "../../semantics/ids.js";
 import {
   handlerClauseContinuationTempId,
   handlerClauseTailGuardTempId,
@@ -52,6 +59,7 @@ import {
   resolveEffectSignatureTypes,
 } from "../effects/effect-signature.js";
 import { walkHirExpression } from "../hir-walk.js";
+import { canonicalEffectOperation } from "../effects/static-specialization.js";
 
 const bin = binaryen as unknown as AugmentedBinaryen;
 
@@ -140,6 +148,81 @@ const currentHandlerValue = (
   return ctx.mod.local.get(fnCtx.currentHandler.index, fnCtx.currentHandler.type);
 };
 
+const unwrapValueOnlyBlock = ({
+  exprId,
+  ctx,
+}: {
+  exprId: number;
+  ctx: CodegenContext;
+}): number => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  if (
+    expr?.exprKind === "block" &&
+    expr.statements.length === 0 &&
+    typeof expr.value === "number"
+  ) {
+    return unwrapValueOnlyBlock({ exprId: expr.value, ctx });
+  }
+  return exprId;
+};
+
+const tailResumeValueExpr = ({
+  expr,
+  clauseIndex,
+  ctx,
+}: {
+  expr: HirEffectHandlerExpr;
+  clauseIndex: number;
+  ctx: CodegenContext;
+}): number | undefined | false => {
+  if (!ctx.optimization || typeof expr.finallyBranch === "number") {
+    return false;
+  }
+  const clause = expr.handlers[clauseIndex];
+  const continuation = clause?.parameters[0];
+  if (!clause || clause.resumable !== "fn" || !continuation) {
+    return false;
+  }
+  const bodyExprId = unwrapValueOnlyBlock({ exprId: clause.body, ctx });
+  const body = ctx.module.hir.expressions.get(bodyExprId);
+  if (!body || body.exprKind !== "call") {
+    return false;
+  }
+  const callee = ctx.module.hir.expressions.get(body.callee);
+  if (callee?.exprKind !== "identifier" || callee.symbol !== continuation.symbol) {
+    return false;
+  }
+  if (body.args.length > 1) {
+    return false;
+  }
+  return body.args[0]?.expr;
+};
+
+const expressionContainsPerform = ({
+  exprId,
+  ctx,
+}: {
+  exprId: number;
+  ctx: CodegenContext;
+}): boolean => {
+  let found = false;
+  walkHirExpression({
+    exprId,
+    ctx,
+    visitLambdaBodies: false,
+    visitHandlerBodies: false,
+    visitor: {
+      onExpr: (nestedExprId) => {
+        if (effectsFacade(ctx).callKind(nestedExprId) === "perform") {
+          found = true;
+          return "stop";
+        }
+      },
+    },
+  });
+  return found;
+};
+
 const collectClauseCaptureSymbols = ({
   expr,
   fnCtx,
@@ -169,6 +252,79 @@ const collectClauseCaptureSymbols = ({
     });
   });
   return symbols;
+};
+
+const staticCaptureMode = ({
+  field,
+  ctx,
+}: {
+  field: ClauseEnvField;
+  ctx: CodegenContext;
+}): "value" | "storage-ref" =>
+  field.storageType === getInlineHeapBoxType({ typeId: field.typeId, ctx })
+    ? "storage-ref"
+    : "value";
+
+const buildStaticEffectContext = ({
+  expr,
+  env,
+  ctx,
+  fnCtx,
+}: {
+  expr: HirEffectHandlerExpr;
+  env: ReturnType<typeof buildClauseEnv>;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): StaticEffectHandlerContext | undefined => {
+  if (!ctx.optimization || typeof expr.finallyBranch === "number") {
+    return undefined;
+  }
+
+  const handlers = new Map<ProgramSymbolId, StaticEffectHandlerClause>();
+  for (let index = 0; index < expr.handlers.length; index += 1) {
+    const resumeValueExpr = tailResumeValueExpr({ expr, clauseIndex: index, ctx });
+    if (resumeValueExpr === false) {
+      continue;
+    }
+    if (
+      typeof resumeValueExpr === "number" &&
+      expressionContainsPerform({ exprId: resumeValueExpr, ctx })
+    ) {
+      continue;
+    }
+    const clause = expr.handlers[index]!;
+    const signature = ctx.program.functions.getSignature(ctx.moduleId, clause.operation);
+    if (!signature || signature.typeParams.length > 0) {
+      continue;
+    }
+    const operation = canonicalEffectOperation(ctx, clause.operation);
+    handlers.set(operation, {
+      operation,
+      resumeValueExpr,
+      paramSymbols: clause.parameters.slice(1).map((param) => param.symbol),
+      returnTypeId: signature.returnType,
+    });
+  }
+  if (handlers.size === 0) {
+    return undefined;
+  }
+
+  const captures: StaticEffectHandlerCapture[] = env.fields.map((field) => ({
+    symbol: field.symbol,
+    typeId: field.typeId,
+    wasmType: field.wasmType,
+    paramType: field.storageType,
+    mode: staticCaptureMode({ field, ctx }),
+    mutable: true,
+  }));
+  const instanceKey = handlerInstanceKey(fnCtx);
+  const key = [
+    `h${expr.id}`,
+    `i${instanceKey}`,
+    ...[...handlers.keys()].sort((a, b) => a - b).map((operation) => `o${operation}`),
+    ...captures.map((capture) => `c${capture.symbol}_${capture.typeId}_${capture.mode}`),
+  ].join("_");
+  return { key, handlers, captures };
 };
 
 const buildClauseEnv = ({
@@ -696,6 +852,7 @@ export const compileEffectHandlerExpr = (
   const handlerResultTypeId = getRequiredExprType(expr.id, ctx, typeInstanceId);
 
   const env = buildClauseEnv({ expr, ctx, fnCtx });
+  const staticEffectContext = buildStaticEffectContext({ expr, env, ctx, fnCtx });
   const prevHandlerLocal = allocateTempLocal(
     ctx.effectsRuntime.handlerFrameType,
     fnCtx
@@ -779,6 +936,10 @@ export const compileEffectHandlerExpr = (
   );
   pushHandlerScope(fnCtx, { prevHandler: prevHandlerLocal, label: expr.id });
 
+  const previousStaticEffectContext = fnCtx.staticEffectContext;
+  if (staticEffectContext) {
+    fnCtx.staticEffectContext = staticEffectContext;
+  }
   const body = compileExpr({
     exprId: expr.body,
     ctx,
@@ -786,6 +947,7 @@ export const compileEffectHandlerExpr = (
     tailPosition,
     expectedResultTypeId,
   });
+  fnCtx.staticEffectContext = previousStaticEffectContext;
   const resultType = getRequiredExprType(expr.id, ctx, typeInstanceId);
   const resultWasmType = wasmTypeFor(resultType, ctx);
   const resultLocal =

--- a/packages/compiler/src/codegen/functions.ts
+++ b/packages/compiler/src/codegen/functions.ts
@@ -69,6 +69,11 @@ import { walkHirExpression } from "./hir-walk.js";
 import { markDependencyFunctionReachable } from "./function-dependencies.js";
 import { boxSignatureSpillValue, unboxSignatureSpillValue } from "./signature-spill.js";
 import { createSerializedExportSpecialCaseResolver } from "./serialized-export-special-cases.js";
+import {
+  markStaticEffectSpecializationCompiled,
+  takePendingStaticEffectSpecializations,
+  type StaticEffectSpecialization,
+} from "./effects/static-specialization.js";
 
 const REACHABILITY_STATE = Symbol.for("voyd.codegen.reachabilityState");
 const FUNCTION_METADATA_REGISTRATION_STATE = Symbol.for(
@@ -1122,6 +1127,7 @@ export const compileFunctions = ({
       compiledCount += 1;
     });
   }
+  compiledCount += compilePendingStaticEffectSpecializations(ctx);
   return compiledCount;
 };
 
@@ -1885,6 +1891,121 @@ const compileFunctionItem = (
     fnCtx.locals,
     functionBody,
   );
+};
+
+const compileStaticEffectSpecialization = (
+  specialization: StaticEffectSpecialization,
+  ctx: CodegenContext,
+): void => {
+  const { item: fn, meta, context } = specialization;
+  if (ctx.mod.getFunction(meta.wasmName) !== 0) {
+    markStaticEffectSpecializationCompiled({ ctx, wasmName: meta.wasmName });
+    return;
+  }
+
+  const fnCtx: FunctionContext = {
+    bindings: new Map(),
+    tempLocals: new Map(),
+    locals: [],
+    nextLocalIndex: meta.paramTypes.length,
+    returnTypeId: meta.resultTypeId,
+    returnWasmType: meta.resultType,
+    returnAbiKind: meta.resultAbiKind,
+    instanceId: meta.instanceId,
+    typeInstanceId: meta.instanceId,
+    effectful: false,
+    staticEffectContext: context,
+  };
+  const paramInitOps = bindRawFunctionParameters({
+    fn,
+    meta,
+    ctx,
+    fnCtx,
+    handlerOffset: 0,
+  });
+  const captureStart = fn.parameters.reduce(
+    (offset, _param, index) => offset + (meta.paramAbiTypes[index]?.length ?? 0),
+    0,
+  );
+  context.captures.forEach((capture, index) => {
+    const paramIndex = captureStart + index;
+    if (capture.mode === "storage-ref") {
+      fnCtx.bindings.set(
+        capture.symbol,
+        createStorageRefBinding({
+          index: paramIndex,
+          typeId: capture.typeId,
+          mutable: capture.mutable,
+          ctx,
+        }),
+      );
+      return;
+    }
+    fnCtx.bindings.set(capture.symbol, {
+      kind: "local",
+      index: paramIndex,
+      type: capture.wasmType,
+      storageType: capture.paramType,
+      typeId: capture.typeId,
+    });
+  });
+  const defaultInitOps = compileDefaultParameterInitialization({
+    fn,
+    meta,
+    ctx,
+    fnCtx,
+  });
+  const body = compileExpression({
+    exprId: fn.body,
+    ctx,
+    fnCtx,
+    tailPosition: true,
+    expectedResultTypeId: fnCtx.returnTypeId,
+  });
+  const bodyExpr =
+    defaultInitOps.length > 0
+      ? ctx.mod.block(
+          null,
+          [...paramInitOps, ...defaultInitOps, body.expr],
+          binaryen.getExpressionType(body.expr),
+        )
+      : paramInitOps.length > 0
+        ? ctx.mod.block(
+            null,
+            [...paramInitOps, body.expr],
+            binaryen.getExpressionType(body.expr),
+          )
+        : body.expr;
+  const functionBody =
+    meta.resultTypeId !== ctx.program.primitives.void &&
+    binaryen.getExpressionType(bodyExpr) !== binaryen.none &&
+    binaryen.getExpressionType(bodyExpr) !== binaryen.unreachable
+      ? boxSignatureSpillValue({
+          value: bodyExpr,
+          typeId: meta.resultTypeId,
+          ctx,
+          fnCtx,
+        })
+      : bodyExpr;
+
+  ctx.mod.addFunction(
+    meta.wasmName,
+    binaryen.createType(meta.paramTypes as number[]),
+    meta.resultType,
+    fnCtx.locals,
+    functionBody,
+  );
+  markStaticEffectSpecializationCompiled({ ctx, wasmName: meta.wasmName });
+};
+
+const compilePendingStaticEffectSpecializations = (
+  ctx: CodegenContext,
+): number => {
+  const pending = takePendingStaticEffectSpecializations(ctx);
+  pending.forEach((specialization) =>
+    compileStaticEffectSpecialization(specialization, ctx)
+  );
+  return pending.length;
 };
 
 const makeFunctionName = (


### PR DESCRIPTION
## Summary
- specialize eligible local tail effect handlers during optimized codegen
- lower handled performs directly to the handler tail expression when safe
- clone simple same-module helper calls into pure handled specializations with hidden handler captures
- add compiler regression coverage for direct and helper local tail effects

## Benchmark
Isolated local-tail hot path benchmark with compiler optimization facts enabled:
- baseline HEAD median: 0.004167 ms
- current median: 0.000917 ms
- speedup: about 4.5x
- baseline wasm bytes: 44,315
- current wasm bytes: 39,839
- checksum: 629 before and after

A vtrace-shaped RNG probe was attempted first, but the generic tail-continuation path produced a checksum mismatch under isolated optimizer facts, so it was not used as the headline comparison.

## Verification
- npx tsc --noEmit --pretty false -p packages/compiler/tsconfig.json
- npx vitest packages/compiler/src/codegen/__tests__/effects-perform.test.ts --run
- npm run typecheck
- npm test