### PR TITLE
Optimize closed receiver dispatch

### DIFF
--- a/packages/compiler/src/__tests__/optimize-pipeline.test.ts
+++ b/packages/compiler/src/__tests__/optimize-pipeline.test.ts
@@ -124,6 +124,26 @@ const findModuleLet = ({
       program.symbols.getName(program.symbols.idOf({ moduleId, symbol: item.symbol })) === name,
   );
 
+const findObjectNominal = ({
+  moduleId,
+  name,
+  program,
+}: {
+  moduleId: string;
+  name: string;
+  program: ReturnType<typeof buildProgramCodegenView>;
+}) => {
+  const item = Array.from(program.modules.get(moduleId)?.hir.items.values() ?? [])
+    .find((candidate) => candidate.kind === "object" && program.symbols.getName(
+      program.symbols.idOf({ moduleId, symbol: candidate.symbol }),
+    ) === name);
+  return item?.kind === "object"
+    ? program.objects.getTemplate(
+        program.symbols.idOf({ moduleId, symbol: item.symbol }),
+      )?.nominal
+    : undefined;
+};
+
 const getFunctionBodyValueExpr = ({
   moduleId,
   symbol,
@@ -299,6 +319,757 @@ pub fn main() -> i32
     if (!callExpr || callExpr.exprKind !== "method-call") return;
     const callInfo = optimized.program.calls.getCallInfo("src::main", callExpr.id);
     expect(callInfo.traitDispatch).toBe(false);
+  });
+
+  it("propagates exact receiver facts across monomorphic trait-typed call edges", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+trait Runner
+  fn run(self) -> i32
+
+obj Box {
+  value: i32
+}
+
+obj Alt {
+  value: i32
+}
+
+impl Runner for Box
+  fn run(self) -> i32
+    self.value
+
+impl Runner for Alt
+  fn run(self) -> i32
+    self.value + 1
+
+fn helper(runner: Runner) -> i32
+  runner.run()
+
+fn invoke(runner: Runner) -> i32
+  helper(runner)
+
+pub fn main() -> i32
+  invoke(Box { value: 4 })
+`,
+      },
+    });
+
+    const moduleId = "src::main";
+    const program = optimized.program;
+    const boxItem = Array.from(program.modules.get(moduleId)?.hir.items.values() ?? [])
+      .find((item) => item.kind === "object" && program.symbols.getName(
+        program.symbols.idOf({ moduleId, symbol: item.symbol }),
+      ) === "Box");
+    const boxType =
+      boxItem?.kind === "object"
+        ? program.objects.getTemplate(
+            program.symbols.idOf({ moduleId, symbol: boxItem.symbol }),
+          )?.nominal
+        : undefined;
+    expect(typeof boxType).toBe("number");
+    if (typeof boxType !== "number") return;
+
+    for (const name of ["invoke", "helper"]) {
+      const fn = findFunction({ moduleId, name, program });
+      expect(fn?.kind, name).toBe("function");
+      if (!fn || fn.kind !== "function") continue;
+      const instanceId = program.functions.getInstanceId(moduleId, fn.symbol, []);
+      expect(typeof instanceId, name).toBe("number");
+      if (typeof instanceId !== "number") continue;
+      expect(
+        optimized.facts.exactParameterTypes
+          .get(instanceId)
+          ?.get(fn.parameters[0]!.symbol),
+        name,
+      ).toBe(boxType);
+    }
+  });
+
+  it("maps labeled call arguments when propagating exact receiver facts", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+trait Runner
+  fn run(self, offset: i32) -> i32
+
+obj Box {
+  value: i32
+}
+
+obj Alt {
+  value: i32
+}
+
+impl Runner for Box
+  fn run(self, offset: i32) -> i32
+    self.value + offset
+
+impl Runner for Alt
+  fn run(self, offset: i32) -> i32
+    self.value + offset + 1
+
+fn helper({ offset: i32, runner: Runner }) -> i32
+  runner.run(offset)
+
+fn invoke({ offset: i32, runner: Runner }) -> i32
+  helper(runner: runner, offset: offset)
+
+pub fn main() -> i32
+  invoke(runner: Box { value: 4 }, offset: 2)
+`,
+      },
+    });
+
+    const moduleId = "src::main";
+    const program = optimized.program;
+    const boxType = findObjectNominal({ moduleId, name: "Box", program });
+    expect(typeof boxType).toBe("number");
+    if (typeof boxType !== "number") return;
+
+    for (const name of ["invoke", "helper"]) {
+      const fn = findFunction({ moduleId, name, program });
+      expect(fn?.kind, name).toBe("function");
+      if (!fn || fn.kind !== "function") continue;
+      const runner = fn.parameters.find((parameter) => parameter.label === "runner");
+      expect(runner, name).toBeDefined();
+      if (!runner) continue;
+      const instanceId = program.functions.getInstanceId(moduleId, fn.symbol, []);
+      expect(typeof instanceId, name).toBe("number");
+      if (typeof instanceId !== "number") continue;
+      expect(
+        optimized.facts.exactParameterTypes
+          .get(instanceId)
+          ?.get(runner.symbol),
+        name,
+      ).toBe(boxType);
+    }
+  });
+
+  it("devirtualizes monomorphic trait-typed callees using propagated exact receiver facts", async () => {
+    const { optimized, entryModuleId } = await buildOptimized({
+      files: {
+        "main.voyd": `
+trait Runner
+  fn run(self) -> i32
+
+obj Box {
+  value: i32
+}
+
+obj Alt {
+  value: i32
+}
+
+impl Runner for Box
+  fn run(self) -> i32
+    self.value
+
+impl Runner for Alt
+  fn run(self) -> i32
+    self.value + 1
+
+fn invoke(runner: Runner) -> i32
+  runner.run()
+
+pub fn main() -> i32
+  invoke(Box { value: 4 })
+`,
+      },
+    });
+
+    const invokeFn = findFunction({
+      moduleId: "src::main",
+      name: "invoke",
+      program: optimized.program,
+    });
+    expect(invokeFn?.kind).toBe("function");
+    if (!invokeFn || invokeFn.kind !== "function") return;
+    const moduleView = optimized.program.modules.get("src::main");
+    const callExpr = (() => {
+      if (!moduleView) {
+        return undefined;
+      }
+      let found: HirMethodCallExpr | undefined;
+      walkExpression({
+        exprId: invokeFn.body,
+        hir: moduleView.hir,
+        onEnterExpression: (_exprId, expr) => {
+          if (expr.exprKind !== "method-call") {
+            return;
+          }
+          found = expr;
+          return { stop: true };
+        },
+      });
+      return found;
+    })();
+    expect(callExpr?.exprKind).toBe("method-call");
+    if (!callExpr || callExpr.exprKind !== "method-call") return;
+    const callInfo = optimized.program.calls.getCallInfo("src::main", callExpr.id);
+    expect(callInfo.traitDispatch).toBe(false);
+    expect(new Set(callInfo.targets?.values()).size).toBe(1);
+
+    const { module } = codegenProgram({
+      program: optimized.program,
+      entryModuleId,
+      optimization: optimized.facts,
+      options: {
+        optimize: false,
+        validate: true,
+        runtimeDiagnostics: false,
+      },
+    });
+    const wasmText = module.emitText();
+    expect(wasmText).toContain("call $src__main__run_");
+    expect(wasmText).not.toContain("call $__lookup_method_accessor");
+  });
+
+  it("does not specialize externally callable trait-parameter exports from internal edges", async () => {
+    const { optimized } = await buildOptimized({
+      optimizeOptions: { boundaryExports: "auto" },
+      files: {
+        "main.voyd": `
+trait Runner
+  fn run(self) -> i32
+
+obj Box {
+  value: i32
+}
+
+obj Alt {
+  value: i32
+}
+
+impl Runner for Box
+  fn run(self) -> i32
+    self.value
+
+impl Runner for Alt
+  fn run(self) -> i32
+    self.value + 1
+
+pub fn score(runner: Runner) -> i32
+  runner.run()
+
+fn internal() -> i32
+  score(Box { value: 4 })
+
+pub fn main() -> i32
+  internal()
+`,
+      },
+    });
+
+    const moduleId = "src::main";
+    const program = optimized.program;
+    const scoreFn = findFunction({ moduleId, name: "score", program });
+    expect(scoreFn?.kind).toBe("function");
+    if (!scoreFn || scoreFn.kind !== "function") return;
+    const scoreInstanceId = program.functions.getInstanceId(
+      moduleId,
+      scoreFn.symbol,
+      [],
+    );
+    expect(typeof scoreInstanceId).toBe("number");
+    if (typeof scoreInstanceId !== "number") return;
+
+    expect(
+      optimized.facts.exactParameterTypes
+        .get(scoreInstanceId)
+        ?.get(scoreFn.parameters[0]!.symbol),
+    ).toBeUndefined();
+    expect(
+      optimized.facts.knownParameterTypes
+        .get(scoreInstanceId)
+        ?.get(scoreFn.parameters[0]!.symbol),
+    ).toBeUndefined();
+
+    const moduleView = program.modules.get(moduleId);
+    expect(moduleView).toBeDefined();
+    if (!moduleView) return;
+    let dispatchCall: HirMethodCallExpr | undefined;
+    walkExpression({
+      exprId: scoreFn.body,
+      hir: moduleView.hir,
+      onEnterExpression: (_exprId, expr) => {
+        if (expr.exprKind !== "method-call") {
+          return;
+        }
+        dispatchCall = expr;
+        return { stop: true };
+      },
+    });
+    expect(dispatchCall?.exprKind).toBe("method-call");
+    if (!dispatchCall) return;
+    expect(program.calls.getCallInfo(moduleId, dispatchCall.id).traitDispatch).toBe(
+      true,
+    );
+  });
+
+  it("treats entry-module re-exported trait-parameter functions as externally callable", async () => {
+    const { optimized } = await buildOptimized({
+      entryFile: "pkg.voyd",
+      optimizeOptions: { boundaryExports: "auto" },
+      files: {
+        "pkg.voyd": `
+use src::util::internal
+pub use src::util::score
+
+pub fn main() -> i32
+  internal()
+`,
+        "util.voyd": `
+trait Runner
+  fn run(self) -> i32
+
+obj Box {
+  value: i32
+}
+
+obj Alt {
+  value: i32
+}
+
+impl Runner for Box
+  fn run(self) -> i32
+    self.value
+
+impl Runner for Alt
+  fn run(self) -> i32
+    self.value + 1
+
+pub fn score(runner: Runner) -> i32
+  runner.run()
+
+pub fn internal() -> i32
+  score(Box { value: 4 })
+`,
+      },
+    });
+
+    const moduleId = "src::util";
+    const program = optimized.program;
+    const scoreFn = findFunction({ moduleId, name: "score", program });
+    expect(scoreFn?.kind).toBe("function");
+    if (!scoreFn || scoreFn.kind !== "function") return;
+    const scoreInstanceId = program.functions.getInstanceId(
+      moduleId,
+      scoreFn.symbol,
+      [],
+    );
+    expect(typeof scoreInstanceId).toBe("number");
+    if (typeof scoreInstanceId !== "number") return;
+
+    expect(
+      optimized.facts.exactParameterTypes
+        .get(scoreInstanceId)
+        ?.get(scoreFn.parameters[0]!.symbol),
+    ).toBeUndefined();
+    expect(
+      optimized.facts.knownParameterTypes
+        .get(scoreInstanceId)
+        ?.get(scoreFn.parameters[0]!.symbol),
+    ).toBeUndefined();
+
+    const moduleView = program.modules.get(moduleId);
+    expect(moduleView).toBeDefined();
+    if (!moduleView) return;
+    let dispatchCall: HirMethodCallExpr | undefined;
+    walkExpression({
+      exprId: scoreFn.body,
+      hir: moduleView.hir,
+      onEnterExpression: (_exprId, expr) => {
+        if (expr.exprKind !== "method-call") {
+          return;
+        }
+        dispatchCall = expr;
+        return { stop: true };
+      },
+    });
+    expect(dispatchCall?.exprKind).toBe("method-call");
+    if (!dispatchCall) return;
+    expect(program.calls.getCallInfo(moduleId, dispatchCall.id).traitDispatch).toBe(
+      true,
+    );
+  });
+
+  it("keeps functions used as values open for exact receiver facts", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+trait Runner
+  fn run(self) -> i32
+
+obj Box {
+  value: i32
+}
+
+obj Alt {
+  value: i32
+}
+
+impl Runner for Box
+  fn run(self) -> i32
+    self.value
+
+impl Runner for Alt
+  fn run(self) -> i32
+    self.value + 1
+
+fn score(runner: Runner) -> i32
+  runner.run()
+
+fn apply(cb: fn(Runner) -> i32, runner: Runner) -> i32
+  cb(runner)
+
+fn internal() -> i32
+  score(Box { value: 4 }) + apply(score, Alt { value: 5 })
+
+pub fn main() -> i32
+  internal()
+`,
+      },
+    });
+
+    const moduleId = "src::main";
+    const program = optimized.program;
+    const scoreFn = findFunction({ moduleId, name: "score", program });
+    expect(scoreFn?.kind).toBe("function");
+    if (!scoreFn || scoreFn.kind !== "function") return;
+    const scoreInstanceId = program.functions.getInstanceId(
+      moduleId,
+      scoreFn.symbol,
+      [],
+    );
+    expect(typeof scoreInstanceId).toBe("number");
+    if (typeof scoreInstanceId !== "number") return;
+
+    expect(
+      optimized.facts.exactParameterTypes
+        .get(scoreInstanceId)
+        ?.get(scoreFn.parameters[0]!.symbol),
+    ).toBeUndefined();
+    expect(
+      optimized.facts.knownParameterTypes
+        .get(scoreInstanceId)
+        ?.get(scoreFn.parameters[0]!.symbol),
+    ).toBeUndefined();
+
+    const moduleView = program.modules.get(moduleId);
+    expect(moduleView).toBeDefined();
+    if (!moduleView) return;
+    let dispatchCall: HirMethodCallExpr | undefined;
+    walkExpression({
+      exprId: scoreFn.body,
+      hir: moduleView.hir,
+      onEnterExpression: (_exprId, expr) => {
+        if (expr.exprKind !== "method-call") {
+          return;
+        }
+        dispatchCall = expr;
+        return { stop: true };
+      },
+    });
+    expect(dispatchCall?.exprKind).toBe("method-call");
+    if (!dispatchCall) return;
+    expect(program.calls.getCallInfo(moduleId, dispatchCall.id).traitDispatch).toBe(
+      true,
+    );
+  });
+
+  it("still propagates exact facts for non-entry public helper exports", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+use src::util::run_box
+
+pub fn main() -> i32
+  run_box()
+`,
+        "util.voyd": `
+trait Runner
+  fn run(self) -> i32
+
+obj Box {
+  value: i32
+}
+
+obj Alt {
+  value: i32
+}
+
+impl Runner for Box
+  fn run(self) -> i32
+    self.value
+
+impl Runner for Alt
+  fn run(self) -> i32
+    self.value + 1
+
+pub fn score(runner: Runner) -> i32
+  runner.run()
+
+pub fn run_box() -> i32
+  score(Box { value: 4 })
+`,
+      },
+    });
+
+    const moduleId = "src::util";
+    const program = optimized.program;
+    const boxType = findObjectNominal({ moduleId, name: "Box", program });
+    expect(typeof boxType).toBe("number");
+    if (typeof boxType !== "number") return;
+    const scoreFn = findFunction({ moduleId, name: "score", program });
+    expect(scoreFn?.kind).toBe("function");
+    if (!scoreFn || scoreFn.kind !== "function") return;
+    const scoreInstanceId = program.functions.getInstanceId(
+      moduleId,
+      scoreFn.symbol,
+      [],
+    );
+    expect(typeof scoreInstanceId).toBe("number");
+    if (typeof scoreInstanceId !== "number") return;
+    expect(
+      optimized.facts.exactParameterTypes
+        .get(scoreInstanceId)
+        ?.get(scoreFn.parameters[0]!.symbol),
+    ).toBe(boxType);
+  });
+
+  it("creates receiver-specialized clones for exact method call edges", async () => {
+    const { optimized, entryModuleId } = await buildOptimized({
+      files: {
+        "main.voyd": `
+trait Runner
+  fn run(self, offset: i32) -> i32
+
+obj Box {
+  value: i32
+}
+
+obj Alt {
+  value: i32
+}
+
+impl Runner for Box
+  fn run(self, offset: i32) -> i32
+    self.value + offset
+
+impl Runner for Alt
+  fn run(self, offset: i32) -> i32
+    self.value + offset + 1
+
+fn helper(runner: Runner, offset: i32) -> i32
+  runner.run(offset)
+
+obj Service {
+  base: i32
+}
+
+impl Service
+  fn invoke(self, runner: Runner, offset: i32) -> i32
+    helper(runner, offset) + self.base
+
+pub fn main() -> i32
+  use_box() + use_alt()
+
+fn use_box() -> i32
+  Service { base: 1 }.invoke(Box { value: 4 }, 2)
+
+fn use_alt() -> i32
+  Service { base: 1 }.invoke(Alt { value: 5 }, 3)
+`,
+      },
+    });
+
+    expect(optimized.facts.receiverSpecializationRequests.size).toBeGreaterThan(0);
+
+    const { module } = codegenProgram({
+      program: optimized.program,
+      entryModuleId,
+      optimization: optimized.facts,
+      options: {
+        optimize: false,
+        validate: false,
+        runtimeDiagnostics: false,
+      },
+    });
+    const wasmText = module.emitText();
+    expect(wasmText).toMatch(/call \$src__main__invoke_\d+__receiver_/);
+    expect(wasmText).toMatch(/call \$src__main__helper_\d+__receiver_/);
+    expect(wasmText).not.toContain("call $__lookup_method_accessor");
+  });
+
+  it("uses global exact facts when ordinary functions request downstream receiver clones", async () => {
+    const { optimized, entryModuleId } = await buildOptimized({
+      files: {
+        "main.voyd": `
+trait Runner
+  fn run(self, offset: i32) -> i32
+
+obj Box {
+  value: i32
+}
+
+obj Alt {
+  value: i32
+}
+
+impl Runner for Box
+  fn run(self, offset: i32) -> i32
+    self.value + offset
+
+impl Runner for Alt
+  fn run(self, offset: i32) -> i32
+    self.value + offset + 1
+
+fn leaf(runner: Runner, offset: i32) -> i32
+  runner.run(offset)
+
+fn exact_forward(runner: Runner, offset: i32) -> i32
+  leaf(runner, offset)
+
+fn use_box() -> i32
+  exact_forward(Box { value: 4 }, 2)
+
+fn use_alt() -> i32
+  leaf(Alt { value: 5 }, 3)
+
+pub fn main() -> i32
+  use_box() + use_alt()
+`,
+      },
+    });
+
+    const { module } = codegenProgram({
+      program: optimized.program,
+      entryModuleId,
+      optimization: optimized.facts,
+      options: {
+        optimize: false,
+        validate: false,
+        runtimeDiagnostics: false,
+      },
+    });
+    const wasmText = module.emitText();
+    expect(wasmText).toMatch(/call \$src__main__leaf_\d+__receiver_/);
+    expect(wasmText).not.toContain("call $__lookup_method_accessor");
+  });
+
+  it("narrows direct trait switches to known receiver sets from multiple monomorphic call edges", async () => {
+    const { optimized, entryModuleId } = await buildOptimized({
+      files: {
+        "main.voyd": `
+trait Runner
+  fn run(self, offset: i32) -> i32
+
+obj Box {
+  value: i32
+}
+
+obj Alt {
+  value: i32
+}
+
+obj ExtraA {
+  value: i32
+}
+
+obj ExtraB {
+  value: i32
+}
+
+obj ExtraC {
+  value: i32
+}
+
+impl Runner for Box
+  fn run(self, offset: i32) -> i32
+    self.value + offset
+
+impl Runner for Alt
+  fn run(self, offset: i32) -> i32
+    self.value + offset + 1
+
+impl Runner for ExtraA
+  fn run(self, offset: i32) -> i32
+    self.value + offset + 2
+
+impl Runner for ExtraB
+  fn run(self, offset: i32) -> i32
+    self.value + offset + 3
+
+impl Runner for ExtraC
+  fn run(self, offset: i32) -> i32
+    self.value + offset + 4
+
+fn helper(runner: Runner, offset: i32) -> i32
+  runner.run(offset)
+
+fn invoke(runner: Runner, offset: i32) -> i32
+  helper(runner, offset)
+
+fn use_box() -> i32
+  invoke(Box { value: 4 }, 2)
+
+fn use_alt() -> i32
+  invoke(Alt { value: 5 }, 3)
+
+pub fn main() -> i32
+  use_box() + use_alt()
+`,
+      },
+    });
+
+    const moduleId = "src::main";
+    const program = optimized.program;
+    const boxType = findObjectNominal({ moduleId, name: "Box", program });
+    const altType = findObjectNominal({ moduleId, name: "Alt", program });
+    expect(typeof boxType).toBe("number");
+    expect(typeof altType).toBe("number");
+    if (typeof boxType !== "number" || typeof altType !== "number") return;
+
+    const invokeFn = findFunction({ moduleId, name: "invoke", program });
+    expect(invokeFn?.kind).toBe("function");
+    if (!invokeFn || invokeFn.kind !== "function") return;
+    const invokeInstanceId = program.functions.getInstanceId(
+      moduleId,
+      invokeFn.symbol,
+      [],
+    );
+    expect(typeof invokeInstanceId).toBe("number");
+    if (typeof invokeInstanceId !== "number") return;
+
+    expect(
+      optimized.facts.exactParameterTypes
+        .get(invokeInstanceId)
+        ?.get(invokeFn.parameters[0]!.symbol),
+    ).toBeUndefined();
+    expect(
+      optimized.facts.knownParameterTypes
+        .get(invokeInstanceId)
+        ?.get(invokeFn.parameters[0]!.symbol),
+    ).toEqual(new Set([boxType, altType]));
+
+    const { module } = codegenProgram({
+      program,
+      entryModuleId,
+      optimization: optimized.facts,
+      options: {
+        optimize: false,
+        validate: true,
+        runtimeDiagnostics: false,
+      },
+    });
+    const wasmText = module.emitText();
+    expect(wasmText).toContain("__receiver_");
+    expect(wasmText).toMatch(/call \$src__main__invoke_\d+__receiver_/);
+    expect(wasmText).toMatch(/call \$src__main__helper_\d+__receiver_/);
+    expect(wasmText).not.toContain("call $__lookup_method_accessor");
+    expect(wasmText).not.toMatch(/\(func \$.*__method_\d+_/);
   });
 
   it("tracks reachable cross-module module lets and prunes unrelated specializations", async () => {
@@ -570,6 +1341,57 @@ pub fn main(): Log -> i32
     expect(discriminant?.exprKind).toBe("call");
   });
 
+  it("uses exact parameter facts to simplify constructor matches", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Box {
+  value: i32
+}
+
+obj Alt {
+  value: i32
+}
+
+type Runner = Box | Alt
+
+fn classify(runner: Runner) -> i32
+  match(runner)
+    Box: 7
+    else: 8
+
+fn invoke(runner: Runner) -> i32
+  classify(runner)
+
+pub fn main() -> i32
+  invoke(Box { value: 4 })
+`,
+      },
+    });
+
+    const moduleId = "src::main";
+    const program = optimized.program;
+    const classifyFn = findFunction({ moduleId, name: "classify", program });
+    expect(classifyFn?.kind).toBe("function");
+    if (!classifyFn || classifyFn.kind !== "function") return;
+    const moduleView = program.modules.get(moduleId);
+    expect(moduleView).toBeDefined();
+    if (!moduleView) return;
+
+    let sawMatch = false;
+    walkExpression({
+      exprId: classifyFn.body,
+      hir: moduleView.hir,
+      onEnterExpression: (_exprId, expr) => {
+        if (expr.exprKind === "match") {
+          sawMatch = true;
+          return { stop: true };
+        }
+      },
+    });
+    expect(sawMatch).toBe(false);
+  });
+
   it("keeps non-entry test exports reachable in optimized all-module test builds", async () => {
     const { optimized, entryModuleId, tests } = await buildOptimized({
       files: {
@@ -681,7 +1503,7 @@ pub fn main() -> i32
       files: {
         "main.voyd": `
 trait Runner
-  fn run(self) -> i32
+  fn run(self, offset: i32) -> i32
 
 obj Box {
   value: i32
@@ -692,18 +1514,31 @@ obj Alt {
 }
 
 impl Runner for Box
-  fn run(self) -> i32
-    self.value
+  fn run(self, offset: i32) -> i32
+    self.value + offset
 
 impl Runner for Alt
-  fn run(self) -> i32
-    self.value + 1
+  fn run(self, offset: i32) -> i32
+    self.value + offset + 1
 
-fn invoke(runner: Runner) -> i32
-  runner.run()
+fn box_runner(value: i32) -> Runner
+  Box { value }
+
+fn alt_runner(value: i32) -> Runner
+  Alt { value }
+
+fn choose(flag: bool) -> Runner
+  if
+    flag:
+      box_runner(4)
+    else:
+      alt_runner(5)
+
+fn invoke(runner: Runner, offset: i32) -> i32
+  runner.run(offset)
 
 pub fn main() -> i32
-  invoke(Box { value: 4 })
+  invoke(choose(true), 2)
 `,
       },
     });

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/effects-call-convention.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/effects-call-convention.voyd
@@ -5,7 +5,15 @@ obj Worker {
   value: i32,
 }
 
+obj Assistant {
+  value: i32,
+}
+
 impl Runner for Worker
+  fn run(self) -> i32
+    effectful_value()
+
+impl Runner for Assistant
   fn run(self) -> i32
     effectful_value()
 

--- a/packages/compiler/src/codegen/__tests__/effects-call-convention-lowering.test.ts
+++ b/packages/compiler/src/codegen/__tests__/effects-call-convention-lowering.test.ts
@@ -81,6 +81,14 @@ const loadModuleText = (): string => {
   return module.emitText();
 };
 
+const emittedFunction = (text: string, name: string): string => {
+  const match = text.match(
+    new RegExp(`\\(func \\$[^\\s)]*${name}[^\\n]*[\\s\\S]*?\\n \\)`, "m")
+  );
+  expect(match, name).not.toBeNull();
+  return match?.[0] ?? "";
+};
+
 describe("effectful call convention lowering", () => {
   it("widens effectful functions with handler params and $Outcome results", () => {
     const text = loadModuleText();
@@ -97,18 +105,19 @@ describe("effectful call convention lowering", () => {
     expect(text).toMatch(
       /\(func \$[^\s)]*call_direct[\s\S]*call \$[^\s)]*effectful_value[^\)]*\(ref\.null none\)/
     );
-    expect(text).toMatch(
-      /\(func \$[^\s)]*call_closure[\s\S]*call_ref[^\)]*ref\.null none/
-    );
+    const callClosure = emittedFunction(text, "call_closure");
+    expect(callClosure).toMatch(/call_ref[\s\S]*\(ref\.null none\)/);
   });
 
-  it("threads handler locals through effectful and trait-dispatched calls", () => {
+  it("threads handler locals through effectful and direct trait-dispatched calls", () => {
     const text = loadModuleText();
     expect(text).toMatch(
       /\(func \$[^\s)]*effectful_forward[\s\S]*\(param(?: \$\d+)? \(ref null \$voydHandlerFrame\)\)[\s\S]*call \$[^\s)]*effectful_value[^\)]*\(local\.get \$0\)/
     );
-    expect(text).toMatch(
-      /\(func \$[^\s)]*call_trait[\s\S]*call_ref[^\)]*ref\.null none/
-    );
+    const callTrait = emittedFunction(text, "call_trait");
+    expect(callTrait).toContain("call $__has_type");
+    expect(callTrait).toMatch(/call \$[^\s)]*run_[\s\S]*\(ref\.null none\)/);
+    expect(callTrait).not.toContain("__method_");
+    expect(callTrait).not.toContain("call $__lookup_method_accessor");
   });
 });

--- a/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
+++ b/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
@@ -81,6 +81,9 @@ const compileEffectFixtureWithCompilerOptimization = async (
       reachableFunctionSymbols: undefined as never,
       reachableModuleLets: new Map(),
       usedTraitDispatchSignatures: usedTraitDispatchSignaturesFor(program),
+      receiverSpecializationRequests: new Map(),
+      exactParameterTypes: new Map(),
+      knownParameterTypes: new Map(),
       codegenPlan: { representations: {} },
     },
   });
@@ -300,7 +303,7 @@ describe("effect perform lowering", { timeout: 60_000 }, () => {
     expect(text).toMatch(/loop_sum_\d+__handled/);
     expect(text).toMatch(/match_value_\d+__handled/);
     expect(text).toMatch(/open_sum_\d+__handled/);
-    expect(text).toMatch(/local_then_dynamic_\d+__handled/);
+    expect(text).toMatch(/local_then_dynamic_\d+(?:__receiver_[^\s)]*)?__handled/);
 
     const host = await createVoydHost({ wasm: specialized.wasm });
     await expect(host.run<number>("triple_sum")).resolves.toBe(6);

--- a/packages/compiler/src/codegen/context.ts
+++ b/packages/compiler/src/codegen/context.ts
@@ -94,6 +94,7 @@ export interface FunctionMetadata {
   paramTypeIds: readonly TypeId[];
   parameters: readonly {
     typeId: TypeId;
+    symbol?: SymbolId;
     label?: string;
     optional?: boolean;
     name?: string;
@@ -108,6 +109,7 @@ export interface FunctionMetadata {
   instanceId: ProgramFunctionInstanceId;
   effectful: boolean;
   effectRow?: EffectRowId;
+  exactParameterTypes?: ReadonlyMap<SymbolId, TypeId>;
 }
 
 export interface StaticEffectHandlerCapture {
@@ -348,6 +350,7 @@ export interface FunctionContext {
   continuations?: Map<SymbolId, ContinuationBinding>;
   suppressTailResumptionExitChecks?: boolean;
   staticEffectContext?: StaticEffectHandlerContext;
+  exactParameterTypes?: ReadonlyMap<SymbolId, TypeId>;
   continuation?: {
     cfg: GroupContinuationCfg;
     startedLocal: LocalBindingLocal;

--- a/packages/compiler/src/codegen/effects/static-specialization.ts
+++ b/packages/compiler/src/codegen/effects/static-specialization.ts
@@ -277,7 +277,7 @@ export const getOrCreateStaticEffectSpecialization = ({
   }
 
   const state = stateOf(ctx);
-  const key = `${meta.moduleId}:${meta.instanceId}:${context.key}`;
+  const key = `${meta.moduleId}:${meta.instanceId}:${meta.wasmName}:${context.key}`;
   const existing = state.byKey.get(key);
   if (existing) {
     return existing.meta;

--- a/packages/compiler/src/codegen/expressions/call/entrypoints.ts
+++ b/packages/compiler/src/codegen/expressions/call/entrypoints.ts
@@ -4,6 +4,7 @@ import type {
   CompileCallOptions,
   ExpressionCompiler,
   FunctionContext,
+  FunctionMetadata,
   HirCallExpr,
   HirExpression,
   HirMethodCallExpr,
@@ -12,6 +13,7 @@ import type {
 import type {
   ProgramFunctionInstanceId,
   ProgramSymbolId,
+  SymbolId,
 } from "../../../semantics/ids.js";
 import { compileIntrinsicCall } from "../../intrinsics.js";
 import { effectsFacade } from "../../effects/facade.js";
@@ -22,6 +24,7 @@ import { getFunctionMetadataForCall } from "./metadata.js";
 import { emitResolvedCall } from "./resolved-call.js";
 import { compileTraitDispatchCall } from "./trait-dispatch.js";
 import { compileCallArgExpressionsWithTemps } from "./shared.js";
+import { getOrCreateReceiverSpecialization } from "../../receiver-specialization.js";
 
 export const compileCallExpr = (
   expr: HirCallExpr,
@@ -188,15 +191,21 @@ export const compileCallExpr = (
       typeInstanceId,
     });
     if (meta) {
+      const resolvedMeta = receiverSpecializedMetaForCall({
+        expr,
+        meta,
+        ctx,
+        fnCtx,
+      });
       const args = compileCallArguments({
         call: expr,
-        meta,
+        meta: resolvedMeta,
         ctx,
         fnCtx,
         compileExpr,
       });
       return emitResolvedCall({
-        meta,
+        meta: resolvedMeta,
         args,
         callId: expr.id,
         ctx,
@@ -296,16 +305,22 @@ export const compileMethodCallExpr = (
   if (!meta) {
     throw new Error(`codegen cannot call symbol ${targetRef.moduleId}::${targetRef.symbol}`);
   }
+  const resolvedMeta = receiverSpecializedMetaForCall({
+    expr: callView,
+    meta,
+    ctx,
+    fnCtx,
+  });
 
   const args = compileCallArguments({
     call: callView,
-    meta,
+    meta: resolvedMeta,
     ctx,
     fnCtx,
     compileExpr,
   });
   return emitResolvedCall({
-    meta,
+    meta: resolvedMeta,
     args,
     callId: expr.id,
     ctx,
@@ -329,6 +344,65 @@ const toMethodCallView = (expr: HirMethodCallExpr): HirCallExpr => ({
   args: [{ expr: expr.target }, ...expr.args],
   typeArguments: expr.typeArguments,
 });
+
+const receiverSpecializationCallSiteKey = ({
+  moduleId,
+  exprId,
+}: {
+  moduleId: string;
+  exprId: number;
+}): string => `${moduleId}:${exprId}`;
+
+const receiverSpecializationContextKey = ({
+  instanceId,
+  exactParameterTypes,
+}: {
+  instanceId: ProgramFunctionInstanceId;
+  exactParameterTypes: ReadonlyMap<SymbolId, TypeId> | undefined;
+}): string => {
+  const serializedFacts = Array.from(exactParameterTypes?.entries() ?? [])
+    .sort(([left], [right]) => left - right)
+    .map(([symbol, type]) => `${symbol}=${type}`)
+    .join(",");
+  return `${instanceId}:${serializedFacts}`;
+};
+
+const receiverSpecializedMetaForCall = ({
+  expr,
+  meta,
+  ctx,
+  fnCtx,
+}: {
+  expr: HirCallExpr;
+  meta: FunctionMetadata;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): FunctionMetadata => {
+  if (!ctx.optimization || typeof fnCtx.instanceId !== "number") {
+    return meta;
+  }
+
+  const callSiteKey = receiverSpecializationCallSiteKey({
+    moduleId: ctx.moduleId,
+    exprId: expr.id,
+  });
+  const callerContextKey = receiverSpecializationContextKey({
+    instanceId: fnCtx.instanceId,
+    exactParameterTypes: fnCtx.exactParameterTypes,
+  });
+  const exactParameterTypes = ctx.optimization.receiverSpecializationRequests
+    .get(callSiteKey)
+    ?.get(callerContextKey);
+  if (!exactParameterTypes || exactParameterTypes.size === 0) {
+    return meta;
+  }
+
+  return getOrCreateReceiverSpecialization({
+    ctx,
+    meta,
+    exactParameterTypes,
+  }) ?? meta;
+};
 
 const compileResolvedSymbolCall = ({
   expr,
@@ -421,16 +495,22 @@ const compileResolvedSymbolCall = ({
   if (!targetMeta) {
     throw new Error(`codegen cannot call symbol ${moduleId}::${symbol}`);
   }
+  const resolvedMeta = receiverSpecializedMetaForCall({
+    expr,
+    meta: targetMeta,
+    ctx,
+    fnCtx,
+  });
 
   const args = compileCallArguments({
     call: expr,
-    meta: targetMeta,
+    meta: resolvedMeta,
     ctx,
     fnCtx,
     compileExpr,
   });
   return emitResolvedCall({
-    meta: targetMeta,
+    meta: resolvedMeta,
     args,
     callId: expr.id,
     ctx,

--- a/packages/compiler/src/codegen/expressions/call/trait-dispatch.ts
+++ b/packages/compiler/src/codegen/expressions/call/trait-dispatch.ts
@@ -54,6 +54,7 @@ import {
   boxSignatureSpillValue,
   unboxSignatureSpillValue,
 } from "../../signature-spill.js";
+import { wrapValueInOutcome } from "../../effects/outcome-values.js";
 
 const MAX_DIRECT_TRAIT_SWITCH_IMPLS = 4;
 
@@ -135,6 +136,8 @@ const flattenTraitDispatchArgument = ({
 
 type DirectTraitDispatchCandidate = {
   meta: FunctionMetadata;
+  implName: string;
+  receiverType: binaryen.Type;
   runtimeTypeId: number;
   wrapperName: string;
 };
@@ -162,7 +165,7 @@ const resolveDirectTraitDispatchCandidate = ({
   }
 
   const structInfo = getStructuralTypeInfo(impl.target, ctx);
-  if (!structInfo) {
+  if (!structInfo || structInfo.layoutKind !== "heap-object") {
     return undefined;
   }
 
@@ -196,15 +199,113 @@ const resolveDirectTraitDispatchCandidate = ({
     runtimeType: ctx.rtt.baseType,
     ctx,
   });
-  if (!meta || meta.effectful) {
+  if (!meta) {
+    return undefined;
+  }
+  const receiverType = meta.paramTypes[meta.firstUserParamIndex];
+  if (typeof receiverType !== "number") {
     return undefined;
   }
 
   return {
     meta,
+    implName: meta.wasmName,
+    receiverType,
     runtimeTypeId: structInfo.runtimeTypeId,
     wrapperName: `${structInfo.typeLabel}__method_${mapping.traitSymbol}_${mapping.traitMethodSymbol}_${method.implMethod}`,
   };
+};
+
+const exactNominalTypeId = ({
+  typeId,
+  ctx,
+}: {
+  typeId: TypeId | undefined;
+  ctx: CodegenContext;
+}): TypeId | undefined => {
+  if (typeof typeId !== "number") {
+    return undefined;
+  }
+  const desc = ctx.program.types.getTypeDesc(typeId);
+  if (desc.kind === "nominal-object" || desc.kind === "value-object") {
+    return typeId;
+  }
+  if (desc.kind === "intersection" && typeof desc.nominal === "number") {
+    return desc.nominal;
+  }
+  return undefined;
+};
+
+const knownReceiverTypesForDirectSwitch = ({
+  expr,
+  ctx,
+  fnCtx,
+}: {
+  expr: HirCallExpr;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): ReadonlySet<TypeId> | undefined => {
+  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+  const receiverExprId = expr.args[0]?.expr;
+  if (typeof receiverExprId !== "number") {
+    return undefined;
+  }
+  const exact = exactNominalTypeId({
+    typeId: getRequiredExprType(receiverExprId, ctx, typeInstanceId),
+    ctx,
+  });
+  if (typeof exact === "number") {
+    return new Set([exact]);
+  }
+  if (!ctx.optimization || typeof fnCtx.instanceId !== "number") {
+    return undefined;
+  }
+  const receiverExpr = ctx.module.hir.expressions.get(receiverExprId);
+  if (receiverExpr?.exprKind !== "identifier") {
+    return undefined;
+  }
+  const specializedExact = fnCtx.exactParameterTypes?.get(receiverExpr.symbol);
+  if (typeof specializedExact === "number") {
+    return new Set([specializedExact]);
+  }
+  return ctx.optimization.knownParameterTypes
+    .get(fnCtx.instanceId)
+    ?.get(receiverExpr.symbol);
+};
+
+const directSwitchImpls = ({
+  expr,
+  mapping,
+  ctx,
+  fnCtx,
+}: {
+  expr: HirCallExpr;
+  mapping: NonNullable<ReturnType<CodegenContext["program"]["traits"]["getTraitMethodImpl"]>>;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): readonly CodegenTraitImplInstance[] => {
+  const knownReceiverTypes = knownReceiverTypesForDirectSwitch({
+    expr,
+    ctx,
+    fnCtx,
+  });
+  if (!knownReceiverTypes) {
+    return ctx.program.traits.getImplsByTrait(mapping.traitSymbol);
+  }
+
+  const seen = new Set<ProgramSymbolId>();
+  return Array.from(knownReceiverTypes).flatMap((receiverType) =>
+    ctx.program.traits
+      .getImplsByNominal(receiverType)
+      .filter((impl) => impl.traitSymbol === mapping.traitSymbol)
+      .filter((impl) => {
+        if (seen.has(impl.implSymbol)) {
+          return false;
+        }
+        seen.add(impl.implSymbol);
+        return true;
+      }),
+  );
 };
 
 const compileDirectTraitDispatchSwitch = ({
@@ -215,6 +316,8 @@ const compileDirectTraitDispatchSwitch = ({
   ctx,
   fnCtx,
   compileExpr,
+  tailPosition,
+  expectedResultTypeId,
 }: {
   expr: HirCallExpr;
   meta: FunctionMetadata;
@@ -223,22 +326,30 @@ const compileDirectTraitDispatchSwitch = ({
   ctx: CodegenContext;
   fnCtx: FunctionContext;
   compileExpr: ExpressionCompiler;
+  tailPosition: boolean;
+  expectedResultTypeId?: TypeId;
 }): CompiledExpression | undefined => {
-  if (meta.effectful || resolvedModuleId !== ctx.moduleId) {
+  if (resolvedModuleId !== ctx.moduleId) {
     return undefined;
   }
 
-  if (
+  const dispatchEffectful =
+    meta.effectful ||
     isTraitDispatchMethodEffectful({
       traitSymbol: mapping.traitSymbol,
       traitMethodSymbol: mapping.traitMethodSymbol,
       ctx,
-    })
-  ) {
+    });
+  if (meta.resultAbiKind === "out_ref") {
     return undefined;
   }
 
-  const impls = ctx.program.traits.getImplsByTrait(mapping.traitSymbol);
+  const impls = directSwitchImpls({
+    expr,
+    mapping,
+    ctx,
+    fnCtx,
+  });
   if (impls.length === 0 || impls.length > MAX_DIRECT_TRAIT_SWITCH_IMPLS) {
     return undefined;
   }
@@ -255,28 +366,37 @@ const compileDirectTraitDispatchSwitch = ({
   if (candidates.length === 0) {
     return undefined;
   }
+  if (candidates.some((candidate) => candidate.meta.resultAbiKind === "out_ref")) {
+    return undefined;
+  }
+  if (dispatchEffectful && !exhaustive) {
+    return undefined;
+  }
 
   const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
   const returnTypeId = getRequiredExprType(expr.id, ctx, typeInstanceId);
   const resultWasmType = getExprBinaryenType(expr.id, ctx, typeInstanceId);
   if (
-    ctx.program.types.getTypeDesc(returnTypeId).kind !== "primitive" ||
-    binaryen.expandType(resultWasmType).length !== 1
+    !dispatchEffectful &&
+    (ctx.program.types.getTypeDesc(returnTypeId).kind !== "primitive" ||
+      binaryen.expandType(resultWasmType).length !== 1)
   ) {
     return undefined;
   }
 
-  const baselineUserParamTypes = meta.paramTypes.slice(meta.firstUserParamIndex + 1);
-  if (baselineUserParamTypes.length !== 0) {
+  const baselineUserParamAbiTypes = meta.paramAbiTypes.slice(1);
+  if (baselineUserParamAbiTypes.some((types) => types.length !== 1)) {
     return undefined;
   }
+  const baselineUserParamTypes = baselineUserParamAbiTypes.map((types) => types[0]!);
   const consistentUserParams = candidates.every((candidate) => {
-    const candidateUserParamTypes = candidate.meta.paramTypes.slice(
-      candidate.meta.firstUserParamIndex + 1,
-    );
+    const candidateUserParamAbiTypes = candidate.meta.paramAbiTypes.slice(1);
     return (
-      candidateUserParamTypes.length === baselineUserParamTypes.length &&
-      candidateUserParamTypes.every((type, index) => type === baselineUserParamTypes[index])
+      candidateUserParamAbiTypes.length === baselineUserParamAbiTypes.length &&
+      candidateUserParamAbiTypes.every(
+        (types, index) =>
+          types.length === 1 && types[0] === baselineUserParamTypes[index],
+      )
     );
   });
   if (!consistentUserParams) {
@@ -333,14 +453,30 @@ const compileDirectTraitDispatchSwitch = ({
   const emitCandidateCall = (
     candidate: DirectTraitDispatchCandidate,
   ): binaryen.ExpressionRef => {
+    const implResultType =
+      dispatchEffectful && candidate.meta.effectful
+        ? ctx.effectsBackend.abi.effectfulResultType(ctx)
+        : candidate.meta.resultType;
     const rawCall = ctx.mod.call(
-      candidate.wrapperName,
+      candidate.implName,
       [
-        makeReceiver(),
+        ...(candidate.meta.effectful ? [currentHandlerValue(ctx, fnCtx)] : []),
+        refCast(ctx.mod, makeReceiver(), candidate.receiverType),
         ...userArgTemps.map((temp) => ctx.mod.local.get(temp.index, temp.type)),
       ],
-      candidate.meta.resultType,
+      implResultType,
     );
+    if (dispatchEffectful) {
+      return candidate.meta.effectful
+        ? rawCall
+        : wrapValueInOutcome({
+            valueExpr: rawCall,
+            valueType: candidate.meta.resultType,
+            typeId: candidate.meta.resultTypeId,
+            ctx,
+            fnCtx,
+          });
+    }
     const coerced =
       candidate.meta.resultTypeId === returnTypeId
         ? rawCall
@@ -358,21 +494,21 @@ const compileDirectTraitDispatchSwitch = ({
     });
   };
 
-  const fallback = compileIndirectTraitDispatchCall({
-    expr,
-    meta,
-    mapping,
-    receiverTemp,
-    userArgTemps,
-    ctx,
-    fnCtx,
-    compileExpr,
-  });
-
   const fallbackExpr =
     exhaustive && candidates.length > 0
       ? emitCandidateCall(candidates[candidates.length - 1]!)
-      : fallback.expr;
+      : compileIndirectTraitDispatchCall({
+          expr,
+          meta,
+          mapping,
+          receiverTemp,
+          userArgTemps,
+          ctx,
+          fnCtx,
+          compileExpr,
+          tailPosition,
+          expectedResultTypeId,
+        }).expr;
   const branchCandidates =
     exhaustive && candidates.length > 0 ? candidates.slice(0, -1) : candidates;
   const switchedExpr = branchCandidates.reduceRight(
@@ -388,19 +524,35 @@ const compileDirectTraitDispatchSwitch = ({
       ),
     fallbackExpr,
   );
+  const switchedBlock = ctx.mod.block(
+    null,
+    [
+      ctx.mod.local.set(receiverTemp.index, receiverValue.expr),
+      ...userArgTemps.map((temp, index) =>
+        ctx.mod.local.set(temp.index, userArgValues[index]!),
+      ),
+      switchedExpr,
+    ],
+    dispatchEffectful
+      ? ctx.effectsBackend.abi.effectfulResultType(ctx)
+      : resultWasmType,
+  );
+
+  if (dispatchEffectful) {
+    return ctx.effectsBackend.lowerEffectfulCallResult({
+      callExpr: switchedBlock,
+      callId: expr.id,
+      returnTypeId,
+      expectedResultTypeId,
+      tailPosition,
+      typeInstanceId,
+      ctx,
+      fnCtx,
+    });
+  }
 
   return {
-    expr: ctx.mod.block(
-      null,
-      [
-        ctx.mod.local.set(receiverTemp.index, receiverValue.expr),
-        ...userArgTemps.map((temp, index) =>
-          ctx.mod.local.set(temp.index, userArgValues[index]!),
-        ),
-        switchedExpr,
-      ],
-      resultWasmType,
-    ),
+    expr: switchedBlock,
     usedReturnCall: false,
   };
 };
@@ -471,6 +623,8 @@ export const compileTraitDispatchCall = ({
     ctx,
     fnCtx,
     compileExpr,
+    tailPosition,
+    expectedResultTypeId,
   });
   if (directDispatch) {
     return directDispatch;

--- a/packages/compiler/src/codegen/functions.ts
+++ b/packages/compiler/src/codegen/functions.ts
@@ -74,6 +74,11 @@ import {
   takePendingStaticEffectSpecializations,
   type StaticEffectSpecialization,
 } from "./effects/static-specialization.js";
+import {
+  markReceiverSpecializationCompiled,
+  takePendingReceiverSpecializations,
+  type ReceiverSpecialization,
+} from "./receiver-specialization.js";
 
 const REACHABILITY_STATE = Symbol.for("voyd.codegen.reachabilityState");
 const FUNCTION_METADATA_REGISTRATION_STATE = Symbol.for(
@@ -1009,6 +1014,7 @@ export const registerFunctionMetadata = (ctx: CodegenContext): void => {
           paramTypeIds: descriptor.parameters.map((param) => param.type),
           parameters: descriptor.parameters.map((param, index) => ({
             typeId: param.type,
+            symbol: item.parameters[index]?.symbol,
             label: param.label,
             optional: param.optional,
             name:
@@ -1128,6 +1134,7 @@ export const compileFunctions = ({
     });
   }
   compiledCount += compilePendingStaticEffectSpecializations(ctx);
+  compiledCount += compilePendingReceiverSpecializations(ctx);
   return compiledCount;
 };
 
@@ -1260,6 +1267,7 @@ export const registerImportMetadata = (ctx: CodegenContext): void => {
         ),
         parameters: instantiatedTypeDesc.parameters.map((param, index) => ({
           typeId: param.type,
+          symbol: signature.parameters[index]?.symbol,
           label: param.label,
           optional: param.optional,
           name: signature.parameters[index]?.name,
@@ -1643,6 +1651,7 @@ const compileFunctionItem = (
       typeInstanceId: meta.instanceId,
       effectful: true,
       currentHandler: { index: 0, type: handlerParamType },
+      exactParameterTypes: ctx.optimization?.exactParameterTypes.get(meta.instanceId),
     };
     if (meta.resultAbiKind === "out_ref") {
       implCtx.returnOutPointer = createStorageRefBinding({
@@ -1774,6 +1783,7 @@ const compileFunctionItem = (
     instanceId: meta.instanceId,
     typeInstanceId: meta.instanceId,
     effectful: meta.effectful,
+    exactParameterTypes: ctx.optimization?.exactParameterTypes.get(meta.instanceId),
   };
   if (meta.effectful) {
     fnCtx.currentHandler = {
@@ -1915,6 +1925,7 @@ const compileStaticEffectSpecialization = (
     typeInstanceId: meta.instanceId,
     effectful: meta.effectful,
     staticEffectContext: context,
+    exactParameterTypes: meta.exactParameterTypes,
   };
   if (meta.effectful) {
     fnCtx.currentHandler = {
@@ -2028,6 +2039,311 @@ const compilePendingStaticEffectSpecializations = (
   const pending = takePendingStaticEffectSpecializations(ctx);
   pending.forEach((specialization) =>
     compileStaticEffectSpecialization(specialization, ctx)
+  );
+  return pending.length;
+};
+
+const compileReceiverSpecialization = (
+  specialization: ReceiverSpecialization,
+  ctx: CodegenContext,
+): void => {
+  const { item: fn, meta, exactParameterTypes } = specialization;
+  if (ctx.mod.getFunction(meta.wasmName) !== 0) {
+    markReceiverSpecializationCompiled({ ctx, wasmName: meta.wasmName });
+    return;
+  }
+
+  const effectInfo = effectsFacade(ctx).functionAbi(fn.symbol);
+  if (!effectInfo) {
+    throw new Error(
+      `codegen missing effect information for receiver specialization ${fn.symbol}`,
+    );
+  }
+  const needsWrapper =
+    effectInfo.abiEffectful && effectInfo.typeEffectful === false;
+  const handlerParamType = ctx.effectsBackend.abi.hiddenHandlerParamType(ctx);
+  if (needsWrapper) {
+    const implSignature = ctx.effectsBackend.abi.widenSignature({
+      ctx,
+      effectful: true,
+      userParamTypes: meta.paramTypes,
+      userResultType: meta.resultType,
+    });
+    const implName = `${meta.wasmName}__effectful_impl`;
+    const implCtx: FunctionContext = {
+      bindings: new Map(),
+      tempLocals: new Map(),
+      locals: [],
+      nextLocalIndex: implSignature.paramTypes.length,
+      returnTypeId: meta.resultTypeId,
+      returnWasmType: ctx.effectsBackend.abi.effectfulResultType(ctx),
+      returnAbiKind: meta.resultAbiKind,
+      instanceId: meta.instanceId,
+      typeInstanceId: meta.instanceId,
+      effectful: true,
+      currentHandler: { index: 0, type: handlerParamType },
+      exactParameterTypes,
+    };
+    if (meta.resultAbiKind === "out_ref") {
+      implCtx.returnOutPointer = createStorageRefBinding({
+        index: implSignature.userParamOffset,
+        typeId: meta.resultTypeId,
+        mutable: true,
+        ctx,
+      });
+    }
+
+    const paramInitOps = bindRawFunctionParameters({
+      fn,
+      meta,
+      ctx,
+      fnCtx: implCtx,
+      handlerOffset:
+        implSignature.userParamOffset + (meta.outParamType ? 1 : 0),
+    });
+    const defaultInitOps = compileDefaultParameterInitialization({
+      fn,
+      meta,
+      ctx,
+      fnCtx: implCtx,
+    });
+    const implBody = compileExpression({
+      exprId: fn.body,
+      ctx,
+      fnCtx: implCtx,
+      tailPosition: false,
+      expectedResultTypeId: implCtx.returnTypeId,
+      outResultStorageRef:
+        meta.resultAbiKind === "out_ref" && implCtx.returnOutPointer
+          ? ctx.mod.local.get(
+              implCtx.returnOutPointer.index,
+              implCtx.returnOutPointer.storageType,
+            )
+          : undefined,
+    });
+    const implBodyExpr =
+      defaultInitOps.length > 0
+        ? ctx.mod.block(
+            null,
+            [...paramInitOps, ...defaultInitOps, implBody.expr],
+            binaryen.getExpressionType(implBody.expr),
+          )
+        : paramInitOps.length > 0
+          ? ctx.mod.block(
+              null,
+              [...paramInitOps, implBody.expr],
+              binaryen.getExpressionType(implBody.expr),
+            )
+          : implBody.expr;
+    const implFunctionBody =
+      meta.resultAbiKind === "out_ref" && implCtx.returnOutPointer
+        ? (binaryen.getExpressionType(implBodyExpr) === binaryen.none ||
+            binaryen.getExpressionType(implBodyExpr) === binaryen.unreachable
+            ? implBodyExpr
+            : ctx.mod.block(
+                null,
+                [
+                  storeValueIntoStorageRef({
+                    pointer: () =>
+                      ctx.mod.local.get(
+                        implCtx.returnOutPointer!.index,
+                        implCtx.returnOutPointer!.storageType,
+                      ),
+                    value: implBodyExpr,
+                    typeId: meta.resultTypeId,
+                    ctx,
+                    fnCtx: implCtx,
+                  }),
+                ],
+                binaryen.none,
+              ))
+        : implBodyExpr;
+    const wrappedValueType =
+      meta.resultAbiKind === "out_ref"
+        ? binaryen.none
+        : wasmTypeFor(meta.resultTypeId, ctx);
+    const implExprType = binaryen.getExpressionType(implFunctionBody);
+    const functionBody = !isOutcomeCarrierType({
+      wasmType: implExprType,
+      ctx,
+    })
+      ? wrapValueInOutcome({
+          valueExpr: implFunctionBody,
+          valueType: wrappedValueType,
+          typeId: meta.resultTypeId,
+          ctx,
+          fnCtx: implCtx,
+        })
+      : implFunctionBody;
+
+    ctx.mod.addFunction(
+      implName,
+      binaryen.createType(implSignature.paramTypes as number[]),
+      ctx.effectsBackend.abi.effectfulResultType(ctx),
+      implCtx.locals,
+      functionBody,
+    );
+
+    emitPureSurfaceWrapper({
+      ctx,
+      wrapperName: meta.wasmName,
+      wrapperParamTypes: meta.paramTypes as number[],
+      wrapperResultType: meta.resultType,
+      wrapperResultTypeId: meta.resultTypeId,
+      wrapperStoresResultByRef: meta.resultAbiKind === "out_ref",
+      implName,
+      buildImplCallArgs: () => [
+        ctx.effectsBackend.abi.hiddenHandlerValue(ctx),
+        ...meta.paramTypes.map((type, index) =>
+          ctx.mod.local.get(index, type as number),
+        ),
+      ],
+    });
+    markReceiverSpecializationCompiled({ ctx, wasmName: meta.wasmName });
+    return;
+  }
+
+  const fnCtx: FunctionContext = {
+    bindings: new Map(),
+    tempLocals: new Map(),
+    locals: [],
+    nextLocalIndex: meta.paramTypes.length,
+    returnTypeId: meta.resultTypeId,
+    returnWasmType: meta.resultType,
+    returnAbiKind: meta.resultAbiKind,
+    instanceId: meta.instanceId,
+    typeInstanceId: meta.instanceId,
+    effectful: meta.effectful,
+    exactParameterTypes,
+  };
+  if (meta.effectful) {
+    fnCtx.currentHandler = {
+      index: 0,
+      type: ctx.effectsBackend.abi.hiddenHandlerParamType(ctx),
+    };
+  }
+  if (meta.resultAbiKind === "out_ref") {
+    fnCtx.returnOutPointer = createStorageRefBinding({
+      index: userParamOffsetFor(meta),
+      typeId: meta.resultTypeId,
+      mutable: true,
+      ctx,
+    });
+  }
+
+  const paramInitOps = bindRawFunctionParameters({
+    fn,
+    meta,
+    ctx,
+    fnCtx,
+    handlerOffset: firstUserParamIndexFor(meta),
+  });
+  const defaultInitOps = compileDefaultParameterInitialization({
+    fn,
+    meta,
+    ctx,
+    fnCtx,
+  });
+  const body = compileExpression({
+    exprId: fn.body,
+    ctx,
+    fnCtx,
+    tailPosition: !meta.effectful,
+    expectedResultTypeId: fnCtx.returnTypeId,
+    outResultStorageRef:
+      meta.resultAbiKind === "out_ref" && fnCtx.returnOutPointer
+        ? ctx.mod.local.get(
+            fnCtx.returnOutPointer.index,
+            fnCtx.returnOutPointer.storageType,
+          )
+        : undefined,
+  });
+  const bodyExpr =
+    defaultInitOps.length > 0
+      ? ctx.mod.block(
+          null,
+          [...paramInitOps, ...defaultInitOps, body.expr],
+          binaryen.getExpressionType(body.expr),
+        )
+      : paramInitOps.length > 0
+        ? ctx.mod.block(
+            null,
+            [...paramInitOps, body.expr],
+            binaryen.getExpressionType(body.expr),
+          )
+        : body.expr;
+  const functionBodyBeforeWrap =
+    meta.resultAbiKind === "out_ref" && fnCtx.returnOutPointer
+      ? (binaryen.getExpressionType(bodyExpr) === binaryen.none ||
+          binaryen.getExpressionType(bodyExpr) === binaryen.unreachable
+          ? bodyExpr
+          : ctx.mod.block(
+              null,
+              [
+                storeValueIntoStorageRef({
+                  pointer: () =>
+                    ctx.mod.local.get(
+                      fnCtx.returnOutPointer!.index,
+                      fnCtx.returnOutPointer!.storageType,
+                    ),
+                  value: bodyExpr,
+                  typeId: meta.resultTypeId,
+                  ctx,
+                  fnCtx,
+                }),
+              ],
+              binaryen.none,
+            ))
+      : bodyExpr;
+  const bodyExprType = binaryen.getExpressionType(functionBodyBeforeWrap);
+  const wrappedValueType =
+    meta.resultAbiKind === "out_ref"
+      ? binaryen.none
+      : wasmTypeFor(meta.resultTypeId, ctx);
+  const shouldWrapOutcome =
+    meta.effectful &&
+    !isOutcomeCarrierType({
+      wasmType: bodyExprType,
+      ctx,
+    });
+  const rawFunctionBody = shouldWrapOutcome
+    ? wrapValueInOutcome({
+        valueExpr: functionBodyBeforeWrap,
+        valueType: wrappedValueType,
+        typeId: meta.resultTypeId,
+        ctx,
+        fnCtx,
+      })
+    : functionBodyBeforeWrap;
+  const functionBody =
+    !meta.effectful &&
+    meta.resultTypeId !== ctx.program.primitives.void &&
+    binaryen.getExpressionType(rawFunctionBody) !== binaryen.none &&
+    binaryen.getExpressionType(rawFunctionBody) !== binaryen.unreachable
+      ? boxSignatureSpillValue({
+          value: rawFunctionBody,
+          typeId: meta.resultTypeId,
+          ctx,
+          fnCtx,
+        })
+      : rawFunctionBody;
+
+  ctx.mod.addFunction(
+    meta.wasmName,
+    binaryen.createType(meta.paramTypes as number[]),
+    meta.resultType,
+    fnCtx.locals,
+    functionBody,
+  );
+  markReceiverSpecializationCompiled({ ctx, wasmName: meta.wasmName });
+};
+
+const compilePendingReceiverSpecializations = (
+  ctx: CodegenContext,
+): number => {
+  const pending = takePendingReceiverSpecializations(ctx);
+  pending.forEach((specialization) =>
+    compileReceiverSpecialization(specialization, ctx)
   );
   return pending.length;
 };

--- a/packages/compiler/src/codegen/receiver-specialization.ts
+++ b/packages/compiler/src/codegen/receiver-specialization.ts
@@ -1,0 +1,144 @@
+import type {
+  CodegenContext,
+  FunctionMetadata,
+} from "./context.js";
+import type { HirFunction } from "../semantics/hir/index.js";
+import type { SymbolId, TypeId } from "../semantics/ids.js";
+
+export interface ReceiverSpecialization {
+  base: FunctionMetadata;
+  meta: FunctionMetadata;
+  item: HirFunction;
+  exactParameterTypes: ReadonlyMap<SymbolId, TypeId>;
+}
+
+type ReceiverSpecializationState = {
+  byKey: Map<string, ReceiverSpecialization>;
+  pending: ReceiverSpecialization[];
+  compiled: Set<string>;
+};
+
+const RECEIVER_SPECIALIZATION_STATE = Symbol(
+  "voyd.codegen.receiverSpecializationState",
+);
+
+const MAX_RECEIVER_SPECIALIZATIONS_PER_FUNCTION = 4;
+const MAX_EXACT_PARAMETERS_PER_RECEIVER_SPECIALIZATION = 2;
+
+const stateOf = (ctx: CodegenContext): ReceiverSpecializationState =>
+  ctx.programHelpers.getHelperState<ReceiverSpecializationState>(
+    RECEIVER_SPECIALIZATION_STATE,
+    () => ({
+      byKey: new Map(),
+      pending: [],
+      compiled: new Set(),
+    }),
+  );
+
+const sanitize = (value: string): string =>
+  value.replace(/[^a-zA-Z0-9_]/g, "_");
+
+const functionItemFor = ({
+  ctx,
+  meta,
+}: {
+  ctx: CodegenContext;
+  meta: FunctionMetadata;
+}): HirFunction | undefined => {
+  const targetCtx = ctx.moduleContexts.get(meta.moduleId);
+  const targetModule = targetCtx?.module ?? ctx.program.modules.get(meta.moduleId);
+  return Array.from(targetModule?.hir.items.values() ?? []).find(
+    (item): item is HirFunction =>
+      item.kind === "function" && item.symbol === meta.symbol,
+  );
+};
+
+export const getOrCreateReceiverSpecialization = ({
+  ctx,
+  meta,
+  exactParameterTypes,
+}: {
+  ctx: CodegenContext;
+  meta: FunctionMetadata;
+  exactParameterTypes: ReadonlyMap<SymbolId, TypeId>;
+}): FunctionMetadata | undefined => {
+  if (
+    !ctx.optimization ||
+    exactParameterTypes.size === 0 ||
+    exactParameterTypes.size > MAX_EXACT_PARAMETERS_PER_RECEIVER_SPECIALIZATION
+  ) {
+    return undefined;
+  }
+  const item = functionItemFor({ ctx, meta });
+  if (!item) {
+    return undefined;
+  }
+
+  const combinedFacts = new Map<SymbolId, TypeId>([
+    ...(ctx.optimization?.exactParameterTypes.get(meta.instanceId)?.entries() ?? []),
+    ...(meta.exactParameterTypes?.entries() ?? []),
+    ...exactParameterTypes.entries(),
+  ]);
+  const sortedFacts = Array.from(combinedFacts.entries())
+    .sort(([left], [right]) => left - right);
+  const key = `${meta.moduleId}:${meta.instanceId}:${sortedFacts
+    .map(([symbol, type]) => `${symbol}=${type}`)
+    .join(",")}`;
+  const state = stateOf(ctx);
+  const existing = state.byKey.get(key);
+  if (existing) {
+    return existing.meta;
+  }
+  const existingForFunction = Array.from(state.byKey.values()).filter(
+    (specialization) =>
+      specialization.base.moduleId === meta.moduleId &&
+      specialization.base.instanceId === meta.instanceId,
+  );
+  if (existingForFunction.length >= MAX_RECEIVER_SPECIALIZATIONS_PER_FUNCTION) {
+    return undefined;
+  }
+
+  const specializedMeta: FunctionMetadata = {
+    ...meta,
+    wasmName: `${meta.wasmName}__receiver_${sanitize(
+      sortedFacts.map(([symbol, type]) => `${symbol}_${type}`).join("_"),
+    )}`,
+    exactParameterTypes: new Map(sortedFacts),
+  };
+  const specialization: ReceiverSpecialization = {
+    base: meta,
+    meta: specializedMeta,
+    item,
+    exactParameterTypes: new Map(sortedFacts),
+  };
+  state.byKey.set(key, specialization);
+  state.pending.push(specialization);
+  return specializedMeta;
+};
+
+export const takePendingReceiverSpecializations = (
+  ctx: CodegenContext,
+): ReceiverSpecialization[] => {
+  const state = stateOf(ctx);
+  const pending = state.pending.filter(
+    (specialization) =>
+      specialization.meta.moduleId === ctx.moduleId &&
+      !state.compiled.has(specialization.meta.wasmName),
+  );
+  state.pending = state.pending.filter(
+    (specialization) =>
+      specialization.meta.moduleId !== ctx.moduleId &&
+      !state.compiled.has(specialization.meta.wasmName),
+  );
+  return pending;
+};
+
+export const markReceiverSpecializationCompiled = ({
+  ctx,
+  wasmName,
+}: {
+  ctx: CodegenContext;
+  wasmName: string;
+}): void => {
+  stateOf(ctx).compiled.add(wasmName);
+};

--- a/packages/compiler/src/codegen/structural.ts
+++ b/packages/compiler/src/codegen/structural.ts
@@ -2009,6 +2009,13 @@ export const coerceValueToType = ({
   const actualInfo = getStructuralTypeInfo(actualType, ctx);
   if (!actualInfo) {
     const actualDesc = ctx.program.types.getTypeDesc(actualType);
+    if (actualDesc.kind === "trait") {
+      return coerceExprToWasmType({
+        expr: value,
+        targetType: wasmTypeFor(targetType, ctx),
+        ctx,
+      });
+    }
     const targetDesc = ctx.program.types.getTypeDesc(targetType);
     throw new Error(
       `cannot coerce non-structural value to structural type (actual=${actualType}:${actualDesc.kind}, target=${targetType}:${targetDesc.kind})`,

--- a/packages/compiler/src/optimize/ir.ts
+++ b/packages/compiler/src/optimize/ir.ts
@@ -9,6 +9,7 @@ import type {
   ProgramFunctionInstanceId,
   ProgramSymbolId,
   SymbolId,
+  TypeId,
 } from "../semantics/ids.js";
 import type { SemanticsPipelineResult } from "../semantics/pipeline.js";
 import type { ProgramCodegenOptimizationPlan } from "./codegen-plan.js";
@@ -29,6 +30,18 @@ export type ProgramOptimizationFacts = {
   reachableFunctionSymbols: ReadonlySet<ProgramSymbolId>;
   reachableModuleLets: ReadonlyMap<string, ReadonlySet<SymbolId>>;
   usedTraitDispatchSignatures: ReadonlySet<string>;
+  receiverSpecializationRequests: ReadonlyMap<
+    string,
+    ReadonlyMap<string, ReadonlyMap<SymbolId, TypeId>>
+  >;
+  exactParameterTypes: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, TypeId>
+  >;
+  knownParameterTypes: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, ReadonlySet<TypeId>>
+  >;
   codegenPlan: ProgramCodegenOptimizationPlan;
 };
 

--- a/packages/compiler/src/optimize/pipeline.ts
+++ b/packages/compiler/src/optimize/pipeline.ts
@@ -62,6 +62,18 @@ type MutableOptimizationIr = {
     reachableFunctionSymbols: Set<ProgramSymbolId>;
     reachableModuleLets: Map<string, Set<SymbolId>>;
     usedTraitDispatchSignatures: Set<string>;
+    receiverSpecializationRequests: Map<
+      string,
+      Map<string, Map<SymbolId, TypeId>>
+    >;
+    exactParameterTypes: Map<
+      ProgramFunctionInstanceId,
+      Map<SymbolId, TypeId>
+    >;
+    knownParameterTypes: Map<
+      ProgramFunctionInstanceId,
+      Map<SymbolId, Set<TypeId>>
+    >;
     codegenPlan: ProgramCodegenOptimizationPlan;
   };
 };
@@ -292,6 +304,9 @@ const buildOptimizationIr = ({
       reachableFunctionSymbols: new Set(),
       reachableModuleLets: new Map(),
       usedTraitDispatchSignatures: new Set(),
+      receiverSpecializationRequests: new Map(),
+      exactParameterTypes: new Map(),
+      knownParameterTypes: new Map(),
       codegenPlan: { representations: {} },
     },
   };
@@ -656,6 +671,45 @@ const resolveCallTypeArgs = ({
     return callInfo.typeArgs.get(callerInstanceId) ?? [];
   }
   return callInfo.typeArgs?.size === 1 ? callInfo.typeArgs.values().next().value ?? [] : [];
+};
+
+const resolveCallArgPlan = ({
+  callInfo,
+  callerInstanceId,
+}: {
+  callInfo: OptimizedCallInfo;
+  callerInstanceId?: ProgramFunctionInstanceId;
+}) => {
+  if (
+    typeof callerInstanceId === "number" &&
+    callInfo.argPlans?.has(callerInstanceId)
+  ) {
+    return callInfo.argPlans.get(callerInstanceId);
+  }
+  return callInfo.argPlans?.size === 1
+    ? callInfo.argPlans.values().next().value
+    : undefined;
+};
+
+const callArgumentExprIdForParameter = ({
+  argExprIds,
+  callInfo,
+  callerInstanceId,
+  parameterIndex,
+}: {
+  argExprIds: readonly HirExprId[];
+  callInfo: OptimizedCallInfo | undefined;
+  callerInstanceId: ProgramFunctionInstanceId;
+  parameterIndex: number;
+}): HirExprId | undefined => {
+  const argPlan = callInfo
+    ? resolveCallArgPlan({ callInfo, callerInstanceId })
+    : undefined;
+  if (!argPlan) {
+    return argExprIds[parameterIndex];
+  }
+  const entry = argPlan[parameterIndex];
+  return entry?.kind === "direct" ? argExprIds[entry.argIndex] : undefined;
 };
 
 const isPureHelperCandidate = ({
@@ -1075,65 +1129,141 @@ const constructorKnownSimplificationPass: ProgramOptimizationPass = {
   run(ctx) {
     let changed = false;
 
-    ctx.ir.modules.forEach((moduleView) => {
-      const rootExprIds = collectModuleRootExprIds({ moduleView });
-      rootExprIds.forEach((rootExprId) => {
-        collectPostOrderExprIds({ rootExprId, moduleView }).forEach((exprId) => {
-          const expr = moduleView.hir.expressions.get(exprId);
-          if (!expr || expr.exprKind !== "match") {
-            return;
-          }
+    const exactDiscriminantType = ({
+      moduleView,
+      expr,
+      functionItem,
+    }: {
+      moduleView: OptimizedModuleView;
+      expr: Extract<HirExpression, { exprKind: "match" }>;
+      functionItem?: HirFunction;
+    }): TypeId | undefined => {
+      const staticType = exactNominalForType({
+        typeId: exprTypeFor({ moduleView, exprId: expr.discriminant }),
+        program: ctx.ir.baseProgram,
+      });
+      if (typeof staticType === "number") {
+        return staticType;
+      }
+      if (!functionItem) {
+        return undefined;
+      }
 
-          const discriminantType = exactNominalForType({
-            typeId: exprTypeFor({ moduleView, exprId: expr.discriminant }),
-            program: ctx.ir.baseProgram,
-          });
-          if (typeof discriminantType !== "number") {
-            return;
-          }
-
-          const selectedArm = expr.arms.find((arm) => {
-            if (
-              arm.pattern.kind === "type" &&
-              arm.pattern.binding
-            ) {
-              return false;
-            }
-            if (arm.pattern.kind !== "wildcard" && arm.pattern.kind !== "type") {
-              return false;
-            }
-            if (arm.pattern.kind === "wildcard") {
-              return true;
-            }
-            const patternTypeId =
-              typeof arm.pattern.typeId === "number" ? arm.pattern.typeId : undefined;
-            if (typeof patternTypeId !== "number") {
-              return false;
-            }
-            const nominals = new Set<TypeId>();
-            collectNominals({
-              typeId: patternTypeId,
-              program: ctx.ir.baseProgram,
-              nominals,
-            });
-            return nominals.has(discriminantType);
-          });
-
-          if (!selectedArm) {
-            return;
-          }
-
-          mutableExpressions({ moduleView }).set(
-            exprId,
-            toEvaluatedValueBlockExpr({
-              original: expr,
-              moduleView,
-              exprId: expr.discriminant,
-              value: selectedArm.value,
-            }),
-          );
-          changed = true;
+      const instanceTypes = new Set<TypeId>();
+      for (const instanceId of ctx.ir.facts.reachableFunctionInstances) {
+        const instance = ctx.ir.baseProgram.functions.getInstance(instanceId);
+        if (
+          instance.symbolRef.moduleId !== moduleView.moduleId ||
+          instance.symbolRef.symbol !== functionItem.symbol
+        ) {
+          continue;
+        }
+        const exactType = exactNominalForExpr({
+          moduleView,
+          exprId: expr.discriminant,
+          callerInstanceId: instanceId,
+          program: ctx.ir.baseProgram,
+          exactParameterTypes: ctx.ir.facts.exactParameterTypes,
         });
+        if (typeof exactType !== "number") {
+          return undefined;
+        }
+        instanceTypes.add(exactType);
+        if (instanceTypes.size > 1) {
+          return undefined;
+        }
+      }
+
+      return instanceTypes.size === 1
+        ? instanceTypes.values().next().value
+        : undefined;
+    };
+
+    const simplifyRoot = ({
+      moduleView,
+      rootExprId,
+      functionItem,
+    }: {
+      moduleView: OptimizedModuleView;
+      rootExprId: HirExprId;
+      functionItem?: HirFunction;
+    }): void => {
+      collectPostOrderExprIds({ rootExprId, moduleView }).forEach((exprId) => {
+        const expr = moduleView.hir.expressions.get(exprId);
+        if (!expr || expr.exprKind !== "match") {
+          return;
+        }
+
+        const discriminantType = exactDiscriminantType({
+          moduleView,
+          expr,
+          functionItem,
+        });
+        if (typeof discriminantType !== "number") {
+          return;
+        }
+
+        const selectedArm = expr.arms.find((arm) => {
+          if (
+            arm.pattern.kind === "type" &&
+            arm.pattern.binding
+          ) {
+            return false;
+          }
+          if (arm.pattern.kind !== "wildcard" && arm.pattern.kind !== "type") {
+            return false;
+          }
+          if (arm.pattern.kind === "wildcard") {
+            return true;
+          }
+          const patternTypeId =
+            typeof arm.pattern.typeId === "number" ? arm.pattern.typeId : undefined;
+          if (typeof patternTypeId !== "number") {
+            return false;
+          }
+          const nominals = new Set<TypeId>();
+          collectNominals({
+            typeId: patternTypeId,
+            program: ctx.ir.baseProgram,
+            nominals,
+          });
+          return nominals.has(discriminantType);
+        });
+
+        if (!selectedArm) {
+          return;
+        }
+
+        mutableExpressions({ moduleView }).set(
+          exprId,
+          toEvaluatedValueBlockExpr({
+            original: expr,
+            moduleView,
+            exprId: expr.discriminant,
+            value: selectedArm.value,
+          }),
+        );
+        changed = true;
+      });
+    };
+
+    ctx.ir.modules.forEach((moduleView) => {
+      moduleView.hir.items.forEach((item) => {
+        if (item.kind === "function") {
+          [
+            item.body,
+            ...item.parameters.flatMap((param) =>
+              typeof param.defaultValue === "number" ? [param.defaultValue] : [],
+            ),
+          ].forEach((rootExprId) =>
+            simplifyRoot({ moduleView, rootExprId, functionItem: item })
+          );
+          return;
+        }
+        if (item.kind !== "module-let") {
+          return;
+        }
+        simplifyRoot({ moduleView, rootExprId: item.initializer });
       });
     });
 
@@ -1199,16 +1329,225 @@ const effectFastPathEliminationPass: ProgramOptimizationPass = {
   },
 };
 
+const exactNominalForExpr = ({
+  moduleView,
+  exprId,
+  callerInstanceId,
+  program,
+  exactParameterTypes,
+}: {
+  moduleView: ModuleCodegenView;
+  exprId: HirExprId;
+  callerInstanceId?: ProgramFunctionInstanceId;
+  program: ProgramCodegenView;
+  exactParameterTypes?: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, TypeId>
+  >;
+}): TypeId | undefined => {
+  const typeId =
+    typeof callerInstanceId === "number"
+      ? program.functions.getInstanceExprType(callerInstanceId, exprId) ??
+        exprTypeFor({ moduleView, exprId })
+      : exprTypeFor({ moduleView, exprId });
+  const exactStaticType = exactNominalForType({ typeId, program });
+  if (typeof exactStaticType === "number") {
+    return exactStaticType;
+  }
+
+  const expr = moduleView.hir.expressions.get(exprId);
+  if (
+    expr?.exprKind === "object-literal" &&
+    expr.literalKind === "nominal" &&
+    typeof expr.targetSymbol === "number"
+  ) {
+    const template = program.objects.getTemplate(
+      program.symbols.idOf({
+        moduleId: moduleView.moduleId,
+        symbol: expr.targetSymbol,
+      }),
+    );
+    if (typeof template?.nominal === "number") {
+      return template.nominal;
+    }
+  }
+
+  if (
+    expr?.exprKind === "identifier" &&
+    typeof callerInstanceId === "number"
+  ) {
+    const exactParam = exactParameterTypes?.get(callerInstanceId)?.get(expr.symbol);
+    if (typeof exactParam === "number") {
+      return exactParam;
+    }
+  }
+
+  return undefined;
+};
+
+const traitMethodKey = ({
+  traitSymbol,
+  traitMethodSymbol,
+}: {
+  traitSymbol: ProgramSymbolId;
+  traitMethodSymbol: ProgramSymbolId;
+}): string => `${traitSymbol}:${traitMethodSymbol}`;
+
+const functionTypeSubstitution = ({
+  signature,
+  typeArgs,
+  program,
+}: {
+  signature: NonNullable<ReturnType<ProgramCodegenView["functions"]["getSignature"]>>;
+  typeArgs: readonly TypeId[];
+  program: ProgramCodegenView;
+}) => {
+  if (typeArgs.length === 0) {
+    return undefined;
+  }
+  const paramIds =
+    signature.typeParams.length > 0
+      ? signature.typeParams.map((param) => param.typeParam)
+      : program.types.getScheme(signature.scheme).params;
+  return paramIds.length === typeArgs.length
+    ? new Map(paramIds.map((param, index) => [param, typeArgs[index]!] as const))
+    : undefined;
+};
+
+const receiverParamNominalForTypeArgs = ({
+  signature,
+  typeArgs,
+  program,
+}: {
+  signature: NonNullable<ReturnType<ProgramCodegenView["functions"]["getSignature"]>>;
+  typeArgs: readonly TypeId[];
+  program: ProgramCodegenView;
+}): TypeId | undefined => {
+  const receiverType = signature.parameters[0]?.typeId;
+  if (typeof receiverType !== "number") {
+    return undefined;
+  }
+  const substitution = functionTypeSubstitution({ signature, typeArgs, program });
+  const resolvedReceiverType = substitution
+    ? program.types.substitute(receiverType, substitution)
+    : receiverType;
+  return exactNominalForType({ typeId: resolvedReceiverType, program });
+};
+
+const exactReceiverTraitTarget = ({
+  callInfo,
+  callerInstanceId,
+  exactReceiver,
+  program,
+}: {
+  callInfo: OptimizedCallInfo;
+  callerInstanceId: ProgramFunctionInstanceId;
+  exactReceiver: TypeId;
+  program: ProgramCodegenView;
+}): { functionId: ProgramFunctionId; typeArgs: readonly TypeId[] } | undefined => {
+  if (program.types.getTypeDesc(exactReceiver).kind !== "nominal-object") {
+    return undefined;
+  }
+  const candidateTargets = new Set(
+    Array.from(callInfo.targets?.values() ?? []),
+  );
+  if (candidateTargets.size === 0) {
+    return undefined;
+  }
+
+  const candidateTraitMethods = new Set<string>();
+  candidateTargets.forEach((target) => {
+    const mapping = program.traits.getTraitMethodImpl(target as ProgramSymbolId);
+    if (!mapping) {
+      return;
+    }
+    candidateTraitMethods.add(traitMethodKey(mapping));
+  });
+
+  const matches = new Set<ProgramFunctionId>();
+  program.traits.getImplsByNominal(exactReceiver).forEach((impl) => {
+    impl.methods.forEach((method) => {
+      const methodKey = traitMethodKey({
+        traitSymbol: impl.traitSymbol,
+        traitMethodSymbol: method.traitMethod,
+      });
+      if (
+        candidateTargets.has(method.implMethod) ||
+        candidateTargets.has(method.traitMethod) ||
+        candidateTraitMethods.has(methodKey)
+      ) {
+        matches.add(method.implMethod as ProgramFunctionId);
+      }
+    });
+  });
+
+  if (matches.size !== 1) {
+    return undefined;
+  }
+
+  const functionId = matches.values().next().value;
+  if (typeof functionId !== "number") {
+    return undefined;
+  }
+  const targetRef = program.symbols.refOf(functionId as ProgramSymbolId);
+  const signature = program.functions.getSignature(
+    targetRef.moduleId,
+    targetRef.symbol,
+  );
+  if (!signature) {
+    return undefined;
+  }
+
+  const existingTypeArgs = resolveCallTypeArgs({ callInfo, callerInstanceId });
+  const existingInstanceId = program.functions.getInstanceId(
+    targetRef.moduleId,
+    targetRef.symbol,
+    existingTypeArgs,
+  );
+  if (
+    typeof existingInstanceId === "number" &&
+    receiverParamNominalForTypeArgs({
+      signature,
+      typeArgs: existingTypeArgs,
+      program,
+    }) === exactReceiver
+  ) {
+    return { functionId, typeArgs: existingTypeArgs };
+  }
+
+  const matchingInstantiations = Array.from(
+    program.functions
+      .getInstantiationInfo(targetRef.moduleId, targetRef.symbol)
+      ?.values() ?? [],
+  ).filter(
+    (typeArgs) =>
+      receiverParamNominalForTypeArgs({ signature, typeArgs, program }) ===
+      exactReceiver,
+  );
+  if (matchingInstantiations.length !== 1) {
+    return undefined;
+  }
+  return {
+    functionId,
+    typeArgs: matchingInstantiations[0]!,
+  };
+};
+
 const devirtualizedCallInfo = ({
   moduleView,
   exprId,
   callInfo,
   program,
+  exactParameterTypes,
 }: {
   moduleView: OptimizedModuleView;
   exprId: HirExprId;
   callInfo: OptimizedCallInfo;
   program: ProgramCodegenView;
+  exactParameterTypes?: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, TypeId>
+  >;
 }): OptimizedCallInfo | undefined => {
   if (!callInfo.traitDispatch || !callInfo.targets || callInfo.targets.size === 0) {
     return undefined;
@@ -1222,16 +1561,51 @@ const devirtualizedCallInfo = ({
   if (typeof receiverExprId !== "number") {
     return undefined;
   }
-  const uniqueTargets = new Set(callInfo.targets.values());
+  const narrowedTargets = new Map(callInfo.targets);
+  const narrowedTypeArgs = new Map(callInfo.typeArgs ?? []);
+  let failedNarrowing = false;
+  narrowedTargets.forEach((_target, callerInstanceId) => {
+    const exactReceiver = exactNominalForExpr({
+      moduleView,
+      exprId: receiverExprId,
+      callerInstanceId,
+      program,
+      exactParameterTypes,
+    });
+    if (typeof exactReceiver !== "number") {
+      return;
+    }
+    const exactTarget = exactReceiverTraitTarget({
+      callInfo,
+      callerInstanceId,
+      exactReceiver,
+      program,
+    });
+    if (!exactTarget) {
+      failedNarrowing = true;
+      return;
+    }
+    narrowedTargets.set(callerInstanceId, exactTarget.functionId);
+    narrowedTypeArgs.set(callerInstanceId, exactTarget.typeArgs);
+  });
+  if (failedNarrowing) {
+    return undefined;
+  }
+
+  const uniqueTargets = new Set(narrowedTargets.values());
   if (uniqueTargets.size !== 1) {
     return undefined;
   }
-  const hasConcreteReceiver = Array.from(callInfo.targets.keys()).every((callerInstanceId) => {
-    const receiverType =
-      program.functions.getInstanceExprType(callerInstanceId, receiverExprId) ??
-      exprTypeFor({ moduleView, exprId: receiverExprId });
-    return typeof exactNominalForType({ typeId: receiverType, program }) === "number";
-  });
+  const hasConcreteReceiver = Array.from(narrowedTargets.keys()).every(
+    (callerInstanceId) =>
+      typeof exactNominalForExpr({
+        moduleView,
+        exprId: receiverExprId,
+        callerInstanceId,
+        program,
+        exactParameterTypes,
+      }) === "number",
+  );
   if (!hasConcreteReceiver) {
     return undefined;
   }
@@ -1245,6 +1619,8 @@ const devirtualizedCallInfo = ({
   }
   return {
     ...callInfo,
+    targets: narrowedTargets,
+    typeArgs: narrowedTypeArgs,
     traitDispatch: false,
   };
 };
@@ -1265,6 +1641,7 @@ const traitDispatchDevirtualizationPass: ProgramOptimizationPass = {
           exprId,
           callInfo,
           program: ctx.ir.baseProgram,
+          exactParameterTypes: ctx.ir.facts.exactParameterTypes,
         });
         if (!next) {
           return;
@@ -1405,6 +1782,1327 @@ const functionItemBySymbol = ({
   Array.from(moduleView.hir.items.values()).find(
     (item): item is HirFunction => item.kind === "function" && item.symbol === symbol,
   );
+
+type ExactParameterCandidate = TypeId | "conflict";
+
+const callArgumentExprIds = (
+  expr: HirExpression,
+): readonly HirExprId[] =>
+  expr.exprKind === "call"
+    ? expr.args.map((arg) => arg.expr)
+    : expr.exprKind === "method-call"
+      ? [expr.target, ...expr.args.map((arg) => arg.expr)]
+      : [];
+
+const mergeExactParameterCandidate = ({
+  candidates,
+  instanceId,
+  symbol,
+  exactType,
+}: {
+  candidates: Map<
+    ProgramFunctionInstanceId,
+    Map<SymbolId, ExactParameterCandidate>
+  >;
+  instanceId: ProgramFunctionInstanceId;
+  symbol: SymbolId;
+  exactType: TypeId;
+}): void => {
+  const bySymbol = candidates.get(instanceId) ?? new Map<SymbolId, ExactParameterCandidate>();
+  const existing = bySymbol.get(symbol);
+  bySymbol.set(
+    symbol,
+    existing === undefined || existing === exactType ? exactType : "conflict",
+  );
+  candidates.set(instanceId, bySymbol);
+};
+
+const resolveTargetsForExactPropagation = ({
+  moduleView,
+  exprId,
+  expr,
+  callerInstanceId,
+  ir,
+}: {
+  moduleView: OptimizedModuleView;
+  exprId: HirExprId;
+  expr: Extract<HirExpression, { exprKind: "call" | "method-call" }>;
+  callerInstanceId: ProgramFunctionInstanceId;
+  ir: MutableOptimizationIr;
+}): readonly { functionId: ProgramFunctionId; instanceId?: ProgramFunctionInstanceId }[] => {
+  const resolvedTargets = resolveTargetsForCaller({
+    moduleId: moduleView.moduleId,
+    exprId,
+    callerInstanceId,
+    ir,
+  });
+  if (resolvedTargets.length > 0 || expr.exprKind !== "call") {
+    return resolvedTargets;
+  }
+  const callee = moduleView.hir.expressions.get(expr.callee);
+  if (callee?.exprKind !== "identifier") {
+    return [];
+  }
+  const resolved = resolveImportedSymbol({
+    moduleId: moduleView.moduleId,
+    symbol: callee.symbol,
+    ir,
+  });
+  const module = ir.modules.get(resolved.moduleId);
+  if (!module || !functionItemBySymbol({ moduleView: module, symbol: resolved.symbol })) {
+    return [];
+  }
+  const functionId = canonicalProgramSymbolIdOf({
+    moduleId: resolved.moduleId,
+    symbol: resolved.symbol,
+    ir,
+  });
+  const callInfo = ir.calls.get(moduleView.moduleId)?.get(exprId);
+  const typeArgs = callInfo
+    ? resolveCallTypeArgs({ callInfo, callerInstanceId })
+    : [];
+  return [
+    {
+      functionId,
+      instanceId: ir.baseProgram.functions.getInstanceId(
+        resolved.moduleId,
+        resolved.symbol,
+        typeArgs,
+      ),
+    },
+  ];
+};
+
+const externallyCallableFunctionInstances = (
+  ir: MutableOptimizationIr,
+): Set<ProgramFunctionInstanceId> => {
+  const external = new Set<ProgramFunctionInstanceId>();
+  const addFunctionSymbolInstances = ({
+    moduleId,
+    symbol,
+  }: {
+    moduleId: string;
+    symbol: SymbolId;
+  }): void => {
+    const instantiations = ir.functionInstantiations.get(moduleId)?.get(symbol);
+    if (instantiations) {
+      instantiations.forEach((_typeArgs, instanceId) => {
+        external.add(instanceId);
+      });
+      return;
+    }
+    const instanceId = ir.baseProgram.functions.getInstanceId(
+      moduleId,
+      symbol,
+      [],
+    );
+    if (typeof instanceId === "number") {
+      external.add(instanceId);
+    }
+  };
+
+  const externalModuleIds =
+    ir.options.testMode && ir.options.testScope === "all"
+      ? new Set(ir.modules.keys())
+      : new Set([ir.entryModuleId]);
+  externalModuleIds.forEach((moduleId) => {
+    const moduleView = ir.modules.get(moduleId);
+    if (!moduleView) {
+      return;
+    }
+    moduleView.hir.module.exports.forEach((entry) => {
+      const resolved = resolveImportedSymbol({
+        moduleId,
+        symbol: entry.symbol,
+        ir,
+      });
+      const resolvedModule = ir.modules.get(resolved.moduleId);
+      if (
+        !resolvedModule ||
+        !functionItemBySymbol({
+          moduleView: resolvedModule,
+          symbol: resolved.symbol,
+        })
+      ) {
+        return;
+      }
+      addFunctionSymbolInstances(resolved);
+    });
+  });
+
+  const markEscapedFunctionValues = ({
+    moduleView,
+    rootExprId,
+  }: {
+    moduleView: OptimizedModuleView;
+    rootExprId: HirExprId;
+  }): void => {
+    const directCallCallees = new Set<HirExprId>();
+    const exprIds = collectPostOrderExprIds({ rootExprId, moduleView });
+    exprIds.forEach((exprId) => {
+      const expr = moduleView.hir.expressions.get(exprId);
+      if (expr?.exprKind === "call") {
+        directCallCallees.add(expr.callee);
+      }
+    });
+
+    exprIds.forEach((exprId) => {
+      if (directCallCallees.has(exprId)) {
+        return;
+      }
+      const expr = moduleView.hir.expressions.get(exprId);
+      if (expr?.exprKind !== "identifier") {
+        return;
+      }
+      const resolved = resolveImportedSymbol({
+        moduleId: moduleView.moduleId,
+        symbol: expr.symbol,
+        ir,
+      });
+      const resolvedModule = ir.modules.get(resolved.moduleId);
+      if (
+        !resolvedModule ||
+        !functionItemBySymbol({
+          moduleView: resolvedModule,
+          symbol: resolved.symbol,
+        })
+      ) {
+        return;
+      }
+      addFunctionSymbolInstances(resolved);
+    });
+  };
+
+  ir.facts.reachableFunctionInstances.forEach((instanceId) => {
+    const instance = ir.baseProgram.functions.getInstance(instanceId);
+    const moduleView = ir.modules.get(instance.symbolRef.moduleId);
+    const item = moduleView
+      ? functionItemBySymbol({
+          moduleView,
+          symbol: instance.symbolRef.symbol,
+        })
+      : undefined;
+    if (!moduleView || !item) {
+      return;
+    }
+    [
+      item.body,
+      ...item.parameters.flatMap((parameter) =>
+        typeof parameter.defaultValue === "number" ? [parameter.defaultValue] : [],
+      ),
+    ].forEach((rootExprId) => {
+      markEscapedFunctionValues({ moduleView, rootExprId });
+    });
+  });
+
+  ir.facts.reachableModuleLets.forEach((symbols, moduleId) => {
+    const moduleView = ir.modules.get(moduleId);
+    if (!moduleView) {
+      return;
+    }
+    symbols.forEach((symbol) => {
+      const moduleLet = moduleLetBySymbol({ moduleView, symbol });
+      if (!moduleLet) {
+        return;
+      }
+      markEscapedFunctionValues({
+        moduleView,
+        rootExprId: moduleLet.initializer,
+      });
+    });
+  });
+  return external;
+};
+
+const collectExactParameterCandidates = ({
+  ir,
+  seedFacts,
+  externallyCallableInstances,
+}: {
+  ir: MutableOptimizationIr;
+  seedFacts: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, TypeId>
+  >;
+  externallyCallableInstances: ReadonlySet<ProgramFunctionInstanceId>;
+}): Map<ProgramFunctionInstanceId, Map<SymbolId, ExactParameterCandidate>> => {
+  const candidates = new Map<
+    ProgramFunctionInstanceId,
+    Map<SymbolId, ExactParameterCandidate>
+  >();
+
+  ir.facts.reachableFunctionInstances.forEach((callerInstanceId) => {
+    const caller = ir.baseProgram.functions.getInstance(callerInstanceId);
+    const moduleView = ir.modules.get(caller.symbolRef.moduleId);
+    if (!moduleView) {
+      return;
+    }
+    const item = functionItemBySymbol({
+      moduleView,
+      symbol: caller.symbolRef.symbol,
+    });
+    if (!item) {
+      return;
+    }
+
+    const roots = [
+      item.body,
+      ...item.parameters.flatMap((parameter) =>
+        typeof parameter.defaultValue === "number" ? [parameter.defaultValue] : [],
+      ),
+    ];
+    roots.forEach((rootExprId) => {
+      collectPostOrderExprIds({ rootExprId, moduleView }).forEach((exprId) => {
+        const expr = moduleView.hir.expressions.get(exprId);
+        if (!expr || (expr.exprKind !== "call" && expr.exprKind !== "method-call")) {
+          return;
+        }
+        const argExprIds = callArgumentExprIds(expr);
+        const callInfo = ir.calls.get(moduleView.moduleId)?.get(exprId);
+        const targets = resolveTargetsForExactPropagation({
+          moduleView,
+          exprId,
+          expr,
+          callerInstanceId,
+          ir,
+        });
+        targets.forEach(({ instanceId }) => {
+          if (typeof instanceId !== "number") {
+            return;
+          }
+          if (externallyCallableInstances.has(instanceId)) {
+            return;
+          }
+          const target = ir.baseProgram.functions.getInstance(instanceId);
+          const signature = ir.baseProgram.functions.getSignature(
+            target.symbolRef.moduleId,
+            target.symbolRef.symbol,
+          );
+          if (!signature) {
+            return;
+          }
+          signature.parameters.forEach((parameter, index) => {
+            if (typeof parameter.symbol !== "number") {
+              return;
+            }
+            const argExprId = callArgumentExprIdForParameter({
+              argExprIds,
+              callInfo,
+              callerInstanceId,
+              parameterIndex: index,
+            });
+            if (typeof argExprId !== "number") {
+              return;
+            }
+            const exactType = exactNominalForExpr({
+              moduleView,
+              exprId: argExprId,
+              callerInstanceId,
+              program: ir.baseProgram,
+              exactParameterTypes: seedFacts,
+            });
+            if (typeof exactType !== "number") {
+              return;
+            }
+            mergeExactParameterCandidate({
+              candidates,
+              instanceId,
+              symbol: parameter.symbol,
+              exactType,
+            });
+          });
+        });
+      });
+    });
+  });
+
+  return candidates;
+};
+
+const materializeExactParameterFacts = (
+  candidates: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, ExactParameterCandidate>
+  >,
+): Map<ProgramFunctionInstanceId, Map<SymbolId, TypeId>> => {
+  const facts = new Map<ProgramFunctionInstanceId, Map<SymbolId, TypeId>>();
+  candidates.forEach((bySymbol, instanceId) => {
+    const exactBySymbol = new Map<SymbolId, TypeId>();
+    bySymbol.forEach((candidate, symbol) => {
+      if (candidate !== "conflict") {
+        exactBySymbol.set(symbol, candidate);
+      }
+    });
+    if (exactBySymbol.size > 0) {
+      facts.set(instanceId, exactBySymbol);
+    }
+  });
+  return facts;
+};
+
+const cloneExactParameterFacts = (
+  facts: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, TypeId>
+  >,
+): Map<ProgramFunctionInstanceId, Map<SymbolId, TypeId>> =>
+  new Map(
+    Array.from(facts.entries()).map(([instanceId, bySymbol]) => [
+      instanceId,
+      new Map(bySymbol),
+    ]),
+  );
+
+type KnownParameterCandidate = {
+  types: Set<TypeId>;
+  unknown: boolean;
+};
+
+const cloneKnownParameterFacts = (
+  facts: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, ReadonlySet<TypeId>>
+  >,
+): Map<ProgramFunctionInstanceId, Map<SymbolId, Set<TypeId>>> =>
+  new Map(
+    Array.from(facts.entries()).map(([instanceId, bySymbol]) => [
+      instanceId,
+      new Map(
+        Array.from(bySymbol.entries()).map(([symbol, types]) => [
+          symbol,
+          new Set(types),
+        ]),
+      ),
+    ]),
+  );
+
+const MAX_RECEIVER_SPECIALIZATIONS_PER_FUNCTION = 4;
+const MAX_EXACT_PARAMETERS_PER_RECEIVER_SPECIALIZATION = 2;
+
+const receiverSpecializationCallSiteKey = ({
+  moduleId,
+  exprId,
+}: {
+  moduleId: string;
+  exprId: HirExprId;
+}): string => `${moduleId}:${exprId}`;
+
+const receiverSpecializationContextKey = ({
+  instanceId,
+  exactParameterTypes,
+}: {
+  instanceId: ProgramFunctionInstanceId;
+  exactParameterTypes: ReadonlyMap<SymbolId, TypeId> | undefined;
+}): string => {
+  const serializedFacts = Array.from(exactParameterTypes?.entries() ?? [])
+    .sort(([left], [right]) => left - right)
+    .map(([symbol, type]) => `${symbol}=${type}`)
+    .join(",");
+  return `${instanceId}:${serializedFacts}`;
+};
+
+const cloneReceiverSpecializationRequests = (
+  requests: ReadonlyMap<
+    string,
+    ReadonlyMap<string, ReadonlyMap<SymbolId, TypeId>>
+  >,
+): Map<string, Map<string, Map<SymbolId, TypeId>>> =>
+  new Map(
+    Array.from(requests.entries()).map(([callSiteKey, byContext]) => [
+      callSiteKey,
+      new Map(
+        Array.from(byContext.entries()).map(([contextKey, exactTypes]) => [
+          contextKey,
+          new Map(exactTypes),
+        ]),
+      ),
+    ]),
+  );
+
+const serializeReceiverSpecializationRequests = (
+  requests: ReadonlyMap<
+    string,
+    ReadonlyMap<string, ReadonlyMap<SymbolId, TypeId>>
+  >,
+): string =>
+  JSON.stringify(
+    Array.from(requests.entries())
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([callSiteKey, byContext]) => [
+        callSiteKey,
+        Array.from(byContext.entries())
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([contextKey, exactTypes]) => [
+            contextKey,
+            Array.from(exactTypes.entries()).sort(
+              ([left], [right]) => left - right,
+            ),
+          ]),
+      ]),
+  );
+
+const knownNominalsForExpr = ({
+  moduleView,
+  exprId,
+  callerInstanceId,
+  program,
+  exactParameterTypes,
+  knownParameterTypes,
+}: {
+  moduleView: ModuleCodegenView;
+  exprId: HirExprId;
+  callerInstanceId?: ProgramFunctionInstanceId;
+  program: ProgramCodegenView;
+  exactParameterTypes: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, TypeId>
+  >;
+  knownParameterTypes: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, ReadonlySet<TypeId>>
+  >;
+}): ReadonlySet<TypeId> | undefined => {
+  const exact = exactNominalForExpr({
+    moduleView,
+    exprId,
+    callerInstanceId,
+    program,
+    exactParameterTypes,
+  });
+  if (typeof exact === "number") {
+    return new Set([exact]);
+  }
+  if (typeof callerInstanceId !== "number") {
+    return undefined;
+  }
+  const expr = moduleView.hir.expressions.get(exprId);
+  if (expr?.exprKind !== "identifier") {
+    return undefined;
+  }
+  return knownParameterTypes.get(callerInstanceId)?.get(expr.symbol);
+};
+
+const mergeKnownParameterCandidate = ({
+  candidates,
+  instanceId,
+  symbol,
+  knownTypes,
+}: {
+  candidates: Map<
+    ProgramFunctionInstanceId,
+    Map<SymbolId, KnownParameterCandidate>
+  >;
+  instanceId: ProgramFunctionInstanceId;
+  symbol: SymbolId;
+  knownTypes?: ReadonlySet<TypeId>;
+}): void => {
+  const bySymbol =
+    candidates.get(instanceId) ?? new Map<SymbolId, KnownParameterCandidate>();
+  const existing =
+    bySymbol.get(symbol) ?? { types: new Set<TypeId>(), unknown: false };
+  if (!knownTypes || knownTypes.size === 0) {
+    existing.unknown = true;
+  } else {
+    knownTypes.forEach((type) => existing.types.add(type));
+  }
+  bySymbol.set(symbol, existing);
+  candidates.set(instanceId, bySymbol);
+};
+
+const collectKnownParameterCandidates = ({
+  ir,
+  exactParameterTypes,
+  seedFacts,
+  externallyCallableInstances,
+}: {
+  ir: MutableOptimizationIr;
+  exactParameterTypes: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, TypeId>
+  >;
+  seedFacts: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, ReadonlySet<TypeId>>
+  >;
+  externallyCallableInstances: ReadonlySet<ProgramFunctionInstanceId>;
+}): Map<ProgramFunctionInstanceId, Map<SymbolId, KnownParameterCandidate>> => {
+  const candidates = new Map<
+    ProgramFunctionInstanceId,
+    Map<SymbolId, KnownParameterCandidate>
+  >();
+
+  ir.facts.reachableFunctionInstances.forEach((callerInstanceId) => {
+    const caller = ir.baseProgram.functions.getInstance(callerInstanceId);
+    const moduleView = ir.modules.get(caller.symbolRef.moduleId);
+    if (!moduleView) {
+      return;
+    }
+    const item = functionItemBySymbol({
+      moduleView,
+      symbol: caller.symbolRef.symbol,
+    });
+    if (!item) {
+      return;
+    }
+
+    const roots = [
+      item.body,
+      ...item.parameters.flatMap((parameter) =>
+        typeof parameter.defaultValue === "number" ? [parameter.defaultValue] : [],
+      ),
+    ];
+    roots.forEach((rootExprId) => {
+      collectPostOrderExprIds({ rootExprId, moduleView }).forEach((exprId) => {
+        const expr = moduleView.hir.expressions.get(exprId);
+        if (!expr || (expr.exprKind !== "call" && expr.exprKind !== "method-call")) {
+          return;
+        }
+        const argExprIds = callArgumentExprIds(expr);
+        const callInfo = ir.calls.get(moduleView.moduleId)?.get(exprId);
+        const targets = resolveTargetsForExactPropagation({
+          moduleView,
+          exprId,
+          expr,
+          callerInstanceId,
+          ir,
+        });
+        targets.forEach(({ instanceId }) => {
+          if (typeof instanceId !== "number") {
+            return;
+          }
+          if (externallyCallableInstances.has(instanceId)) {
+            return;
+          }
+          const target = ir.baseProgram.functions.getInstance(instanceId);
+          const signature = ir.baseProgram.functions.getSignature(
+            target.symbolRef.moduleId,
+            target.symbolRef.symbol,
+          );
+          if (!signature) {
+            return;
+          }
+          signature.parameters.forEach((parameter, index) => {
+            if (typeof parameter.symbol !== "number") {
+              return;
+            }
+            const argExprId = callArgumentExprIdForParameter({
+              argExprIds,
+              callInfo,
+              callerInstanceId,
+              parameterIndex: index,
+            });
+            const knownTypes =
+              typeof argExprId === "number"
+                ? knownNominalsForExpr({
+                    moduleView,
+                    exprId: argExprId,
+                    callerInstanceId,
+                    program: ir.baseProgram,
+                    exactParameterTypes,
+                    knownParameterTypes: seedFacts,
+                  })
+                : undefined;
+            mergeKnownParameterCandidate({
+              candidates,
+              instanceId,
+              symbol: parameter.symbol,
+              knownTypes,
+            });
+          });
+        });
+      });
+    });
+  });
+
+  return candidates;
+};
+
+const materializeKnownParameterFacts = (
+  candidates: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, KnownParameterCandidate>
+  >,
+): Map<ProgramFunctionInstanceId, Map<SymbolId, Set<TypeId>>> => {
+  const facts = new Map<ProgramFunctionInstanceId, Map<SymbolId, Set<TypeId>>>();
+  candidates.forEach((bySymbol, instanceId) => {
+    const knownBySymbol = new Map<SymbolId, Set<TypeId>>();
+    bySymbol.forEach((candidate, symbol) => {
+      if (!candidate.unknown && candidate.types.size > 0) {
+        knownBySymbol.set(symbol, new Set(candidate.types));
+      }
+    });
+    if (knownBySymbol.size > 0) {
+      facts.set(instanceId, knownBySymbol);
+    }
+  });
+  return facts;
+};
+
+const setContainsAll = (
+  expected: ReadonlySet<TypeId>,
+  actual: ReadonlySet<TypeId>,
+): boolean => Array.from(actual).every((type) => expected.has(type));
+
+const validateKnownParameterFacts = ({
+  ir,
+  exactParameterTypes,
+  facts,
+}: {
+  ir: MutableOptimizationIr;
+  exactParameterTypes: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, TypeId>
+  >;
+  facts: Map<ProgramFunctionInstanceId, Map<SymbolId, Set<TypeId>>>;
+}): Map<ProgramFunctionInstanceId, Map<SymbolId, Set<TypeId>>> => {
+  const validated = cloneKnownParameterFacts(facts);
+  let changed = true;
+
+  while (changed) {
+    changed = false;
+    ir.facts.reachableFunctionInstances.forEach((callerInstanceId) => {
+      const caller = ir.baseProgram.functions.getInstance(callerInstanceId);
+      const moduleView = ir.modules.get(caller.symbolRef.moduleId);
+      if (!moduleView) {
+        return;
+      }
+      const item = functionItemBySymbol({
+        moduleView,
+        symbol: caller.symbolRef.symbol,
+      });
+      if (!item) {
+        return;
+      }
+      const roots = [
+        item.body,
+        ...item.parameters.flatMap((parameter) =>
+          typeof parameter.defaultValue === "number" ? [parameter.defaultValue] : [],
+        ),
+      ];
+      roots.forEach((rootExprId) => {
+        collectPostOrderExprIds({ rootExprId, moduleView }).forEach((exprId) => {
+          const expr = moduleView.hir.expressions.get(exprId);
+          if (!expr || (expr.exprKind !== "call" && expr.exprKind !== "method-call")) {
+            return;
+          }
+          const argExprIds = callArgumentExprIds(expr);
+          const callInfo = ir.calls.get(moduleView.moduleId)?.get(exprId);
+          resolveTargetsForExactPropagation({
+            moduleView,
+            exprId,
+            expr,
+            callerInstanceId,
+            ir,
+          }).forEach(({ instanceId }) => {
+            if (typeof instanceId !== "number") {
+              return;
+            }
+            const factsBySymbol = validated.get(instanceId);
+            if (!factsBySymbol || factsBySymbol.size === 0) {
+              return;
+            }
+            const target = ir.baseProgram.functions.getInstance(instanceId);
+            const signature = ir.baseProgram.functions.getSignature(
+              target.symbolRef.moduleId,
+              target.symbolRef.symbol,
+            );
+            signature?.parameters.forEach((parameter, index) => {
+              if (typeof parameter.symbol !== "number") {
+                return;
+              }
+              const expected = factsBySymbol.get(parameter.symbol);
+              if (!expected) {
+                return;
+              }
+              const argExprId = callArgumentExprIdForParameter({
+                argExprIds,
+                callInfo,
+                callerInstanceId,
+                parameterIndex: index,
+              });
+              const actual =
+                typeof argExprId === "number"
+                  ? knownNominalsForExpr({
+                      moduleView,
+                      exprId: argExprId,
+                      callerInstanceId,
+                      program: ir.baseProgram,
+                      exactParameterTypes,
+                      knownParameterTypes: validated,
+                    })
+                  : undefined;
+              if (actual && setContainsAll(expected, actual)) {
+                return;
+              }
+              factsBySymbol.delete(parameter.symbol);
+              changed = true;
+            });
+            if (factsBySymbol.size === 0) {
+              validated.delete(instanceId);
+            }
+          });
+        });
+      });
+    });
+  }
+
+  return validated;
+};
+
+const serializeKnownParameterFacts = (
+  facts: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, ReadonlySet<TypeId>>
+  >,
+): string =>
+  JSON.stringify(
+    Array.from(facts.entries())
+      .sort(([left], [right]) => left - right)
+      .map(([instanceId, bySymbol]) => [
+        instanceId,
+        Array.from(bySymbol.entries())
+          .sort(([left], [right]) => left - right)
+          .map(([symbol, types]) => [
+            symbol,
+            Array.from(types).sort((left, right) => left - right),
+          ]),
+      ]),
+  );
+
+const validateExactParameterFacts = ({
+  ir,
+  facts,
+}: {
+  ir: MutableOptimizationIr;
+  facts: Map<ProgramFunctionInstanceId, Map<SymbolId, TypeId>>;
+}): Map<ProgramFunctionInstanceId, Map<SymbolId, TypeId>> => {
+  const validated = cloneExactParameterFacts(facts);
+  let changed = true;
+
+  while (changed) {
+    changed = false;
+    ir.facts.reachableFunctionInstances.forEach((callerInstanceId) => {
+      const caller = ir.baseProgram.functions.getInstance(callerInstanceId);
+      const moduleView = ir.modules.get(caller.symbolRef.moduleId);
+      if (!moduleView) {
+        return;
+      }
+      const item = functionItemBySymbol({
+        moduleView,
+        symbol: caller.symbolRef.symbol,
+      });
+      if (!item) {
+        return;
+      }
+      const roots = [
+        item.body,
+        ...item.parameters.flatMap((parameter) =>
+          typeof parameter.defaultValue === "number" ? [parameter.defaultValue] : [],
+        ),
+      ];
+      roots.forEach((rootExprId) => {
+        collectPostOrderExprIds({ rootExprId, moduleView }).forEach((exprId) => {
+          const expr = moduleView.hir.expressions.get(exprId);
+          if (!expr || (expr.exprKind !== "call" && expr.exprKind !== "method-call")) {
+            return;
+          }
+          const argExprIds = callArgumentExprIds(expr);
+          const callInfo = ir.calls.get(moduleView.moduleId)?.get(exprId);
+          resolveTargetsForExactPropagation({
+            moduleView,
+            exprId,
+            expr,
+            callerInstanceId,
+            ir,
+          }).forEach(({ instanceId }) => {
+            if (typeof instanceId !== "number") {
+              return;
+            }
+            const factsBySymbol = validated.get(instanceId);
+            if (!factsBySymbol || factsBySymbol.size === 0) {
+              return;
+            }
+            const target = ir.baseProgram.functions.getInstance(instanceId);
+            const signature = ir.baseProgram.functions.getSignature(
+              target.symbolRef.moduleId,
+              target.symbolRef.symbol,
+            );
+            signature?.parameters.forEach((parameter, index) => {
+              if (typeof parameter.symbol !== "number") {
+                return;
+              }
+              const expected = factsBySymbol.get(parameter.symbol);
+              if (typeof expected !== "number") {
+                return;
+              }
+              const argExprId = callArgumentExprIdForParameter({
+                argExprIds,
+                callInfo,
+                callerInstanceId,
+                parameterIndex: index,
+              });
+              const actual =
+                typeof argExprId === "number"
+                  ? exactNominalForExpr({
+                      moduleView,
+                      exprId: argExprId,
+                      callerInstanceId,
+                      program: ir.baseProgram,
+                      exactParameterTypes: validated,
+                    })
+                  : undefined;
+              if (actual === expected) {
+                return;
+              }
+              factsBySymbol.delete(parameter.symbol);
+              changed = true;
+            });
+            if (factsBySymbol.size === 0) {
+              validated.delete(instanceId);
+            }
+          });
+        });
+      });
+    });
+  }
+
+  return validated;
+};
+
+const serializeExactParameterFacts = (
+  facts: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, TypeId>
+  >,
+): string =>
+  JSON.stringify(
+    Array.from(facts.entries())
+      .sort(([left], [right]) => left - right)
+      .map(([instanceId, bySymbol]) => [
+        instanceId,
+        Array.from(bySymbol.entries()).sort(([left], [right]) => left - right),
+      ]),
+  );
+
+type ReceiverSpecializationContext = {
+  instanceId: ProgramFunctionInstanceId;
+  exactParameterTypes: Map<SymbolId, TypeId>;
+};
+
+const exactParameterFactsForContext = ({
+  facts,
+  context,
+}: {
+  facts: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, TypeId>
+  >;
+  context: ReceiverSpecializationContext;
+}): Map<ProgramFunctionInstanceId, Map<SymbolId, TypeId>> => {
+  const merged = cloneExactParameterFacts(facts);
+  if (context.exactParameterTypes.size === 0) {
+    return merged;
+  }
+  const existing = new Map(merged.get(context.instanceId) ?? []);
+  context.exactParameterTypes.forEach((type, symbol) => {
+    existing.set(symbol, type);
+  });
+  merged.set(context.instanceId, existing);
+  return merged;
+};
+
+const functionParamCanReachTraitDispatch = ({
+  ir,
+  functionInstanceId,
+  parameterSymbol,
+  seen,
+}: {
+  ir: MutableOptimizationIr;
+  functionInstanceId: ProgramFunctionInstanceId;
+  parameterSymbol: SymbolId;
+  seen: Set<string>;
+}): boolean => {
+  const key = `${functionInstanceId}:${parameterSymbol}`;
+  if (seen.has(key)) {
+    return false;
+  }
+  seen.add(key);
+
+  const instance = ir.baseProgram.functions.getInstance(functionInstanceId);
+  const moduleView = ir.modules.get(instance.symbolRef.moduleId);
+  if (!moduleView) {
+    return false;
+  }
+  const item = functionItemBySymbol({
+    moduleView,
+    symbol: instance.symbolRef.symbol,
+  });
+  if (!item) {
+    return false;
+  }
+
+  const roots = [
+    item.body,
+    ...item.parameters.flatMap((parameter) =>
+      typeof parameter.defaultValue === "number" ? [parameter.defaultValue] : [],
+    ),
+  ];
+  return roots.some((rootExprId) =>
+    collectPostOrderExprIds({ rootExprId, moduleView }).some((exprId) => {
+      const expr = moduleView.hir.expressions.get(exprId);
+      if (!expr || (expr.exprKind !== "call" && expr.exprKind !== "method-call")) {
+        return false;
+      }
+
+      const callInfo = ir.calls.get(moduleView.moduleId)?.get(exprId);
+      if (callInfo?.traitDispatch) {
+        const receiverExprId =
+          expr.exprKind === "method-call" ? expr.target : expr.args[0]?.expr;
+        const receiverExpr =
+          typeof receiverExprId === "number"
+            ? moduleView.hir.expressions.get(receiverExprId)
+            : undefined;
+        if (
+          receiverExpr?.exprKind === "identifier" &&
+          receiverExpr.symbol === parameterSymbol
+        ) {
+          return true;
+        }
+      }
+
+      const argExprIds = callArgumentExprIds(expr);
+      return resolveTargetsForExactPropagation({
+        moduleView,
+        exprId,
+        expr,
+        callerInstanceId: functionInstanceId,
+        ir,
+      }).some(({ instanceId }) => {
+        if (typeof instanceId !== "number") {
+          return false;
+        }
+        const target = ir.baseProgram.functions.getInstance(instanceId);
+        const signature = ir.baseProgram.functions.getSignature(
+          target.symbolRef.moduleId,
+          target.symbolRef.symbol,
+        );
+        return signature?.parameters.some((targetParam, paramIndex) => {
+          if (typeof targetParam.symbol !== "number") {
+            return false;
+          }
+          if (ir.baseProgram.types.getTypeDesc(targetParam.typeId).kind !== "trait") {
+            return false;
+          }
+          const argExprId = callArgumentExprIdForParameter({
+            argExprIds,
+            callInfo,
+            callerInstanceId: functionInstanceId,
+            parameterIndex: paramIndex,
+          });
+          const argExpr =
+            typeof argExprId === "number"
+              ? moduleView.hir.expressions.get(argExprId)
+              : undefined;
+          return (
+            argExpr?.exprKind === "identifier" &&
+            argExpr.symbol === parameterSymbol &&
+            functionParamCanReachTraitDispatch({
+              ir,
+              functionInstanceId: instanceId,
+              parameterSymbol: targetParam.symbol,
+              seen,
+            })
+          );
+        }) ?? false;
+      });
+    }),
+  );
+};
+
+const collectReceiverSpecializationRequests = ({
+  ir,
+  exactParameterTypes,
+}: {
+  ir: MutableOptimizationIr;
+  exactParameterTypes: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, TypeId>
+  >;
+}): Map<string, Map<string, Map<SymbolId, TypeId>>> => {
+  const requests = new Map<string, Map<string, Map<SymbolId, TypeId>>>();
+  const queued: ReceiverSpecializationContext[] = [];
+  const queuedKeys = new Set<string>();
+  const seen = new Set<string>();
+  const specializationKeysByFunction = new Map<
+    ProgramFunctionInstanceId,
+    Set<string>
+  >();
+
+  const enqueueContext = ({
+    instanceId,
+    exactTypes,
+    countsAsSpecialization,
+  }: {
+    instanceId: ProgramFunctionInstanceId;
+    exactTypes?: ReadonlyMap<SymbolId, TypeId>;
+    countsAsSpecialization: boolean;
+  }): void => {
+    const exactParameterMap = new Map(exactTypes ?? []);
+    const contextKey = receiverSpecializationContextKey({
+      instanceId,
+      exactParameterTypes: exactParameterMap,
+    });
+    if (seen.has(contextKey) || queuedKeys.has(contextKey)) {
+      return;
+    }
+    if (countsAsSpecialization) {
+      if (
+        exactParameterMap.size === 0 ||
+        exactParameterMap.size > MAX_EXACT_PARAMETERS_PER_RECEIVER_SPECIALIZATION
+      ) {
+        return;
+      }
+      const knownKeys =
+        specializationKeysByFunction.get(instanceId) ?? new Set<string>();
+      if (
+        !knownKeys.has(contextKey) &&
+        knownKeys.size >= MAX_RECEIVER_SPECIALIZATIONS_PER_FUNCTION
+      ) {
+        return;
+      }
+      knownKeys.add(contextKey);
+      specializationKeysByFunction.set(instanceId, knownKeys);
+    }
+    queuedKeys.add(contextKey);
+    queued.push({
+      instanceId,
+      exactParameterTypes: exactParameterMap,
+    });
+  };
+
+  ir.facts.reachableFunctionInstances.forEach((instanceId) => {
+    enqueueContext({
+      instanceId,
+      exactTypes: exactParameterTypes.get(instanceId),
+      countsAsSpecialization: false,
+    });
+  });
+
+  while (queued.length > 0) {
+    const context = queued.pop()!;
+    const callerContextKey = receiverSpecializationContextKey({
+      instanceId: context.instanceId,
+      exactParameterTypes: context.exactParameterTypes,
+    });
+    queuedKeys.delete(callerContextKey);
+    if (seen.has(callerContextKey)) {
+      continue;
+    }
+    seen.add(callerContextKey);
+
+    const caller = ir.baseProgram.functions.getInstance(context.instanceId);
+    const moduleView = ir.modules.get(caller.symbolRef.moduleId);
+    if (!moduleView) {
+      continue;
+    }
+    const item = functionItemBySymbol({
+      moduleView,
+      symbol: caller.symbolRef.symbol,
+    });
+    if (!item) {
+      continue;
+    }
+    const contextExactFacts = exactParameterFactsForContext({
+      facts: exactParameterTypes,
+      context,
+    });
+    const roots = [
+      item.body,
+      ...item.parameters.flatMap((parameter) =>
+        typeof parameter.defaultValue === "number" ? [parameter.defaultValue] : [],
+      ),
+    ];
+    roots.forEach((rootExprId) => {
+      collectPostOrderExprIds({ rootExprId, moduleView }).forEach((exprId) => {
+        const expr = moduleView.hir.expressions.get(exprId);
+        if (!expr || (expr.exprKind !== "call" && expr.exprKind !== "method-call")) {
+          return;
+        }
+        const targets = resolveTargetsForExactPropagation({
+          moduleView,
+          exprId,
+          expr,
+          callerInstanceId: context.instanceId,
+          ir,
+        });
+        if (targets.length !== 1 || typeof targets[0]?.instanceId !== "number") {
+          return;
+        }
+
+        const targetInstanceId = targets[0].instanceId;
+        const target = ir.baseProgram.functions.getInstance(targetInstanceId);
+        const signature = ir.baseProgram.functions.getSignature(
+          target.symbolRef.moduleId,
+          target.symbolRef.symbol,
+        );
+        if (!signature) {
+          return;
+        }
+        const callInfo = ir.calls.get(moduleView.moduleId)?.get(exprId);
+        const argExprIds = callArgumentExprIds(expr);
+        const requestedExactTypes = new Map<SymbolId, TypeId>();
+        signature.parameters.forEach((parameter, paramIndex) => {
+          if (typeof parameter.symbol !== "number") {
+            return;
+          }
+          if (ir.baseProgram.types.getTypeDesc(parameter.typeId).kind !== "trait") {
+            return;
+          }
+          const argExprId = callArgumentExprIdForParameter({
+            argExprIds,
+            callInfo,
+            callerInstanceId: context.instanceId,
+            parameterIndex: paramIndex,
+          });
+          if (typeof argExprId !== "number") {
+            return;
+          }
+          const exactType = exactNominalForExpr({
+            moduleView,
+            exprId: argExprId,
+            callerInstanceId: context.instanceId,
+            program: ir.baseProgram,
+            exactParameterTypes: contextExactFacts,
+          });
+          if (typeof exactType !== "number") {
+            return;
+          }
+          const existingExact = exactParameterTypes
+            .get(targetInstanceId)
+            ?.get(parameter.symbol);
+          if (existingExact === exactType) {
+            return;
+          }
+          if (
+            !functionParamCanReachTraitDispatch({
+              ir,
+              functionInstanceId: targetInstanceId,
+              parameterSymbol: parameter.symbol,
+              seen: new Set(),
+            })
+          ) {
+            return;
+          }
+          requestedExactTypes.set(parameter.symbol, exactType);
+        });
+
+        if (
+          requestedExactTypes.size === 0 ||
+          requestedExactTypes.size > MAX_EXACT_PARAMETERS_PER_RECEIVER_SPECIALIZATION
+        ) {
+          return;
+        }
+
+        const callSiteKey = receiverSpecializationCallSiteKey({
+          moduleId: moduleView.moduleId,
+          exprId,
+        });
+        const byContext =
+          requests.get(callSiteKey) ?? new Map<string, Map<SymbolId, TypeId>>();
+        byContext.set(callerContextKey, requestedExactTypes);
+        requests.set(callSiteKey, byContext);
+
+        const targetContextExactTypes = new Map(
+          exactParameterTypes.get(targetInstanceId) ?? [],
+        );
+        requestedExactTypes.forEach((type, symbol) => {
+          targetContextExactTypes.set(symbol, type);
+        });
+        enqueueContext({
+          instanceId: targetInstanceId,
+          exactTypes: targetContextExactTypes,
+          countsAsSpecialization: true,
+        });
+      });
+    });
+  }
+
+  return requests;
+};
+
+const exactReceiverPropagationPass: ProgramOptimizationPass = {
+  name: "exact-receiver-propagation",
+  run(ctx) {
+    const externallyCallableInstances = externallyCallableFunctionInstances(
+      ctx.ir as MutableOptimizationIr,
+    );
+    let exactFacts = new Map<ProgramFunctionInstanceId, Map<SymbolId, TypeId>>();
+    let changed = true;
+
+    while (changed) {
+      const candidates = collectExactParameterCandidates({
+        ir: ctx.ir as MutableOptimizationIr,
+        seedFacts: exactFacts,
+        externallyCallableInstances,
+      });
+      const nextFacts = materializeExactParameterFacts(candidates);
+      changed =
+        serializeExactParameterFacts(nextFacts) !==
+        serializeExactParameterFacts(exactFacts);
+      exactFacts = nextFacts;
+    }
+
+    const validatedExact = validateExactParameterFacts({
+      ir: ctx.ir as MutableOptimizationIr,
+      facts: exactFacts,
+    });
+
+    let knownFacts = new Map<ProgramFunctionInstanceId, Map<SymbolId, Set<TypeId>>>();
+    changed = true;
+    while (changed) {
+      const candidates = collectKnownParameterCandidates({
+        ir: ctx.ir as MutableOptimizationIr,
+        exactParameterTypes: validatedExact,
+        seedFacts: knownFacts,
+        externallyCallableInstances,
+      });
+      const nextFacts = materializeKnownParameterFacts(candidates);
+      changed =
+        serializeKnownParameterFacts(nextFacts) !==
+        serializeKnownParameterFacts(knownFacts);
+      knownFacts = nextFacts;
+    }
+
+    const validatedKnown = validateKnownParameterFacts({
+      ir: ctx.ir as MutableOptimizationIr,
+      exactParameterTypes: validatedExact,
+      facts: knownFacts,
+    });
+    const receiverSpecializationRequests =
+      collectReceiverSpecializationRequests({
+        ir: ctx.ir as MutableOptimizationIr,
+        exactParameterTypes: validatedExact,
+      });
+    const previousExact = ctx.ir.facts.exactParameterTypes;
+    const previousKnown = ctx.ir.facts.knownParameterTypes;
+    const previousReceiverSpecializationRequests =
+      ctx.ir.facts.receiverSpecializationRequests;
+    const unchanged =
+      serializeExactParameterFacts(previousExact) ===
+        serializeExactParameterFacts(validatedExact) &&
+      serializeKnownParameterFacts(previousKnown) ===
+        serializeKnownParameterFacts(validatedKnown) &&
+      serializeReceiverSpecializationRequests(
+        previousReceiverSpecializationRequests,
+      ) ===
+        serializeReceiverSpecializationRequests(receiverSpecializationRequests);
+    (ctx.ir as MutableOptimizationIr).facts.exactParameterTypes = validatedExact;
+    (ctx.ir as MutableOptimizationIr).facts.knownParameterTypes = validatedKnown;
+    (ctx.ir as MutableOptimizationIr).facts.receiverSpecializationRequests =
+      receiverSpecializationRequests;
+    return { changed: !unchanged };
+  },
+};
 
 const moduleLetItems = ({
   moduleView,
@@ -1702,6 +3400,210 @@ const traitDispatchSignatureKey = ({
   traitSymbol: ProgramSymbolId;
   traitMethodSymbol: ProgramSymbolId;
 }): string => `${traitSymbol}:${traitMethodSymbol}`;
+
+const MAX_DIRECT_TRAIT_SWITCH_IMPLS = 4;
+
+const isPrimitiveDirectSwitchType = ({
+  typeId,
+  ir,
+}: {
+  typeId: TypeId;
+  ir: MutableOptimizationIr;
+}): boolean =>
+  typeId !== ir.baseProgram.primitives.void &&
+  ir.baseProgram.types.getTypeDesc(typeId).kind === "primitive";
+
+const isPureSignature = ({
+  effectRow,
+  ir,
+}: {
+  effectRow: number;
+  ir: MutableOptimizationIr;
+}): boolean => ir.baseProgram.effects.getRow(effectRow).operations.length === 0;
+
+const traitMethodMatches = ({
+  traitMethod,
+  implMethod,
+  traitMethodImpl,
+  ir,
+}: {
+  traitMethod: ProgramSymbolId;
+  implMethod: ProgramSymbolId;
+  traitMethodImpl: {
+    traitSymbol: ProgramSymbolId;
+    traitMethodSymbol: ProgramSymbolId;
+  };
+  ir: MutableOptimizationIr;
+}): boolean => {
+  const mapping = ir.baseProgram.traits.getTraitMethodImpl(implMethod);
+  const mappedTraitSymbol = mapping?.traitSymbol ?? traitMethodImpl.traitSymbol;
+  const mappedTraitMethod = mapping?.traitMethodSymbol ?? traitMethod;
+  return (
+    mappedTraitSymbol === traitMethodImpl.traitSymbol &&
+    mappedTraitMethod === traitMethodImpl.traitMethodSymbol
+  );
+};
+
+const directSwitchOmittedMethodTableImpls = ({
+  moduleView,
+  expr,
+  callerInstanceId,
+  functionId,
+  traitMethodImpl,
+  ir,
+}: {
+  moduleView: OptimizedModuleView;
+  expr: Extract<HirExpression, { exprKind: "call" | "method-call" }>;
+  callerInstanceId: ProgramFunctionInstanceId;
+  functionId: ProgramFunctionId;
+  traitMethodImpl: {
+    traitSymbol: ProgramSymbolId;
+    traitMethodSymbol: ProgramSymbolId;
+  };
+  ir: MutableOptimizationIr;
+}): readonly { moduleId: string; symbol: SymbolId }[] | undefined => {
+  const targetRef = ir.baseProgram.symbols.refOf(functionId as ProgramSymbolId);
+  if (targetRef.moduleId !== moduleView.moduleId) {
+    return undefined;
+  }
+  const traitSignature = ir.baseProgram.functions.getSignature(
+    targetRef.moduleId,
+    targetRef.symbol,
+  );
+  if (!traitSignature || !isPureSignature({ effectRow: traitSignature.effectRow, ir })) {
+    return undefined;
+  }
+  if (!isPrimitiveDirectSwitchType({ typeId: traitSignature.returnType, ir })) {
+    return undefined;
+  }
+  if (
+    traitSignature.parameters
+      .slice(1)
+      .some((parameter) => !isPrimitiveDirectSwitchType({ typeId: parameter.typeId, ir }))
+  ) {
+    return undefined;
+  }
+
+  const receiverExprId =
+    expr.exprKind === "method-call" ? expr.target : expr.args[0]?.expr;
+  if (typeof receiverExprId !== "number") {
+    return undefined;
+  }
+  const knownReceiverTypes = knownNominalsForExpr({
+    moduleView,
+    exprId: receiverExprId,
+    callerInstanceId,
+    program: ir.baseProgram,
+    exactParameterTypes: ir.facts.exactParameterTypes,
+    knownParameterTypes: ir.facts.knownParameterTypes,
+  });
+  if (
+    !knownReceiverTypes ||
+    knownReceiverTypes.size === 0 ||
+    knownReceiverTypes.size > MAX_DIRECT_TRAIT_SWITCH_IMPLS
+  ) {
+    return undefined;
+  }
+  if (
+    Array.from(knownReceiverTypes).some(
+      (receiverType) =>
+        ir.baseProgram.types.getTypeDesc(receiverType).kind !== "nominal-object",
+    )
+  ) {
+    return undefined;
+  }
+
+  const seenImpls = new Set<ProgramSymbolId>();
+  const impls = Array.from(knownReceiverTypes).flatMap((receiverType) =>
+    ir.baseProgram.traits
+      .getImplsByNominal(receiverType)
+      .filter((impl) => impl.traitSymbol === traitMethodImpl.traitSymbol)
+      .filter((impl) => {
+        if (seenImpls.has(impl.implSymbol)) {
+          return false;
+        }
+        seenImpls.add(impl.implSymbol);
+        return true;
+      }),
+  );
+  if (impls.length === 0 || impls.length > MAX_DIRECT_TRAIT_SWITCH_IMPLS) {
+    return undefined;
+  }
+
+  const implMethods = impls.map((impl) => {
+    const method = impl.methods.find(({ traitMethod, implMethod }) =>
+      traitMethodMatches({
+        traitMethod,
+        implMethod,
+        traitMethodImpl,
+        ir,
+      }),
+    );
+    if (!method) {
+      return undefined;
+    }
+    const implRef = ir.baseProgram.symbols.refOf(
+      method.implMethod as ProgramSymbolId,
+    );
+    const resolvedImpl = resolveImportedSymbol({
+      moduleId: implRef.moduleId,
+      symbol: implRef.symbol,
+      ir,
+    });
+    const implSignature = ir.baseProgram.functions.getSignature(
+      resolvedImpl.moduleId,
+      resolvedImpl.symbol,
+    );
+    const supported = Boolean(
+      implSignature &&
+        isPureSignature({ effectRow: implSignature.effectRow, ir }) &&
+        isPrimitiveDirectSwitchType({ typeId: implSignature.returnType, ir }) &&
+        implSignature.parameters.length === traitSignature.parameters.length &&
+        implSignature.parameters
+          .slice(1)
+          .every((parameter, index) =>
+            isPrimitiveDirectSwitchType({ typeId: parameter.typeId, ir }) &&
+            parameter.typeId === traitSignature.parameters[index + 1]?.typeId,
+          ),
+    );
+    return supported ? resolvedImpl : undefined;
+  });
+
+  return implMethods.every(Boolean)
+    ? (implMethods as { moduleId: string; symbol: SymbolId }[])
+    : undefined;
+};
+
+const traitDispatchOmittedMethodTableImpls = ({
+  callerInstanceId,
+  functionId,
+  moduleView,
+  expr,
+  traitMethodImpl,
+  ir,
+}: {
+  moduleView: OptimizedModuleView;
+  expr: Extract<HirExpression, { exprKind: "call" | "method-call" }>;
+  callerInstanceId?: ProgramFunctionInstanceId;
+  functionId: ProgramFunctionId;
+  traitMethodImpl: {
+    traitSymbol: ProgramSymbolId;
+    traitMethodSymbol: ProgramSymbolId;
+  };
+  ir: MutableOptimizationIr;
+}): readonly { moduleId: string; symbol: SymbolId }[] | undefined => {
+  if (typeof callerInstanceId !== "number") {
+    return undefined;
+  }
+  return directSwitchOmittedMethodTableImpls({
+    moduleView,
+    expr,
+    callerInstanceId,
+    functionId,
+    traitMethodImpl,
+    ir,
+  });
+};
 
 const resolveTargetsForCaller = ({
   moduleId,
@@ -2010,6 +3912,20 @@ const wholeProgramSpecializationPruningPass: ProgramOptimizationPass = {
               functionId as ProgramSymbolId,
             );
             if (!traitMethodImpl) {
+              return;
+            }
+            const omittedMethodTableImpls = traitDispatchOmittedMethodTableImpls({
+              moduleView,
+              expr,
+              callerInstanceId,
+              functionId,
+              traitMethodImpl,
+              ir: ctx.ir as MutableOptimizationIr,
+            });
+            if (omittedMethodTableImpls) {
+              omittedMethodTableImpls.forEach((impl) =>
+                enqueueKnownFunctionInstances(impl)
+              );
               return;
             }
             usedTraitDispatchSignatures.add(
@@ -2358,6 +4274,27 @@ const finalizeOptimization = ({
         ]),
       ),
       usedTraitDispatchSignatures: new Set(ir.facts.usedTraitDispatchSignatures),
+      receiverSpecializationRequests: cloneReceiverSpecializationRequests(
+        ir.facts.receiverSpecializationRequests,
+      ),
+      exactParameterTypes: new Map(
+        Array.from(ir.facts.exactParameterTypes.entries()).map(
+          ([instanceId, bySymbol]) => [instanceId, new Map(bySymbol)],
+        ),
+      ),
+      knownParameterTypes: new Map(
+        Array.from(ir.facts.knownParameterTypes.entries()).map(
+          ([instanceId, bySymbol]) => [
+            instanceId,
+            new Map(
+              Array.from(bySymbol.entries()).map(([symbol, types]) => [
+                symbol,
+                new Set(types),
+              ]),
+            ),
+          ],
+        ),
+      ),
       codegenPlan,
     },
   };
@@ -2369,8 +4306,15 @@ const OPTIMIZATION_PASSES: readonly ProgramOptimizationPass[] = [
   constructorKnownSimplificationPass,
   effectFastPathEliminationPass,
   closureEnvironmentShrinkingPass,
-  traitDispatchDevirtualizationPass,
   continuationAndHandlerEnvironmentShrinkingPass,
+  wholeProgramSpecializationPruningPass,
+  exactReceiverPropagationPass,
+  constructorKnownSimplificationPass,
+  traitDispatchDevirtualizationPass,
+  wholeProgramSpecializationPruningPass,
+  exactReceiverPropagationPass,
+  constructorKnownSimplificationPass,
+  traitDispatchDevirtualizationPass,
   wholeProgramSpecializationPruningPass,
 ];
 


### PR DESCRIPTION
## Summary

- Adds optimizer facts for exact and known receiver parameter types across closed call edges.
- Uses those facts in codegen to create bounded receiver-specialized function clones.
- Lowers proven monomorphic trait dispatch and small safe receiver sets to direct calls/switches instead of method-table lookup.
- Preserves open-world safety for public entry exports/re-exports, higher-order function escapes, value-object receivers, cross-module/ABI cases, and generic target type arguments.
- Adds focused compiler/codegen regression coverage for the optimizer facts, receiver clone generation, direct-switch reachability, effectful dispatch conventions, and safety guardrails.

## Notes

This PR is scoped to V-327/V-328 implementation and regression coverage only. Investigation-only smoke benchmark files and package scripts were intentionally left out of the branch.

Local size checks during investigation showed the optimizer materially reduces emitted Wasm for dispatch-heavy fixtures, but runtime-oriented wrapper specialization is not part of this PR.

## Verification

- `npm run typecheck`
- `npm test`
- `npx vitest packages/compiler/src/__tests__/optimize-pipeline.test.ts packages/compiler/src/codegen/__tests__/effects-call-convention-lowering.test.ts packages/compiler/src/codegen/__tests__/effects-perform.test.ts --run --config vitest.config.ts`

Review loop completed during implementation:

- implementation-gap reviewers clean after fixes
- correctness reviewers clean after fixes

Linear updates posted for V-327 and V-328.
