### PR TITLE
Fix `use ...::all` effect-op import collisions and restore `std::log`

### DIFF
--- a/apps/smoke/fixtures/std-input-output.voyd
+++ b/apps/smoke/fixtures/std-input-output.voyd
@@ -6,6 +6,7 @@ use std::output::Output
 use std::optional::types::all
 use std::output::{ write, write_line, flush, is_tty as output_is_tty, StdErr }
 use std::result::types::all
+use std::test::assertions::all
 
 fn sum_bytes(bytes: Bytes): () -> i32
   let values = bytes.to_array()
@@ -163,4 +164,8 @@ pub fn print_text(): Output -> i32
 
 pub fn print_number(): Output -> i32
   print(42)
+  1
+
+pub fn prelude_log_module_with_assertions_all() -> i32
+  let _ = log::LogInfo {}
   1

--- a/apps/smoke/src/std-input-output.test.ts
+++ b/apps/smoke/src/std-input-output.test.ts
@@ -125,6 +125,7 @@ describe("smoke: std input/output", () => {
 
     await expect(host.run<number>("print_text")).resolves.toBe(1);
     await expect(host.run<number>("print_number")).resolves.toBe(1);
+    await expect(host.run<number>("prelude_log_module_with_assertions_all")).resolves.toBe(1);
 
     expect(writes).toEqual([
       { target: "stdout", value: "hello\n" },

--- a/packages/compiler/src/semantics/__tests__/binding.test.ts
+++ b/packages/compiler/src/semantics/__tests__/binding.test.ts
@@ -20,7 +20,10 @@ import type {
   ModuleHost,
   ModuleNode,
 } from "../../modules/types.js";
-import type { ModuleExportTable } from "../modules.js";
+import type {
+  ModuleExportSurfaceTable,
+  ModuleExportTable,
+} from "../modules.js";
 import { resolve, sep } from "node:path";
 import {
   packageVisibility,
@@ -640,6 +643,260 @@ fn main(value: util::Thing): util::Fx -> util::Thing
         diag.message.includes("Cannot import compare as value"),
     );
     expect(conflict).toBeDefined();
+  });
+
+  it("does not import effect ops from wildcard imports in full export tables", () => {
+    const source = "use self::log\nuse self::assertions::all";
+    const ast = parse(source, "pkg.voyd");
+    const useForm = ast.rest.find((entry) => isForm(entry) && entry.calls("use")) as
+      | Form
+      | undefined;
+    const span = toSourceSpan(useForm ?? ast);
+    const modulePath = { namespace: "src" as const, segments: ["main"] as const };
+    const moduleId = modulePathToString(modulePath);
+    const logPath = {
+      namespace: "src" as const,
+      segments: ["main", "log"] as const,
+    };
+    const assertionsPath = {
+      namespace: "src" as const,
+      segments: ["main", "assertions"] as const,
+    };
+    const assertionsId = modulePathToString(assertionsPath);
+    const moduleNode: ModuleNode = {
+      id: moduleId,
+      path: modulePath,
+      origin: { kind: "file", filePath: "pkg.voyd" },
+      ast,
+      source,
+      dependencies: [
+        { kind: "use", path: logPath, span },
+        { kind: "use", path: assertionsPath, span },
+      ],
+    };
+    const graph: ModuleGraph = {
+      entry: moduleId,
+      modules: new Map([[moduleId, moduleNode]]),
+      diagnostics: [],
+    };
+    const symbolTable = new SymbolTable({ rootOwner: ast.syntaxId });
+    symbolTable.declare({
+      name: "pkg.voyd",
+      kind: "module",
+      declaredAt: ast.syntaxId,
+    });
+
+    const moduleExports: Map<string, ModuleExportTable> = new Map([
+      [
+        assertionsId,
+        new Map([
+          [
+            "log",
+            {
+              name: "log",
+              symbol: 99,
+              moduleId: assertionsId,
+              modulePath: assertionsPath,
+              packageId: packageIdFromPath(assertionsPath),
+              kind: "effect-op",
+              visibility: packageVisibility(),
+            },
+          ],
+          [
+            "assert",
+            {
+              name: "assert",
+              symbol: 100,
+              moduleId: assertionsId,
+              modulePath: assertionsPath,
+              packageId: packageIdFromPath(assertionsPath),
+              kind: "value",
+              visibility: packageVisibility(),
+            },
+          ],
+        ]),
+      ],
+    ]);
+
+    const binding = runBindingPipeline({
+      moduleForm: ast,
+      symbolTable,
+      module: moduleNode,
+      graph,
+      moduleExports,
+    });
+
+    expect(binding.diagnostics).toHaveLength(0);
+    const logSymbols = Array.from(symbolTable.symbolsInScope(symbolTable.rootScope))
+      .filter((symbol) => symbolTable.getSymbol(symbol).name === "log")
+      .map((symbol) => symbolTable.getSymbol(symbol).kind);
+    expect(logSymbols).toEqual(["module"]);
+    const assertSymbol = symbolTable.resolve("assert", symbolTable.rootScope);
+    expect(typeof assertSymbol).toBe("number");
+    if (typeof assertSymbol === "number") {
+      expect(symbolTable.getSymbol(assertSymbol).kind).toBe("value");
+    }
+  });
+
+  it("does not import effect ops from wildcard imports in cyclic export surfaces", () => {
+    const source = "use self::log\nuse self::assertions::all";
+    const ast = parse(source, "pkg.voyd");
+    const useForm = ast.rest.find((entry) => isForm(entry) && entry.calls("use")) as
+      | Form
+      | undefined;
+    const span = toSourceSpan(useForm ?? ast);
+    const modulePath = { namespace: "src" as const, segments: ["main"] as const };
+    const moduleId = modulePathToString(modulePath);
+    const logPath = {
+      namespace: "src" as const,
+      segments: ["main", "log"] as const,
+    };
+    const assertionsPath = {
+      namespace: "src" as const,
+      segments: ["main", "assertions"] as const,
+    };
+    const assertionsId = modulePathToString(assertionsPath);
+    const moduleNode: ModuleNode = {
+      id: moduleId,
+      path: modulePath,
+      origin: { kind: "file", filePath: "pkg.voyd" },
+      ast,
+      source,
+      dependencies: [
+        { kind: "use", path: logPath, span },
+        { kind: "use", path: assertionsPath, span },
+      ],
+    };
+    const graph: ModuleGraph = {
+      entry: moduleId,
+      modules: new Map([[moduleId, moduleNode]]),
+      diagnostics: [],
+    };
+    const symbolTable = new SymbolTable({ rootOwner: ast.syntaxId });
+    symbolTable.declare({
+      name: "pkg.voyd",
+      kind: "module",
+      declaredAt: ast.syntaxId,
+    });
+
+    const moduleExportSurfaces: Map<string, ModuleExportSurfaceTable> = new Map([
+      [
+        assertionsId,
+        new Map([
+          [
+            "log",
+            {
+              name: "log",
+              moduleId: assertionsId,
+              modulePath: assertionsPath,
+              packageId: packageIdFromPath(assertionsPath),
+              kind: "effect-op",
+              visibility: packageVisibility(),
+            },
+          ],
+          [
+            "assert",
+            {
+              name: "assert",
+              moduleId: assertionsId,
+              modulePath: assertionsPath,
+              packageId: packageIdFromPath(assertionsPath),
+              kind: "value",
+              visibility: packageVisibility(),
+            },
+          ],
+        ]),
+      ],
+    ]);
+
+    const binding = runBindingPipeline({
+      moduleForm: ast,
+      symbolTable,
+      module: moduleNode,
+      graph,
+      moduleExportSurfaces,
+    });
+
+    expect(binding.diagnostics).toHaveLength(0);
+    const logSymbols = Array.from(symbolTable.symbolsInScope(symbolTable.rootScope))
+      .filter((symbol) => symbolTable.getSymbol(symbol).name === "log")
+      .map((symbol) => symbolTable.getSymbol(symbol).kind);
+    expect(logSymbols).toEqual(["module"]);
+    const assertSymbol = symbolTable.resolve("assert", symbolTable.rootScope);
+    expect(typeof assertSymbol).toBe("number");
+    if (typeof assertSymbol === "number") {
+      expect(symbolTable.getSymbol(assertSymbol).kind).toBe("value");
+    }
+  });
+
+  it("preserves explicit named effect-op imports", () => {
+    const source = "use self::assertions::log";
+    const ast = parse(source, "pkg.voyd");
+    const useForm = ast.rest.find((entry) => isForm(entry) && entry.calls("use")) as
+      | Form
+      | undefined;
+    const span = toSourceSpan(useForm ?? ast);
+    const modulePath = { namespace: "src" as const, segments: ["main"] as const };
+    const moduleId = modulePathToString(modulePath);
+    const assertionsPath = {
+      namespace: "src" as const,
+      segments: ["main", "assertions"] as const,
+    };
+    const assertionsId = modulePathToString(assertionsPath);
+    const moduleNode: ModuleNode = {
+      id: moduleId,
+      path: modulePath,
+      origin: { kind: "file", filePath: "pkg.voyd" },
+      ast,
+      source,
+      dependencies: [{ kind: "use", path: assertionsPath, span }],
+    };
+    const graph: ModuleGraph = {
+      entry: moduleId,
+      modules: new Map([[moduleId, moduleNode]]),
+      diagnostics: [],
+    };
+    const symbolTable = new SymbolTable({ rootOwner: ast.syntaxId });
+    symbolTable.declare({
+      name: "pkg.voyd",
+      kind: "module",
+      declaredAt: ast.syntaxId,
+    });
+
+    const moduleExports: Map<string, ModuleExportTable> = new Map([
+      [
+        assertionsId,
+        new Map([
+          [
+            "log",
+            {
+              name: "log",
+              symbol: 99,
+              moduleId: assertionsId,
+              modulePath: assertionsPath,
+              packageId: packageIdFromPath(assertionsPath),
+              kind: "effect-op",
+              visibility: packageVisibility(),
+            },
+          ],
+        ]),
+      ],
+    ]);
+
+    const binding = runBindingPipeline({
+      moduleForm: ast,
+      symbolTable,
+      module: moduleNode,
+      graph,
+      moduleExports,
+    });
+
+    expect(binding.diagnostics).toHaveLength(0);
+    const logSymbol = symbolTable.resolve("log", symbolTable.rootScope);
+    expect(typeof logSymbol).toBe("number");
+    if (typeof logSymbol === "number") {
+      expect(symbolTable.getSymbol(logSymbol).kind).toBe("effect-op");
+    }
   });
 
   it("reports overload-name collisions for top-level non-function declarations", () => {

--- a/packages/compiler/src/semantics/binding/binders/module.ts
+++ b/packages/compiler/src/semantics/binding/binders/module.ts
@@ -735,8 +735,15 @@ const bindImportsFromExportTable = ({
     return true;
   };
 
+  const includeInWildcardImport = (
+    exported: Pick<ModuleExportEntry, "kind">,
+  ): boolean => exported.kind !== "effect-op";
+
   if (entry.selectionKind === "all") {
     const allowed = Array.from(exports.values()).filter((item) => {
+      if (!includeInWildcardImport(item)) {
+        return false;
+      }
       const accessible = canAccessExport({
         exported: item,
         moduleId,
@@ -869,8 +876,13 @@ const bindImportsFromExportSurface = ({
       ctx,
     });
 
+  const includeInWildcardImport = (
+    exported: Pick<ModuleExportSurfaceEntry, "kind">,
+  ): boolean => exported.kind !== "effect-op";
+
   if (entry.selectionKind === "all") {
     return Array.from(exportSurface.values())
+      .filter((item) => includeInWildcardImport(item))
       .filter((item) => isAccessible(item))
       .flatMap((item) =>
         declareSurfaceImportedSymbol({

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -800,7 +800,9 @@ export const typeMethodCallExpr = (
   }
 
   const selectedRef = selected.symbolRef
-    ? canonicalSymbolRefInTypingContext(selected.symbolRef, ctx)
+    ? selected.symbolRef.moduleId === ctx.moduleId
+      ? canonicalSymbolRefInTypingContext(selected.symbolRef, ctx)
+      : selected.symbolRef
     : canonicalSymbolRefForTypingContext(selected.symbol, ctx);
   const targets =
     ctx.callResolution.targets.get(expr.id) ?? new Map<string, SymbolRef>();
@@ -2738,7 +2740,11 @@ const instantiationRefKeyForCall = ({
   calleeModuleId?: string;
   ctx: TypingContext;
 }): string => {
-  const imported = ctx.importsByLocal.get(calleeSymbol);
+  const imported = importedCalleeRefForCall({
+    calleeSymbol,
+    calleeModuleId,
+    ctx,
+  });
   if (imported) {
     return symbolRefKey(imported);
   }
@@ -2746,6 +2752,25 @@ const instantiationRefKeyForCall = ({
     return symbolRefKey({ moduleId: calleeModuleId, symbol: calleeSymbol });
   }
   return symbolRefKey(canonicalSymbolRefForTypingContext(calleeSymbol, ctx));
+};
+
+const importedCalleeRefForCall = ({
+  calleeSymbol,
+  calleeModuleId,
+  ctx,
+}: {
+  calleeSymbol: SymbolId;
+  calleeModuleId?: string;
+  ctx: TypingContext;
+}): SymbolRef | undefined => {
+  const imported = ctx.importsByLocal.get(calleeSymbol);
+  if (!imported) {
+    return undefined;
+  }
+  if (!calleeModuleId || calleeModuleId === ctx.moduleId) {
+    return imported;
+  }
+  return imported.moduleId === calleeModuleId ? imported : undefined;
 };
 
 const getTraitMethodTypeBindings = ({
@@ -4550,22 +4575,28 @@ const typeFunctionCall = ({
     });
     const callKey = formatFunctionInstanceKey(calleeSymbol, appliedTypeArgs);
     if (typeof calleeExprId === "number") {
-      // Avoid re-canonicalizing external overload symbols.
-      // Some call paths resolve directly to dependency symbols (methods, operator overloads, etc).
-      // Those symbols are not guaranteed to exist in the caller's symbol table, so fall back to
-      // the provided `calleeModuleId` when we can't canonicalize via local import metadata.
-      const imported = ctx.importsByLocal.get(calleeSymbol);
-      const calleeRef =
-        imported ??
-        (calleeModuleId && calleeModuleId !== ctx.moduleId
+      // Direct identifier calls use caller-local symbols. Imported callees must
+      // therefore resolve through the local import map before falling back to an
+      // external module id supplied by overload resolution.
+      const importedCalleeRef = importedCalleeRefForCall({
+        calleeSymbol,
+        calleeModuleId,
+        ctx,
+      });
+      const externalCalleeRef =
+        calleeModuleId && calleeModuleId !== ctx.moduleId
           ? { moduleId: calleeModuleId, symbol: calleeSymbol }
-          : (() => {
-              try {
-                return canonicalSymbolRefForTypingContext(calleeSymbol, ctx);
-              } catch {
-                return { moduleId: ctx.moduleId, symbol: calleeSymbol };
-              }
-            })());
+          : undefined;
+      const calleeRef =
+        importedCalleeRef ??
+        externalCalleeRef ??
+        (() => {
+          try {
+            return canonicalSymbolRefForTypingContext(calleeSymbol, ctx);
+          } catch {
+            return { moduleId: ctx.moduleId, symbol: calleeSymbol };
+          }
+        })();
       const existingTargets =
         ctx.callResolution.targets.get(callId) ?? new Map();
       existingTargets.set(callerInstanceKey, calleeRef);

--- a/packages/std/src/prelude.voyd
+++ b/packages/std/src/prelude.voyd
@@ -21,6 +21,7 @@ pub std::set::{ Set }
 pub std::bytes::{ Byte, Bytes, ByteBuffer }
 pub std::box::{ Box }
 pub std::math
+pub std::log
 pub std::output
 pub std::output::print
 


### PR DESCRIPTION
## Summary
- Skip `effect-op` exports during wildcard imports in the binder, in both export-table and cyclic-surface paths.
- Restore `std::log` to the implicit prelude now that wildcard imports no longer pull `log` into user scope.
- Add regressions covering wildcard imports, explicit named effect-op imports, and the prelude `log`/`assertions::all` interaction.
- Tighten call-target and instantiation symbol-ref handling so restored prelude imports do not collide with unrelated dependency symbols.

## Testing
- `npx vitest packages/compiler/src/semantics/__tests__/binding.test.ts`
- `npx vitest apps/smoke/src/std-input-output.test.ts`
- `npx vitest apps/smoke/src/value-types.test.ts`
- `npm test`
- `npm run typecheck`