### PR TITLE
Add V-309 Tier 2 optimizer passes and benchmarks

### DIFF
--- a/docs/architecture/compiler-optimization-pipeline.md
+++ b/docs/architecture/compiler-optimization-pipeline.md
@@ -1,342 +1,347 @@
 # Compiler Optimization Pipeline
 
-Status: Proposed
+Status: Current
 Owner: Compiler Architecture Working Group
-Scope: `packages/compiler/src/pipeline-shared.ts`, new `packages/compiler/src/optimize/*`, `packages/compiler/src/codegen/*`, `packages/sdk/src/node.ts`
+Scope: `packages/compiler/src/pipeline-shared.ts`, `packages/compiler/src/optimize/*`, `packages/compiler/src/codegen/*`, `packages/lib/src/lib/binaryen-optimize.ts`
 
-## Goal
+## Purpose
 
-Introduce a compiler-owned optimization layer before Wasm codegen, while keeping Binaryen responsible for Wasm-level and Binaryen-IR-level optimization.
+Voyd has a compiler-owned optimization layer between semantic linking and Wasm
+codegen. Its job is to use Voyd semantic information while that information is
+still explicit: types, effects, trait resolution, monomorphized instances,
+call-shape metadata, capture sets, and constructor facts.
 
-The design goal is not "replace Binaryen". The goal is to do the optimizations that require Voyd semantic information before that information is erased by lowering to Wasm.
+Binaryen remains responsible for Wasm-level cleanup and optimization after
+Voyd has lowered the program. The compiler optimizer should not duplicate
+Binaryen's generic local cleanup, CFG cleanup, Wasm peepholes, low-level
+inlining, or Binaryen GC passes.
 
-## Current Pipeline
+## Optimized Pipeline
 
-Today the relevant whole-program pipeline is:
+The optimized whole-program path is:
 
-1. Analyze modules.
-2. `monomorphizeProgram(...)`
-3. `buildProgramCodegenView(...)`
-4. `codegen.codegenProgram(...)`
-5. Binaryen `module.optimize()` when `CodegenOptions.optimize` is enabled
-6. In `@voyd-lang/sdk`, read emitted wasm back into Binaryen and run another `module.optimize()`
+1. Load and analyze modules.
+2. Lower analyzed modules into ordered semantic modules.
+3. `monomorphizeProgram(...)` builds callable instance metadata.
+4. `buildProgramCodegenView(...)` builds the stable codegen-facing semantic
+   view.
+5. `optimizeProgram(...)` runs when `CodegenOptions.optimize` is enabled.
+6. `codegenProgram(...)` receives the optimized program plus optimization facts.
+7. Codegen emits a Binaryen module and, when optimized, runs the configured
+   Binaryen optimization profile.
 
-The current call sites are:
+The optimization layer is invoked from both public emission paths in
+`packages/compiler/src/pipeline-shared.ts`:
 
-- `packages/compiler/src/pipeline-shared.ts`
-  - `emitProgram(...)`
-  - `emitProgramWithContinuationFallback(...)`
-- `packages/compiler/src/codegen/codegen.ts`
-  - `mod.optimize()`
-- `packages/sdk/src/node.ts`
-  - `binaryen.setShrinkLevel(3)`
-  - `binaryen.setOptimizeLevel(3)`
-  - `module.optimize()`
+- `emitProgram(...)`
+- `emitProgramWithContinuationFallback(...)`
 
-This means Voyd currently relies on Binaryen for all optimization after language lowering. There is no compiler-owned optimization stage between semantic linking and Wasm emission.
+Both paths build the same `ProgramCodegenView`, optionally call
+`optimizeProgram(...)`, and pass `optimized?.program` plus `optimized?.facts`
+into codegen.
 
-## What Binaryen Already Does
+## Ownership Boundary
 
-This repository currently depends on `binaryen` `^125.0.0` (`packages/sdk/package.json`, `packages/lib/package.json`).
+The boundary between compiler optimization and codegen is
+`ProgramCodegenView` plus `ProgramOptimizationFacts`.
 
-Research basis:
+The optimizer may:
 
-- Official Binaryen README: [`WebAssembly/binaryen/README.md`](https://github.com/WebAssembly/binaryen/blob/main/README.md)
-- Local Binaryen package docs: `node_modules/binaryen/README.md`
-- Local Binaryen tool inventory: `node_modules/binaryen/bin/wasm-opt --help`
-- Verified default `-O` pipeline via `node_modules/binaryen/bin/wasm-opt /tmp/min.wat -O --debug`
+- clone and mutate HIR in its own `ProgramOptimizationIR`
+- rewrite compiler-level call metadata
+- prune monomorphized instances and other semantic artifacts before codegen
+- compute facts that tell codegen to choose a more direct lowering
 
-Important confirmed facts:
+The optimizer must not:
 
-- `Module#optimize()` runs Binaryen's default optimization passes.
-- The Binaryen JS defaults are currently:
-  - `optimizeLevel = 2`
-  - `shrinkLevel = 1`
-- In Binaryen's CLI, `-O` is equivalent to `-Os`.
+- mutate typing internals directly
+- transform Binaryen IR
+- perform generic Wasm-level peepholes
+- infer broad escape/scalar-replacement behavior unless that is explicitly
+  owned by a dedicated semantic pass
 
-### Default Binaryen Passes Already Observed In The Pipeline
+Codegen may consume optimization facts when choosing a lowering, but it should
+still validate local preconditions at the use site. Facts are a guide to avoid
+rediscovering semantic information, not permission to emit unsafe Wasm.
 
-The default `-O`/`-Os` pipeline already runs the following pass names on a minimal module:
+## Core Files
 
-- `duplicate-function-elimination`
-- `remove-unused-module-elements`
-- `memory-packing`
-- `once-reduction`
-- `ssa-nomerge`
-- `dce`
-- `remove-unused-names`
-- `remove-unused-brs`
-- `optimize-instructions`
-- `pick-load-signs`
-- `precompute`
-- `code-pushing`
-- `simplify-locals-nostructure`
-- `vacuum`
-- `reorder-locals`
-- `coalesce-locals`
-- `local-cse`
-- `simplify-locals`
-- `code-folding`
-- `merge-blocks`
-- `rse`
-- `dae-optimizing`
-- `inlining-optimizing`
-- `duplicate-import-elimination`
-- `simplify-globals-optimizing`
-- `reorder-globals`
-- `directize`
-
-### Binaryen Also Already Provides Additional Optimization Passes
-
-`wasm-opt --help` also exposes many non-default passes that are still clearly Binaryen territory:
-
-- `licm`
-- `optimize-added-constants`
-- `merge-locals`
-- `merge-similar-functions`
-- `signature-pruning`
-- `signature-refining`
-- `global-refining`
-- `gto`
-- `gufa`
-- `heap-store-optimization`
-- `heap2local`
-- `type-refining`
-- `tuple-optimization`
-
-### Implication
-
-Voyd should not duplicate:
-
-- Wasm peepholes
-- local/temp cleanup
-- generic DCE/CSE/RSE/SSA passes
-- low-level inlining
-- block merging / CFG cleanup at Binaryen IR granularity
-- load/store offset folding
-- import/function deduplication
-- memory/data-segment packing
-- directization of Wasm indirect calls
-- GC heap/store optimizations that Binaryen already models directly
-
-If a pass can be expressed purely as a Wasm or Binaryen-IR transform, Binaryen should remain the owner.
-
-## What Voyd Should Optimize Before Codegen
-
-The compiler-owned layer should focus on transformations that need typed, effect-aware, trait-aware Voyd semantics.
-
-### Tier 1: High-value passes to implement first
-
-- Trait dispatch devirtualization
-  - Rewrite trait-method calls to direct calls when the concrete impl is known from `ProgramCodegenView`.
-  - This is not the same as Binaryen `directize`, which only turns constant table indexes into direct Wasm calls after lowering.
-
-- Effect fast-path elimination
-  - Remove effect-handler scaffolding when the callee is statically pure or when the effect row proves an operation cannot occur.
-  - Specialize handler lowering for resume-only / tail-resume-only cases.
-
-- Closure environment shrinking
-  - Remove uncaptured values from closure environments before any closure struct type is emitted.
-  - This reduces generated Wasm GC field counts and helper code, which Binaryen cannot recover once the extra fields exist.
-
-- Continuation / handler environment shrinking
-  - Prune captured state from effect trampolines and continuation environments using effect-lowering facts.
-
-- Constructor-known simplification
-  - Fold `Option`/union/intersection/tag-style checks when the constructor or exact nominal head is already proven.
-  - Example: eliminate branches after inlining overload resolution or monomorphization has made the variant exact.
-
-- Whole-program specialization pruning
-  - Drop unreachable monomorphized instances, trait impl wrappers, and helper stubs before Wasm emission.
-  - Binaryen can remove unused emitted functions, but it cannot prevent us from generating unnecessary type metadata, helper bodies, or GC shapes in the first place.
-
-- Pure compile-time evaluation
-  - Evaluate a tightly controlled set of compiler-known pure intrinsics and annotated library helpers when all inputs are compile-time constants.
-  - Keep this at the semantic layer, not as a generic arithmetic peephole pass.
-
-### Tier 2: Good follow-on passes
-
-- Call-shape specialization
-  - Specialize resolved calls based on labels/default-argument plans already computed by semantics so codegen emits smaller direct call sequences.
-
-- Redundant runtime type-check elimination
-  - Remove casts/tests that are semantically proven by the type arena, trait resolution, or constructor propagation before they become Wasm `ref.test` / `ref.cast`.
-
-- Semantic copy forwarding
-  - Forward fields out of freshly constructed aggregates when the aggregate is immediately destructured and does not escape.
-  - This should stay narrowly focused on semantic constructs, not devolve into a generic local-value optimizer.
-
-- Addressable wide-local scratch lowering
-  - Reuse already-addressable local/out-result storage for wide aggregate construction and mutation when the storage stays within the current lowering region.
-  - This is intentionally narrower than future escape-analysis (`V-325`) or scalar-replacement (`V-326`) work: it does not infer reusable whole-program escape facts and it does not split aggregates into scalar locals.
-
-### Explicit non-goals for the compiler pass layer
-
-- Arithmetic peepholes
-- local.get/local.set cleanup
-- generic inlining heuristics
-- loop-invariant code motion
-- Wasm CFG cleanup
-- stack-machine shaping
-- low-level GC heap store optimization
-
-## Proposed Architecture
-
-Add a new compiler package area:
-
-- `packages/compiler/src/optimize/`
-
-Recommended top-level files:
-
-- `packages/compiler/src/optimize/pipeline.ts`
 - `packages/compiler/src/optimize/ir.ts`
+  - defines `ProgramOptimizationIR`, `ProgramOptimizationFacts`, and
+    `ProgramOptimizationResult`
 - `packages/compiler/src/optimize/pass.ts`
-- `packages/compiler/src/optimize/analysis/*`
-- `packages/compiler/src/optimize/passes/*`
+  - defines the pass interface and cached analysis API
+- `packages/compiler/src/optimize/pipeline.ts`
+  - builds the optimization IR, runs the pass list, and finalizes the optimized
+    program/facts
+- `packages/compiler/src/optimize/codegen-plan.ts`
+  - contains longer-lived codegen planning data
+- `packages/compiler/src/codegen/optimization/*`
+  - contains small codegen helpers that consume optimizer facts
+- `packages/lib/src/lib/binaryen-optimize.ts`
+  - owns the shared Binaryen optimization profiles
 
-### IR Boundary
+## Optimization IR
 
-Do not run optimization passes directly on Binaryen IR.
+`ProgramOptimizationIR` is built from `ProgramCodegenView` and the semantic
+pipeline results. It keeps cloned module views so passes can mutate optimized
+HIR without changing the original semantics-owned data.
 
-Do not run them by mutating typing internals either.
+The IR currently tracks:
 
-Instead:
+- the original `ProgramCodegenView`
+- the entry module id and selected codegen options
+- optimized module views with cloned HIR/effect data
+- normalized call lowering info per module/expression
+- function instantiation metadata
+- surviving monomorphized instances
+- accumulated optimization facts
 
-1. Keep `ProgramCodegenView` as the stable semantics-owned boundary.
-2. Build a compiler-owned `ProgramOptimizationIR` from that view.
-3. Run optimization passes on `ProgramOptimizationIR`.
-4. Feed optimized function bodies plus optimization facts into codegen.
+`ProgramOptimizationFacts` currently includes:
 
-### `ProgramOptimizationIR`
+- reachable function instances and function symbols
+- reachable module lets
+- effect handler clause capture sets
+- used trait-dispatch signatures
+- receiver specialization requests
+- exact and known parameter type facts
+- runtime type-check elision candidates for field access
+- semantic copy-forwarding candidates for field access
+- a codegen optimization plan
 
-`ProgramOptimizationIR` should contain only the data that is useful for code generation and optimization:
+## Pass API
 
-- reachable `ProgramFunctionInstanceId`s only
-- normalized, explicit control-flow expressions
-- resolved direct-call targets
-- explicit trait-dispatch nodes
-- effect rows on expressions/functions
-- closure and continuation capture sets
-- constructor / nominal-head facts
-- exact value type ids
-
-It should not re-expose general binding internals or parser shapes.
-
-### Pass API
-
-Use a small pass manager with explicit analysis invalidation:
+Optimization passes implement this interface:
 
 ```ts
 type ProgramOptimizationPass = {
   name: string;
   run(ctx: ProgramOptimizationContext): ProgramOptimizationPassResult;
 };
-
-type ProgramOptimizationPassResult = {
-  changed: boolean;
-  invalidates?: readonly OptimizationAnalysisKey[];
-};
 ```
 
-Analyses should be cached and recomputed on demand:
+`ProgramOptimizationContext` gives passes access to the IR and a small cached
+analysis mechanism. Analyses are invalidated explicitly by returning
+`invalidates` from a pass.
 
-- call graph
-- effect reachability
-- escape analysis
-- capture analysis
-- constructor-known facts
-- exact-impl / exact-target facts
+Current cached analysis keys are:
 
-### Codegen Integration
+- `reachable-function-instances`
+- `handler-captures`
+- `trait-dispatch-signatures`
 
-In the short term, codegen can consume:
+## Current Pass Order
 
-- `ProgramCodegenView` for type/layout metadata
-- optimized per-instance bodies from `ProgramOptimizationIR`
-- optimization facts that affect lowering decisions
+The optimizer intentionally runs some passes more than once because earlier
+rewrites can expose new exact-receiver, constructor, trait-dispatch, or
+reachability facts.
 
-That lets us introduce the optimization layer without rewriting every codegen index at once.
+The current pass list is:
 
-Long-term, function-body codegen should consume optimized IR directly, while the non-body indexes remain semantics-owned via `ProgramCodegenView`.
+1. `pure-compile-time-evaluation`
+2. `simplify-boolean-branch`
+3. `constructor-known-simplification`
+4. `effect-fast-path-elimination`
+5. `closure-environment-shrinking`
+6. `continuation-and-handler-environment-shrinking`
+7. `whole-program-specialization-pruning`
+8. `exact-receiver-propagation`
+9. `constructor-known-simplification`
+10. `trait-dispatch-devirtualization`
+11. `whole-program-specialization-pruning`
+12. `exact-receiver-propagation`
+13. `constructor-known-simplification`
+14. `trait-dispatch-devirtualization`
+15. `whole-program-specialization-pruning`
+16. `redundant-runtime-type-check-elimination`
+17. `semantic-copy-forwarding`
 
-## Proposed Pipeline Placement
+## Implemented Semantic Optimizations
 
-The optimization pass should run in:
+### Pure Compile-Time Evaluation
 
-- `packages/compiler/src/pipeline-shared.ts`
+Evaluates a controlled set of compiler-known pure expressions and intrinsics
+when all inputs are compile-time constants. This is semantic constant
+evaluation, not a generic arithmetic peephole pass.
 
-Specifically:
+### Boolean Branch Simplification
 
-- in `emitProgram(...)`
-- in `emitProgramWithContinuationFallback(...)`
-- immediately after `buildProgramCodegenView(...)`
-- immediately before `codegen.codegenProgram(...)` / `codegenProgramWithContinuationFallback(...)`
+Simplifies branches whose condition is already known from earlier semantic
+rewrites or constant evaluation.
 
-The intended pipeline becomes:
+### Constructor-Known Simplification
 
-1. `analyzeModules(...)`
-2. `monomorphizeProgram(...)`
-3. `buildProgramCodegenView(...)`
-4. `optimizeProgram(...)`
-5. `codegen.codegenProgram(...)`
-6. Binaryen `module.optimize()`
+Uses constructor and exact nominal facts to simplify `Option`,
+union/intersection, and tag-style checks before they lower into runtime
+dispatch or type tests.
 
-This is the right boundary because:
+### Effect Fast-Path Elimination
 
-- monomorphization has already exposed whole-program callable instances
-- the stable semantics/codegen contract already exists here
-- codegen stays focused on Wasm emission
-- Binaryen remains the final Wasm optimizer instead of becoming the place where language-level policy lives
+Uses effect information to remove effect scaffolding when the compiler can
+prove a callee is pure or an effect operation cannot be performed on a path.
 
-## Optimization Policy
+### Closure Environment Shrinking
 
-Public SDK policy should stay intentionally narrow for now:
+Shrinks closure environments before closure struct types are emitted, so unused
+captures never become Wasm GC fields.
 
-- `optimize?: boolean` remains the public SDK switch.
-- `optimize: true` should mean the most aggressive validated optimization behavior.
-- Less aggressive behavior should be opt-in through compiler-internal or codegen-internal profiles, not through public Binaryen pass configuration in `@voyd-lang/sdk`.
+### Continuation And Handler Environment Shrinking
 
-Current aggressive Binaryen policy should include safe non-default passes,
-especially heap-focused passes such as `heap-store-optimization` and
-`heap2local`.
+Prunes captured state from continuation and handler environments using
+effect-lowering and handler capture facts.
 
-Current aggressive Binaryen policy should exclude high-risk categories such as:
+### Whole-Program Specialization Pruning
 
-- passes that require `closed-world` assumptions
-- JS-lowering / ABI-legalization passes
-- instrumentation passes
-- semantic mode-changing passes such as trap-mode rewrites
-- unvalidated whole-program GC/type-global refinement passes
+Drops unreachable monomorphized instances, function symbols, module lets, trait
+dispatch signatures, and helper artifacts before codegen emits them. Binaryen
+can remove unused functions after emission, but it cannot prevent Voyd from
+emitting unnecessary type metadata and helper shapes.
 
-In other words, "aggressive" should mean "strongest profile we have validated on
-real Voyd output", not "enable every Binaryen flag blindly".
+### Exact Receiver Propagation
 
-Important rule:
+Propagates exact and known parameter type facts across reachable call contexts.
+These facts feed trait dispatch devirtualization, receiver specialization, and
+runtime type-check elision.
 
-- Voyd compiler passes decide semantic rewrites.
-- Binaryen remains the Wasm optimizer, but its exact pass settings should be compiler policy, not a public SDK configuration surface.
+### Trait Dispatch Devirtualization
 
-That means:
+Rewrites trait-method calls to direct calls when the concrete implementation is
+known. This is not the same as Binaryen `directize`; Voyd is resolving language
+trait dispatch before it becomes lower-level Wasm call/table behavior.
 
-- do not expose raw Binaryen optimize/shrink/pass lists through the SDK yet
-- keep the canonical optimization policy in compiler code, not SDK post-processing
-- allow a coarse internal profile such as `"standard"` vs `"aggressive"` if the compiler needs it
-- keep the reusable Binaryen execution helper in a shared low-level package so compiler and SDK can invoke the same validated pass bundle
+### Redundant Runtime Type-Check Elimination
 
-## Suggested Implementation Order
+Marks field accesses whose target type is semantically exact enough for codegen
+to avoid guarded nominal field fast paths. Codegen still checks the exact
+nominal precondition before emitting a direct field load.
 
-1. Add `packages/compiler/src/optimize/pipeline.ts` with a no-op `optimizeProgram(...)`.
-2. Call it from both `emitProgram(...)` and `emitProgramWithContinuationFallback(...)`.
-3. Introduce `ProgramOptimizationIR` for reachable function instances only.
-4. Land `trait dispatch devirtualization`.
-5. Land `effect fast-path elimination`.
-6. Land `closure/continuation environment shrinking`.
-7. Keep Binaryen optimization policy compiler-owned, with aggressive as the default optimized profile.
+### Semantic Copy Forwarding
 
-## Success Criteria
+Marks direct object-literal field access opportunities where fields can be
+forwarded out of a freshly constructed aggregate without materializing the
+aggregate. Codegen keeps this intentionally narrow: direct object-literal field
+access without spreads, with all field initializers still evaluated in source
+order.
 
-- Language-level optimization decisions happen before Wasm emission.
-- Binaryen remains responsible for Wasm/IR cleanup and final optimization.
-- Codegen does not need to rediscover semantic facts during lowering.
-- New optimizations are testable in compiler/smoke layers without diffing Binaryen internals.
-- The compiler generates fewer unnecessary helper functions, dispatch stubs, and GC fields before Binaryen ever runs.
+This pass should remain separate from broader escape analysis and scalar
+replacement. General non-escaping aggregate analysis belongs to `V-325` and
+`V-326`, not this pass.
+
+## Codegen-Owned Lowering Optimizations
+
+Some performance-sensitive lowering choices belong in codegen instead of the
+optimization pass manager because the needed facts are local to lowering state.
+
+### Addressable Wide-Local Scratch Lowering
+
+Addressable wide-local scratch lowering is handled as codegen lowering, tracked
+by `V-331`, not as a `V-309` optimizer pass.
+
+The implemented shape is:
+
+- `compilePatternInitialization(...)` detects when a binding has reusable
+  addressable storage.
+- Wide value-object, tuple, optional, and compatible call construction can
+  receive an `outResultStorageRef` and store directly into that storage.
+- Control-flow and call lowering can forward the same out-result storage through
+  compatible regions.
+- Mutable-ref call arguments materialize addressable local storage when needed.
+
+This covers the narrow intent from the original architecture plan: reuse
+already-addressable local or out-result storage for wide value/inline aggregate
+construction and mutation within the current lowering region.
+
+It does not own reusable whole-program escape facts, and it does not split
+aggregates into scalar locals. It also does not remove allocation for arbitrary
+nominal `obj` locals. Those responsibilities belong to the broader value-like
+workload roadmap: `V-325` for escape facts and `V-326` for scalar replacement.
+
+## Binaryen Optimization
+
+After Voyd codegen emits the Binaryen module, `CodegenOptions.optimize` runs
+the shared helper in `@voyd-lang/lib/binaryen-optimize`.
+
+The compiler supports two profiles:
+
+- `standard`
+  - Binaryen optimize level 2
+  - Binaryen shrink level 1
+  - `module.optimize()`
+- `aggressive`
+  - Binaryen optimize level 3
+  - Binaryen shrink level 2
+  - `module.optimize()`
+  - extra validated passes
+  - a second `module.optimize()`
+
+The current aggressive extra passes are:
+
+- `const-hoisting`
+- `heap-store-optimization`
+- `heap2local`
+- `licm`
+- `merge-locals`
+- `merge-similar-functions`
+- `optimize-casts`
+- `precompute-propagate`
+- `tuple-optimization`
+
+`aggressive` is the default optimized profile in codegen. The SDK exposes the
+coarse `optimize?: boolean` switch, not raw Binaryen pass configuration.
+
+## Explicit Non-Goals
+
+The compiler optimizer should not own:
+
+- arithmetic peepholes
+- generic local.get/local.set cleanup
+- generic inlining heuristics
+- loop-invariant code motion unless it depends on Voyd-only semantics
+- Wasm CFG cleanup
+- stack-machine shaping
+- low-level GC heap store optimization
+- generic scalar replacement without a dedicated semantic pass
+
+If a transform can be expressed purely as a Wasm or Binaryen-IR pass, Binaryen
+or the shared Binaryen optimization profile should own it.
+
+## Known Open Work
+
+- `V-316`: call-shape specialization remains a backlog optimizer pass. Current
+  codegen already consumes resolved call lowering metadata, but there is no
+  standalone optimizer pass that specializes call shapes beyond the existing
+  call info and receiver-specialization facts.
+- `V-325`: reusable whole-program escape facts remain outside this optimizer
+  layer until a benchmark justifies the added analysis surface.
+- `V-326`: broad scalar replacement for non-escaping aggregates remains
+  separate from semantic copy forwarding and addressable storage reuse.
+
+## Testing Guidance
+
+Use the narrowest layer that owns the behavior:
+
+- `packages/compiler/src/__tests__/optimize-pipeline.test.ts`
+  - optimizer facts, optimized call metadata, pruned instances, and codegen
+    effects of optimizer facts
+- `packages/compiler/src/codegen/__tests__`
+  - local lowering behavior such as out-result storage and addressable scratch
+    paths
+- `apps/smoke`
+  - end-to-end public behavior and realistic integration checks
+- benchmark scripts
+  - performance/code-size decisions for optimizations whose value is uncertain
+
+Avoid tests that only assert Binaryen's internal text output unless the test is
+protecting a Voyd-owned lowering decision that would otherwise be invisible.
+
+## Maintenance Rules
+
+- Keep new optimizer facts explicit in `ProgramOptimizationFacts`.
+- Keep codegen fact consumers local and removable.
+- Re-run meaningful benchmarks before adding broad or complex passes.
+- Prefer a narrow semantic pass over general data-flow machinery until a real
+  benchmark shows the broader machinery pays for itself.
+- Keep `V-318`-style immediate forwarding separate from `V-325`/`V-326` escape
+  analysis and scalar replacement.
+- Keep `V-331`-style addressable storage reuse in codegen unless it needs
+  reusable semantic facts that belong in the optimizer.

--- a/packages/compiler/src/__tests__/optimize-pipeline.test.ts
+++ b/packages/compiler/src/__tests__/optimize-pipeline.test.ts
@@ -1472,6 +1472,9 @@ pub fn main() -> i32
       },
     });
 
+    const candidates = optimized.facts.runtimeTypeCheckElisionFieldAccesses.get("src::main");
+    expect(candidates?.size).toBeGreaterThanOrEqual(2);
+
     const optimizedCodegen = codegenProgram({
       program: optimized.program,
       entryModuleId,
@@ -1494,8 +1497,43 @@ pub fn main() -> i32
     const optimizedWasmText = optimizedCodegen.module.emitText();
     const baselineWasmText = baselineCodegen.module.emitText();
 
-    expect(optimizedWasmText).toContain("call $__has_type");
-    expect(baselineWasmText).not.toContain("call $__has_type");
+    expect(optimizedWasmText).not.toContain("call $__has_type");
+    expect(optimizedWasmText).not.toContain("call $__lookup_field_accessor");
+    expect(baselineWasmText).toContain("call $__lookup_field_accessor");
+  });
+
+  it("marks direct object-literal field accesses for semantic copy forwarding", async () => {
+    const { optimized, entryModuleId } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn bump(value: i32) -> i32
+  value + 1
+
+pub fn main() -> i32
+  (Vec2 { x: bump(1), y: bump(2) }).y
+`,
+      },
+    });
+
+    const candidates = optimized.facts.semanticCopyForwardingFieldAccesses.get("src::main");
+    expect(candidates?.size).toBe(1);
+
+    const codegen = codegenProgram({
+      program: optimized.program,
+      entryModuleId,
+      optimization: optimized.facts,
+      options: {
+        optimize: false,
+        validate: false,
+        runtimeDiagnostics: false,
+      },
+    });
+    expect(codegen.diagnostics).toHaveLength(0);
   });
 
   it("lowers small trait-dispatch sets to direct type switches", async () => {

--- a/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
+++ b/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
@@ -84,6 +84,8 @@ const compileEffectFixtureWithCompilerOptimization = async (
       receiverSpecializationRequests: new Map(),
       exactParameterTypes: new Map(),
       knownParameterTypes: new Map(),
+      runtimeTypeCheckElisionFieldAccesses: new Map(),
+      semanticCopyForwardingFieldAccesses: new Map(),
       codegenPlan: { representations: {} },
     },
   });

--- a/packages/compiler/src/codegen/expressions/objects.ts
+++ b/packages/compiler/src/codegen/expressions/objects.ts
@@ -42,6 +42,8 @@ import {
 import { coerceExprToWasmType } from "../wasm-type-coercions.js";
 import { maybeReportValueBoxingNote } from "../value-boxing-notes.js";
 import { tryCompileProjectedFieldAccess } from "../projected-element-views.js";
+import { exactNominalForRuntimeTypeCheckElision } from "../optimization/runtime-type-checks.js";
+import { tryCompileSemanticCopyForwardedFieldAccess } from "../optimization/semantic-copy-forwarding.js";
 import { compileCallArgExpressionsWithTemps } from "./call/shared.js";
 
 export const compileObjectLiteralExpr = (
@@ -582,6 +584,18 @@ export const compileFieldAccessExpr = (
   const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
   const expectedFieldTypeId = getRequiredExprType(expr.id, ctx, typeInstanceId);
   const expectedFieldWasmType = getExprBinaryenType(expr.id, ctx, typeInstanceId);
+  const copyForwarded = tryCompileSemanticCopyForwardedFieldAccess({
+    expr,
+    expectedFieldTypeId,
+    expectedFieldWasmType,
+    ctx,
+    fnCtx,
+    compileExpr,
+  });
+  if (copyForwarded) {
+    return copyForwarded;
+  }
+
   const targetExpr = ctx.module.hir.expressions.get(expr.target);
 
   const actualTargetTypeId = getUnresolvedExprType(expr.target, ctx, typeInstanceId);
@@ -632,6 +646,12 @@ export const compileFieldAccessExpr = (
     throw new Error("field access requires a structural object");
   }
   const targetTypeId = requiredStructInfo ? requiredTargetTypeId : actualTargetTypeId;
+  const exactNominalTypeId = exactNominalForRuntimeTypeCheckElision({
+    expr,
+    targetTypeId,
+    ctx,
+    fnCtx,
+  });
 
   const actualField = structInfo.fieldMap.get(expr.field);
   if (!actualField) {
@@ -915,6 +935,7 @@ export const compileFieldAccessExpr = (
     structInfo,
     field: actualField,
     pointer: () => directPointer ?? loadLocalValue(pointerTemp, ctx),
+    exactNominalTypeId,
     ctx,
   });
 

--- a/packages/compiler/src/codegen/optimization/runtime-type-checks.ts
+++ b/packages/compiler/src/codegen/optimization/runtime-type-checks.ts
@@ -1,0 +1,57 @@
+import type {
+  CodegenContext,
+  FunctionContext,
+  HirFieldAccessExpr,
+  TypeId,
+} from "../context.js";
+
+const exactNominalForType = ({
+  typeId,
+  ctx,
+}: {
+  typeId: TypeId | undefined;
+  ctx: CodegenContext;
+}): TypeId | undefined => {
+  if (typeof typeId !== "number") {
+    return undefined;
+  }
+
+  const desc = ctx.program.types.getTypeDesc(typeId);
+  if (desc.kind === "nominal-object" || desc.kind === "value-object") {
+    return typeId;
+  }
+  if (desc.kind === "intersection" && typeof desc.nominal === "number") {
+    return desc.nominal;
+  }
+  return undefined;
+};
+
+export const exactNominalForRuntimeTypeCheckElision = ({
+  expr,
+  targetTypeId,
+  ctx,
+  fnCtx,
+}: {
+  expr: HirFieldAccessExpr;
+  targetTypeId: TypeId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): TypeId | undefined => {
+  if (
+    !ctx.optimization?.runtimeTypeCheckElisionFieldAccesses
+      .get(ctx.moduleId)
+      ?.has(expr.id)
+  ) {
+    return undefined;
+  }
+
+  const targetExpr = ctx.module.hir.expressions.get(expr.target);
+  if (targetExpr?.exprKind === "identifier") {
+    const exactParameterType = fnCtx.exactParameterTypes?.get(targetExpr.symbol);
+    if (typeof exactParameterType === "number") {
+      return exactParameterType;
+    }
+  }
+
+  return exactNominalForType({ typeId: targetTypeId, ctx });
+};

--- a/packages/compiler/src/codegen/optimization/semantic-copy-forwarding.ts
+++ b/packages/compiler/src/codegen/optimization/semantic-copy-forwarding.ts
@@ -1,0 +1,131 @@
+import binaryen from "binaryen";
+import type {
+  CodegenContext,
+  CompiledExpression,
+  ExpressionCompiler,
+  FunctionContext,
+  HirFieldAccessExpr,
+} from "../context.js";
+import {
+  allocateTempLocal,
+  loadLocalValue,
+  storeLocalValue,
+} from "../locals.js";
+import { coerceValueToType } from "../structural.js";
+import {
+  getRequiredExprType,
+  getStructuralTypeInfo,
+} from "../types.js";
+import { coerceExprToWasmType } from "../wasm-type-coercions.js";
+import { asStatement } from "../expressions/utils.js";
+import { compileCallArgExpressionsWithTemps } from "../expressions/call/shared.js";
+
+export const tryCompileSemanticCopyForwardedFieldAccess = ({
+  expr,
+  expectedFieldTypeId,
+  expectedFieldWasmType,
+  ctx,
+  fnCtx,
+  compileExpr,
+}: {
+  expr: HirFieldAccessExpr;
+  expectedFieldTypeId: number;
+  expectedFieldWasmType: binaryen.Type;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+}): CompiledExpression | undefined => {
+  if (
+    !ctx.optimization?.semanticCopyForwardingFieldAccesses
+      .get(ctx.moduleId)
+      ?.has(expr.id)
+  ) {
+    return undefined;
+  }
+
+  const targetExpr = ctx.module.hir.expressions.get(expr.target);
+  if (
+    targetExpr?.exprKind !== "object-literal" ||
+    targetExpr.entries.some((entry) => entry.kind !== "field")
+  ) {
+    return undefined;
+  }
+
+  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+  const targetTypeId = getRequiredExprType(expr.target, ctx, typeInstanceId);
+  const structInfo = getStructuralTypeInfo(targetTypeId, ctx);
+  const selectedIndex = targetExpr.entries.findIndex(
+    (entry) => entry.kind === "field" && entry.name === expr.field,
+  );
+  const selectedField = structInfo?.fieldMap.get(expr.field);
+  if (!structInfo || selectedIndex < 0 || !selectedField) {
+    return undefined;
+  }
+
+  const entryValues = compileCallArgExpressionsWithTemps({
+    callId: targetExpr.id,
+    args: targetExpr.entries.map((entry) => ({ expr: entry.value })),
+    expectedTypeIdAt: (index) => {
+      const entry = targetExpr.entries[index];
+      return entry?.kind === "field"
+        ? structInfo.fieldMap.get(entry.name)?.typeId
+        : undefined;
+    },
+    ctx,
+    fnCtx,
+    compileExpr,
+  });
+  const selectedTemp = allocateTempLocal(
+    expectedFieldWasmType,
+    fnCtx,
+    expectedFieldTypeId,
+    ctx,
+  );
+
+  const ops = targetExpr.entries.map((entry, index) => {
+    if (entry.kind !== "field") {
+      throw new Error("copy-forwarded object literal unexpectedly contains a spread");
+    }
+
+    const field = structInfo.fieldMap.get(entry.name);
+    const actualTypeId = getRequiredExprType(entry.value, ctx, typeInstanceId);
+    const value = coerceValueToType({
+      value: entryValues[index]!,
+      actualType: field?.typeId ?? actualTypeId,
+      targetType: field?.typeId,
+      ctx,
+      fnCtx,
+    });
+
+    if (index !== selectedIndex) {
+      return asStatement(ctx, value, fnCtx);
+    }
+
+    const selectedValue = coerceValueToType({
+      value,
+      actualType: selectedField.typeId,
+      targetType: expectedFieldTypeId,
+      ctx,
+      fnCtx,
+    });
+    return storeLocalValue({
+      binding: selectedTemp,
+      value: coerceExprToWasmType({
+        expr: selectedValue,
+        targetType: expectedFieldWasmType,
+        ctx,
+      }),
+      ctx,
+      fnCtx,
+    });
+  });
+
+  return {
+    expr: ctx.mod.block(
+      null,
+      [...ops, loadLocalValue(selectedTemp, ctx)],
+      expectedFieldWasmType,
+    ),
+    usedReturnCall: false,
+  };
+};

--- a/packages/compiler/src/codegen/structural.ts
+++ b/packages/compiler/src/codegen/structural.ts
@@ -2399,11 +2399,13 @@ export const loadStructuralField = ({
   structInfo,
   field,
   pointer,
+  exactNominalTypeId,
   ctx,
 }: {
   structInfo: StructuralTypeInfo;
   field: StructuralTypeInfo["fields"][number];
   pointer: () => binaryen.ExpressionRef;
+  exactNominalTypeId?: TypeId;
   ctx: CodegenContext;
 }): binaryen.ExpressionRef => {
   if (structInfo.layoutKind === "value-object") {
@@ -2421,6 +2423,17 @@ export const loadStructuralField = ({
   });
   if (!shouldUseNominalFieldFastPath(structInfo, ctx)) {
     return dynamicLoad;
+  }
+  if (
+    typeof exactNominalTypeId === "number" &&
+    exactNominalTypeId === structInfo.nominalId
+  ) {
+    return makeDirectStructuralFieldLoad({
+      structInfo,
+      field,
+      pointer,
+      ctx,
+    });
   }
 
   const exactTypeMatch = ctx.mod.call(

--- a/packages/compiler/src/optimize/ir.ts
+++ b/packages/compiler/src/optimize/ir.ts
@@ -42,6 +42,8 @@ export type ProgramOptimizationFacts = {
     ProgramFunctionInstanceId,
     ReadonlyMap<SymbolId, ReadonlySet<TypeId>>
   >;
+  runtimeTypeCheckElisionFieldAccesses: ReadonlyMap<string, ReadonlySet<HirExprId>>;
+  semanticCopyForwardingFieldAccesses: ReadonlyMap<string, ReadonlySet<HirExprId>>;
   codegenPlan: ProgramCodegenOptimizationPlan;
 };
 

--- a/packages/compiler/src/optimize/pipeline.ts
+++ b/packages/compiler/src/optimize/pipeline.ts
@@ -74,6 +74,8 @@ type MutableOptimizationIr = {
       ProgramFunctionInstanceId,
       Map<SymbolId, Set<TypeId>>
     >;
+    runtimeTypeCheckElisionFieldAccesses: Map<string, Set<HirExprId>>;
+    semanticCopyForwardingFieldAccesses: Map<string, Set<HirExprId>>;
     codegenPlan: ProgramCodegenOptimizationPlan;
   };
 };
@@ -307,6 +309,8 @@ const buildOptimizationIr = ({
       receiverSpecializationRequests: new Map(),
       exactParameterTypes: new Map(),
       knownParameterTypes: new Map(),
+      runtimeTypeCheckElisionFieldAccesses: new Map(),
+      semanticCopyForwardingFieldAccesses: new Map(),
       codegenPlan: { representations: {} },
     },
   };
@@ -3104,6 +3108,85 @@ const exactReceiverPropagationPass: ProgramOptimizationPass = {
   },
 };
 
+const redundantRuntimeTypeCheckEliminationPass: ProgramOptimizationPass = {
+  name: "redundant-runtime-type-check-elimination",
+  run(ctx) {
+    const ir = ctx.ir as MutableOptimizationIr;
+    let changed = false;
+
+    ir.modules.forEach((moduleView, moduleId) => {
+      const candidates =
+        ir.facts.runtimeTypeCheckElisionFieldAccesses.get(moduleId) ?? new Set<HirExprId>();
+
+      moduleView.hir.expressions.forEach((expr, exprId) => {
+        if (expr.exprKind !== "field-access") {
+          return;
+        }
+
+        const targetTypeId = exprTypeFor({ moduleView, exprId: expr.target });
+        if (
+          typeof exactNominalForType({
+            typeId: targetTypeId,
+            program: ir.baseProgram,
+          }) !== "number"
+        ) {
+          return;
+        }
+
+        if (!candidates.has(exprId)) {
+          candidates.add(exprId);
+          changed = true;
+        }
+      });
+
+      if (candidates.size > 0) {
+        ir.facts.runtimeTypeCheckElisionFieldAccesses.set(moduleId, candidates);
+      }
+    });
+
+    return { changed };
+  },
+};
+
+const semanticCopyForwardingPass: ProgramOptimizationPass = {
+  name: "semantic-copy-forwarding",
+  run(ctx) {
+    const ir = ctx.ir as MutableOptimizationIr;
+    let changed = false;
+
+    ir.modules.forEach((moduleView, moduleId) => {
+      const candidates =
+        ir.facts.semanticCopyForwardingFieldAccesses.get(moduleId) ?? new Set<HirExprId>();
+
+      moduleView.hir.expressions.forEach((expr, exprId) => {
+        if (expr.exprKind !== "field-access") {
+          return;
+        }
+
+        const target = moduleView.hir.expressions.get(expr.target);
+        if (
+          target?.exprKind !== "object-literal" ||
+          target.entries.some((entry) => entry.kind !== "field") ||
+          !target.entries.some((entry) => entry.kind === "field" && entry.name === expr.field)
+        ) {
+          return;
+        }
+
+        if (!candidates.has(exprId)) {
+          candidates.add(exprId);
+          changed = true;
+        }
+      });
+
+      if (candidates.size > 0) {
+        ir.facts.semanticCopyForwardingFieldAccesses.set(moduleId, candidates);
+      }
+    });
+
+    return { changed };
+  },
+};
+
 const moduleLetItems = ({
   moduleView,
 }: {
@@ -4295,6 +4378,16 @@ const finalizeOptimization = ({
           ],
         ),
       ),
+      runtimeTypeCheckElisionFieldAccesses: new Map(
+        Array.from(ir.facts.runtimeTypeCheckElisionFieldAccesses.entries()).map(
+          ([moduleId, exprIds]) => [moduleId, new Set(exprIds)],
+        ),
+      ),
+      semanticCopyForwardingFieldAccesses: new Map(
+        Array.from(ir.facts.semanticCopyForwardingFieldAccesses.entries()).map(
+          ([moduleId, exprIds]) => [moduleId, new Set(exprIds)],
+        ),
+      ),
       codegenPlan,
     },
   };
@@ -4316,6 +4409,8 @@ const OPTIMIZATION_PASSES: readonly ProgramOptimizationPass[] = [
   constructorKnownSimplificationPass,
   traitDispatchDevirtualizationPass,
   wholeProgramSpecializationPruningPass,
+  redundantRuntimeTypeCheckEliminationPass,
+  semanticCopyForwardingPass,
 ];
 
 export const optimizeProgram = ({

--- a/scripts/bench-v309.ts
+++ b/scripts/bench-v309.ts
@@ -1,0 +1,178 @@
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { gzipSync } from "node:zlib";
+import { createSdk, type CompileResult } from "@voyd-lang/sdk";
+import { createVoydHost } from "@voyd-lang/sdk/js-host";
+
+type Scenario = {
+  name: string;
+  entryName: string;
+  iterations: number;
+  warmups: number;
+  expected: number;
+  source?: string;
+  entryPath?: string;
+};
+
+type ScenarioResult = {
+  name: string;
+  wasmBytes: number;
+  gzipBytes: number;
+  medianMs: number;
+  samplesMs: number[];
+};
+
+const focusedSource = `
+obj Vec3 {
+  x: i32,
+  y: i32,
+  z: i32
+}
+
+fn sum_vec(vec: Vec3) -> i32
+  vec.x + vec.y + vec.z
+
+pub fn runtime_type_check_elision() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    total = total + sum_vec(Vec3 { x: i, y: i + 1, z: i + 2 })
+    i = i + 1
+  total
+
+pub fn semantic_copy_forwarding() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    total = total + (Vec3 { x: i, y: i + 1, z: i + 2 }).y
+    i = i + 1
+  total
+`;
+
+const defaultIterations = Number.parseInt(process.env.VOYD_BENCH_ITERATIONS ?? "9", 10);
+const vtraceIterations = Number.parseInt(process.env.VOYD_BENCH_VTRACE_ITERATIONS ?? "3", 10);
+
+const scenarios: Scenario[] = [
+  {
+    name: "focused/runtime-type-check-elision",
+    source: focusedSource,
+    entryName: "runtime_type_check_elision",
+    iterations: defaultIterations,
+    warmups: 2,
+    expected: 600_030_000,
+  },
+  {
+    name: "focused/semantic-copy-forwarding",
+    source: focusedSource,
+    entryName: "semantic_copy_forwarding",
+    iterations: defaultIterations,
+    warmups: 2,
+    expected: 200_010_000,
+  },
+  {
+    name: "realistic/vtrace-main",
+    entryPath: path.join(
+      import.meta.dirname,
+      "..",
+      "apps",
+      "smoke",
+      "fixtures",
+      "vtrace-compute-benchmark.voyd"
+    ),
+    entryName: "main",
+    iterations: vtraceIterations,
+    warmups: 1,
+    expected: 3_825_271,
+  },
+];
+
+const expectCompileSuccess = (
+  result: CompileResult,
+  name: string
+): Extract<CompileResult, { success: true }> => {
+  if (result.success) {
+    return result;
+  }
+
+  throw new Error(
+    `${name} failed to compile:\n${result.diagnostics
+      .map((diagnostic) => diagnostic.message)
+      .join("\n")}`
+  );
+};
+
+const median = (values: number[]): number => {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+};
+
+const runScenario = async (scenario: Scenario): Promise<ScenarioResult> => {
+  const sdk = createSdk();
+  const compiled = expectCompileSuccess(
+    await sdk.compile({
+      entryPath: scenario.entryPath,
+      source: scenario.source,
+      optimize: true,
+    }),
+    scenario.name
+  );
+  const host = await createVoydHost({ wasm: compiled.wasm });
+
+  for (let warmup = 0; warmup < scenario.warmups; warmup += 1) {
+    const result = await host.run<number>(scenario.entryName);
+    if (result !== scenario.expected) {
+      throw new Error(
+        `${scenario.name} returned ${result} during warmup, expected ${scenario.expected}`
+      );
+    }
+  }
+
+  const samplesMs: number[] = [];
+  for (let iteration = 0; iteration < scenario.iterations; iteration += 1) {
+    const startedAt = performance.now();
+    const result = await host.run<number>(scenario.entryName);
+    const durationMs = performance.now() - startedAt;
+    if (result !== scenario.expected) {
+      throw new Error(
+        `${scenario.name} returned ${result}, expected ${scenario.expected}`
+      );
+    }
+    samplesMs.push(durationMs);
+  }
+
+  return {
+    name: scenario.name,
+    wasmBytes: compiled.wasm.byteLength,
+    gzipBytes: gzipSync(compiled.wasm).byteLength,
+    medianMs: median(samplesMs),
+    samplesMs,
+  };
+};
+
+const printResults = (results: readonly ScenarioResult[]): void => {
+  console.log("name,wasmBytes,gzipBytes,medianMs,samplesMs");
+  for (const result of results) {
+    console.log(
+      [
+        result.name,
+        result.wasmBytes.toString(),
+        result.gzipBytes.toString(),
+        result.medianMs.toFixed(3),
+        result.samplesMs.map((sample) => sample.toFixed(3)).join("|"),
+      ].join(",")
+    );
+  }
+};
+
+const main = async (): Promise<void> => {
+  const results: ScenarioResult[] = [];
+  for (const scenario of scenarios) {
+    results.push(await runScenario(scenario));
+  }
+  printResults(results);
+};
+
+await main();


### PR DESCRIPTION
## Summary

Implements the V-309 Tier 2 optimizer work that proved worthwhile in benchmarking:

- Add redundant runtime type-check elision for exact nominal field accesses.
- Add narrow semantic copy forwarding for direct object-literal field access.
- Add `scripts/bench-v309.ts` to measure runtime and optimized Wasm size on focused cases plus the realistic `vtrace` compute fixture.
- Update the compiler optimization architecture doc so it describes the current pipeline, pass order, optimizer/codegen boundary, Binaryen profile ownership, and the V-331 wide-local scratch lowering boundary.

The implementation keeps the new behavior modular:

- optimizer facts are explicit in `ProgramOptimizationFacts`
- the new passes only collect candidate facts
- codegen helpers live under `packages/compiler/src/codegen/optimization`
- codegen still re-checks local safety before using the facts

## Benchmarks

Command:

```sh
NODE_OPTIONS=--conditions=development ./node_modules/.bin/tsx scripts/bench-v309.ts
```

Before:

| Scenario | Wasm bytes | Gzip bytes | Median runtime |
| --- | ---: | ---: | ---: |
| focused/runtime-type-check-elision | 19,638 | 6,803 | 0.165ms |
| focused/semantic-copy-forwarding | 19,638 | 6,803 | 0.141ms |
| realistic/vtrace-main | 69,519 | 20,782 | 420.092ms |

After:

| Scenario | Wasm bytes | Gzip bytes | Median runtime |
| --- | ---: | ---: | ---: |
| focused/runtime-type-check-elision | 17,644 | 6,421 | 0.066ms |
| focused/semantic-copy-forwarding | 17,644 | 6,421 | 0.053ms |
| realistic/vtrace-main | 60,278 | 19,438 | 261.477ms |

Delta:

| Scenario | Wasm bytes | Gzip bytes | Median runtime |
| --- | ---: | ---: | ---: |
| focused/runtime-type-check-elision | -10.2% | -5.6% | -60.0% |
| focused/semantic-copy-forwarding | -10.2% | -5.6% | -62.4% |
| realistic/vtrace-main | -13.3% | -6.5% | -37.8% |

## Testing

- `npm run --workspace @voyd-lang/compiler typecheck`
- `npx vitest run packages/compiler/src/__tests__/optimize-pipeline.test.ts`
- `npm run typecheck`
- `npm test`
- `git diff --check`

## Notes

- V-331 is documented as codegen-owned wide value / inline aggregate scratch lowering, not a V-309 optimizer pass.
- V-316 call-shape specialization remains open backlog work.
