### PR TITLE
Add safe array loop fast paths for std Array bounds checks

### DIFF
--- a/packages/compiler/src/codegen/__tests__/__fixtures__/std_array_smoke.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/std_array_smoke.voyd
@@ -56,3 +56,117 @@ pub fn direct_at_out_of_bounds() -> i32
   let ~arr = Array<i32>::with_capacity(1)
   arr.push(10)
   arr.at(1)
+
+fn build_ints() -> Array<i32>
+  let ~arr = Array<i32>::with_capacity(4)
+  arr.push(1)
+  arr.push(2)
+  arr.push(3)
+  arr.push(4)
+  arr
+
+pub fn safe_while_sum() -> i32
+  let values = build_ints()
+  var index = 0
+  var total = 0
+  while index < values.len():
+    total = total + values.at(index)
+    index = index + 1
+  total
+
+pub fn safe_while_cached_len_sum() -> i32
+  let values = build_ints()
+  let length = values.len()
+  var index = 0
+  var total = 0
+  while index < length:
+    total = total + values.at(index)
+    index = index + 1
+  total
+
+pub fn safe_while_value_sum() -> i32
+  let ~values = Array<Vec2>::with_capacity(2)
+  values.push(Vec2 { x: 3, y: 4 })
+  values.push(Vec2 { x: 5, y: 6 })
+  var index = 0
+  var total = 0
+  while index < values.len():
+    let value = values.at(index)
+    total = total + value.x + value.y
+    index = index + 1
+  total
+
+pub fn safe_for_sum() -> i32
+  let values = build_ints()
+  var total = 0
+  for index in 0..values.len():
+    total = total + values.at(index)
+  total
+
+pub fn while_non_zero_start_sum() -> i32
+  let values = build_ints()
+  var index = 1
+  var total = 0
+  while index < values.len():
+    total = total + values.at(index)
+    index = index + 1
+  total
+
+pub fn while_non_unit_step_sum() -> i32
+  let values = build_ints()
+  var index = 0
+  var total = 0
+  while index < values.len():
+    total = total + values.at(index)
+    index = index + 2
+  total
+
+pub fn while_unknown_bound_sum() -> i32
+  let values = build_ints()
+  let limit = 2
+  var index = 0
+  var total = 0
+  while index < limit:
+    total = total + values.at(index)
+    index = index + 1
+  total
+
+pub fn while_mutates_array_sum() -> i32
+  let ~values = Array<i32>::with_capacity(4)
+  values.push(1)
+  values.push(2)
+  let length = values.len()
+  var index = 0
+  var total = 0
+  while index < length:
+    total = total + values.at(index)
+    values.push(9)
+    index = index + 1
+  total
+
+pub fn while_alias_mutation_sum() -> i32
+  let ~values = Array<i32>::with_capacity(4)
+  values.push(1)
+  values.push(2)
+  let ~alias = values
+  let length = values.len()
+  var index = 0
+  var total = 0
+  while index < length:
+    total = total + values.at(index)
+    alias.push(9)
+    index = index + 1
+  total
+
+pub fn while_stale_length_sum() -> i32
+  let ~values = Array<i32>::with_capacity(4)
+  values.push(1)
+  values.push(2)
+  let length = values.len()
+  values.push(3)
+  var index = 0
+  var total = 0
+  while index < length:
+    total = total + values.at(index)
+    index = index + 1
+  total

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/std_array_smoke.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/std_array_smoke.voyd
@@ -2,6 +2,11 @@ use std::array::Array
 use std::fixed_array::fns::{ get, length }
 use std::optional::fns::{ unwrap_or }
 
+pub val Vec2 {
+  x: i32,
+  y: i32
+}
+
 pub fn entry_tail() -> i32
   let ~arr = Array<i32>::with_capacity(2)
   arr.push(1)
@@ -22,3 +27,32 @@ pub fn enumerate_length() -> i32
   arr.push(1)
   arr.push(2)
   arr.enumerate().len()
+
+pub fn direct_len_at_sum() -> i32
+  let ~arr = Array<i32>::with_capacity(3)
+  arr.push(10)
+  arr.push(20)
+  arr.push(30)
+  arr.len() + arr.at(0) + arr.at(-1)
+
+pub fn direct_value_len_at_sum() -> i32
+  let ~arr = Array<Vec2>::with_capacity(2)
+  arr.push(Vec2 { x: 3, y: 4 })
+  arr.push(Vec2 { x: 5, y: 6 })
+  let first = arr.at(0)
+  let last = arr.at(-1)
+  arr.len() + first.x + first.y + last.x + last.y
+
+fn push_and_choose(~arr: Array<i32>) -> i32
+  arr.push(20)
+  1
+
+pub fn direct_at_index_side_effect() -> i32
+  let ~arr = Array<i32>::with_capacity(1)
+  arr.push(10)
+  arr.at(push_and_choose(arr))
+
+pub fn direct_at_out_of_bounds() -> i32
+  let ~arr = Array<i32>::with_capacity(1)
+  arr.push(10)
+  arr.at(1)

--- a/packages/compiler/src/codegen/__tests__/std-array-smoke.test.ts
+++ b/packages/compiler/src/codegen/__tests__/std-array-smoke.test.ts
@@ -1,38 +1,79 @@
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { compileProgram, type CompileProgramResult } from "../../pipeline.js";
-import { createFsModuleHost } from "../../modules/fs-host.js";
+import { createVoydHost } from "@voyd-lang/js-host";
+import type { CodegenOptions } from "../context.js";
+import { compileEffectFixture } from "./support/effects-harness.js";
 
 const fixtureRoot = resolve(import.meta.dirname, "__fixtures__");
-const stdRoot = resolve(import.meta.dirname, "../../../../std/src");
+const fixturePath = resolve(fixtureRoot, "std_array_smoke.voyd");
 
-const expectCompileSuccess = (
-  result: CompileProgramResult,
-): Extract<CompileProgramResult, { success: true }> => {
-  expect(result.success).toBe(true);
-  if (!result.success) {
-    throw new Error(JSON.stringify(result.diagnostics, null, 2));
+const extractWatFunction = (wat: string, functionId: string): string => {
+  const start = wat.indexOf(`(func $${functionId} `);
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  let depth = 0;
+  for (let index = start; index < wat.length; index += 1) {
+    const char = wat[index];
+    if (char === "(") depth += 1;
+    if (char === ")") depth -= 1;
+    if (depth === 0) {
+      return wat.slice(start, index + 1);
+    }
   }
-  return result;
+
+  throw new Error(`unterminated function $${functionId}`);
 };
 
-const compileStdArrayFixture = async (): Promise<Uint8Array> => {
-  const entryPath = resolve(fixtureRoot, "std_array_smoke.voyd");
-  const result = expectCompileSuccess(await compileProgram({
-    entryPath,
-    roots: { src: fixtureRoot, std: stdRoot },
-    host: createFsModuleHost(),
-    codegenOptions: { validate: true },
-  }));
-  if (!result.wasm) {
-    throw new Error("missing wasm output");
-  }
-  return result.wasm;
-};
+const compileStdArrayFixture = async (
+  codegenOptions: CodegenOptions = {},
+) =>
+  compileEffectFixture({
+    entryPath: fixturePath,
+    codegenOptions: {
+      validate: true,
+      effectsHostBoundary: "off",
+      ...codegenOptions,
+    },
+  });
 
 describe("std::array compile smoke", () => {
   it("compiles std::array helpers with wasm validation", async () => {
-    const wasm = await compileStdArrayFixture();
-    expect(wasm.byteLength).toBeGreaterThan(0);
+    const result = await compileStdArrayFixture();
+    expect(result.wasm.byteLength).toBeGreaterThan(0);
+  });
+
+  it("runs optimized direct len/at access", async () => {
+    const result = await compileStdArrayFixture({
+      optimize: true,
+      boundaryExports: false,
+    });
+    const host = await createVoydHost({ wasm: result.wasm });
+    await expect(host.run<number>("direct_len_at_sum")).resolves.toBe(43);
+    await expect(host.run<number>("direct_value_len_at_sum")).resolves.toBe(20);
+    await expect(host.run<number>("direct_at_index_side_effect")).resolves.toBe(20);
+  });
+
+  it("traps optimized direct at access when out of bounds", async () => {
+    const result = await compileStdArrayFixture({
+      optimize: true,
+      boundaryExports: false,
+    });
+    const host = await createVoydHost({ wasm: result.wasm });
+    await expect(host.run<number>("direct_at_out_of_bounds")).rejects.toThrow();
+  });
+
+  it("lowers optimized direct len/at access without dynamic dispatch", async () => {
+    const result = await compileStdArrayFixture({
+      optimize: true,
+      boundaryExports: false,
+    });
+    const wat = result.module.emitText();
+    const exportMatch = wat.match(/\(export "direct_len_at_sum" \(func \$(\d+)\)\)/);
+    expect(exportMatch).not.toBeNull();
+    const functionWat = extractWatFunction(wat, exportMatch?.[1] ?? "");
+
+    expect(functionWat).toContain("struct.get");
+    expect(functionWat).toContain("array.get");
+    expect(functionWat).not.toContain("call_ref");
   });
 });

--- a/packages/compiler/src/codegen/__tests__/std-array-smoke.test.ts
+++ b/packages/compiler/src/codegen/__tests__/std-array-smoke.test.ts
@@ -36,6 +36,14 @@ const compileStdArrayFixture = async (
     },
   });
 
+const watForExport = (wat: string, exportName: string): string => {
+  const exportMatch = wat.match(
+    new RegExp(`\\(export "${exportName}" \\(func \\$([^\\s\\)]+)\\)\\)`),
+  );
+  expect(exportMatch).not.toBeNull();
+  return extractWatFunction(wat, exportMatch?.[1] ?? "");
+};
+
 describe("std::array compile smoke", () => {
   it("compiles std::array helpers with wasm validation", async () => {
     const result = await compileStdArrayFixture();
@@ -51,6 +59,16 @@ describe("std::array compile smoke", () => {
     await expect(host.run<number>("direct_len_at_sum")).resolves.toBe(43);
     await expect(host.run<number>("direct_value_len_at_sum")).resolves.toBe(20);
     await expect(host.run<number>("direct_at_index_side_effect")).resolves.toBe(20);
+    await expect(host.run<number>("safe_while_sum")).resolves.toBe(10);
+    await expect(host.run<number>("safe_while_cached_len_sum")).resolves.toBe(10);
+    await expect(host.run<number>("safe_while_value_sum")).resolves.toBe(18);
+    await expect(host.run<number>("safe_for_sum")).resolves.toBe(10);
+    await expect(host.run<number>("while_non_zero_start_sum")).resolves.toBe(9);
+    await expect(host.run<number>("while_non_unit_step_sum")).resolves.toBe(4);
+    await expect(host.run<number>("while_unknown_bound_sum")).resolves.toBe(3);
+    await expect(host.run<number>("while_mutates_array_sum")).resolves.toBe(3);
+    await expect(host.run<number>("while_alias_mutation_sum")).resolves.toBe(3);
+    await expect(host.run<number>("while_stale_length_sum")).resolves.toBe(3);
   });
 
   it("traps optimized direct at access when out of bounds", async () => {
@@ -64,16 +82,53 @@ describe("std::array compile smoke", () => {
 
   it("lowers optimized direct len/at access without dynamic dispatch", async () => {
     const result = await compileStdArrayFixture({
-      optimize: true,
       boundaryExports: false,
     });
     const wat = result.module.emitText();
-    const exportMatch = wat.match(/\(export "direct_len_at_sum" \(func \$(\d+)\)\)/);
-    expect(exportMatch).not.toBeNull();
-    const functionWat = extractWatFunction(wat, exportMatch?.[1] ?? "");
+    const functionWat = watForExport(wat, "direct_len_at_sum");
 
     expect(functionWat).toContain("struct.get");
     expect(functionWat).toContain("array.get");
     expect(functionWat).not.toContain("call_ref");
+  });
+
+  it("elides loop-proven Array.at checks in safe counted loops", async () => {
+    const result = await compileStdArrayFixture({
+      boundaryExports: false,
+    });
+    const wat = result.module.emitText();
+
+    for (const exportName of [
+      "safe_while_sum",
+      "safe_while_cached_len_sum",
+      "safe_while_value_sum",
+      "safe_for_sum",
+    ]) {
+      const functionWat = watForExport(wat, exportName);
+      expect(functionWat).toContain("array.get");
+      expect(functionWat).not.toContain("unreachable");
+      expect(functionWat).not.toContain("call_ref");
+      expect(functionWat).not.toContain("call_indirect");
+    }
+  });
+
+  it("keeps Array.at checks when loop safety proof is invalid", async () => {
+    const result = await compileStdArrayFixture({
+      boundaryExports: false,
+    });
+    const wat = result.module.emitText();
+
+    for (const exportName of [
+      "while_non_zero_start_sum",
+      "while_non_unit_step_sum",
+      "while_unknown_bound_sum",
+      "while_mutates_array_sum",
+      "while_alias_mutation_sum",
+      "while_stale_length_sum",
+    ]) {
+      const functionWat = watForExport(wat, exportName);
+      expect(functionWat).toContain("array.get");
+      expect(functionWat).toContain("unreachable");
+    }
   });
 });

--- a/packages/compiler/src/codegen/context.ts
+++ b/packages/compiler/src/codegen/context.ts
@@ -326,6 +326,11 @@ export interface LoopScope {
   label?: string;
 }
 
+export interface SafeArrayLoopScope {
+  arraySymbol: SymbolId;
+  indexSymbol: SymbolId;
+}
+
 export interface FunctionContext {
   bindings: Map<SymbolId, LocalBinding>;
   tempLocals: Map<number, LocalBindingLocal>;
@@ -345,6 +350,8 @@ export interface FunctionContext {
   effectful: boolean;
   handlerStack?: HandlerScope[];
   loopStack?: LoopScope[];
+  safeArrayLoopScopes?: readonly SafeArrayLoopScope[];
+  safeArrayLengthSymbols?: ReadonlyMap<SymbolId, SymbolId>;
   continuations?: Map<SymbolId, ContinuationBinding>;
   suppressTailResumptionExitChecks?: boolean;
   staticEffectContext?: StaticEffectHandlerContext;

--- a/packages/compiler/src/codegen/expressions/blocks.ts
+++ b/packages/compiler/src/codegen/expressions/blocks.ts
@@ -29,6 +29,11 @@ import { wrapValueInOutcome } from "../effects/outcome-values.js";
 import { handlerCleanupOps } from "../effects/handler-stack.js";
 import { tailResumptionExitChecks } from "../effects/tail-resumptions.js";
 import { boxSignatureSpillValue } from "../signature-spill.js";
+import {
+  arrayLengthBindingForStatement,
+  tryCompileArraySafeForStatement,
+  tryCompileArraySafeWhileStatement,
+} from "../optimization/array-fast-paths.js";
 
 const expressionUsesExpectedResultType = ({
   exprId,
@@ -72,6 +77,7 @@ export const withBlockScope = <T>({
     next: collectSimpleIdentifierAliases({ expr, ctx }),
   });
   const previousNonBorrowable = fnCtx.nonBorrowableProjectedSymbols;
+  const previousSafeArrayLengthSymbols = fnCtx.safeArrayLengthSymbols;
   fnCtx.simpleIdentifierAliases = aliasSets;
   fnCtx.nonBorrowableProjectedSymbols = collectNonBorrowableProjectedSymbols({
     expr,
@@ -84,6 +90,7 @@ export const withBlockScope = <T>({
   } finally {
     fnCtx.simpleIdentifierAliases = previousAliases;
     fnCtx.nonBorrowableProjectedSymbols = previousNonBorrowable;
+    fnCtx.safeArrayLengthSymbols = previousSafeArrayLengthSymbols;
   }
 };
 
@@ -106,8 +113,45 @@ export const compileBlockExpr = (
     ctx,
     fnCtx,
     run: () => {
-      expr.statements.forEach((stmtId) => {
-        statements.push(compileStatement(stmtId, ctx, fnCtx, compileExpr));
+      expr.statements.forEach((stmtId, statementIndex) => {
+        statements.push(
+          tryCompileArraySafeWhileStatement({
+            block: expr,
+            statementIndex,
+            ctx,
+            fnCtx,
+            compileExpr,
+          }) ??
+            tryCompileArraySafeForStatement({
+              block: expr,
+              statementIndex,
+              ctx,
+              fnCtx,
+              compileExpr,
+              compileStatement: (nestedStmtId) =>
+                compileStatement(nestedStmtId, ctx, fnCtx, compileExpr),
+            }) ??
+            compileStatement(stmtId, ctx, fnCtx, compileExpr),
+        );
+        const lengthBinding = arrayLengthBindingForStatement({
+          stmtId,
+          ctx,
+          fnCtx,
+        });
+        if (lengthBinding) {
+          fnCtx.safeArrayLengthSymbols = new Map([
+            ...(fnCtx.safeArrayLengthSymbols?.entries() ?? []),
+            [lengthBinding.lengthSymbol, lengthBinding.arraySymbol],
+          ]);
+          return;
+        }
+        const stmt = ctx.module.hir.statements.get(stmtId);
+        const initializer = stmt?.kind === "let"
+          ? ctx.module.hir.expressions.get(stmt.initializer)
+          : undefined;
+        if (stmt?.kind !== "let" || initializer?.exprKind !== "literal") {
+          fnCtx.safeArrayLengthSymbols = undefined;
+        }
       });
       if (typeof expr.value === "number") {
         const value = compileExpr({

--- a/packages/compiler/src/codegen/expressions/index.ts
+++ b/packages/compiler/src/codegen/expressions/index.ts
@@ -21,6 +21,7 @@ import {
 } from "./objects.js";
 import { compileLambdaExpr } from "./lambdas.js";
 import { tryCompileProjectedElementValueExpr } from "../projected-element-views.js";
+import { tryCompileArrayMethodFastPath } from "../optimization/array-fast-paths.js";
 import {
   compileIdentifierExpr,
   compileLiteralExpr,
@@ -80,6 +81,16 @@ export const compileExpression: ExpressionCompiler = ({
       });
       if (projected) {
         return projected;
+      }
+      const arrayFastPath = tryCompileArrayMethodFastPath({
+        expr,
+        expectedResultTypeId,
+        ctx,
+        fnCtx,
+        compileExpr: compileExpression,
+      });
+      if (arrayFastPath) {
+        return arrayFastPath;
       }
       return compileMethodCallExpr(expr, ctx, fnCtx, compileExpression, {
         tailPosition,

--- a/packages/compiler/src/codegen/optimization/array-fast-paths.ts
+++ b/packages/compiler/src/codegen/optimization/array-fast-paths.ts
@@ -1,0 +1,354 @@
+import binaryen from "binaryen";
+import {
+  arrayGet,
+  structGetFieldValue,
+} from "@voyd-lang/lib/binaryen-gc/index.js";
+import type {
+  CodegenContext,
+  CompiledExpression,
+  ExpressionCompiler,
+  FunctionContext,
+  HirMethodCallExpr,
+  StructuralFieldInfo,
+  StructuralTypeInfo,
+  TypeId,
+} from "../context.js";
+import { allocateTempLocal, loadLocalValue, storeLocalValue } from "../locals.js";
+import {
+  coerceValueToType,
+  fixedArrayStorageElementType,
+  liftFixedArrayElementValue,
+  liftHeapValueToInline,
+} from "../structural.js";
+import {
+  getExprBinaryenType,
+  getRequiredExprType,
+  getStructuralTypeInfo,
+  wasmTypeFor,
+} from "../types.js";
+import { coerceExprToWasmType } from "../wasm-type-coercions.js";
+
+type ArrayMethodInfo = {
+  targetTypeId: TypeId;
+  structInfo: StructuralTypeInfo;
+  storageField: StructuralFieldInfo;
+  countField: StructuralFieldInfo;
+};
+
+const isStdArrayType = ({
+  typeId,
+  ctx,
+}: {
+  typeId: TypeId;
+  ctx: CodegenContext;
+}): boolean => {
+  const desc = ctx.program.types.getTypeDesc(typeId);
+  const nominal =
+    desc.kind === "nominal-object"
+      ? desc
+      : desc.kind === "intersection" && typeof desc.nominal === "number"
+        ? ctx.program.types.getTypeDesc(desc.nominal)
+        : undefined;
+  if (nominal?.kind !== "nominal-object") {
+    return false;
+  }
+  return (
+    nominal.name === "Array" &&
+    ctx.program.symbols.getPackageId(nominal.owner) === "std"
+  );
+};
+
+const arrayMethodInfo = ({
+  expr,
+  ctx,
+  fnCtx,
+}: {
+  expr: HirMethodCallExpr;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): ArrayMethodInfo | undefined => {
+  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+  const targetTypeId = getRequiredExprType(expr.target, ctx, typeInstanceId);
+  if (!isStdArrayType({ typeId: targetTypeId, ctx })) {
+    return undefined;
+  }
+
+  const structInfo = getStructuralTypeInfo(targetTypeId, ctx);
+  const storageField = structInfo?.fieldMap.get("storage");
+  const countField = structInfo?.fieldMap.get("count");
+  if (!structInfo || !storageField || !countField) {
+    return undefined;
+  }
+
+  return { targetTypeId, structInfo, storageField, countField };
+};
+
+const directArrayFieldLoad = ({
+  target,
+  structInfo,
+  field,
+  ctx,
+}: {
+  target: () => binaryen.ExpressionRef;
+  structInfo: StructuralTypeInfo;
+  field: StructuralFieldInfo;
+  ctx: CodegenContext;
+}): binaryen.ExpressionRef =>
+  liftHeapValueToInline({
+    value: structGetFieldValue({
+      mod: ctx.mod,
+      fieldType: field.heapWasmType,
+      fieldIndex: field.runtimeIndex,
+      exprRef: coerceExprToWasmType({
+        expr: target(),
+        targetType: structInfo.runtimeType,
+        ctx,
+      }),
+    }),
+    typeId: field.typeId,
+    ctx,
+  });
+
+const compileArrayTarget = ({
+  expr,
+  info,
+  ctx,
+  fnCtx,
+  compileExpr,
+}: {
+  expr: HirMethodCallExpr;
+  info: ArrayMethodInfo;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+}) => {
+  const targetLocal = allocateTempLocal(
+    wasmTypeFor(info.targetTypeId, ctx),
+    fnCtx,
+    info.targetTypeId,
+    ctx,
+  );
+  const setup = storeLocalValue({
+    binding: targetLocal,
+    value: compileExpr({
+      exprId: expr.target,
+      ctx,
+      fnCtx,
+      expectedResultTypeId: info.targetTypeId,
+    }).expr,
+    ctx,
+    fnCtx,
+  });
+  return {
+    setup,
+    target: () => loadLocalValue(targetLocal, ctx),
+  };
+};
+
+const compileArrayLenFastPath = ({
+  expr,
+  info,
+  ctx,
+  fnCtx,
+  compileExpr,
+}: {
+  expr: HirMethodCallExpr;
+  info: ArrayMethodInfo;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+}): CompiledExpression | undefined => {
+  if (expr.args.length !== 0) {
+    return undefined;
+  }
+
+  const { setup, target } = compileArrayTarget({
+    expr,
+    info,
+    ctx,
+    fnCtx,
+    compileExpr,
+  });
+  const count = directArrayFieldLoad({
+    target,
+    structInfo: info.structInfo,
+    field: info.countField,
+    ctx,
+  });
+  return {
+    expr: ctx.mod.block(null, [setup, count], binaryen.i32),
+    usedReturnCall: false,
+  };
+};
+
+const compileArrayAtFastPath = ({
+  expr,
+  info,
+  expectedResultTypeId,
+  ctx,
+  fnCtx,
+  compileExpr,
+}: {
+  expr: HirMethodCallExpr;
+  info: ArrayMethodInfo;
+  expectedResultTypeId?: TypeId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+}): CompiledExpression | undefined => {
+  if (expr.args.length !== 1) {
+    return undefined;
+  }
+
+  const storageDesc = ctx.program.types.getTypeDesc(info.storageField.typeId);
+  if (storageDesc.kind !== "fixed-array") {
+    return undefined;
+  }
+
+  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+  const returnTypeId = getRequiredExprType(expr.id, ctx, typeInstanceId);
+  const resultTypeId = expectedResultTypeId ?? returnTypeId;
+  const resultWasmType = getExprBinaryenType(expr.id, ctx, typeInstanceId);
+  const elementStorageType = fixedArrayStorageElementType({
+    typeId: storageDesc.element,
+    ctx,
+  });
+  const storageLocal = allocateTempLocal(
+    wasmTypeFor(info.storageField.typeId, ctx),
+    fnCtx,
+    info.storageField.typeId,
+    ctx,
+  );
+  const countLocal = allocateTempLocal(binaryen.i32, fnCtx);
+  const indexLocal = allocateTempLocal(binaryen.i32, fnCtx);
+  const computedIndexLocal = allocateTempLocal(binaryen.i32, fnCtx);
+  const { setup: setupTarget, target } = compileArrayTarget({
+    expr,
+    info,
+    ctx,
+    fnCtx,
+    compileExpr,
+  });
+  const storage = () => loadLocalValue(storageLocal, ctx);
+  const count = () => ctx.mod.local.get(countLocal.index, binaryen.i32);
+  const index = () => ctx.mod.local.get(indexLocal.index, binaryen.i32);
+  const computedIndex = () =>
+    ctx.mod.local.get(computedIndexLocal.index, binaryen.i32);
+  const boundsCheck = ctx.mod.if(
+    ctx.mod.i32.or(
+      ctx.mod.i32.lt_s(computedIndex(), ctx.mod.i32.const(0)),
+      ctx.mod.i32.ge_s(computedIndex(), count()),
+    ),
+    ctx.mod.unreachable(),
+  );
+  const rawValue = arrayGet(
+    ctx.mod,
+    storage(),
+    computedIndex(),
+    elementStorageType,
+    false,
+  );
+  const inlineValue = liftFixedArrayElementValue({
+    value: rawValue,
+    typeId: storageDesc.element,
+    ctx,
+    fnCtx,
+  });
+  const coerced = coerceExprToWasmType({
+    expr:
+      storageDesc.element === resultTypeId
+        ? inlineValue
+        : coerceValueToType({
+            value: inlineValue,
+            actualType: storageDesc.element,
+            targetType: resultTypeId,
+            ctx,
+            fnCtx,
+          }),
+    targetType: resultWasmType,
+    ctx,
+  });
+
+  return {
+    expr: ctx.mod.block(
+      null,
+      [
+        setupTarget,
+        ctx.mod.local.set(
+          indexLocal.index,
+          compileExpr({
+            exprId: expr.args[0]!.expr,
+            ctx,
+            fnCtx,
+            expectedResultTypeId: ctx.program.primitives.i32,
+          }).expr,
+        ),
+        storeLocalValue({
+          binding: storageLocal,
+          value: directArrayFieldLoad({
+            target,
+            structInfo: info.structInfo,
+            field: info.storageField,
+            ctx,
+          }),
+          ctx,
+          fnCtx,
+        }),
+        ctx.mod.local.set(
+          countLocal.index,
+          directArrayFieldLoad({
+            target,
+            structInfo: info.structInfo,
+            field: info.countField,
+            ctx,
+          }),
+        ),
+        ctx.mod.local.set(
+          computedIndexLocal.index,
+          ctx.mod.if(
+            ctx.mod.i32.lt_s(index(), ctx.mod.i32.const(0)),
+            ctx.mod.i32.add(count(), index()),
+            index(),
+          ),
+        ),
+        boundsCheck,
+        coerced,
+      ],
+      resultWasmType,
+    ),
+    usedReturnCall: false,
+  };
+};
+
+export const tryCompileArrayMethodFastPath = ({
+  expr,
+  expectedResultTypeId,
+  ctx,
+  fnCtx,
+  compileExpr,
+}: {
+  expr: HirMethodCallExpr;
+  expectedResultTypeId?: TypeId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+}): CompiledExpression | undefined => {
+  if (expr.method !== "len" && expr.method !== "at") {
+    return undefined;
+  }
+  const info = arrayMethodInfo({ expr, ctx, fnCtx });
+  if (!info) {
+    return undefined;
+  }
+  if (expr.method === "len") {
+    return compileArrayLenFastPath({ expr, info, ctx, fnCtx, compileExpr });
+  }
+  return compileArrayAtFastPath({
+    expr,
+    info,
+    expectedResultTypeId,
+    ctx,
+    fnCtx,
+    compileExpr,
+  });
+};

--- a/packages/compiler/src/codegen/optimization/array-fast-paths.ts
+++ b/packages/compiler/src/codegen/optimization/array-fast-paths.ts
@@ -8,11 +8,24 @@ import type {
   CompiledExpression,
   ExpressionCompiler,
   FunctionContext,
+  HirBlockExpr,
+  HirCallExpr,
+  HirExpression,
+  HirExprId,
+  HirPattern,
   HirMethodCallExpr,
+  HirWhileExpr,
+  SafeArrayLoopScope,
   StructuralFieldInfo,
   StructuralTypeInfo,
+  SymbolId,
   TypeId,
 } from "../context.js";
+import {
+  allocateLoopLabels,
+  withLoopScope,
+} from "../control-flow-stack.js";
+import { walkHirExpression } from "../hir-walk.js";
 import { allocateTempLocal, loadLocalValue, storeLocalValue } from "../locals.js";
 import {
   coerceValueToType,
@@ -34,6 +47,20 @@ type ArrayMethodInfo = {
   storageField: StructuralFieldInfo;
   countField: StructuralFieldInfo;
 };
+
+type SafeArrayWhileLoopAnalysis = {
+  scope: SafeArrayLoopScope;
+  whileExpr: HirWhileExpr;
+  cachedLengthExpr?: HirExprId;
+};
+
+type SafeArrayForLoopAnalysis = {
+  scope: SafeArrayLoopScope;
+  lengthExpr: HirExprId;
+  userStatements: readonly number[];
+};
+
+type StatementCompiler = (stmtId: number) => binaryen.ExpressionRef;
 
 const isStdArrayType = ({
   typeId,
@@ -145,6 +172,1042 @@ const compileArrayTarget = ({
   };
 };
 
+const expressionSymbol = ({
+  exprId,
+  ctx,
+}: {
+  exprId: HirExprId;
+  ctx: CodegenContext;
+}): SymbolId | undefined => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  return expr?.exprKind === "identifier" ? expr.symbol : undefined;
+};
+
+const isLiteralI32 = ({
+  exprId,
+  value,
+  ctx,
+}: {
+  exprId: HirExprId;
+  value: string;
+  ctx: CodegenContext;
+}): boolean => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  return (
+    expr?.exprKind === "literal" &&
+    expr.literalKind === "i32" &&
+    expr.value === value
+  );
+};
+
+const callHasName = ({
+  expr,
+  name,
+  ctx,
+}: {
+  expr: HirCallExpr;
+  name: string;
+  ctx: CodegenContext;
+}): boolean => {
+  const callee = ctx.module.hir.expressions.get(expr.callee);
+  if (callee?.exprKind !== "identifier") {
+    return false;
+  }
+  const calleeId = ctx.program.symbols.canonicalIdOf(ctx.moduleId, callee.symbol);
+  return (
+    ctx.program.symbols.getName(calleeId) === name ||
+    ctx.program.symbols.getIntrinsicName(calleeId) === name
+  );
+};
+
+const isCallNamed = ({
+  expr,
+  name,
+  ctx,
+}: {
+  expr: HirExpression;
+  name: string;
+  ctx: CodegenContext;
+}): boolean =>
+  expr.exprKind === "call" && callHasName({ expr, name, ctx });
+
+const parseArrayLenExpr = ({
+  exprId,
+  ctx,
+  fnCtx,
+}: {
+  exprId: HirExprId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): { arraySymbol: SymbolId; expr: HirMethodCallExpr } | undefined => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  if (
+    expr?.exprKind !== "method-call" ||
+    expr.method !== "len" ||
+    expr.args.length !== 0 ||
+    !arrayMethodInfo({ expr, ctx, fnCtx })
+  ) {
+    return undefined;
+  }
+
+  const arraySymbol = expressionSymbol({ exprId: expr.target, ctx });
+  return typeof arraySymbol === "number" ? { arraySymbol, expr } : undefined;
+};
+
+const aliasesFor = ({
+  symbol,
+  fnCtx,
+}: {
+  symbol: SymbolId;
+  fnCtx: FunctionContext;
+}): ReadonlySet<SymbolId> =>
+  fnCtx.simpleIdentifierAliases?.get(symbol) ?? new Set([symbol]);
+
+const exprIsIndexIncrement = ({
+  exprId,
+  indexSymbol,
+  ctx,
+}: {
+  exprId: HirExprId;
+  indexSymbol: SymbolId;
+  ctx: CodegenContext;
+}): boolean => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  if (
+    !expr ||
+    expr.exprKind !== "call" ||
+    !isCallNamed({ expr, name: "+", ctx }) ||
+    expr.args.length !== 2
+  ) {
+    return false;
+  }
+
+  const [left, right] = expr.args;
+  const leftSymbol = left ? expressionSymbol({ exprId: left.expr, ctx }) : undefined;
+  const rightSymbol = right
+    ? expressionSymbol({ exprId: right.expr, ctx })
+    : undefined;
+
+  return (
+    (leftSymbol === indexSymbol &&
+      Boolean(right && isLiteralI32({ exprId: right.expr, value: "1", ctx }))) ||
+    (rightSymbol === indexSymbol &&
+      Boolean(left && isLiteralI32({ exprId: left.expr, value: "1", ctx })))
+  );
+};
+
+const targetIdentifierSymbol = ({
+  exprId,
+  ctx,
+}: {
+  exprId: HirExprId | undefined;
+  ctx: CodegenContext;
+}): SymbolId | undefined =>
+  typeof exprId === "number" ? expressionSymbol({ exprId, ctx }) : undefined;
+
+const isSafeArrayLoopRead = ({
+  expr,
+  indexSymbol,
+  ctx,
+}: {
+  expr: HirMethodCallExpr;
+  indexSymbol: SymbolId;
+  ctx: CodegenContext;
+}): boolean => {
+  if (expr.method === "len" && expr.args.length === 0) {
+    return true;
+  }
+  if (expr.method !== "at" || expr.args.length !== 1) {
+    return false;
+  }
+  return expressionSymbol({ exprId: expr.args[0]!.expr, ctx }) === indexSymbol;
+};
+
+const bodyPreservesArrayLoopProof = ({
+  bodyExprId,
+  indexSymbol,
+  arraySymbol,
+  indexUpdate,
+  ctx,
+  fnCtx,
+}: {
+  bodyExprId: HirExprId;
+  indexSymbol: SymbolId;
+  arraySymbol: SymbolId;
+  indexUpdate: "increment" | "none";
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): boolean => {
+  const arrayAliases = aliasesFor({ symbol: arraySymbol, fnCtx });
+  let indexIncrements = 0;
+  let valid = true;
+
+  walkHirExpression({
+    exprId: bodyExprId,
+    ctx,
+    visitor: {
+      onExpr: (exprId, expr) => {
+        if (!valid) {
+          return "stop";
+        }
+        if (exprId !== bodyExprId && (expr.exprKind === "while" || expr.exprKind === "loop")) {
+          valid = false;
+          return "stop";
+        }
+        if (expr.exprKind === "break" || expr.exprKind === "continue") {
+          valid = false;
+          return "stop";
+        }
+        if (expr.exprKind === "assign") {
+          const targetSymbol = targetIdentifierSymbol({
+            exprId: expr.target,
+            ctx,
+          });
+          if (typeof targetSymbol === "number" && arrayAliases.has(targetSymbol)) {
+            valid = false;
+            return "stop";
+          }
+          if (targetSymbol === indexSymbol) {
+            if (!exprIsIndexIncrement({ exprId: expr.value, indexSymbol, ctx })) {
+              valid = false;
+              return "stop";
+            }
+            indexIncrements += 1;
+          }
+          return undefined;
+        }
+        if (expr.exprKind === "method-call") {
+          const targetSymbol = expressionSymbol({ exprId: expr.target, ctx });
+          if (
+            typeof targetSymbol === "number" &&
+            arrayAliases.has(targetSymbol) &&
+            !isSafeArrayLoopRead({ expr, indexSymbol, ctx })
+          ) {
+            valid = false;
+            return "stop";
+          }
+          return undefined;
+        }
+        if (expr.exprKind === "call") {
+          if (
+            expr.args.some((arg) => {
+              const argSymbol = expressionSymbol({ exprId: arg.expr, ctx });
+              return typeof argSymbol === "number" && arrayAliases.has(argSymbol);
+            })
+          ) {
+            valid = false;
+            return "stop";
+          }
+        }
+        return undefined;
+      },
+    },
+  });
+
+  return valid && indexIncrements === (indexUpdate === "increment" ? 1 : 0);
+};
+
+const indexInitStatement = ({
+  block,
+  statementIndex,
+  indexSymbol,
+  ctx,
+}: {
+  block: HirBlockExpr;
+  statementIndex: number;
+  indexSymbol: SymbolId;
+  ctx: CodegenContext;
+}): { statementIndex: number; indexSymbol: SymbolId } | undefined => {
+  for (let index = statementIndex - 1; index >= 0; index -= 1) {
+    const stmt = ctx.module.hir.statements.get(block.statements[index]!);
+    if (stmt?.kind !== "let") {
+      return undefined;
+    }
+    if (
+      stmt.mutable &&
+      stmt.pattern.kind === "identifier" &&
+      stmt.pattern.symbol === indexSymbol
+    ) {
+      return isLiteralI32({ exprId: stmt.initializer, value: "0", ctx })
+        ? { statementIndex: index, indexSymbol }
+        : undefined;
+    }
+  }
+  return undefined;
+};
+
+const lengthLetStatement = ({
+  block,
+  statementIndex,
+  lengthSymbol,
+  ctx,
+  fnCtx,
+}: {
+  block: HirBlockExpr;
+  statementIndex: number;
+  lengthSymbol: SymbolId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): { arraySymbol: SymbolId } | undefined => {
+  for (let index = statementIndex - 1; index >= 0; index -= 1) {
+    const stmt = ctx.module.hir.statements.get(block.statements[index]!);
+    if (stmt?.kind !== "let") {
+      return undefined;
+    }
+    if (
+      !stmt.mutable &&
+      stmt.pattern.kind === "identifier" &&
+      stmt.pattern.symbol === lengthSymbol
+    ) {
+      return parseArrayLenExpr({
+        exprId: stmt.initializer,
+        ctx,
+        fnCtx,
+      });
+    }
+  }
+  return undefined;
+};
+
+export const arrayLengthBindingForStatement = ({
+  stmtId,
+  ctx,
+  fnCtx,
+}: {
+  stmtId: number;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): { lengthSymbol: SymbolId; arraySymbol: SymbolId } | undefined => {
+  const stmt = ctx.module.hir.statements.get(stmtId);
+  if (
+    stmt?.kind !== "let" ||
+    stmt.mutable ||
+    stmt.pattern.kind !== "identifier"
+  ) {
+    return undefined;
+  }
+  const length = parseArrayLenExpr({
+    exprId: stmt.initializer,
+    ctx,
+    fnCtx,
+  });
+  return length
+    ? {
+        lengthSymbol: stmt.pattern.symbol,
+        arraySymbol: length.arraySymbol,
+      }
+    : undefined;
+};
+
+const analyzeWhileCondition = ({
+  expr,
+  block,
+  statementIndex,
+  ctx,
+  fnCtx,
+}: {
+  expr: HirWhileExpr;
+  block: HirBlockExpr;
+  statementIndex: number;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): {
+  indexSymbol: SymbolId;
+  arraySymbol: SymbolId;
+  cachedLengthExpr?: HirExprId;
+} | undefined => {
+  const condition = ctx.module.hir.expressions.get(expr.condition);
+  if (
+    !condition ||
+    condition.exprKind !== "call" ||
+    !isCallNamed({ expr: condition, name: "<", ctx })
+  ) {
+    return undefined;
+  }
+  const [left, right] = condition.args;
+  if (!left || !right) {
+    return undefined;
+  }
+  const indexSymbol = expressionSymbol({ exprId: left.expr, ctx });
+  if (typeof indexSymbol !== "number") {
+    return undefined;
+  }
+
+  const directLength = parseArrayLenExpr({
+    exprId: right.expr,
+    ctx,
+    fnCtx,
+  });
+  if (directLength) {
+    return {
+      indexSymbol,
+      arraySymbol: directLength.arraySymbol,
+      cachedLengthExpr: right.expr,
+    };
+  }
+
+  const lengthSymbol = expressionSymbol({ exprId: right.expr, ctx });
+  if (typeof lengthSymbol !== "number") {
+    return undefined;
+  }
+  const length = lengthLetStatement({
+    block,
+    statementIndex,
+    lengthSymbol,
+    ctx,
+    fnCtx,
+  });
+  const scopedArraySymbol = fnCtx.safeArrayLengthSymbols?.get(lengthSymbol);
+  return length
+    ? {
+        indexSymbol,
+        arraySymbol: length.arraySymbol,
+      }
+    : typeof scopedArraySymbol === "number"
+      ? {
+          indexSymbol,
+          arraySymbol: scopedArraySymbol,
+        }
+    : undefined;
+};
+
+const tryAnalyzeSafeArrayWhileLoop = ({
+  block,
+  statementIndex,
+  ctx,
+  fnCtx,
+}: {
+  block: HirBlockExpr;
+  statementIndex: number;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): SafeArrayWhileLoopAnalysis | undefined => {
+  const currentStmtId = block.statements[statementIndex];
+  const currentStmt =
+    typeof currentStmtId === "number"
+      ? ctx.module.hir.statements.get(currentStmtId)
+      : undefined;
+  if (currentStmt?.kind !== "expr-stmt") {
+    return undefined;
+  }
+  const whileExpr = ctx.module.hir.expressions.get(currentStmt.expr);
+  if (whileExpr?.exprKind !== "while") {
+    return undefined;
+  }
+
+  const condition = analyzeWhileCondition({
+    expr: whileExpr,
+    block,
+    statementIndex,
+    ctx,
+    fnCtx,
+  });
+  if (!condition) {
+    return undefined;
+  }
+
+  const indexInit = indexInitStatement({
+    block,
+    statementIndex,
+    indexSymbol: condition.indexSymbol,
+    ctx,
+  });
+  if (!indexInit) {
+    return undefined;
+  }
+
+  if (
+    !bodyPreservesArrayLoopProof({
+      bodyExprId: whileExpr.body,
+      indexSymbol: indexInit.indexSymbol,
+      arraySymbol: condition.arraySymbol,
+      indexUpdate: "increment",
+      ctx,
+      fnCtx,
+    })
+  ) {
+    return undefined;
+  }
+
+  return {
+    whileExpr,
+    scope: {
+      arraySymbol: condition.arraySymbol,
+      indexSymbol: indexInit.indexSymbol,
+    },
+    cachedLengthExpr: condition.cachedLengthExpr,
+  };
+};
+
+const loadI32Local = ({
+  symbol,
+  ctx,
+  fnCtx,
+}: {
+  symbol: SymbolId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef | undefined => {
+  const binding = fnCtx.bindings.get(symbol);
+  if (!binding || binding.kind !== "local") {
+    return undefined;
+  }
+  return ctx.mod.local.get(binding.index, binaryen.i32);
+};
+
+const withSafeArrayLoopScope = <T>({
+  scope,
+  fnCtx,
+  run,
+}: {
+  scope: SafeArrayLoopScope;
+  fnCtx: FunctionContext;
+  run: () => T;
+}): T => {
+  const previousScopes = fnCtx.safeArrayLoopScopes;
+  fnCtx.safeArrayLoopScopes = [...(previousScopes ?? []), scope];
+  try {
+    return run();
+  } finally {
+    fnCtx.safeArrayLoopScopes = previousScopes;
+  }
+};
+
+const compileSafeArrayWhileLoop = ({
+  analysis,
+  ctx,
+  fnCtx,
+  compileExpr,
+}: {
+  analysis: SafeArrayWhileLoopAnalysis;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+}): binaryen.ExpressionRef | undefined => {
+  const { loopLabel, breakLabel } = allocateLoopLabels({
+    fnCtx,
+    prefix: `array_safe_while_loop_${analysis.whileExpr.id}`,
+  });
+  const setup: binaryen.ExpressionRef[] = [];
+  let conditionExpr: binaryen.ExpressionRef | undefined;
+  if (typeof analysis.cachedLengthExpr === "number") {
+    const lengthLocal = allocateTempLocal(binaryen.i32, fnCtx);
+    const indexValue = loadI32Local({
+      symbol: analysis.scope.indexSymbol,
+      ctx,
+      fnCtx,
+    });
+    if (typeof indexValue !== "number") {
+      return undefined;
+    }
+    setup.push(
+      ctx.mod.local.set(
+        lengthLocal.index,
+        compileExpr({
+          exprId: analysis.cachedLengthExpr,
+          ctx,
+          fnCtx,
+          expectedResultTypeId: ctx.program.primitives.i32,
+        }).expr,
+      ),
+    );
+    conditionExpr = ctx.mod.i32.lt_s(
+      indexValue,
+      ctx.mod.local.get(lengthLocal.index, binaryen.i32),
+    );
+  } else {
+    conditionExpr = compileExpr({
+      exprId: analysis.whileExpr.condition,
+      ctx,
+      fnCtx,
+    }).expr;
+  }
+
+  const conditionCheck = ctx.mod.if(
+    ctx.mod.i32.eqz(conditionExpr),
+    ctx.mod.br(breakLabel),
+  );
+  const body = withSafeArrayLoopScope({
+    scope: analysis.scope,
+    fnCtx,
+    run: () =>
+      withLoopScope(
+        fnCtx,
+        { breakLabel, continueLabel: loopLabel },
+        () =>
+          compileExpr({
+            exprId: analysis.whileExpr.body,
+            ctx,
+            fnCtx,
+          }).expr,
+      ),
+  });
+  const loopBody = ctx.mod.block(
+    null,
+    [conditionCheck, body, ctx.mod.br(loopLabel)],
+    binaryen.none,
+  );
+
+  return ctx.mod.block(
+    breakLabel,
+    [...setup, ctx.mod.loop(loopLabel, loopBody)],
+    binaryen.none,
+  );
+};
+
+export const tryCompileArraySafeWhileStatement = ({
+  block,
+  statementIndex,
+  ctx,
+  fnCtx,
+  compileExpr,
+}: {
+  block: HirBlockExpr;
+  statementIndex: number;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+}): binaryen.ExpressionRef | undefined => {
+  const analysis = tryAnalyzeSafeArrayWhileLoop({
+    block,
+    statementIndex,
+    ctx,
+    fnCtx,
+  });
+  if (!analysis) {
+    return undefined;
+  }
+  return compileSafeArrayWhileLoop({
+    analysis,
+    ctx,
+    fnCtx,
+    compileExpr,
+  });
+};
+
+const patternTypeName = (pattern: HirPattern): string | undefined => {
+  if (pattern.kind !== "type" || pattern.type.typeKind !== "named") {
+    return undefined;
+  }
+  return pattern.type.path.at(-1);
+};
+
+const somePayloadExpr = ({
+  exprId,
+  ctx,
+}: {
+  exprId: HirExprId;
+  ctx: CodegenContext;
+}): HirExprId | undefined => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  if (
+    !expr ||
+    expr.exprKind !== "call" ||
+    !isCallNamed({ expr, name: "some", ctx }) ||
+    expr.args.length !== 1
+  ) {
+    return undefined;
+  }
+  return expr.args[0]!.expr;
+};
+
+const parseRangeForIterator = ({
+  initializer,
+  ctx,
+  fnCtx,
+}: {
+  initializer: HirExprId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): { arraySymbol: SymbolId; lengthExpr: HirExprId } | undefined => {
+  const iterCall = ctx.module.hir.expressions.get(initializer);
+  if (
+    iterCall?.exprKind !== "method-call" ||
+    iterCall.method !== "iter" ||
+    iterCall.args.length !== 0
+  ) {
+    return undefined;
+  }
+  const range = ctx.module.hir.expressions.get(iterCall.target);
+  if (range?.exprKind !== "object-literal" || range.literalKind !== "nominal") {
+    return undefined;
+  }
+  const start = range.entries.find((entry) => entry.kind === "field" && entry.name === "start");
+  const end = range.entries.find((entry) => entry.kind === "field" && entry.name === "end");
+  const includeEnd = range.entries.find(
+    (entry) => entry.kind === "field" && entry.name === "include_end",
+  );
+  if (!start || start.kind !== "field" || !end || end.kind !== "field") {
+    return undefined;
+  }
+  if (
+    !includeEnd ||
+    includeEnd.kind !== "field" ||
+    !isLiteralBoolean({ exprId: includeEnd.value, value: "false", ctx })
+  ) {
+    return undefined;
+  }
+  const startValue = somePayloadExpr({ exprId: start.value, ctx });
+  const endValue = somePayloadExpr({ exprId: end.value, ctx });
+  if (
+    typeof startValue !== "number" ||
+    !isLiteralI32({ exprId: startValue, value: "0", ctx }) ||
+    typeof endValue !== "number"
+  ) {
+    return undefined;
+  }
+  const length = parseArrayLenExpr({
+    exprId: endValue,
+    ctx,
+    fnCtx,
+  });
+  return length
+    ? {
+        arraySymbol: length.arraySymbol,
+        lengthExpr: endValue,
+      }
+    : undefined;
+};
+
+const isLiteralBoolean = ({
+  exprId,
+  value,
+  ctx,
+}: {
+  exprId: HirExprId;
+  value: string;
+  ctx: CodegenContext;
+}): boolean => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  return (
+    expr?.exprKind === "literal" &&
+    expr.literalKind === "boolean" &&
+    expr.value === value
+  );
+};
+
+const isBreakBlock = ({
+  exprId,
+  ctx,
+}: {
+  exprId: HirExprId;
+  ctx: CodegenContext;
+}): boolean => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  if (expr?.exprKind === "break") {
+    return true;
+  }
+  if (expr?.exprKind !== "block" || expr.statements.length !== 0) {
+    return false;
+  }
+  return typeof expr.value === "number" && isBreakBlock({ exprId: expr.value, ctx });
+};
+
+const parseRangeForBody = ({
+  whileExpr,
+  iteratorSymbol,
+  arraySymbol,
+  ctx,
+  fnCtx,
+}: {
+  whileExpr: HirWhileExpr;
+  iteratorSymbol: SymbolId;
+  arraySymbol: SymbolId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): { indexSymbol: SymbolId; userStatements: readonly number[] } | undefined => {
+  if (!isLiteralBoolean({ exprId: whileExpr.condition, value: "true", ctx })) {
+    return undefined;
+  }
+  const body = ctx.module.hir.expressions.get(whileExpr.body);
+  if (body?.exprKind !== "block" || body.statements.length !== 1) {
+    return undefined;
+  }
+  const nextStmt = ctx.module.hir.statements.get(body.statements[0]!);
+  if (
+    nextStmt?.kind !== "let" ||
+    nextStmt.mutable ||
+    nextStmt.pattern.kind !== "identifier"
+  ) {
+    return undefined;
+  }
+  const nextValueSymbol = nextStmt.pattern.symbol;
+  const nextCall = ctx.module.hir.expressions.get(nextStmt.initializer);
+  if (
+    nextCall?.exprKind !== "method-call" ||
+    nextCall.method !== "next" ||
+    expressionSymbol({ exprId: nextCall.target, ctx }) !== iteratorSymbol
+  ) {
+    return undefined;
+  }
+  const match = typeof body.value === "number"
+    ? ctx.module.hir.expressions.get(body.value)
+    : undefined;
+  if (
+    match?.exprKind !== "match" ||
+    expressionSymbol({ exprId: match.discriminant, ctx }) !== nextValueSymbol
+  ) {
+    return undefined;
+  }
+  const someArm = match.arms.find((arm) => patternTypeName(arm.pattern) === "Some");
+  const noneArm = match.arms.find((arm) => patternTypeName(arm.pattern) === "None");
+  if (!someArm || !noneArm || !isBreakBlock({ exprId: noneArm.value, ctx })) {
+    return undefined;
+  }
+  const someBlock = ctx.module.hir.expressions.get(someArm.value);
+  if (someBlock?.exprKind !== "block" || someBlock.statements.length === 0) {
+    return undefined;
+  }
+  const indexStmt = ctx.module.hir.statements.get(someBlock.statements[0]!);
+  if (
+    indexStmt?.kind !== "let" ||
+    indexStmt.mutable ||
+    indexStmt.pattern.kind !== "identifier"
+  ) {
+    return undefined;
+  }
+  const payload = ctx.module.hir.expressions.get(indexStmt.initializer);
+  if (
+    payload?.exprKind !== "field-access" ||
+    payload.field !== "value" ||
+    expressionSymbol({ exprId: payload.target, ctx }) !== nextValueSymbol
+  ) {
+    return undefined;
+  }
+  const indexSymbol = indexStmt.pattern.symbol;
+  if (
+    !bodyPreservesArrayLoopProof({
+      bodyExprId: someArm.value,
+      indexSymbol,
+      arraySymbol,
+      indexUpdate: "none",
+      ctx,
+      fnCtx,
+    })
+  ) {
+    return undefined;
+  }
+  return {
+    indexSymbol,
+    userStatements: someBlock.statements.slice(1),
+  };
+};
+
+const tryAnalyzeSafeArrayForLoop = ({
+  block,
+  statementIndex,
+  ctx,
+  fnCtx,
+}: {
+  block: HirBlockExpr;
+  statementIndex: number;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): SafeArrayForLoopAnalysis | undefined => {
+  const currentStmt = ctx.module.hir.statements.get(block.statements[statementIndex]!);
+  if (currentStmt?.kind !== "expr-stmt") {
+    return undefined;
+  }
+  const wrapper = ctx.module.hir.expressions.get(currentStmt.expr);
+  if (wrapper?.exprKind !== "block" || wrapper.statements.length !== 1) {
+    return undefined;
+  }
+  const iteratorStmt = ctx.module.hir.statements.get(wrapper.statements[0]!);
+  if (
+    iteratorStmt?.kind !== "let" ||
+    iteratorStmt.mutable ||
+    iteratorStmt.pattern.kind !== "identifier"
+  ) {
+    return undefined;
+  }
+  const iterator = parseRangeForIterator({
+    initializer: iteratorStmt.initializer,
+    ctx,
+    fnCtx,
+  });
+  const whileExpr = typeof wrapper.value === "number"
+    ? ctx.module.hir.expressions.get(wrapper.value)
+    : undefined;
+  if (!iterator || whileExpr?.exprKind !== "while") {
+    return undefined;
+  }
+  const body = parseRangeForBody({
+    whileExpr,
+    iteratorSymbol: iteratorStmt.pattern.symbol,
+    arraySymbol: iterator.arraySymbol,
+    ctx,
+    fnCtx,
+  });
+  if (!body) {
+    return undefined;
+  }
+  return {
+    scope: {
+      arraySymbol: iterator.arraySymbol,
+      indexSymbol: body.indexSymbol,
+    },
+    lengthExpr: iterator.lengthExpr,
+    userStatements: body.userStatements,
+  };
+};
+
+const compileSafeArrayForLoop = ({
+  analysis,
+  ctx,
+  fnCtx,
+  compileExpr,
+  compileStatement,
+}: {
+  analysis: SafeArrayForLoopAnalysis;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+  compileStatement: StatementCompiler;
+}): binaryen.ExpressionRef => {
+  const { loopLabel, breakLabel } = allocateLoopLabels({
+    fnCtx,
+    prefix: "array_safe_for_loop",
+  });
+  const lengthLocal = allocateTempLocal(binaryen.i32, fnCtx);
+  const indexLocal = allocateTempLocal(
+    binaryen.i32,
+    fnCtx,
+    ctx.program.primitives.i32,
+    ctx,
+  );
+  const previousIndexBinding = fnCtx.bindings.get(analysis.scope.indexSymbol);
+  fnCtx.bindings.set(analysis.scope.indexSymbol, {
+    ...indexLocal,
+    kind: "local",
+    typeId: ctx.program.primitives.i32,
+  });
+  const body = (() => {
+    try {
+      return withSafeArrayLoopScope({
+        scope: analysis.scope,
+        fnCtx,
+        run: () =>
+          withLoopScope(
+            fnCtx,
+            { breakLabel, continueLabel: loopLabel },
+            () =>
+              ctx.mod.block(
+                null,
+                analysis.userStatements.map((stmtId) => compileStatement(stmtId)),
+                binaryen.none,
+              ),
+          ),
+      });
+    } finally {
+      if (previousIndexBinding) {
+        fnCtx.bindings.set(analysis.scope.indexSymbol, previousIndexBinding);
+      } else {
+        fnCtx.bindings.delete(analysis.scope.indexSymbol);
+      }
+    }
+  })();
+
+  const conditionCheck = ctx.mod.if(
+    ctx.mod.i32.eqz(
+      ctx.mod.i32.lt_s(
+        ctx.mod.local.get(indexLocal.index, binaryen.i32),
+        ctx.mod.local.get(lengthLocal.index, binaryen.i32),
+      ),
+    ),
+    ctx.mod.br(breakLabel),
+  );
+  const loopBody = ctx.mod.block(
+    null,
+    [
+      conditionCheck,
+      body,
+      ctx.mod.local.set(
+        indexLocal.index,
+        ctx.mod.i32.add(
+          ctx.mod.local.get(indexLocal.index, binaryen.i32),
+          ctx.mod.i32.const(1),
+        ),
+      ),
+      ctx.mod.br(loopLabel),
+    ],
+    binaryen.none,
+  );
+  return ctx.mod.block(
+    breakLabel,
+    [
+      ctx.mod.local.set(
+        lengthLocal.index,
+        compileExpr({
+          exprId: analysis.lengthExpr,
+          ctx,
+          fnCtx,
+          expectedResultTypeId: ctx.program.primitives.i32,
+        }).expr,
+      ),
+      ctx.mod.local.set(indexLocal.index, ctx.mod.i32.const(0)),
+      ctx.mod.loop(loopLabel, loopBody),
+    ],
+    binaryen.none,
+  );
+};
+
+export const tryCompileArraySafeForStatement = ({
+  block,
+  statementIndex,
+  ctx,
+  fnCtx,
+  compileExpr,
+  compileStatement,
+}: {
+  block: HirBlockExpr;
+  statementIndex: number;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+  compileStatement: StatementCompiler;
+}): binaryen.ExpressionRef | undefined => {
+  const analysis = tryAnalyzeSafeArrayForLoop({
+    block,
+    statementIndex,
+    ctx,
+    fnCtx,
+  });
+  return analysis
+    ? compileSafeArrayForLoop({
+        analysis,
+        ctx,
+        fnCtx,
+        compileExpr,
+        compileStatement,
+      })
+    : undefined;
+};
+
+const activeSafeArrayLoopScope = ({
+  expr,
+  fnCtx,
+  ctx,
+}: {
+  expr: HirMethodCallExpr;
+  fnCtx: FunctionContext;
+  ctx: CodegenContext;
+}): SafeArrayLoopScope | undefined => {
+  if (expr.args.length !== 1) {
+    return undefined;
+  }
+  const targetSymbol = expressionSymbol({ exprId: expr.target, ctx });
+  const indexSymbol = expressionSymbol({ exprId: expr.args[0]!.expr, ctx });
+  if (typeof targetSymbol !== "number" || typeof indexSymbol !== "number") {
+    return undefined;
+  }
+  return [...(fnCtx.safeArrayLoopScopes ?? [])]
+    .reverse()
+    .find(
+      (scope) =>
+        scope.arraySymbol === targetSymbol && scope.indexSymbol === indexSymbol,
+    );
+};
+
 const compileArrayLenFastPath = ({
   expr,
   info,
@@ -213,6 +1276,84 @@ const compileArrayAtFastPath = ({
     typeId: storageDesc.element,
     ctx,
   });
+  const safeLoopScope = activeSafeArrayLoopScope({ expr, fnCtx, ctx });
+  if (safeLoopScope) {
+    const storageLocal = allocateTempLocal(
+      wasmTypeFor(info.storageField.typeId, ctx),
+      fnCtx,
+      info.storageField.typeId,
+      ctx,
+    );
+    const indexLocal = allocateTempLocal(binaryen.i32, fnCtx);
+    const { setup: setupTarget, target } = compileArrayTarget({
+      expr,
+      info,
+      ctx,
+      fnCtx,
+      compileExpr,
+    });
+    const storage = () => loadLocalValue(storageLocal, ctx);
+    const index = () => ctx.mod.local.get(indexLocal.index, binaryen.i32);
+    const rawValue = arrayGet(
+      ctx.mod,
+      storage(),
+      index(),
+      elementStorageType,
+      false,
+    );
+    const inlineValue = liftFixedArrayElementValue({
+      value: rawValue,
+      typeId: storageDesc.element,
+      ctx,
+      fnCtx,
+    });
+    const coerced = coerceExprToWasmType({
+      expr:
+        storageDesc.element === resultTypeId
+          ? inlineValue
+          : coerceValueToType({
+              value: inlineValue,
+              actualType: storageDesc.element,
+              targetType: resultTypeId,
+              ctx,
+              fnCtx,
+            }),
+      targetType: resultWasmType,
+      ctx,
+    });
+
+    return {
+      expr: ctx.mod.block(
+        null,
+        [
+          setupTarget,
+          ctx.mod.local.set(
+            indexLocal.index,
+            compileExpr({
+              exprId: expr.args[0]!.expr,
+              ctx,
+              fnCtx,
+              expectedResultTypeId: ctx.program.primitives.i32,
+            }).expr,
+          ),
+          storeLocalValue({
+            binding: storageLocal,
+            value: directArrayFieldLoad({
+              target,
+              structInfo: info.structInfo,
+              field: info.storageField,
+              ctx,
+            }),
+            ctx,
+            fnCtx,
+          }),
+          coerced,
+        ],
+        resultWasmType,
+      ),
+      usedReturnCall: false,
+    };
+  }
   const storageLocal = allocateTempLocal(
     wasmTypeFor(info.storageField.typeId, ctx),
     fnCtx,

--- a/scripts/bench-v309.ts
+++ b/scripts/bench-v309.ts
@@ -16,6 +16,7 @@ type Scenario = {
 
 type ScenarioResult = {
   name: string;
+  compileMs: number;
   wasmBytes: number;
   gzipBytes: number;
   medianMs: number;
@@ -49,6 +50,32 @@ pub fn semantic_copy_forwarding() -> i32
   total
 `;
 
+const arrayFastPathSource = `
+use std::array::Array
+use std::number::all
+
+fn build_values(count: i32) -> Array<i32>
+  let ~values = Array<i32>::with_capacity(count)
+  var index = 0
+  while index < count:
+    values.push((index % 17) + 1)
+    index = index + 1
+  values
+
+pub fn std_array_len_at_loop() -> i32
+  let values = build_values(4096)
+  let length = values.len()
+  var total = 0
+  var round = 0
+  while round < 1500:
+    var index = 0
+    while index < length:
+      total = total + values.at(index)
+      index = index + 1
+    round = round + 1
+  total
+`;
+
 const defaultIterations = Number.parseInt(process.env.VOYD_BENCH_ITERATIONS ?? "9", 10);
 const vtraceIterations = Number.parseInt(process.env.VOYD_BENCH_VTRACE_ITERATIONS ?? "3", 10);
 
@@ -68,6 +95,14 @@ const scenarios: Scenario[] = [
     iterations: defaultIterations,
     warmups: 2,
     expected: 200_010_000,
+  },
+  {
+    name: "focused/std-array-len-at-loop",
+    source: arrayFastPathSource,
+    entryName: "std_array_len_at_loop",
+    iterations: defaultIterations,
+    warmups: 2,
+    expected: 55_284_000,
   },
   {
     name: "realistic/vtrace-main",
@@ -111,6 +146,7 @@ const median = (values: number[]): number => {
 
 const runScenario = async (scenario: Scenario): Promise<ScenarioResult> => {
   const sdk = createSdk();
+  const compileStartedAt = performance.now();
   const compiled = expectCompileSuccess(
     await sdk.compile({
       entryPath: scenario.entryPath,
@@ -119,6 +155,7 @@ const runScenario = async (scenario: Scenario): Promise<ScenarioResult> => {
     }),
     scenario.name
   );
+  const compileMs = performance.now() - compileStartedAt;
   const host = await createVoydHost({ wasm: compiled.wasm });
 
   for (let warmup = 0; warmup < scenario.warmups; warmup += 1) {
@@ -145,6 +182,7 @@ const runScenario = async (scenario: Scenario): Promise<ScenarioResult> => {
 
   return {
     name: scenario.name,
+    compileMs,
     wasmBytes: compiled.wasm.byteLength,
     gzipBytes: gzipSync(compiled.wasm).byteLength,
     medianMs: median(samplesMs),
@@ -153,11 +191,12 @@ const runScenario = async (scenario: Scenario): Promise<ScenarioResult> => {
 };
 
 const printResults = (results: readonly ScenarioResult[]): void => {
-  console.log("name,wasmBytes,gzipBytes,medianMs,samplesMs");
+  console.log("name,compileMs,wasmBytes,gzipBytes,medianMs,samplesMs");
   for (const result of results) {
     console.log(
       [
         result.name,
+        result.compileMs.toFixed(3),
         result.wasmBytes.toString(),
         result.gzipBytes.toString(),
         result.medianMs.toFixed(3),

--- a/scripts/bench-v309.ts
+++ b/scripts/bench-v309.ts
@@ -54,11 +54,29 @@ const arrayFastPathSource = `
 use std::array::Array
 use std::number::all
 
+val BenchVec3 {
+  x: i32,
+  y: i32,
+  z: i32
+}
+
 fn build_values(count: i32) -> Array<i32>
   let ~values = Array<i32>::with_capacity(count)
   var index = 0
   while index < count:
     values.push((index % 17) + 1)
+    index = index + 1
+  values
+
+fn build_vectors(count: i32) -> Array<BenchVec3>
+  let ~values = Array<BenchVec3>::with_capacity(count)
+  var index = 0
+  while index < count:
+    values.push(BenchVec3 {
+      x: (index % 7) + 1,
+      y: (index % 5) + 2,
+      z: (index % 3) + 3
+    })
     index = index + 1
   values
 
@@ -72,6 +90,41 @@ pub fn std_array_len_at_loop() -> i32
     while index < length:
       total = total + values.at(index)
       index = index + 1
+    round = round + 1
+  total
+
+pub fn std_array_for_len_at_loop() -> i32
+  let values = build_values(4096)
+  var total = 0
+  var round = 0
+  while round < 1500:
+    for index in 0..values.len():
+      total = total + values.at(index)
+    round = round + 1
+  total
+
+pub fn std_array_value_len_at_loop() -> i32
+  let values = build_vectors(2048)
+  let length = values.len()
+  var total = 0
+  var round = 0
+  while round < 1000:
+    var index = 0
+    while index < length:
+      let value = values.at(index)
+      total = total + value.x + value.y + value.z
+      index = index + 1
+    round = round + 1
+  total
+
+pub fn std_array_value_for_len_at_loop() -> i32
+  let values = build_vectors(2048)
+  var total = 0
+  var round = 0
+  while round < 1000:
+    for index in 0..values.len():
+      let value = values.at(index)
+      total = total + value.x + value.y + value.z
     round = round + 1
   total
 `;
@@ -103,6 +156,30 @@ const scenarios: Scenario[] = [
     iterations: defaultIterations,
     warmups: 2,
     expected: 55_284_000,
+  },
+  {
+    name: "focused/std-array-for-len-at-loop",
+    source: arrayFastPathSource,
+    entryName: "std_array_for_len_at_loop",
+    iterations: defaultIterations,
+    warmups: 2,
+    expected: 55_284_000,
+  },
+  {
+    name: "focused/std-array-value-len-at-loop",
+    source: arrayFastPathSource,
+    entryName: "std_array_value_len_at_loop",
+    iterations: defaultIterations,
+    warmups: 2,
+    expected: 24_566_000,
+  },
+  {
+    name: "focused/std-array-value-for-len-at-loop",
+    source: arrayFastPathSource,
+    entryName: "std_array_value_for_len_at_loop",
+    iterations: defaultIterations,
+    warmups: 2,
+    expected: 24_566_000,
   },
   {
     name: "realistic/vtrace-main",


### PR DESCRIPTION
## Summary
- Add compiler-side fast paths for proven-safe `std::Array` loops and `Array.at` access.
- Recognize safe `while` and `for` loop shapes, cache valid `len()` facts, and fall back to the checked path when proofs do not hold.
- Extend the std array smoke fixture and benchmark scenarios to cover the new lowering behavior.

## Testing
- Added and ran focused compiler smoke tests for safe and unsafe array loop shapes.
- Ran the existing compiler test suite coverage around the new array fast paths.