### PR TITLE
Add whole-program escape analysis facts and benchmarks

### DIFF
--- a/docs/architecture/compiler-optimization-pipeline.md
+++ b/docs/architecture/compiler-optimization-pipeline.md
@@ -105,6 +105,9 @@ The IR currently tracks:
 - used trait-dispatch signatures
 - receiver specialization requests
 - exact and known parameter type facts
+- whole-program escape facts for aggregate origins, trait-object receiver
+  temporaries, closure environments, effect handler environments, and parameter
+  boundary behavior
 - runtime type-check elision candidates for field access
 - semantic copy-forwarding candidates for field access
 - a codegen optimization plan
@@ -155,6 +158,7 @@ The current pass list is:
 15. `whole-program-specialization-pruning`
 16. `redundant-runtime-type-check-elimination`
 17. `semantic-copy-forwarding`
+18. `whole-program-escape-analysis`
 
 ## Implemented Semantic Optimizations
 
@@ -227,6 +231,22 @@ This pass should remain separate from broader escape analysis and scalar
 replacement. General non-escaping aggregate analysis belongs to `V-325` and
 `V-326`, not this pass.
 
+### Whole-Program Escape Analysis
+
+Records conservative, reusable escape facts after reachability, exact receiver
+propagation, and trait-dispatch devirtualization have stabilized. The facts are
+available through `ProgramOptimizationFacts.escapeAnalysis` and cover:
+
+- aggregate origins such as object literals and tuples
+- trait-object receiver temporaries at direct call boundaries
+- closure environment origins and captured aggregate escapes
+- effect handler environment origins and captured aggregate escapes
+- per-function-instance parameter escape behavior
+
+The pass intentionally does not scalar-replace aggregates or skip
+materialization by itself. Downstream codegen and SROA work must consume these
+facts and re-check local lowering preconditions before changing representation.
+
 ## Codegen-Owned Lowering Optimizations
 
 Some performance-sensitive lowering choices belong in codegen instead of the
@@ -251,10 +271,10 @@ This covers the narrow intent from the original architecture plan: reuse
 already-addressable local or out-result storage for wide value/inline aggregate
 construction and mutation within the current lowering region.
 
-It does not own reusable whole-program escape facts, and it does not split
-aggregates into scalar locals. It also does not remove allocation for arbitrary
-nominal `obj` locals. Those responsibilities belong to the broader value-like
-workload roadmap: `V-325` for escape facts and `V-326` for scalar replacement.
+It does not compute whole-program escape facts, and it does not split
+aggregates into scalar locals. Reusable escape facts are owned by the
+whole-program escape-analysis pass; broad scalar replacement and allocation
+elision remain separate `V-326` work.
 
 ## Binaryen Optimization
 
@@ -311,8 +331,10 @@ or the shared Binaryen optimization profile should own it.
   codegen already consumes resolved call lowering metadata, but there is no
   standalone optimizer pass that specializes call shapes beyond the existing
   call info and receiver-specialization facts.
-- `V-325`: reusable whole-program escape facts remain outside this optimizer
-  layer until a benchmark justifies the added analysis surface.
+- `V-325`: reusable whole-program escape facts are present. Downstream
+  representation changes must consume those facts through
+  `ProgramOptimizationFacts.escapeAnalysis` rather than rediscovering typing
+  internals.
 - `V-326`: broad scalar replacement for non-escaping aggregates remains
   separate from semantic copy forwarding and addressable storage reuse.
 

--- a/docs/notes/v-325-escape-analysis.md
+++ b/docs/notes/v-325-escape-analysis.md
@@ -21,7 +21,9 @@ Facts are conservative. Unknown calls, dynamic dispatch, effectful calls,
 mutable-ref call arguments, returns, public exports, aggregate storage, closure
 captures, and effect handler captures are treated as escapes. Direct pure calls
 can keep an aggregate non-escaping when the callee parameter is proven
-non-escaping by the whole-program fixpoint.
+non-escaping by the whole-program fixpoint. Local aliases of parameters are
+tracked back to their original parameter symbols, so returning, passing, or
+capturing an alias marks the parameter as escaping.
 
 ## Complexity Proof
 
@@ -49,9 +51,8 @@ Boundary coupling:
 
 Maintenance risk:
 
-- The main risk is conservative false negatives when new HIR forms gain
-  ownership semantics. Those should add escape reasons/tests rather than
-  weakening existing facts.
+- The main risk is false negatives when new HIR forms gain ownership semantics.
+  Those should add escape reasons/tests rather than weakening existing facts.
 - The pass does not rewrite HIR and does not mutate call metadata, so incorrect
   facts are less likely to create immediate correctness bugs unless a downstream
   lowering consumes them without re-checking local preconditions.
@@ -67,6 +68,11 @@ Simpler alternatives:
 
 - Local-only escape analysis was rejected because it cannot distinguish direct
   pure call boundaries from functions that return/store parameters.
+- Doing escape analysis privately inside V-326 was rejected because V-326 needs
+  to combine aggregate SROA with value-lane forwarding and call-boundary
+  materialization decisions. A reusable fact surface keeps those consumers from
+  duplicating whole-program call/parameter reasoning or reaching back into
+  typing internals.
 - Reusing exact receiver facts alone was rejected because it only answers
   concrete type identity, not whether value identity/materialization escapes.
 - Doing nothing would leave V-326 and value-lane forwarding without a stable
@@ -77,8 +83,14 @@ Why land this now:
 - The pass establishes the reusable contract needed by V-326 without coupling
   codegen to typing internals.
 - Tests cover positive non-escaping aggregates, returned/call-boundary escapes,
-  public boundary escapes, trait-object receiver temporaries, closure captures,
-  and effect handler captures.
+  local aliases of parameters, public boundary escapes, trait-object receiver
+  temporaries, closure captures, and effect handler captures.
+- Facts are precise enough for V-326 to consume: origins carry kind, type id,
+  direct local bindings, use sites, and concrete escape reasons; parameters are
+  keyed by function instance and symbol with the same escape reason vocabulary.
+- No runtime or wasm-size regression is expected because this PR records facts
+  but does not change HIR, call metadata, codegen, Binaryen options, or
+  materialization lowering.
 - No scalar replacement or object materialization elision is enabled in this
   patch. Those transformations must consume these facts later and prove their
   own local lowering preconditions.
@@ -89,15 +101,50 @@ Run from the repository root:
 
 ```sh
 NODE_OPTIONS=--conditions=development \
-  VOYD_BENCH_ITERATIONS=1 \
-  VOYD_BENCH_REPRESENTATIVE_ITERATIONS=1 \
+  VOYD_BENCH_OPTIMIZE_MODES=true \
+  VOYD_BENCH_ITERATIONS=0 \
+  VOYD_BENCH_REPRESENTATIVE_ITERATIONS=0 \
   npx tsx scripts/bench-v325.ts
 ```
 
 The `development` condition is needed in an unbuilt workspace so Node resolves
 workspace TypeScript sources instead of `dist` package exports.
 
-## Baseline Run
+For runtime context, set `VOYD_BENCH_ITERATIONS=1` and
+`VOYD_BENCH_REPRESENTATIVE_ITERATIONS=1`. Runtime numbers are not used as the
+V-325 proof because this PR intentionally does not change codegen.
+
+## PR Base/Head Optimized Compile-Time
+
+Machine/date: local Codex worktree, 2026-06-11.
+
+Base: `dd31b5e59e1164b806008919afee4423a75cd4d7` (`main` at PR merge-base).
+
+```csv
+name,baseCompileMs,headCompileMs,deltaMs,deltaPct,baseWasmBytes,headWasmBytes,baseGzipBytes,headGzipBytes,wasmHashChanged
+focused/non-escaping-aggregate,2919.040,2954.322,35.282,1.2,18154,18154,6584,6584,false
+focused/mutable-temporary-record,2410.651,2246.498,-164.153,-6.8,18154,18154,6584,6584,false
+focused/trait-typed-temporary,2250.888,2189.378,-61.510,-2.7,18154,18154,6584,6584,false
+focused/call-boundary-escape,2237.506,2168.737,-68.769,-3.1,18154,18154,6584,6584,false
+representative/vtrace-compute-main,5466.791,5612.162,145.371,2.7,60098,60098,19436,19436,false
+```
+
+The focused compile-time measurements are noise-dominated at this scale. Across
+the listed scenarios, total optimized compile time changed from 15284.876 ms to
+15171.097 ms (-0.7%). The representative vtrace compile rose by 2.7% in this
+single run.
+
+The optimized wasm SHA-256 was unchanged for every row:
+
+- focused scenarios:
+  `93603688432242014f5adc953914877d7b379c68508fa216953cbaa81a34eb5c`
+- representative/vtrace-compute-main:
+  `a2444f0099b9f1ba4f091cec7f2f4cc66c9b7b232abe1f338ac947d63d0d8130`
+
+Because the optimized wasm is byte-identical between PR base and PR head, no
+runtime or wasm-size regression is expected or observed from this PR.
+
+## Optimized/Unoptimized Context
 
 Machine/date: local Codex worktree, 2026-06-11.
 
@@ -116,9 +163,10 @@ representative/vtrace-compute-main,true,5825.309,60098,19436,277.359,277.359
 ```
 
 These numbers are end-to-end optimized versus unoptimized baselines for the
-current compiler. V-325 does not claim a WAT/codegen shape change by itself; the
-new facts are the shape contract for downstream V-326 materialization and SROA
-work.
+current compiler. They mostly measure the existing optimizer and Binaryen
+profile, not this PR. V-325 does not claim a WAT/codegen shape change by itself;
+the new facts are the shape contract for downstream V-326 materialization and
+SROA work.
 
 ## External Examples Status
 

--- a/docs/notes/v-325-escape-analysis.md
+++ b/docs/notes/v-325-escape-analysis.md
@@ -1,0 +1,133 @@
+# V-325 Escape Analysis Notes
+
+Status: implemented as reusable optimizer facts.
+
+## Implemented Surface
+
+V-325 adds `ProgramOptimizationFacts.escapeAnalysis` as the compiler/codegen
+boundary contract for escape facts. The pass runs after reachability,
+exact-receiver propagation, trait-dispatch devirtualization, runtime type-check
+elision marking, and semantic copy-forwarding marking.
+
+The fact surface records:
+
+- aggregate origins from object literals and tuple expressions
+- trait-object receiver temporaries at direct call boundaries
+- closure environment origins
+- effect handler environment origins
+- per-function-instance parameter escape behavior
+
+Facts are conservative. Unknown calls, dynamic dispatch, effectful calls,
+mutable-ref call arguments, returns, public exports, aggregate storage, closure
+captures, and effect handler captures are treated as escapes. Direct pure calls
+can keep an aggregate non-escaping when the callee parameter is proven
+non-escaping by the whole-program fixpoint.
+
+## Complexity Proof
+
+New compiler concepts:
+
+- `EscapeAnalysisOriginFact`
+- `EscapeAnalysisParameterFact`
+- origin kinds for aggregates, trait objects, closure environments, and effect
+  handler environments
+- escape reasons suitable for downstream diagnostics and representation
+  decisions
+
+Pass-ordering dependency:
+
+- The pass intentionally runs late so it consumes the optimized reachable
+  instance set and devirtualized call info. Running earlier would mark direct
+  calls and trait receivers as unknown more often.
+
+Boundary coupling:
+
+- The pass uses `ProgramCodegenView`, optimized HIR, optimized call metadata,
+  and existing function/effect/type indexes.
+- Codegen receives facts through `ProgramOptimizationFacts`. It does not import
+  typing stores or optimizer internals.
+
+Maintenance risk:
+
+- The main risk is conservative false negatives when new HIR forms gain
+  ownership semantics. Those should add escape reasons/tests rather than
+  weakening existing facts.
+- The pass does not rewrite HIR and does not mutate call metadata, so incorrect
+  facts are less likely to create immediate correctness bugs unless a downstream
+  lowering consumes them without re-checking local preconditions.
+
+Expected compile-time cost:
+
+- Linear in reachable optimized HIR roots, plus a monotonic parameter fixpoint
+  over reachable direct call edges.
+- The fact map is proportional to reachable aggregate/lambda/effect-handler
+  origins plus reachable function parameters.
+
+Simpler alternatives:
+
+- Local-only escape analysis was rejected because it cannot distinguish direct
+  pure call boundaries from functions that return/store parameters.
+- Reusing exact receiver facts alone was rejected because it only answers
+  concrete type identity, not whether value identity/materialization escapes.
+- Doing nothing would leave V-326 and value-lane forwarding without a stable
+  boundary contract.
+
+Why land this now:
+
+- The pass establishes the reusable contract needed by V-326 without coupling
+  codegen to typing internals.
+- Tests cover positive non-escaping aggregates, returned/call-boundary escapes,
+  public boundary escapes, trait-object receiver temporaries, closure captures,
+  and effect handler captures.
+- No scalar replacement or object materialization elision is enabled in this
+  patch. Those transformations must consume these facts later and prove their
+  own local lowering preconditions.
+
+## Benchmark Command
+
+Run from the repository root:
+
+```sh
+NODE_OPTIONS=--conditions=development \
+  VOYD_BENCH_ITERATIONS=1 \
+  VOYD_BENCH_REPRESENTATIVE_ITERATIONS=1 \
+  npx tsx scripts/bench-v325.ts
+```
+
+The `development` condition is needed in an unbuilt workspace so Node resolves
+workspace TypeScript sources instead of `dist` package exports.
+
+## Baseline Run
+
+Machine/date: local Codex worktree, 2026-06-11.
+
+```csv
+name,optimize,compileMs,wasmBytes,gzipBytes,medianMs,samplesMs
+focused/non-escaping-aggregate,false,1813.767,51994,14230,0.270,0.270
+focused/non-escaping-aggregate,true,2686.846,18154,6584,0.168,0.168
+focused/mutable-temporary-record,false,1430.948,51994,14230,0.257,0.257
+focused/mutable-temporary-record,true,2415.187,18154,6584,0.666,0.666
+focused/trait-typed-temporary,false,1335.653,51994,14230,0.349,0.349
+focused/trait-typed-temporary,true,2371.753,18154,6584,0.058,0.058
+focused/call-boundary-escape,false,1337.524,51994,14230,0.523,0.523
+focused/call-boundary-escape,true,2365.108,18154,6584,0.068,0.068
+representative/vtrace-compute-main,false,1797.738,173132,44619,995.187,995.187
+representative/vtrace-compute-main,true,5825.309,60098,19436,277.359,277.359
+```
+
+These numbers are end-to-end optimized versus unoptimized baselines for the
+current compiler. V-325 does not claim a WAT/codegen shape change by itself; the
+new facts are the shape contract for downstream V-326 materialization and SROA
+work.
+
+## External Examples Status
+
+`/Users/drew/projects/voyd_examples` is not currently a clean benchmark target:
+
+- `/Users/drew/projects/voyd_examples/src/vtrace_fast.voyd` is absent.
+- `/Users/drew/projects/voyd_examples/src/main.voyd` fails to compile with
+  `undefined identifier 'forward'` and an unavailable `src::pkgs::vtrace::pkg`
+  import under the current compiler.
+
+The benchmark script keeps the old `vtrace_fast.voyd` hook optional so it will
+participate automatically if that fixture is restored.

--- a/packages/compiler/src/__tests__/optimize-pipeline.test.ts
+++ b/packages/compiler/src/__tests__/optimize-pipeline.test.ts
@@ -1392,6 +1392,271 @@ pub fn main() -> i32
     expect(sawMatch).toBe(false);
   });
 
+  it("records non-escaping aggregate and parameter facts across direct pure calls", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn sum(vec: Vec2) -> i32
+  vec.x + vec.y
+
+pub fn main() -> i32
+  let vec = Vec2 { x: 1, y: 2 }
+  sum(vec)
+`,
+      },
+    });
+
+    const moduleId = "src::main";
+    const program = optimized.program;
+    const aggregateFact = Array.from(
+      optimized.facts.escapeAnalysis.origins.get(moduleId)?.values() ?? [],
+    ).find(
+      (fact) =>
+        fact.originKind === "aggregate" &&
+        !fact.escapes &&
+        fact.directLocalSymbols.length === 1,
+    );
+    expect(aggregateFact).toMatchObject({
+      originKind: "aggregate",
+      escapes: false,
+      escapeReasons: [],
+    });
+    expect(aggregateFact?.directLocalSymbols).toHaveLength(1);
+
+    const sumFn = findFunction({ moduleId, name: "sum", program });
+    expect(sumFn?.kind).toBe("function");
+    if (!sumFn || sumFn.kind !== "function") return;
+    const sumInstanceId = program.functions.getInstanceId(moduleId, sumFn.symbol, []);
+    expect(typeof sumInstanceId).toBe("number");
+    if (typeof sumInstanceId !== "number") return;
+    expect(
+      optimized.facts.escapeAnalysis.parameters
+        .get(sumInstanceId)
+        ?.get(sumFn.parameters[0]!.symbol),
+    ).toMatchObject({
+      escapes: false,
+      escapeReasons: [],
+    });
+  });
+
+  it("marks returned parameters and callers that cross those boundaries", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn identity(vec: Vec2) -> Vec2
+  vec
+
+pub fn main() -> i32
+  let vec = Vec2 { x: 1, y: 2 }
+  identity(vec).x
+`,
+      },
+    });
+
+    const moduleId = "src::main";
+    const program = optimized.program;
+    const identityFn = findFunction({ moduleId, name: "identity", program });
+    expect(identityFn?.kind).toBe("function");
+    if (!identityFn || identityFn.kind !== "function") return;
+    const identityInstanceId = program.functions.getInstanceId(
+      moduleId,
+      identityFn.symbol,
+      [],
+    );
+    expect(typeof identityInstanceId).toBe("number");
+    if (typeof identityInstanceId !== "number") return;
+    expect(
+      optimized.facts.escapeAnalysis.parameters
+        .get(identityInstanceId)
+        ?.get(identityFn.parameters[0]!.symbol),
+    ).toMatchObject({
+      escapes: true,
+      escapeReasons: ["return"],
+    });
+
+    const aggregateFact = Array.from(
+      optimized.facts.escapeAnalysis.origins.get(moduleId)?.values() ?? [],
+    ).find(
+      (fact) =>
+        fact.originKind === "aggregate" &&
+        fact.directLocalSymbols.length === 1 &&
+        fact.escapeReasons.includes("call-boundary"),
+    );
+    expect(aggregateFact).toMatchObject({
+      originKind: "aggregate",
+      escapes: true,
+      escapeReasons: ["call-boundary"],
+    });
+  });
+
+  it("treats exported aggregate parameters as public-boundary escapes", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+pub fn exported(vec: Vec2) -> i32
+  vec.x
+`,
+      },
+    });
+
+    const moduleId = "src::main";
+    const program = optimized.program;
+    const exportedFn = findFunction({ moduleId, name: "exported", program });
+    expect(exportedFn?.kind).toBe("function");
+    if (!exportedFn || exportedFn.kind !== "function") return;
+    const exportedInstanceId = program.functions.getInstanceId(
+      moduleId,
+      exportedFn.symbol,
+      [],
+    );
+    expect(typeof exportedInstanceId).toBe("number");
+    if (typeof exportedInstanceId !== "number") return;
+    expect(
+      optimized.facts.escapeAnalysis.parameters
+        .get(exportedInstanceId)
+        ?.get(exportedFn.parameters[0]!.symbol),
+    ).toMatchObject({
+      escapes: true,
+      escapeReasons: ["public-boundary"],
+    });
+  });
+
+  it("tracks trait-object receiver temporaries through non-escaping direct calls", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+trait Runner
+  fn run(self) -> i32
+
+obj Box {
+  value: i32
+}
+
+impl Runner for Box
+  fn run(self) -> i32
+    self.value
+
+fn invoke(runner: Runner) -> i32
+  runner.run()
+
+pub fn main() -> i32
+  invoke(Box { value: 4 })
+`,
+      },
+    });
+
+    const moduleId = "src::main";
+    const program = optimized.program;
+    const invokeFn = findFunction({ moduleId, name: "invoke", program });
+    expect(invokeFn?.kind).toBe("function");
+    if (!invokeFn || invokeFn.kind !== "function") return;
+    const invokeInstanceId = program.functions.getInstanceId(
+      moduleId,
+      invokeFn.symbol,
+      [],
+    );
+    expect(typeof invokeInstanceId).toBe("number");
+    if (typeof invokeInstanceId !== "number") return;
+
+    const runnerParam = invokeFn.parameters[0]!;
+    expect(
+      program.types.getTypeDesc(
+        program.functions.getSignature(moduleId, invokeFn.symbol)!.parameters[0]!.typeId,
+      ).kind,
+    ).toBe("trait");
+    expect(
+      optimized.facts.escapeAnalysis.parameters
+        .get(invokeInstanceId)
+        ?.get(runnerParam.symbol),
+    ).toMatchObject({
+      escapes: false,
+      escapeReasons: [],
+    });
+
+    const traitObjectFact = Array.from(
+      optimized.facts.escapeAnalysis.origins.get(moduleId)?.values() ?? [],
+    ).find((fact) => fact.originKind === "trait-object");
+    expect(traitObjectFact).toMatchObject({
+      escapes: false,
+      escapeReasons: [],
+    });
+  });
+
+  it("marks aggregate captures into closures and effect handler environments", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+eff Log
+  info(resume, x: i32) -> i32
+
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn worker(): Log -> i32
+  Log::info(5)
+
+fn closure_capture() -> i32
+  let vec = Vec2 { x: 1, y: 2 }
+  let cb = () => vec.x
+  cb()
+
+pub fn main(): () -> i32
+  let vec = Vec2 { x: 3, y: 4 }
+  closure_capture() + try
+    worker()
+  Log::info(resume, x):
+    vec.x + x
+`,
+      },
+    });
+
+    const moduleId = "src::main";
+    const facts = Array.from(
+      optimized.facts.escapeAnalysis.origins.get(moduleId)?.values() ?? [],
+    );
+    expect(facts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          originKind: "closure-environment",
+          escapes: false,
+          escapeReasons: [],
+        }),
+        expect.objectContaining({
+          originKind: "effect-environment",
+          escapes: false,
+          escapeReasons: [],
+        }),
+        expect.objectContaining({
+          originKind: "aggregate",
+          escapes: true,
+          escapeReasons: ["closure-capture"],
+        }),
+        expect.objectContaining({
+          originKind: "aggregate",
+          escapes: true,
+          escapeReasons: ["effect-handler-capture"],
+        }),
+      ]),
+    );
+  });
+
   it("keeps non-entry test exports reachable in optimized all-module test builds", async () => {
     const { optimized, entryModuleId, tests } = await buildOptimized({
       files: {

--- a/packages/compiler/src/__tests__/optimize-pipeline.test.ts
+++ b/packages/compiler/src/__tests__/optimize-pipeline.test.ts
@@ -1499,6 +1499,98 @@ pub fn main() -> i32
     });
   });
 
+  it("tracks local aliases back to parameter escape facts", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+eff Log
+  info(resume, x: i32) -> i32
+
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn worker(): Log -> i32
+  Log::info(5)
+
+fn escaping_identity(vec: Vec2) -> Vec2
+  vec
+
+fn identity_alias(vec: Vec2) -> Vec2
+  let alias = vec
+  alias
+
+fn alias_to_escaping_callee(vec: Vec2) -> Vec2
+  let alias = vec
+  escaping_identity(alias)
+
+fn alias_closure_capture(vec: Vec2) -> i32
+  let alias = vec
+  let cb = () => alias.x
+  cb()
+
+fn alias_effect_capture(vec: Vec2): () -> i32
+  let alias = vec
+  try
+    worker()
+  Log::info(resume, x):
+    alias.x + x
+
+fn alias_non_escape(vec: Vec2) -> i32
+  let alias = vec
+  alias.x + alias.y
+
+pub fn main(): () -> i32
+  identity_alias(Vec2 { x: 1, y: 2 }).x +
+    alias_to_escaping_callee(Vec2 { x: 3, y: 4 }).x +
+    alias_closure_capture(Vec2 { x: 5, y: 6 }) +
+    alias_effect_capture(Vec2 { x: 7, y: 8 }) +
+    alias_non_escape(Vec2 { x: 9, y: 10 })
+`,
+      },
+    });
+
+    const moduleId = "src::main";
+    const program = optimized.program;
+    const parameterFact = (name: string) => {
+      const fn = findFunction({ moduleId, name, program });
+      expect(fn?.kind, name).toBe("function");
+      if (!fn || fn.kind !== "function") {
+        return undefined;
+      }
+      const instanceId = program.functions.getInstanceId(moduleId, fn.symbol, []);
+      expect(typeof instanceId, name).toBe("number");
+      if (typeof instanceId !== "number") {
+        return undefined;
+      }
+      return optimized.facts.escapeAnalysis.parameters
+        .get(instanceId)
+        ?.get(fn.parameters[0]!.symbol);
+    };
+
+    expect(parameterFact("identity_alias")).toMatchObject({
+      escapes: true,
+      escapeReasons: ["return"],
+    });
+    expect(parameterFact("alias_to_escaping_callee")).toMatchObject({
+      escapes: true,
+      escapeReasons: ["call-boundary"],
+    });
+    expect(parameterFact("alias_closure_capture")).toMatchObject({
+      escapes: true,
+      escapeReasons: ["closure-capture"],
+    });
+    expect(parameterFact("alias_effect_capture")).toMatchObject({
+      escapes: true,
+      escapeReasons: ["effect-handler-capture"],
+    });
+    expect(parameterFact("alias_non_escape")).toMatchObject({
+      escapes: false,
+      escapeReasons: [],
+    });
+  });
+
   it("treats exported aggregate parameters as public-boundary escapes", async () => {
     const { optimized } = await buildOptimized({
       files: {

--- a/packages/compiler/src/__tests__/optimize-pipeline.test.ts
+++ b/packages/compiler/src/__tests__/optimize-pipeline.test.ts
@@ -1591,6 +1591,119 @@ pub fn main(): () -> i32
     });
   });
 
+  it("tracks aliases through value-producing initializers", async () => {
+    const { optimized } = await buildOptimized({
+      files: {
+        "main.voyd": `
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn if_alias(vec: Vec2, flag: bool) -> Vec2
+  let alias =
+    if flag:
+      vec
+    else:
+      vec
+  alias
+
+fn block_alias(vec: Vec2) -> Vec2
+  let alias =
+    let inner = vec
+    inner
+  alias
+
+fn aggregate_if(flag: bool) -> Vec2
+  let alias =
+    if flag:
+      Vec2 { x: 1, y: 2 }
+    else:
+      Vec2 { x: 3, y: 4 }
+  alias
+
+fn aggregate_block() -> Vec2
+  let alias =
+    let inner = Vec2 { x: 5, y: 6 }
+    inner
+  alias
+
+pub fn main() -> i32
+  if_alias(Vec2 { x: 7, y: 8 }, true).x +
+    block_alias(Vec2 { x: 9, y: 10 }).x +
+    aggregate_if(false).x +
+    aggregate_block().x
+`,
+      },
+    });
+
+    const moduleId = "src::main";
+    const program = optimized.program;
+    const parameterFact = (name: string) => {
+      const fn = findFunction({ moduleId, name, program });
+      expect(fn?.kind, name).toBe("function");
+      if (!fn || fn.kind !== "function") {
+        return undefined;
+      }
+      const instanceId = program.functions.getInstanceId(moduleId, fn.symbol, []);
+      expect(typeof instanceId, name).toBe("number");
+      if (typeof instanceId !== "number") {
+        return undefined;
+      }
+      return optimized.facts.escapeAnalysis.parameters
+        .get(instanceId)
+        ?.get(fn.parameters[0]!.symbol);
+    };
+    const aggregateFactsForFunction = (name: string) => {
+      const fn = findFunction({ moduleId, name, program });
+      expect(fn?.kind, name).toBe("function");
+      if (!fn || fn.kind !== "function") {
+        return [];
+      }
+      const moduleView = program.modules.get(moduleId);
+      const facts = optimized.facts.escapeAnalysis.origins.get(moduleId);
+      const exprIds: number[] = [];
+      if (!moduleView || !facts) {
+        return [];
+      }
+      walkExpression({
+        exprId: fn.body,
+        hir: moduleView.hir,
+        onEnterExpression: (exprId, expr) => {
+          if (expr.exprKind === "object-literal") {
+            exprIds.push(exprId);
+          }
+        },
+      });
+      return exprIds.map((exprId) => facts.get(exprId));
+    };
+
+    expect(parameterFact("if_alias")).toMatchObject({
+      escapes: true,
+      escapeReasons: ["return"],
+    });
+    expect(parameterFact("block_alias")).toMatchObject({
+      escapes: true,
+      escapeReasons: ["return"],
+    });
+    expect(aggregateFactsForFunction("aggregate_if")).toEqual([
+      expect.objectContaining({
+        escapes: true,
+        escapeReasons: ["return"],
+      }),
+      expect.objectContaining({
+        escapes: true,
+        escapeReasons: ["return"],
+      }),
+    ]);
+    expect(aggregateFactsForFunction("aggregate_block")).toEqual([
+      expect.objectContaining({
+        escapes: true,
+        escapeReasons: ["return"],
+      }),
+    ]);
+  });
+
   it("treats exported aggregate parameters as public-boundary escapes", async () => {
     const { optimized } = await buildOptimized({
       files: {

--- a/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
+++ b/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
@@ -84,6 +84,7 @@ const compileEffectFixtureWithCompilerOptimization = async (
       receiverSpecializationRequests: new Map(),
       exactParameterTypes: new Map(),
       knownParameterTypes: new Map(),
+      escapeAnalysis: { origins: new Map(), parameters: new Map() },
       runtimeTypeCheckElisionFieldAccesses: new Map(),
       semanticCopyForwardingFieldAccesses: new Map(),
       codegenPlan: { representations: {} },

--- a/packages/compiler/src/optimize/ir.ts
+++ b/packages/compiler/src/optimize/ir.ts
@@ -21,6 +21,50 @@ export type OptimizedModuleView = ModuleCodegenView & {
   semantics: SemanticsPipelineResult;
 };
 
+export type EscapeAnalysisOriginKind =
+  | "aggregate"
+  | "trait-object"
+  | "closure-environment"
+  | "effect-environment";
+
+export type EscapeAnalysisEscapeReason =
+  | "public-boundary"
+  | "return"
+  | "module-let"
+  | "stored-in-aggregate"
+  | "call-boundary"
+  | "dynamic-dispatch"
+  | "effectful-call"
+  | "mutable-call-argument"
+  | "closure-capture"
+  | "effect-handler-capture"
+  | "handler-resumption-escape"
+  | "assignment"
+  | "unknown";
+
+export type EscapeAnalysisOriginFact = {
+  originKind: EscapeAnalysisOriginKind;
+  typeId?: TypeId;
+  escapes: boolean;
+  escapeReasons: readonly EscapeAnalysisEscapeReason[];
+  directLocalSymbols: readonly SymbolId[];
+  useExprIds: readonly HirExprId[];
+};
+
+export type EscapeAnalysisParameterFact = {
+  escapes: boolean;
+  escapeReasons: readonly EscapeAnalysisEscapeReason[];
+  useExprIds: readonly HirExprId[];
+};
+
+export type ProgramEscapeAnalysisFacts = {
+  origins: ReadonlyMap<string, ReadonlyMap<HirExprId, EscapeAnalysisOriginFact>>;
+  parameters: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, EscapeAnalysisParameterFact>
+  >;
+};
+
 export type ProgramOptimizationFacts = {
   handlerClauseCaptures: ReadonlyMap<
     string,
@@ -42,6 +86,7 @@ export type ProgramOptimizationFacts = {
     ProgramFunctionInstanceId,
     ReadonlyMap<SymbolId, ReadonlySet<TypeId>>
   >;
+  escapeAnalysis: ProgramEscapeAnalysisFacts;
   runtimeTypeCheckElisionFieldAccesses: ReadonlyMap<string, ReadonlySet<HirExprId>>;
   semanticCopyForwardingFieldAccesses: ReadonlyMap<string, ReadonlySet<HirExprId>>;
   codegenPlan: ProgramCodegenOptimizationPlan;

--- a/packages/compiler/src/optimize/pipeline.ts
+++ b/packages/compiler/src/optimize/pipeline.ts
@@ -4567,6 +4567,13 @@ const localParameterAliasesForSymbol = ({
   symbol: SymbolId;
 }): ReadonlySet<SymbolId> | undefined => state.localParameterAliases.get(symbol);
 
+const unionInto = <T>(target: Set<T>, values: Iterable<T> | undefined): void => {
+  if (!values) {
+    return;
+  }
+  Array.from(values).forEach((value) => target.add(value));
+};
+
 const parameterAliasesForInitializer = ({
   state,
   exprId,
@@ -4575,13 +4582,63 @@ const parameterAliasesForInitializer = ({
   exprId: HirExprId;
 }): Set<SymbolId> => {
   const expr = state.moduleView.hir.expressions.get(exprId);
-  if (expr?.exprKind !== "identifier") {
+  if (!expr) {
     return new Set();
   }
-  return new Set([
-    ...(state.parameterSymbols.has(expr.symbol) ? [expr.symbol] : []),
-    ...(localParameterAliasesForSymbol({ state, symbol: expr.symbol }) ?? []),
-  ]);
+  if (expr.exprKind === "identifier") {
+    return new Set([
+      ...(state.parameterSymbols.has(expr.symbol) ? [expr.symbol] : []),
+      ...(localParameterAliasesForSymbol({ state, symbol: expr.symbol }) ?? []),
+    ]);
+  }
+  if (expr.exprKind === "block") {
+    return typeof expr.value === "number"
+      ? parameterAliasesForInitializer({ state, exprId: expr.value })
+      : new Set();
+  }
+  if (expr.exprKind === "if" || expr.exprKind === "cond") {
+    const aliases = new Set<SymbolId>();
+    expr.branches.forEach((branch) => {
+      unionInto(
+        aliases,
+        parameterAliasesForInitializer({ state, exprId: branch.value }),
+      );
+    });
+    if (typeof expr.defaultBranch === "number") {
+      unionInto(
+        aliases,
+        parameterAliasesForInitializer({ state, exprId: expr.defaultBranch }),
+      );
+    }
+    return aliases;
+  }
+  if (expr.exprKind === "match") {
+    const aliases = new Set<SymbolId>();
+    expr.arms.forEach((arm) => {
+      unionInto(
+        aliases,
+        parameterAliasesForInitializer({ state, exprId: arm.value }),
+      );
+    });
+    return aliases;
+  }
+  if (expr.exprKind === "effect-handler") {
+    const aliases = parameterAliasesForInitializer({ state, exprId: expr.body });
+    expr.handlers.forEach((handler) => {
+      unionInto(
+        aliases,
+        parameterAliasesForInitializer({ state, exprId: handler.body }),
+      );
+    });
+    if (typeof expr.finallyBranch === "number") {
+      unionInto(
+        aliases,
+        parameterAliasesForInitializer({ state, exprId: expr.finallyBranch }),
+      );
+    }
+    return aliases;
+  }
+  return new Set();
 };
 
 const bindLocalParameterAliases = ({
@@ -4664,25 +4721,69 @@ const markSymbolSetUse = ({
   );
 };
 
-const originExprIdForInitializer = ({
+const originExprIdsForInitializer = ({
   state,
   exprId,
 }: {
   state: EscapeAnalysisState;
   exprId: HirExprId;
-}): HirExprId | undefined => {
+}): Set<HirExprId> => {
   const expr = state.moduleView.hir.expressions.get(exprId);
   if (!expr) {
-    return undefined;
+    return new Set();
+  }
+  if (expr.exprKind === "effect-handler") {
+    const origins = new Set<HirExprId>([exprId]);
+    unionInto(origins, originExprIdsForInitializer({ state, exprId: expr.body }));
+    expr.handlers.forEach((handler) => {
+      unionInto(
+        origins,
+        originExprIdsForInitializer({ state, exprId: handler.body }),
+      );
+    });
+    if (typeof expr.finallyBranch === "number") {
+      unionInto(
+        origins,
+        originExprIdsForInitializer({ state, exprId: expr.finallyBranch }),
+      );
+    }
+    return origins;
   }
   if (originKindForExpr({ moduleView: state.moduleView, exprId, ir: state.ir })) {
-    return exprId;
+    return new Set([exprId]);
   }
   if (expr.exprKind === "identifier") {
-    const origins = localOriginsForSymbol({ state, symbol: expr.symbol });
-    return origins?.size === 1 ? origins.values().next().value : undefined;
+    return new Set(localOriginsForSymbol({ state, symbol: expr.symbol }) ?? []);
   }
-  return undefined;
+  if (expr.exprKind === "block") {
+    return typeof expr.value === "number"
+      ? originExprIdsForInitializer({ state, exprId: expr.value })
+      : new Set();
+  }
+  if (expr.exprKind === "if" || expr.exprKind === "cond") {
+    const origins = new Set<HirExprId>();
+    expr.branches.forEach((branch) => {
+      unionInto(
+        origins,
+        originExprIdsForInitializer({ state, exprId: branch.value }),
+      );
+    });
+    if (typeof expr.defaultBranch === "number") {
+      unionInto(
+        origins,
+        originExprIdsForInitializer({ state, exprId: expr.defaultBranch }),
+      );
+    }
+    return origins;
+  }
+  if (expr.exprKind === "match") {
+    const origins = new Set<HirExprId>();
+    expr.arms.forEach((arm) => {
+      unionInto(origins, originExprIdsForInitializer({ state, exprId: arm.value }));
+    });
+    return origins;
+  }
+  return new Set();
 };
 
 const isTraitType = ({
@@ -5047,33 +5148,33 @@ const analyzeEscapeStatement = ({
   }
 
   if (statement.pattern.kind === "identifier") {
-    const boundOrigin = originExprIdForInitializer({
+    const boundSymbol = statement.pattern.symbol;
+    analyzeEscapeExpression({
+      exprId: statement.initializer,
+      context: emptyEscapeUseContext,
+      state,
+    });
+
+    const boundOrigins = originExprIdsForInitializer({
       state,
       exprId: statement.initializer,
     });
-    if (typeof boundOrigin === "number") {
+    boundOrigins.forEach((originExprId) => {
       bindLocalOrigin({
         state,
-        symbol: statement.pattern.symbol,
-        originExprId: boundOrigin,
+        symbol: boundSymbol,
+        originExprId,
       });
-    }
+    });
     bindLocalParameterAliases({
       state,
-      symbol: statement.pattern.symbol,
+      symbol: boundSymbol,
       parameterSymbols: parameterAliasesForInitializer({
         state,
         exprId: statement.initializer,
       }),
     });
-    if (typeof boundOrigin === "number") {
-      analyzeEscapeExpression({
-        exprId: statement.initializer,
-        context: emptyEscapeUseContext,
-        state,
-      });
-      return;
-    }
+    return;
   }
 
   analyzeEscapeExpression({

--- a/packages/compiler/src/optimize/pipeline.ts
+++ b/packages/compiler/src/optimize/pipeline.ts
@@ -32,6 +32,10 @@ import {
   type OptimizationAnalysisKey,
 } from "./pass.js";
 import type {
+  EscapeAnalysisEscapeReason,
+  EscapeAnalysisOriginFact,
+  EscapeAnalysisOriginKind,
+  EscapeAnalysisParameterFact,
   OptimizedCallInfo,
   OptimizedModuleView,
   ProgramOptimizationResult,
@@ -74,6 +78,13 @@ type MutableOptimizationIr = {
       ProgramFunctionInstanceId,
       Map<SymbolId, Set<TypeId>>
     >;
+    escapeAnalysis: {
+      origins: Map<string, Map<HirExprId, EscapeAnalysisOriginFact>>;
+      parameters: Map<
+        ProgramFunctionInstanceId,
+        Map<SymbolId, EscapeAnalysisParameterFact>
+      >;
+    };
     runtimeTypeCheckElisionFieldAccesses: Map<string, Set<HirExprId>>;
     semanticCopyForwardingFieldAccesses: Map<string, Set<HirExprId>>;
     codegenPlan: ProgramCodegenOptimizationPlan;
@@ -309,6 +320,10 @@ const buildOptimizationIr = ({
       receiverSpecializationRequests: new Map(),
       exactParameterTypes: new Map(),
       knownParameterTypes: new Map(),
+      escapeAnalysis: {
+        origins: new Map(),
+        parameters: new Map(),
+      },
       runtimeTypeCheckElisionFieldAccesses: new Map(),
       semanticCopyForwardingFieldAccesses: new Map(),
       codegenPlan: { representations: {} },
@@ -4259,6 +4274,979 @@ const wholeProgramSpecializationPruningPass: ProgramOptimizationPass = {
   },
 };
 
+type MutableEscapeOriginFact = {
+  originKind: EscapeAnalysisOriginKind;
+  typeId?: TypeId;
+  escapes: boolean;
+  escapeReasons: Set<EscapeAnalysisEscapeReason>;
+  directLocalSymbols: Set<SymbolId>;
+  useExprIds: Set<HirExprId>;
+};
+
+type MutableEscapeParameterFact = {
+  escapes: boolean;
+  escapeReasons: Set<EscapeAnalysisEscapeReason>;
+  useExprIds: Set<HirExprId>;
+};
+
+type EscapeUseContext = {
+  reason?: EscapeAnalysisEscapeReason;
+  traitBoundary?: boolean;
+};
+
+type EscapeAnalysisState = {
+  ir: MutableOptimizationIr;
+  moduleView: OptimizedModuleView;
+  callerInstanceId?: ProgramFunctionInstanceId;
+  parameterSymbols: ReadonlySet<SymbolId>;
+  parameterFacts: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, MutableEscapeParameterFact>
+  >;
+  mutableParameterFacts?: Map<SymbolId, MutableEscapeParameterFact>;
+  mutableOriginFacts?: Map<string, Map<HirExprId, MutableEscapeOriginFact>>;
+  localOrigins: Map<SymbolId, Set<HirExprId>>;
+};
+
+const emptyEscapeUseContext: EscapeUseContext = {};
+
+const cloneMutableParameterFacts = (
+  facts: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, MutableEscapeParameterFact>
+  >,
+): Map<ProgramFunctionInstanceId, Map<SymbolId, MutableEscapeParameterFact>> =>
+  new Map(
+    Array.from(facts.entries()).map(([instanceId, bySymbol]) => [
+      instanceId,
+      new Map(
+        Array.from(bySymbol.entries()).map(([symbol, fact]) => [
+          symbol,
+          {
+            escapes: fact.escapes,
+            escapeReasons: new Set(fact.escapeReasons),
+            useExprIds: new Set(fact.useExprIds),
+          },
+        ]),
+      ),
+    ]),
+  );
+
+const serializeMutableParameterFacts = (
+  facts: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, MutableEscapeParameterFact>
+  >,
+): string =>
+  JSON.stringify(
+    Array.from(facts.entries())
+      .sort(([left], [right]) => left - right)
+      .map(([instanceId, bySymbol]) => [
+        instanceId,
+        Array.from(bySymbol.entries())
+          .sort(([left], [right]) => left - right)
+          .map(([symbol, fact]) => [
+            symbol,
+            fact.escapes,
+            Array.from(fact.escapeReasons).sort(),
+            Array.from(fact.useExprIds).sort((left, right) => left - right),
+          ]),
+      ]),
+  );
+
+const toImmutableParameterFacts = (
+  facts: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, MutableEscapeParameterFact>
+  >,
+): Map<ProgramFunctionInstanceId, Map<SymbolId, EscapeAnalysisParameterFact>> =>
+  new Map(
+    Array.from(facts.entries()).map(([instanceId, bySymbol]) => [
+      instanceId,
+      new Map(
+        Array.from(bySymbol.entries()).map(([symbol, fact]) => [
+          symbol,
+          {
+            escapes: fact.escapes,
+            escapeReasons: Array.from(fact.escapeReasons).sort(),
+            useExprIds: Array.from(fact.useExprIds).sort((left, right) => left - right),
+          },
+        ]),
+      ),
+    ]),
+  );
+
+const toImmutableOriginFacts = (
+  facts: ReadonlyMap<string, ReadonlyMap<HirExprId, MutableEscapeOriginFact>>,
+): Map<string, Map<HirExprId, EscapeAnalysisOriginFact>> =>
+  new Map(
+    Array.from(facts.entries()).map(([moduleId, byExpr]) => [
+      moduleId,
+      new Map(
+        Array.from(byExpr.entries()).map(([exprId, fact]) => [
+          exprId,
+          {
+            originKind: fact.originKind,
+            typeId: fact.typeId,
+            escapes: fact.escapes,
+            escapeReasons: Array.from(fact.escapeReasons).sort(),
+            directLocalSymbols: Array.from(fact.directLocalSymbols).sort(
+              (left, right) => left - right,
+            ),
+            useExprIds: Array.from(fact.useExprIds).sort((left, right) => left - right),
+          },
+        ]),
+      ),
+    ]),
+  );
+
+const mutableParameterFactFor = ({
+  facts,
+  instanceId,
+  symbol,
+}: {
+  facts: Map<ProgramFunctionInstanceId, Map<SymbolId, MutableEscapeParameterFact>>;
+  instanceId: ProgramFunctionInstanceId;
+  symbol: SymbolId;
+}): MutableEscapeParameterFact => {
+  const bySymbol = facts.get(instanceId) ?? new Map<SymbolId, MutableEscapeParameterFact>();
+  const fact =
+    bySymbol.get(symbol) ?? {
+      escapes: false,
+      escapeReasons: new Set<EscapeAnalysisEscapeReason>(),
+      useExprIds: new Set<HirExprId>(),
+    };
+  bySymbol.set(symbol, fact);
+  facts.set(instanceId, bySymbol);
+  return fact;
+};
+
+const markParameterUse = ({
+  fact,
+  exprId,
+  reason,
+}: {
+  fact: MutableEscapeParameterFact;
+  exprId: HirExprId;
+  reason?: EscapeAnalysisEscapeReason;
+}): void => {
+  fact.useExprIds.add(exprId);
+  if (!reason) {
+    return;
+  }
+  fact.escapes = true;
+  fact.escapeReasons.add(reason);
+};
+
+const markOriginUse = ({
+  fact,
+  exprId,
+  reason,
+  traitBoundary,
+}: {
+  fact: MutableEscapeOriginFact;
+  exprId: HirExprId;
+  reason?: EscapeAnalysisEscapeReason;
+  traitBoundary?: boolean;
+}): void => {
+  fact.useExprIds.add(exprId);
+  if (traitBoundary && fact.originKind === "aggregate") {
+    fact.originKind = "trait-object";
+  }
+  const effectiveReason =
+    fact.originKind === "effect-environment" && reason !== "handler-resumption-escape"
+      ? undefined
+      : reason;
+  if (!effectiveReason) {
+    return;
+  }
+  fact.escapes = true;
+  fact.escapeReasons.add(effectiveReason);
+};
+
+const originKindForExpr = ({
+  moduleView,
+  exprId,
+  ir,
+}: {
+  moduleView: OptimizedModuleView;
+  exprId: HirExprId;
+  ir: MutableOptimizationIr;
+}): EscapeAnalysisOriginKind | undefined => {
+  const expr = moduleView.hir.expressions.get(exprId);
+  if (!expr) {
+    return undefined;
+  }
+  if (expr.exprKind === "lambda") {
+    return "closure-environment";
+  }
+  if (expr.exprKind === "effect-handler") {
+    return "effect-environment";
+  }
+  if (expr.exprKind !== "object-literal" && expr.exprKind !== "tuple") {
+    return undefined;
+  }
+
+  const typeId = exprTypeFor({ moduleView, exprId });
+  if (typeof typeId !== "number") {
+    return "aggregate";
+  }
+  const desc = ir.baseProgram.types.getTypeDesc(typeId);
+  return desc.kind === "trait" ||
+    (desc.kind === "intersection" && (desc.traits?.length ?? 0) > 0)
+    ? "trait-object"
+    : "aggregate";
+};
+
+const ensureOriginFact = ({
+  state,
+  exprId,
+}: {
+  state: EscapeAnalysisState;
+  exprId: HirExprId;
+}): MutableEscapeOriginFact | undefined => {
+  const originKind = originKindForExpr({
+    moduleView: state.moduleView,
+    exprId,
+    ir: state.ir,
+  });
+  if (!originKind || !state.mutableOriginFacts) {
+    return undefined;
+  }
+  const byModule =
+    state.mutableOriginFacts.get(state.moduleView.moduleId) ??
+    new Map<HirExprId, MutableEscapeOriginFact>();
+  const existing = byModule.get(exprId);
+  if (existing) {
+    return existing;
+  }
+  const typeId = exprTypeFor({ moduleView: state.moduleView, exprId });
+  const fact: MutableEscapeOriginFact = {
+    originKind,
+    typeId,
+    escapes: false,
+    escapeReasons: new Set(),
+    directLocalSymbols: new Set(),
+    useExprIds: new Set(),
+  };
+  byModule.set(exprId, fact);
+  state.mutableOriginFacts.set(state.moduleView.moduleId, byModule);
+  return fact;
+};
+
+const localOriginsForSymbol = ({
+  state,
+  symbol,
+}: {
+  state: EscapeAnalysisState;
+  symbol: SymbolId;
+}): ReadonlySet<HirExprId> | undefined => state.localOrigins.get(symbol);
+
+const bindLocalOrigin = ({
+  state,
+  symbol,
+  originExprId,
+}: {
+  state: EscapeAnalysisState;
+  symbol: SymbolId;
+  originExprId: HirExprId;
+}): void => {
+  const origins = state.localOrigins.get(symbol) ?? new Set<HirExprId>();
+  origins.add(originExprId);
+  state.localOrigins.set(symbol, origins);
+  const fact = ensureOriginFact({ state, exprId: originExprId });
+  fact?.directLocalSymbols.add(symbol);
+};
+
+const markSymbolUse = ({
+  state,
+  symbol,
+  exprId,
+  context,
+}: {
+  state: EscapeAnalysisState;
+  symbol: SymbolId;
+  exprId: HirExprId;
+  context: EscapeUseContext;
+}): void => {
+  const origins = localOriginsForSymbol({ state, symbol });
+  origins?.forEach((originExprId) => {
+    const fact = ensureOriginFact({ state, exprId: originExprId });
+    if (!fact) {
+      return;
+    }
+    markOriginUse({
+      fact,
+      exprId,
+      reason: context.reason,
+      traitBoundary: context.traitBoundary,
+    });
+  });
+
+  if (!state.parameterSymbols.has(symbol)) {
+    return;
+  }
+  const fact = state.mutableParameterFacts?.get(symbol);
+  if (!fact) {
+    return;
+  }
+  markParameterUse({
+    fact,
+    exprId,
+    reason: context.reason,
+  });
+};
+
+const markSymbolSetUse = ({
+  state,
+  symbols,
+  exprId,
+  reason,
+}: {
+  state: EscapeAnalysisState;
+  symbols: Iterable<SymbolId>;
+  exprId: HirExprId;
+  reason: EscapeAnalysisEscapeReason;
+}): void => {
+  Array.from(symbols).forEach((symbol) =>
+    markSymbolUse({
+      state,
+      symbol,
+      exprId,
+      context: { reason },
+    })
+  );
+};
+
+const originExprIdForInitializer = ({
+  state,
+  exprId,
+}: {
+  state: EscapeAnalysisState;
+  exprId: HirExprId;
+}): HirExprId | undefined => {
+  const expr = state.moduleView.hir.expressions.get(exprId);
+  if (!expr) {
+    return undefined;
+  }
+  if (originKindForExpr({ moduleView: state.moduleView, exprId, ir: state.ir })) {
+    return exprId;
+  }
+  if (expr.exprKind === "identifier") {
+    const origins = localOriginsForSymbol({ state, symbol: expr.symbol });
+    return origins?.size === 1 ? origins.values().next().value : undefined;
+  }
+  return undefined;
+};
+
+const isTraitType = ({
+  typeId,
+  ir,
+}: {
+  typeId: TypeId | undefined;
+  ir: MutableOptimizationIr;
+}): boolean => {
+  if (typeof typeId !== "number") {
+    return false;
+  }
+  const desc = ir.baseProgram.types.getTypeDesc(typeId);
+  return desc.kind === "trait" ||
+    (desc.kind === "intersection" && (desc.traits?.length ?? 0) > 0);
+};
+
+const contextForCallArgument = ({
+  moduleView,
+  exprId,
+  expr,
+  argExprId,
+  argIndex,
+  state,
+}: {
+  moduleView: OptimizedModuleView;
+  exprId: HirExprId;
+  expr: Extract<HirExpression, { exprKind: "call" | "method-call" }>;
+  argExprId: HirExprId;
+  argIndex: number;
+  state: EscapeAnalysisState;
+}): EscapeUseContext => {
+  const callInfo = state.ir.calls.get(moduleView.moduleId)?.get(exprId);
+  if (callInfo?.traitDispatch) {
+    return {
+      reason: argIndex === 0 ? "dynamic-dispatch" : "call-boundary",
+      traitBoundary: argIndex === 0,
+    };
+  }
+
+  const targets =
+    typeof state.callerInstanceId === "number"
+      ? resolveTargetsForExactPropagation({
+          moduleView,
+          exprId,
+          expr,
+          callerInstanceId: state.callerInstanceId,
+          ir: state.ir,
+        })
+      : resolveTargetsForCaller({
+          moduleId: moduleView.moduleId,
+          exprId,
+          callerInstanceId: state.callerInstanceId,
+          ir: state.ir,
+        });
+  if (targets.length === 0) {
+    return { reason: "unknown" };
+  }
+
+  let traitBoundary = false;
+  let unsafeReason: EscapeAnalysisEscapeReason | undefined;
+  targets.forEach(({ instanceId }) => {
+    if (unsafeReason || typeof instanceId !== "number") {
+      unsafeReason = unsafeReason ?? "unknown";
+      return;
+    }
+    const target = state.ir.baseProgram.functions.getInstance(instanceId);
+    const signature = state.ir.baseProgram.functions.getSignature(
+      target.symbolRef.moduleId,
+      target.symbolRef.symbol,
+    );
+    if (!signature) {
+      unsafeReason = "unknown";
+      return;
+    }
+    if (!state.ir.baseProgram.effects.isEmpty(signature.effectRow)) {
+      unsafeReason = "effectful-call";
+      return;
+    }
+
+    const parameterIndex =
+      typeof state.callerInstanceId === "number"
+        ? signature.parameters.findIndex((_parameter, index) => {
+            const mappedArgExprId = callArgumentExprIdForParameter({
+              argExprIds: callArgumentExprIds(expr),
+              callInfo,
+              callerInstanceId: state.callerInstanceId!,
+              parameterIndex: index,
+            });
+            return mappedArgExprId === argExprId;
+          })
+        : argIndex;
+    const parameter = signature.parameters[parameterIndex];
+    if (!parameter || typeof parameter.symbol !== "number") {
+      unsafeReason = "unknown";
+      return;
+    }
+    traitBoundary = traitBoundary || isTraitType({ typeId: parameter.typeId, ir: state.ir });
+    if (parameter.bindingKind === "mutable-ref") {
+      unsafeReason = "mutable-call-argument";
+      return;
+    }
+    const targetFact = state.parameterFacts.get(instanceId)?.get(parameter.symbol);
+    if (!targetFact || targetFact.escapes) {
+      unsafeReason = "call-boundary";
+    }
+  });
+
+  return unsafeReason ? { reason: unsafeReason, traitBoundary } : { traitBoundary };
+};
+
+const analyzeEscapeExpression = ({
+  exprId,
+  context,
+  state,
+}: {
+  exprId: HirExprId;
+  context: EscapeUseContext;
+  state: EscapeAnalysisState;
+}): void => {
+  const expr = state.moduleView.hir.expressions.get(exprId);
+  if (!expr) {
+    return;
+  }
+
+  const originFact = ensureOriginFact({ state, exprId });
+  if (originFact) {
+    markOriginUse({
+      fact: originFact,
+      exprId,
+      reason: context.reason,
+      traitBoundary: context.traitBoundary,
+    });
+  }
+
+  switch (expr.exprKind) {
+    case "literal":
+    case "overload-set":
+    case "continue":
+      return;
+    case "identifier":
+      markSymbolUse({ state, symbol: expr.symbol, exprId, context });
+      return;
+    case "block": {
+      expr.statements.forEach((statementId) =>
+        analyzeEscapeStatement({ statementId, state })
+      );
+      if (typeof expr.value === "number") {
+        analyzeEscapeExpression({ exprId: expr.value, context, state });
+      }
+      return;
+    }
+    case "tuple":
+      expr.elements.forEach((element) =>
+        analyzeEscapeExpression({
+          exprId: element,
+          context: { reason: "stored-in-aggregate" },
+          state,
+        })
+      );
+      return;
+    case "object-literal":
+      expr.entries.forEach((entry) =>
+        analyzeEscapeExpression({
+          exprId: entry.value,
+          context: { reason: "stored-in-aggregate" },
+          state,
+        })
+      );
+      return;
+    case "field-access":
+      analyzeEscapeExpression({
+        exprId: expr.target,
+        context: emptyEscapeUseContext,
+        state,
+      });
+      return;
+    case "assign": {
+      if (typeof expr.target === "number") {
+        const target = state.moduleView.hir.expressions.get(expr.target);
+        if (target?.exprKind === "field-access") {
+          analyzeEscapeExpression({
+            exprId: target.target,
+            context: emptyEscapeUseContext,
+            state,
+          });
+        } else {
+          analyzeEscapeExpression({
+            exprId: expr.target,
+            context: { reason: "assignment" },
+            state,
+          });
+        }
+      }
+      analyzeEscapeExpression({
+        exprId: expr.value,
+        context: { reason: "assignment" },
+        state,
+      });
+      return;
+    }
+    case "call":
+    case "method-call": {
+      if (expr.exprKind === "call") {
+        analyzeEscapeExpression({
+          exprId: expr.callee,
+          context: emptyEscapeUseContext,
+          state,
+        });
+      }
+      callArgumentExprIds(expr).forEach((argExprId, argIndex) =>
+        analyzeEscapeExpression({
+          exprId: argExprId,
+          context: contextForCallArgument({
+            moduleView: state.moduleView,
+            exprId,
+            expr,
+            argExprId,
+            argIndex,
+            state,
+          }),
+          state,
+        })
+      );
+      return;
+    }
+    case "lambda":
+      markSymbolSetUse({
+        state,
+        symbols: expr.captures.map((capture) => capture.symbol),
+        exprId,
+        reason: "closure-capture",
+      });
+      return;
+    case "effect-handler": {
+      analyzeEscapeExpression({ exprId: expr.body, context, state });
+      const captures = collectHandlerCaptures({ moduleView: state.moduleView }).get(expr.id);
+      captures?.forEach((symbols) =>
+        markSymbolSetUse({
+          state,
+          symbols,
+          exprId: expr.id,
+          reason: "effect-handler-capture",
+        })
+      );
+      expr.handlers.forEach((handler) => {
+        if (handler.tailResumption?.escapes) {
+          const fact = ensureOriginFact({ state, exprId: expr.id });
+          if (fact) {
+            markOriginUse({
+              fact,
+              exprId: expr.id,
+              reason: "handler-resumption-escape",
+            });
+          }
+        }
+        analyzeEscapeExpression({
+          exprId: handler.body,
+          context: emptyEscapeUseContext,
+          state,
+        });
+      });
+      if (typeof expr.finallyBranch === "number") {
+        analyzeEscapeExpression({
+          exprId: expr.finallyBranch,
+          context: emptyEscapeUseContext,
+          state,
+        });
+      }
+      return;
+    }
+    case "loop":
+      analyzeEscapeExpression({
+        exprId: expr.body,
+        context: emptyEscapeUseContext,
+        state,
+      });
+      return;
+    case "while":
+      analyzeEscapeExpression({
+        exprId: expr.condition,
+        context: emptyEscapeUseContext,
+        state,
+      });
+      analyzeEscapeExpression({
+        exprId: expr.body,
+        context: emptyEscapeUseContext,
+        state,
+      });
+      return;
+    case "if":
+    case "cond":
+      expr.branches.forEach((branch) => {
+        analyzeEscapeExpression({
+          exprId: branch.condition,
+          context: emptyEscapeUseContext,
+          state,
+        });
+        analyzeEscapeExpression({ exprId: branch.value, context, state });
+      });
+      if (typeof expr.defaultBranch === "number") {
+        analyzeEscapeExpression({ exprId: expr.defaultBranch, context, state });
+      }
+      return;
+    case "match":
+      analyzeEscapeExpression({
+        exprId: expr.discriminant,
+        context: emptyEscapeUseContext,
+        state,
+      });
+      expr.arms.forEach((arm) => {
+        if (typeof arm.guard === "number") {
+          analyzeEscapeExpression({
+            exprId: arm.guard,
+            context: emptyEscapeUseContext,
+            state,
+          });
+        }
+        analyzeEscapeExpression({ exprId: arm.value, context, state });
+      });
+      return;
+    case "break":
+      if (typeof expr.value === "number") {
+        analyzeEscapeExpression({
+          exprId: expr.value,
+          context: emptyEscapeUseContext,
+          state,
+        });
+      }
+      return;
+  }
+};
+
+const analyzeEscapeStatement = ({
+  statementId,
+  state,
+}: {
+  statementId: number;
+  state: EscapeAnalysisState;
+}): void => {
+  const statement = state.moduleView.hir.statements.get(statementId);
+  if (!statement) {
+    return;
+  }
+  if (statement.kind === "expr-stmt") {
+    analyzeEscapeExpression({
+      exprId: statement.expr,
+      context: emptyEscapeUseContext,
+      state,
+    });
+    return;
+  }
+  if (statement.kind === "return") {
+    if (typeof statement.value === "number") {
+      analyzeEscapeExpression({
+        exprId: statement.value,
+        context: { reason: "return" },
+        state,
+      });
+    }
+    return;
+  }
+
+  const boundOrigin = originExprIdForInitializer({
+    state,
+    exprId: statement.initializer,
+  });
+  if (statement.pattern.kind === "identifier" && typeof boundOrigin === "number") {
+    bindLocalOrigin({
+      state,
+      symbol: statement.pattern.symbol,
+      originExprId: boundOrigin,
+    });
+    analyzeEscapeExpression({
+      exprId: statement.initializer,
+      context: emptyEscapeUseContext,
+      state,
+    });
+    return;
+  }
+
+  analyzeEscapeExpression({
+    exprId: statement.initializer,
+    context: emptyEscapeUseContext,
+    state,
+  });
+};
+
+const parameterSymbolsForFunction = (item: HirFunction): Set<SymbolId> =>
+  new Set(item.parameters.map((parameter) => parameter.symbol));
+
+const seedParameterFacts = ({
+  ir,
+  externalInstances,
+}: {
+  ir: MutableOptimizationIr;
+  externalInstances: ReadonlySet<ProgramFunctionInstanceId>;
+}): Map<ProgramFunctionInstanceId, Map<SymbolId, MutableEscapeParameterFact>> => {
+  const facts = new Map<ProgramFunctionInstanceId, Map<SymbolId, MutableEscapeParameterFact>>();
+  ir.facts.reachableFunctionInstances.forEach((instanceId) => {
+    const instance = ir.baseProgram.functions.getInstance(instanceId);
+    const signature = ir.baseProgram.functions.getSignature(
+      instance.symbolRef.moduleId,
+      instance.symbolRef.symbol,
+    );
+    signature?.parameters.forEach((parameter) => {
+      if (typeof parameter.symbol !== "number") {
+        return;
+      }
+      const fact = mutableParameterFactFor({ facts, instanceId, symbol: parameter.symbol });
+      if (externalInstances.has(instanceId)) {
+        fact.escapes = true;
+        fact.escapeReasons.add("public-boundary");
+      }
+    });
+  });
+  return facts;
+};
+
+const analyzeParameterEscapes = ({
+  ir,
+  seedFacts,
+}: {
+  ir: MutableOptimizationIr;
+  seedFacts: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, MutableEscapeParameterFact>
+  >;
+}): Map<ProgramFunctionInstanceId, Map<SymbolId, MutableEscapeParameterFact>> => {
+  const facts = cloneMutableParameterFacts(seedFacts);
+  ir.facts.reachableFunctionInstances.forEach((instanceId) => {
+    const instance = ir.baseProgram.functions.getInstance(instanceId);
+    const moduleView = ir.modules.get(instance.symbolRef.moduleId);
+    const item = moduleView
+      ? functionItemBySymbol({
+          moduleView,
+          symbol: instance.symbolRef.symbol,
+        })
+      : undefined;
+    if (!moduleView || !item) {
+      return;
+    }
+    const mutableParameterFacts = facts.get(instanceId);
+    if (!mutableParameterFacts) {
+      return;
+    }
+    analyzeEscapeExpression({
+      exprId: item.body,
+      context: { reason: "return" },
+      state: {
+        ir,
+        moduleView,
+        callerInstanceId: instanceId,
+        parameterSymbols: parameterSymbolsForFunction(item),
+        parameterFacts: seedFacts,
+        mutableParameterFacts,
+        localOrigins: new Map(),
+      },
+    });
+  });
+  return facts;
+};
+
+const computeParameterEscapeFacts = ({
+  ir,
+}: {
+  ir: MutableOptimizationIr;
+}): Map<ProgramFunctionInstanceId, Map<SymbolId, MutableEscapeParameterFact>> => {
+  const externalInstances = externallyCallableFunctionInstances(ir);
+  const seedFacts = seedParameterFacts({ ir, externalInstances });
+  let facts = seedFacts;
+  let changed = true;
+
+  while (changed) {
+    const next = analyzeParameterEscapes({ ir, seedFacts: facts });
+    changed =
+      serializeMutableParameterFacts(next) !==
+      serializeMutableParameterFacts(facts);
+    facts = next;
+  }
+
+  return facts;
+};
+
+const computeOriginEscapeFacts = ({
+  ir,
+  parameterFacts,
+}: {
+  ir: MutableOptimizationIr;
+  parameterFacts: ReadonlyMap<
+    ProgramFunctionInstanceId,
+    ReadonlyMap<SymbolId, MutableEscapeParameterFact>
+  >;
+}): Map<string, Map<HirExprId, MutableEscapeOriginFact>> => {
+  const originFacts = new Map<string, Map<HirExprId, MutableEscapeOriginFact>>();
+
+  ir.facts.reachableFunctionInstances.forEach((instanceId) => {
+    const instance = ir.baseProgram.functions.getInstance(instanceId);
+    const moduleView = ir.modules.get(instance.symbolRef.moduleId);
+    const item = moduleView
+      ? functionItemBySymbol({
+          moduleView,
+          symbol: instance.symbolRef.symbol,
+        })
+      : undefined;
+    if (!moduleView || !item) {
+      return;
+    }
+    analyzeEscapeExpression({
+      exprId: item.body,
+      context: { reason: "return" },
+      state: {
+        ir,
+        moduleView,
+        callerInstanceId: instanceId,
+        parameterSymbols: parameterSymbolsForFunction(item),
+        parameterFacts,
+        mutableOriginFacts: originFacts,
+        localOrigins: new Map(),
+      },
+    });
+  });
+
+  ir.facts.reachableModuleLets.forEach((symbols, moduleId) => {
+    const moduleView = ir.modules.get(moduleId);
+    if (!moduleView) {
+      return;
+    }
+    symbols.forEach((symbol) => {
+      const moduleLet = moduleLetBySymbol({ moduleView, symbol });
+      if (!moduleLet) {
+        return;
+      }
+      analyzeEscapeExpression({
+        exprId: moduleLet.initializer,
+        context: { reason: "module-let" },
+        state: {
+          ir,
+          moduleView,
+          parameterSymbols: new Set(),
+          parameterFacts,
+          mutableOriginFacts: originFacts,
+          localOrigins: new Map(),
+        },
+      });
+    });
+  });
+
+  return originFacts;
+};
+
+const serializeOriginFacts = (
+  facts: ReadonlyMap<string, ReadonlyMap<HirExprId, EscapeAnalysisOriginFact>>,
+): string =>
+  JSON.stringify(
+    Array.from(facts.entries())
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([moduleId, byExpr]) => [
+        moduleId,
+        Array.from(byExpr.entries())
+          .sort(([left], [right]) => left - right)
+          .map(([exprId, fact]) => [
+            exprId,
+            fact.originKind,
+            fact.typeId,
+            fact.escapes,
+            fact.escapeReasons,
+            fact.directLocalSymbols,
+            fact.useExprIds,
+          ]),
+      ]),
+  );
+
+const escapeAnalysisPass: ProgramOptimizationPass = {
+  name: "whole-program-escape-analysis",
+  run(ctx) {
+    const ir = ctx.ir as MutableOptimizationIr;
+    const parameterFacts = computeParameterEscapeFacts({ ir });
+    const originFacts = computeOriginEscapeFacts({ ir, parameterFacts });
+    const immutableParameters = toImmutableParameterFacts(parameterFacts);
+    const immutableOrigins = toImmutableOriginFacts(originFacts);
+    const previous = ir.facts.escapeAnalysis;
+    const changed =
+      serializeMutableParameterFacts(parameterFacts) !==
+        JSON.stringify(
+          Array.from(previous.parameters.entries())
+            .sort(([left], [right]) => left - right)
+            .map(([instanceId, bySymbol]) => [
+              instanceId,
+              Array.from(bySymbol.entries())
+                .sort(([left], [right]) => left - right)
+                .map(([symbol, fact]) => [
+                  symbol,
+                  fact.escapes,
+                  fact.escapeReasons,
+                  fact.useExprIds,
+                ]),
+            ]),
+        ) ||
+      serializeOriginFacts(immutableOrigins) !== serializeOriginFacts(previous.origins);
+
+    ir.facts.escapeAnalysis = {
+      origins: immutableOrigins,
+      parameters: immutableParameters,
+    };
+
+    return { changed };
+  },
+};
+
 const rebuildEffectsInfo = ({
   moduleView,
 }: {
@@ -4378,6 +5366,43 @@ const finalizeOptimization = ({
           ],
         ),
       ),
+      escapeAnalysis: {
+        origins: new Map(
+          Array.from(ir.facts.escapeAnalysis.origins.entries()).map(
+            ([moduleId, byExpr]) => [
+              moduleId,
+              new Map(
+                Array.from(byExpr.entries()).map(([exprId, fact]) => [
+                  exprId,
+                  {
+                    ...fact,
+                    escapeReasons: [...fact.escapeReasons],
+                    directLocalSymbols: [...fact.directLocalSymbols],
+                    useExprIds: [...fact.useExprIds],
+                  },
+                ]),
+              ),
+            ],
+          ),
+        ),
+        parameters: new Map(
+          Array.from(ir.facts.escapeAnalysis.parameters.entries()).map(
+            ([instanceId, bySymbol]) => [
+              instanceId,
+              new Map(
+                Array.from(bySymbol.entries()).map(([symbol, fact]) => [
+                  symbol,
+                  {
+                    ...fact,
+                    escapeReasons: [...fact.escapeReasons],
+                    useExprIds: [...fact.useExprIds],
+                  },
+                ]),
+              ),
+            ],
+          ),
+        ),
+      },
       runtimeTypeCheckElisionFieldAccesses: new Map(
         Array.from(ir.facts.runtimeTypeCheckElisionFieldAccesses.entries()).map(
           ([moduleId, exprIds]) => [moduleId, new Set(exprIds)],
@@ -4411,6 +5436,7 @@ const OPTIMIZATION_PASSES: readonly ProgramOptimizationPass[] = [
   wholeProgramSpecializationPruningPass,
   redundantRuntimeTypeCheckEliminationPass,
   semanticCopyForwardingPass,
+  escapeAnalysisPass,
 ];
 
 export const optimizeProgram = ({

--- a/packages/compiler/src/optimize/pipeline.ts
+++ b/packages/compiler/src/optimize/pipeline.ts
@@ -4306,6 +4306,7 @@ type EscapeAnalysisState = {
   mutableParameterFacts?: Map<SymbolId, MutableEscapeParameterFact>;
   mutableOriginFacts?: Map<string, Map<HirExprId, MutableEscapeOriginFact>>;
   localOrigins: Map<SymbolId, Set<HirExprId>>;
+  localParameterAliases: Map<SymbolId, Set<SymbolId>>;
 };
 
 const emptyEscapeUseContext: EscapeUseContext = {};
@@ -4558,6 +4559,48 @@ const bindLocalOrigin = ({
   fact?.directLocalSymbols.add(symbol);
 };
 
+const localParameterAliasesForSymbol = ({
+  state,
+  symbol,
+}: {
+  state: EscapeAnalysisState;
+  symbol: SymbolId;
+}): ReadonlySet<SymbolId> | undefined => state.localParameterAliases.get(symbol);
+
+const parameterAliasesForInitializer = ({
+  state,
+  exprId,
+}: {
+  state: EscapeAnalysisState;
+  exprId: HirExprId;
+}): Set<SymbolId> => {
+  const expr = state.moduleView.hir.expressions.get(exprId);
+  if (expr?.exprKind !== "identifier") {
+    return new Set();
+  }
+  return new Set([
+    ...(state.parameterSymbols.has(expr.symbol) ? [expr.symbol] : []),
+    ...(localParameterAliasesForSymbol({ state, symbol: expr.symbol }) ?? []),
+  ]);
+};
+
+const bindLocalParameterAliases = ({
+  state,
+  symbol,
+  parameterSymbols,
+}: {
+  state: EscapeAnalysisState;
+  symbol: SymbolId;
+  parameterSymbols: ReadonlySet<SymbolId>;
+}): void => {
+  if (parameterSymbols.size === 0) {
+    return;
+  }
+  const aliases = state.localParameterAliases.get(symbol) ?? new Set<SymbolId>();
+  parameterSymbols.forEach((parameterSymbol) => aliases.add(parameterSymbol));
+  state.localParameterAliases.set(symbol, aliases);
+};
+
 const markSymbolUse = ({
   state,
   symbol,
@@ -4583,17 +4626,20 @@ const markSymbolUse = ({
     });
   });
 
-  if (!state.parameterSymbols.has(symbol)) {
-    return;
-  }
-  const fact = state.mutableParameterFacts?.get(symbol);
-  if (!fact) {
-    return;
-  }
-  markParameterUse({
-    fact,
-    exprId,
-    reason: context.reason,
+  const parameterSymbols = new Set([
+    ...(state.parameterSymbols.has(symbol) ? [symbol] : []),
+    ...(localParameterAliasesForSymbol({ state, symbol }) ?? []),
+  ]);
+  parameterSymbols.forEach((parameterSymbol) => {
+    const fact = state.mutableParameterFacts?.get(parameterSymbol);
+    if (!fact) {
+      return;
+    }
+    markParameterUse({
+      fact,
+      exprId,
+      reason: context.reason,
+    });
   });
 };
 
@@ -5000,22 +5046,34 @@ const analyzeEscapeStatement = ({
     return;
   }
 
-  const boundOrigin = originExprIdForInitializer({
-    state,
-    exprId: statement.initializer,
-  });
-  if (statement.pattern.kind === "identifier" && typeof boundOrigin === "number") {
-    bindLocalOrigin({
+  if (statement.pattern.kind === "identifier") {
+    const boundOrigin = originExprIdForInitializer({
+      state,
+      exprId: statement.initializer,
+    });
+    if (typeof boundOrigin === "number") {
+      bindLocalOrigin({
+        state,
+        symbol: statement.pattern.symbol,
+        originExprId: boundOrigin,
+      });
+    }
+    bindLocalParameterAliases({
       state,
       symbol: statement.pattern.symbol,
-      originExprId: boundOrigin,
+      parameterSymbols: parameterAliasesForInitializer({
+        state,
+        exprId: statement.initializer,
+      }),
     });
-    analyzeEscapeExpression({
-      exprId: statement.initializer,
-      context: emptyEscapeUseContext,
-      state,
-    });
-    return;
+    if (typeof boundOrigin === "number") {
+      analyzeEscapeExpression({
+        exprId: statement.initializer,
+        context: emptyEscapeUseContext,
+        state,
+      });
+      return;
+    }
   }
 
   analyzeEscapeExpression({
@@ -5094,6 +5152,7 @@ const analyzeParameterEscapes = ({
         parameterFacts: seedFacts,
         mutableParameterFacts,
         localOrigins: new Map(),
+        localParameterAliases: new Map(),
       },
     });
   });
@@ -5156,6 +5215,7 @@ const computeOriginEscapeFacts = ({
         parameterFacts,
         mutableOriginFacts: originFacts,
         localOrigins: new Map(),
+        localParameterAliases: new Map(),
       },
     });
   });
@@ -5180,6 +5240,7 @@ const computeOriginEscapeFacts = ({
           parameterFacts,
           mutableOriginFacts: originFacts,
           localOrigins: new Map(),
+          localParameterAliases: new Map(),
         },
       });
     });

--- a/scripts/bench-v325.ts
+++ b/scripts/bench-v325.ts
@@ -1,0 +1,256 @@
+import fs from "node:fs";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { gzipSync } from "node:zlib";
+import { createSdk, type CompileResult } from "@voyd-lang/sdk";
+import { createVoydHost } from "@voyd-lang/sdk/js-host";
+
+type Scenario = {
+  name: string;
+  iterations: number;
+  warmups: number;
+  source?: string;
+  entryPath?: string;
+  entryName?: string;
+  expected?: number;
+};
+
+type ScenarioResult = {
+  name: string;
+  optimize: boolean;
+  compileMs: number;
+  wasmBytes: number;
+  gzipBytes: number;
+  medianMs?: number;
+  samplesMs: number[];
+};
+
+const focusedSource = `
+obj Pair {
+  x: i32,
+  y: i32
+}
+
+trait Scored
+  fn score(self) -> i32
+
+impl Scored for Pair
+  fn score(self) -> i32
+    self.x + self.y
+
+fn pair_sum(pair: Pair) -> i32
+  pair.x + pair.y
+
+fn identity(pair: Pair) -> Pair
+  pair
+
+pub fn non_escaping_aggregate() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    let pair = Pair { x: i, y: i + 1 }
+    total = total + pair_sum(pair)
+    i = i + 1
+  total
+
+pub fn mutable_temporary_record() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    let ~pair = Pair { x: i, y: i + 1 }
+    pair.x = pair.x + 1
+    total = total + pair.x + pair.y
+    i = i + 1
+  total
+
+pub fn trait_typed_temporary() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    total = total + score_trait(Pair { x: i, y: i + 1 })
+    i = i + 1
+  total
+
+fn score_trait(value: Scored) -> i32
+  value.score()
+
+pub fn call_boundary_escape() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    total = total + identity(Pair { x: i, y: i + 1 }).x
+    i = i + 1
+  total
+`;
+
+const defaultIterations = Number.parseInt(process.env.VOYD_BENCH_ITERATIONS ?? "5", 10);
+const representativeIterations = Number.parseInt(
+  process.env.VOYD_BENCH_REPRESENTATIVE_ITERATIONS ?? "1",
+  10,
+);
+
+const maybeFileScenario = (scenario: Scenario): Scenario[] =>
+  scenario.entryPath && !fs.existsSync(scenario.entryPath) ? [] : [scenario];
+
+const scenarios: Scenario[] = [
+  {
+    name: "focused/non-escaping-aggregate",
+    source: focusedSource,
+    entryName: "non_escaping_aggregate",
+    expected: 400_000_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/mutable-temporary-record",
+    source: focusedSource,
+    entryName: "mutable_temporary_record",
+    expected: 400_020_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/trait-typed-temporary",
+    source: focusedSource,
+    entryName: "trait_typed_temporary",
+    expected: 400_000_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/call-boundary-escape",
+    source: focusedSource,
+    entryName: "call_boundary_escape",
+    expected: 199_990_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "representative/vtrace-compute-main",
+    entryPath: path.join(
+      import.meta.dirname,
+      "..",
+      "apps",
+      "smoke",
+      "fixtures",
+      "vtrace-compute-benchmark.voyd",
+    ),
+    entryName: "main",
+    expected: 3_825_271,
+    iterations: representativeIterations,
+    warmups: 1,
+  },
+  ...maybeFileScenario({
+    name: "voyd-examples/vtrace-fast-compile",
+    entryPath: "/Users/drew/projects/voyd_examples/src/vtrace_fast.voyd",
+    iterations: 0,
+    warmups: 0,
+  }),
+];
+
+const expectCompileSuccess = (
+  result: CompileResult,
+  name: string,
+): Extract<CompileResult, { success: true }> => {
+  if (result.success) {
+    return result;
+  }
+
+  throw new Error(
+    `${name} failed to compile:\n${result.diagnostics
+      .map((diagnostic) => diagnostic.message)
+      .join("\n")}`,
+  );
+};
+
+const median = (values: readonly number[]): number | undefined => {
+  if (values.length === 0) {
+    return undefined;
+  }
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1]! + sorted[middle]!) / 2
+    : sorted[middle];
+};
+
+const runScenario = async ({
+  scenario,
+  optimize,
+}: {
+  scenario: Scenario;
+  optimize: boolean;
+}): Promise<ScenarioResult> => {
+  const sdk = createSdk();
+  const compileStartedAt = performance.now();
+  const compiled = expectCompileSuccess(
+    await sdk.compile({
+      entryPath: scenario.entryPath,
+      source: scenario.source,
+      optimize,
+    }),
+    scenario.name,
+  );
+  const compileMs = performance.now() - compileStartedAt;
+
+  const samplesMs: number[] = [];
+  if (scenario.entryName && typeof scenario.expected === "number") {
+    const host = await createVoydHost({ wasm: compiled.wasm });
+    for (let warmup = 0; warmup < scenario.warmups; warmup += 1) {
+      const result = await host.run<number>(scenario.entryName);
+      if (result !== scenario.expected) {
+        throw new Error(
+          `${scenario.name} returned ${result} during warmup, expected ${scenario.expected}`,
+        );
+      }
+    }
+    for (let iteration = 0; iteration < scenario.iterations; iteration += 1) {
+      const startedAt = performance.now();
+      const result = await host.run<number>(scenario.entryName);
+      if (result !== scenario.expected) {
+        throw new Error(
+          `${scenario.name} returned ${result}, expected ${scenario.expected}`,
+        );
+      }
+      samplesMs.push(performance.now() - startedAt);
+    }
+  }
+
+  return {
+    name: scenario.name,
+    optimize,
+    compileMs,
+    wasmBytes: compiled.wasm.byteLength,
+    gzipBytes: gzipSync(compiled.wasm).byteLength,
+    medianMs: median(samplesMs),
+    samplesMs,
+  };
+};
+
+const printResults = (results: readonly ScenarioResult[]): void => {
+  console.log("name,optimize,compileMs,wasmBytes,gzipBytes,medianMs,samplesMs");
+  results.forEach((result) => {
+    console.log(
+      [
+        result.name,
+        result.optimize ? "true" : "false",
+        result.compileMs.toFixed(3),
+        result.wasmBytes.toString(),
+        result.gzipBytes.toString(),
+        result.medianMs === undefined ? "" : result.medianMs.toFixed(3),
+        result.samplesMs.map((sample) => sample.toFixed(3)).join("|"),
+      ].join(","),
+    );
+  });
+};
+
+const main = async (): Promise<void> => {
+  const results: ScenarioResult[] = [];
+  for (const scenario of scenarios) {
+    results.push(await runScenario({ scenario, optimize: false }));
+    results.push(await runScenario({ scenario, optimize: true }));
+  }
+  printResults(results);
+};
+
+await main();

--- a/scripts/bench-v325.ts
+++ b/scripts/bench-v325.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { createHash } from "node:crypto";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { gzipSync } from "node:zlib";
@@ -21,6 +22,7 @@ type ScenarioResult = {
   compileMs: number;
   wasmBytes: number;
   gzipBytes: number;
+  wasmSha256: string;
   medianMs?: number;
   samplesMs: number[];
 };
@@ -88,6 +90,19 @@ const representativeIterations = Number.parseInt(
   process.env.VOYD_BENCH_REPRESENTATIVE_ITERATIONS ?? "1",
   10,
 );
+const optimizeModes = (process.env.VOYD_BENCH_OPTIMIZE_MODES ?? "false,true")
+  .split(",")
+  .map((value) => value.trim().toLowerCase())
+  .filter((value) => value.length > 0)
+  .map((value) => {
+    if (value === "true" || value === "1") {
+      return true;
+    }
+    if (value === "false" || value === "0") {
+      return false;
+    }
+    throw new Error(`invalid VOYD_BENCH_OPTIMIZE_MODES entry ${value}`);
+  });
 
 const maybeFileScenario = (scenario: Scenario): Scenario[] =>
   scenario.entryPath && !fs.existsSync(scenario.entryPath) ? [] : [scenario];
@@ -222,13 +237,14 @@ const runScenario = async ({
     compileMs,
     wasmBytes: compiled.wasm.byteLength,
     gzipBytes: gzipSync(compiled.wasm).byteLength,
+    wasmSha256: createHash("sha256").update(compiled.wasm).digest("hex"),
     medianMs: median(samplesMs),
     samplesMs,
   };
 };
 
 const printResults = (results: readonly ScenarioResult[]): void => {
-  console.log("name,optimize,compileMs,wasmBytes,gzipBytes,medianMs,samplesMs");
+  console.log("name,optimize,compileMs,wasmBytes,gzipBytes,wasmSha256,medianMs,samplesMs");
   results.forEach((result) => {
     console.log(
       [
@@ -237,6 +253,7 @@ const printResults = (results: readonly ScenarioResult[]): void => {
         result.compileMs.toFixed(3),
         result.wasmBytes.toString(),
         result.gzipBytes.toString(),
+        result.wasmSha256,
         result.medianMs === undefined ? "" : result.medianMs.toFixed(3),
         result.samplesMs.map((sample) => sample.toFixed(3)).join("|"),
       ].join(","),
@@ -247,8 +264,9 @@ const printResults = (results: readonly ScenarioResult[]): void => {
 const main = async (): Promise<void> => {
   const results: ScenarioResult[] = [];
   for (const scenario of scenarios) {
-    results.push(await runScenario({ scenario, optimize: false }));
-    results.push(await runScenario({ scenario, optimize: true }));
+    for (const optimize of optimizeModes) {
+      results.push(await runScenario({ scenario, optimize }));
+    }
   }
   printResults(results);
 };


### PR DESCRIPTION
## Summary
- Add `ProgramOptimizationFacts.escapeAnalysis` and a whole-program escape-analysis pass for aggregates, trait-object receivers, closures, and effect handlers
- Cover positive and negative escape cases with optimizer tests
- Add V-325 benchmark tooling and document the complexity proof and baseline results

## Testing
- Added and ran optimizer pipeline unit tests for escape facts
- Added benchmark script validation for focused scenarios and representative workloads
- Local repo test suite and typecheck passed