### PR TITLE
Consume escape facts for scalar replacement

### DIFF
--- a/apps/smoke/fixtures/scalar-aggregate-representative.voyd
+++ b/apps/smoke/fixtures/scalar-aggregate-representative.voyd
@@ -1,0 +1,23 @@
+obj Vec3 {
+  x: i32,
+  y: i32,
+  z: i32
+}
+
+fn energy(vec: Vec3) -> i32
+  vec.x + vec.y * 3 + vec.z * 5
+
+fn step_particle(seed: i32) -> i32
+  let ~velocity = Vec3 { x: seed, y: seed + 1, z: seed + 2 }
+  velocity.x = velocity.x + 3
+  velocity.y = velocity.y + velocity.x
+  velocity.z = velocity.z + velocity.y
+  energy(velocity)
+
+pub fn main() -> i32
+  var i = 0
+  var total = 0
+  while i < 10000:
+    total = total + step_particle(i)
+    i = i + 1
+  total

--- a/docs/architecture/compiler-optimization-pipeline.md
+++ b/docs/architecture/compiler-optimization-pipeline.md
@@ -276,6 +276,104 @@ aggregates into scalar locals. Reusable escape facts are owned by the
 whole-program escape-analysis pass; broad scalar replacement and allocation
 elision remain separate `V-326` work.
 
+### Scalar Aggregate Replacement
+
+Scalar aggregate replacement is a codegen-owned consumer of
+`ProgramOptimizationFacts.escapeAnalysis`. It does not mutate optimized HIR and
+does not infer escape behavior from local syntax alone. Codegen may split a
+local aggregate into field locals only when all of these checks pass:
+
+- the origin fact exists, is an `aggregate`, has the expected type id, does not
+  escape, and names the local symbol as a direct local symbol
+- the initializer is a direct object literal without spreads, a tuple literal, a
+  block/conditional expression whose branch values meet these same checks, or a
+  small value-object direct-call result
+- the structural layout is small enough for local lane storage
+- all fields are initialized directly or are optional fields that can receive
+  the normal `None` value
+
+The scalar binding rematerializes through `initStructuralValue` when a full
+value is needed, and mutable-ref or storage boundaries continue to use the
+existing materialization paths. Direct value-object parameters whose parameter
+escape facts are non-escaping can bind incoming ABI lanes directly to field
+locals. Direct calls with scalarized heap-object identifier arguments, direct
+heap-object literal arguments, or simple heap-object factory returns may also
+use a private callee specialization whose selected parameters or result receive
+field lanes instead of a heap reference, leaving the original public ABI
+unchanged. Whole-object heap assignment remains a materialization boundary to
+preserve object identity; value-object reassignment may stay scalar.
+
+Unsupported shapes deliberately fall back to the existing materialized
+aggregate path. This keeps the implementation removable and avoids coupling
+codegen to typing internals beyond the codegen-view and optimization-facts
+contracts.
+
+The complexity added by this path is:
+
+- one new local binding representation for scalar aggregate lanes
+- localized field load/store/rematerialization helpers
+- a private direct-call specialization path for selected small heap-object
+  parameters and fresh heap-object results
+- additional local rechecks for mutable method receivers, effectful functions,
+  effect-handler captures, aliasing, and storage-ref capture boundaries
+
+It avoids a separate optimizer rewrite pass and keeps the public function ABI
+unchanged, but it does add coupling between escape facts, call metadata, and
+codegen lowering. The main maintenance risks are stale lane values after
+mutation/capture boundaries and accidentally specializing alias-returning heap
+objects. The implementation pays a compile-time cost in the affected scenarios
+for extra fact checks and specialization metadata, but the hot aggregate cases
+below show runtime and code-size wins where Binaryen alone did not remove the
+semantic allocation pattern. Effectful functions deliberately fall back to
+materialized values until storage/capture semantics can be proven more tightly.
+
+Rejected simpler alternatives:
+
+- local-only pattern matching was too fragile around aliases, method receivers,
+  effect handlers, and public boundary wrappers
+- relying only on Binaryen missed mutable object temporaries and selected direct
+  call shapes
+- a broad optimizer rewrite pass would duplicate codegen ownership of storage
+  refs, projected elements, and ABI lowering
+- doing nothing left aggregate-heavy mutable/direct-call code dependent on GC
+  allocation patterns in hot loops
+
+`scripts/bench-v326.ts` emits revision-tagged raw CSV and can compare two runs:
+
+```sh
+VOYD_BENCH_OPTIMIZE_MODES=true VOYD_BENCH_REVISION=base-484fcd76 \
+  node --conditions=development --import tsx scripts/bench-v326.ts > /tmp/v326-base.csv
+VOYD_BENCH_OPTIMIZE_MODES=true VOYD_BENCH_REVISION=head-worktree \
+  node --conditions=development --import tsx scripts/bench-v326.ts > /tmp/v326-head.csv
+node --conditions=development --import tsx scripts/bench-v326.ts \
+  compare /tmp/v326-base.csv /tmp/v326-head.csv
+```
+
+PR-base (`484fcd76`) vs PR-head validation. Shape columns are whole-module WAT
+counts; runtime is median host-run time:
+
+| Scenario | Runtime ms base -> head | Runtime delta | Compile ms delta | Wasm bytes delta | WAT bytes delta | `struct.new` delta | `tuple.make` delta |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| focused/non-escaping-object-local | 0.082 -> 0.067 | -18.3% | +5.3% | -0.3% | -0.2% | -3 | 0 |
+| focused/mutable-object-temporary | 0.104 -> 0.053 | -49.0% | +17.7% | -0.3% | -0.2% | -3 | 0 |
+| focused/direct-value-call-argument | 0.057 -> 0.049 | -14.0% | +7.8% | -0.3% | -0.2% | -3 | 0 |
+| focused/direct-heap-call-argument | 0.060 -> 0.047 | -21.7% | +18.4% | -0.3% | -0.2% | -3 | 0 |
+| focused/direct-heap-call-literal | 0.046 -> 0.050 | +8.7% | +4.7% | -0.3% | -0.2% | -3 | 0 |
+| focused/direct-heap-call-return | 0.054 -> 0.047 | -13.0% | -0.0% | -0.3% | -0.2% | -3 | 0 |
+| focused/escape-boundary-rematerialization | 0.047 -> 0.047 | 0.0% | +2.0% | -0.3% | -0.2% | -3 | 0 |
+| representative/scalar-aggregate-particle-step | 0.547 -> 0.033 | -94.0% | +0.4% | -1.9% | -1.3% | -4 | 0 |
+| representative/vtrace-compute-main | 271.129 -> 264.969 | -2.3% | +6.1% | +0.9% | +1.5% | +11 | +4 |
+
+The particle-step fixture is the in-repo representative aggregate-heavy
+workload affected by this optimization. `vtrace-compute-main` is retained as a
+broader guardrail; after effectful-function bailouts it shows small runtime
+movement and code-size growth while the aggregate-heavy representative case
+improves. The
+optional `/Users/drew/projects/voyd_examples`
+scenario is included in the script when present, but the current local checkout
+uses older `while ... do:` syntax and is skipped with a warning by this
+compiler.
+
 ## Binaryen Optimization
 
 After Voyd codegen emits the Binaryen module, `CodegenOptions.optimize` runs
@@ -335,8 +433,11 @@ or the shared Binaryen optimization profile should own it.
   representation changes must consume those facts through
   `ProgramOptimizationFacts.escapeAnalysis` rather than rediscovering typing
   internals.
-- `V-326`: broad scalar replacement for non-escaping aggregates remains
-  separate from semantic copy forwarding and addressable storage reuse.
+- Heap-object direct-call scalar ABI specialization is private to selected
+  direct calls and preserves the original function metadata for public exports,
+  trait dispatch, closure values, imports, and other non-specialized calls. It
+  is used only when object identity is not exposed across the optimized
+  boundary.
 
 ## Testing Guidance
 

--- a/packages/compiler/src/codegen/__tests__/scalar-aggregate-replacement.test.ts
+++ b/packages/compiler/src/codegen/__tests__/scalar-aggregate-replacement.test.ts
@@ -1,0 +1,778 @@
+import { describe, expect, it } from "vitest";
+import { getWasmInstance } from "@voyd-lang/lib/wasm.js";
+import { parse } from "../../parser/index.js";
+import { semanticsPipeline } from "../../semantics/pipeline.js";
+import { monomorphizeProgram } from "../../semantics/linking.js";
+import { buildProgramCodegenView } from "../../semantics/codegen-view/index.js";
+import { optimizeProgram } from "../../optimize/pipeline.js";
+import { codegenProgram } from "../index.js";
+import type { ModuleGraph, ModuleNode } from "../../modules/types.js";
+
+const compileOptimized = (source: string) => {
+  const ast = parse(source, "scalar_aggregate_replacement.voyd");
+  const moduleNode: ModuleNode = {
+    id: "std::scalar_aggregate_replacement",
+    path: { namespace: "std", segments: ["scalar_aggregate_replacement"] },
+    origin: {
+      kind: "file",
+      filePath: "scalar_aggregate_replacement.voyd",
+    },
+    ast,
+    source,
+    dependencies: [],
+  };
+  const graph: ModuleGraph = {
+    entry: moduleNode.id,
+    modules: new Map([[moduleNode.id, moduleNode]]),
+    diagnostics: [],
+  };
+  const semantics = semanticsPipeline({ module: moduleNode, graph });
+  const semanticsByModule = new Map([[moduleNode.id, semantics]]);
+  const monomorphized = monomorphizeProgram({
+    modules: [semantics],
+    semantics: semanticsByModule,
+  });
+  const program = buildProgramCodegenView([semantics], {
+    instances: monomorphized.instances,
+    moduleTyping: monomorphized.moduleTyping,
+  });
+  const optimized = optimizeProgram({
+    program,
+    modules: [semantics],
+    entryModuleId: moduleNode.id,
+  });
+  const optimizedCodegen = codegenProgram({
+    program: optimized.program,
+    entryModuleId: moduleNode.id,
+    optimization: optimized.facts,
+    options: { validate: false },
+  });
+  const baselineCodegen = codegenProgram({
+    program: optimized.program,
+    entryModuleId: moduleNode.id,
+    options: { validate: false },
+  });
+  if (optimizedCodegen.diagnostics.length > 0) {
+    throw new Error(JSON.stringify(optimizedCodegen.diagnostics, null, 2));
+  }
+  if (baselineCodegen.diagnostics.length > 0) {
+    throw new Error(JSON.stringify(baselineCodegen.diagnostics, null, 2));
+  }
+  return { optimized, optimizedCodegen, baselineCodegen };
+};
+
+const runMain = (module: ReturnType<typeof compileOptimized>["optimizedCodegen"]["module"]) => {
+  const instance = getWasmInstance(module);
+  return instance.exports.main as () => number;
+};
+
+describe("scalar aggregate replacement", () => {
+  it("keeps non-escaping object literal fields in scalar locals", () => {
+    const { optimized, optimizedCodegen, baselineCodegen } = compileOptimized(`
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn bump(value: i32) -> i32
+  value + 1
+
+pub fn main() -> i32
+  let vec = Vec2 { x: bump(1), y: bump(2) }
+  vec.x + vec.y
+`);
+
+    const originFacts = optimized.facts.escapeAnalysis.origins.get(
+      "std::scalar_aggregate_replacement",
+    );
+    expect([...(originFacts?.values() ?? [])].some((fact) => !fact.escapes)).toBe(true);
+    expect(runMain(optimizedCodegen.module)()).toBe(5);
+
+    const optimizedText = optimizedCodegen.module.emitText();
+    const baselineText = baselineCodegen.module.emitText();
+    expect(baselineText).toMatch(/\(struct\.new \$voyd_struct_shape_/);
+    expect(optimizedText).not.toMatch(/\(struct\.new \$voyd_struct_shape_/);
+  });
+
+  it("rematerializes object literals at return escape boundaries", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn make_vec() -> Vec2
+  let vec = Vec2 { x: 4, y: 5 }
+  vec
+
+pub fn main() -> i32
+  let vec = make_vec()
+  vec.x + vec.y
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(9);
+    expect(optimizedCodegen.module.emitText()).toMatch(/\(struct\.new \$voyd_struct_shape_/);
+  });
+
+  it("keeps return-escaping mutable locals scalar until return materialization", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn make_vec() -> Vec2
+  let ~vec = Vec2 { x: 4, y: 5 }
+  vec.x = vec.x + 1
+  vec
+
+pub fn main() -> i32
+  let vec = make_vec()
+  vec.x + vec.y
+`);
+
+    const optimizedText = optimizedCodegen.module.emitText();
+    const makeVecStart = optimizedText.indexOf(
+      "(func $std__scalar_aggregate_replacement__make_vec_",
+    );
+    expect(makeVecStart).toBeGreaterThanOrEqual(0);
+    const nextFuncStart = optimizedText.indexOf("\n (func ", makeVecStart + 1);
+    const makeVecText = optimizedText.slice(makeVecStart, nextFuncStart);
+    expect(runMain(optimizedCodegen.module)()).toBe(10);
+    expect(makeVecText).toMatch(/\(struct\.new \$voyd_struct_shape_/);
+    expect(makeVecText).not.toMatch(/\(struct\.set \$voyd_struct_shape_/);
+  });
+
+  it("updates non-escaping mutable aggregate fields without materializing", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+pub fn main() -> i32
+  let ~vec = Vec2 { x: 1, y: 2 }
+  vec.x = vec.x + 10
+  vec.x + vec.y
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(13);
+    expect(optimizedCodegen.module.emitText()).not.toMatch(
+      /\(struct\.new \$voyd_struct_shape_/,
+    );
+  });
+
+  it("materializes scalar heap roots before nested value field mutation", () => {
+    const { optimizedCodegen } = compileOptimized(`
+type Inner = { x: i32, y: i32 }
+
+obj Outer {
+  inner: Inner
+}
+
+pub fn main() -> i32
+  let ~outer = Outer { inner: { x: 1, y: 5 } }
+  outer.inner.x = 10
+  outer.inner.x + outer.inner.y
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(15);
+  });
+
+  it("keeps conditional aggregate branch values in scalar locals", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+pub fn main() -> i32
+  let flag = true
+  let vec = if flag then: Vec2 { x: 1, y: 2 } else: Vec2 { x: 10, y: 20 }
+  vec.x + vec.y
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(3);
+    expect(baselineCodegen.module.emitText()).toMatch(
+      /\(struct\.new \$voyd_struct_shape_/,
+    );
+    expect(optimizedCodegen.module.emitText()).not.toMatch(
+      /\(struct\.new \$voyd_struct_shape_/,
+    );
+  });
+
+  it("compiles scalar block initializer statements before the block value", () => {
+    const { optimizedCodegen } = compileOptimized(`
+pub val Vec2 {
+  x: i32,
+  y: i32
+}
+
+pub fn main() -> i32
+  let vec = block
+    let x = 1
+    Vec2 { x: x, y: 2 }
+  vec.x + vec.y
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(3);
+    expect(optimizedCodegen.module.emitText()).not.toMatch(
+      /\(struct\.new \$voyd_struct_shape_/,
+    );
+  });
+
+  it("stores small value-object call returns into scalar field locals", () => {
+    const { optimizedCodegen } = compileOptimized(`
+pub val Vec3 {
+  x: i32,
+  y: i32,
+  z: i32
+}
+
+fn make_vec(seed: i32) -> Vec3
+  Vec3 { x: seed, y: seed + 1, z: seed + 2 }
+
+pub fn main() -> i32
+  let vec = make_vec(4)
+  vec.x + vec.y + vec.z
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(15);
+    expect(optimizedCodegen.module.emitText()).not.toMatch(
+      /\(struct\.new \$voyd_struct_shape_/,
+    );
+  });
+
+  it("returns direct heap-object factory results as scalar lanes for local use", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn make_vec() -> Vec2
+  Vec2 { x: 4, y: 5 }
+
+pub fn main() -> i32
+  let vec = make_vec()
+  vec.x + vec.y
+`);
+
+    const optimizedText = optimizedCodegen.module.emitText();
+    const specializedStart = optimizedText.indexOf("__scalar_agg__result");
+    expect(runMain(optimizedCodegen.module)()).toBe(9);
+    expect(specializedStart).toBeGreaterThanOrEqual(0);
+    const specializedFuncStart = optimizedText.lastIndexOf("(func ", specializedStart);
+    const specializedFuncEnd = optimizedText.indexOf("\n (func ", specializedStart);
+    const specializedText = optimizedText.slice(
+      specializedFuncStart,
+      specializedFuncEnd,
+    );
+    expect(specializedText).not.toMatch(/\(struct\.new \$voyd_struct_shape_/);
+  });
+
+  it("does not scalarize heap-object call returns that may alias existing objects", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn id(box: Box) -> Box
+  box
+
+pub fn main() -> i32
+  let ~a = Box { value: 1 }
+  let ~b = id(a)
+  b.value = 2
+  a.value
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(2);
+    expect(optimizedCodegen.module.emitText()).not.toMatch(/__scalar_agg__result/);
+  });
+
+  it("materializes scalar heap-object locals before alias initialization", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+pub fn main() -> i32
+  let ~a = Box { value: 1 }
+  let ~b = a
+  b.value = 2
+  a.value
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(2);
+  });
+
+  it("keeps statementful heap-object factory returns on the public ABI", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn make_box(seed: i32) -> Box
+  let value = seed + 1
+  Box { value: value }
+
+pub fn main() -> i32
+  let box = make_box(3)
+  box.value
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(4);
+    expect(optimizedCodegen.module.emitText()).not.toMatch(/__scalar_agg__result/);
+  });
+
+  it("does not scalarize heap-object call returns through aliasing wrappers", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn id(box: Box) -> Box
+  box
+
+fn wrap(box: Box) -> Box
+  id(box)
+
+pub fn main() -> i32
+  let ~a = Box { value: 1 }
+  let ~b = wrap(a)
+  b.value = 2
+  a.value
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(2);
+    expect(optimizedCodegen.module.emitText()).not.toMatch(/__scalar_agg__result/);
+  });
+
+  it("does not force scalar call arguments from non-fresh heap-object calls", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn id(box: Box) -> Box
+  box
+
+fn read(box: Box) -> i32
+  box.value
+
+pub fn main() -> i32
+  read(id(Box { value: 5 }))
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(5);
+  });
+
+  it("does not scalarize heap-object parameters mutated by the callee", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn set_value(~box: Box) -> void
+  box.value = 9
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  set_value(box)
+  box.value
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(9);
+  });
+
+  it("does not scalarize heap-object parameters mutated through local aliases", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn mutate_alias(box: Box) -> i32
+  let ~alias = box
+  alias.value = 7
+  box.value
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  mutate_alias(box) * 10 + box.value
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(77);
+    expect(optimizedCodegen.module.emitText()).not.toMatch(
+      /mutate_alias[\s\S]*__scalar_agg__param/,
+    );
+  });
+
+  it("reads current materialized values for later scalar call arguments", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn mutate_alias(box: Box) -> i32
+  let ~alias = box
+  alias.value = 20
+  box.value
+
+fn combine(value: i32, box: Box) -> i32
+  value + box.value
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  combine(mutate_alias(box), box)
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(40);
+  });
+
+  it("does not leak branch-local scalar alias materialization", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  if false:
+    let ~alias = box
+    alias.value = 9
+  box.value
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(1);
+  });
+
+  it("preserves branch alias mutations after the branch", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  if true:
+    let ~alias = box
+    alias.value = 9
+  else:
+    let ~alias = box
+    alias.value = 5
+  box.value
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(9);
+  });
+
+  it("preserves branch nested field mutations after the branch", () => {
+    const { optimizedCodegen } = compileOptimized(`
+type Inner = { x: i32, y: i32 }
+
+obj Outer {
+  inner: Inner
+}
+
+pub fn main() -> i32
+  let ~outer = Outer { inner: { x: 1, y: 2 } }
+  if true:
+    outer.inner.x = 9
+  else:
+    outer.inner.x = 5
+  outer.inner.x + outer.inner.y
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(11);
+  });
+
+  it("preserves branch nested value-object mutations after the branch", () => {
+    const { optimizedCodegen } = compileOptimized(`
+pub val Inner {
+  x: i32,
+  y: i32
+}
+
+pub val Outer {
+  inner: Inner
+}
+
+pub fn main() -> i32
+  let flag = true
+  let ~outer = Outer { inner: Inner { x: 1, y: 2 } }
+  if flag:
+    outer.inner.x = 9
+  else:
+    outer.inner.x = 5
+  outer.inner.x + outer.inner.y
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(11);
+  });
+
+  it("does not leak narrowed match discriminant bindings", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Dog {
+  noses: i32
+}
+
+obj Cat {
+  lives: i32
+}
+
+type Pet = Dog | Cat
+
+pub fn main() -> i32
+  let pet: Pet = Cat { lives: 4 }
+  let first = match(pet)
+    Dog: 1
+    Cat: 2
+  let second = match(pet)
+    Dog: 10
+    Cat: pet.lives + 20
+  first + second
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(26);
+  });
+
+  it("destructures scalar aggregate locals without rematerializing", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+pub fn main() -> i32
+  let vec = Vec2 { x: 4, y: 6 }
+  let { x, y } = vec
+  x + y
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(10);
+    expect(optimizedCodegen.module.emitText()).not.toMatch(
+      /\(struct\.new \$voyd_struct_shape_/,
+    );
+  });
+
+  it("passes scalarized heap-object locals to non-escaping direct calls as lanes", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn sum_vec(vec: Vec2) -> i32
+  vec.x + vec.y
+
+pub fn main() -> i32
+  let vec = Vec2 { x: 7, y: 8 }
+  sum_vec(vec)
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(15);
+    expect(optimizedCodegen.module.emitText()).not.toMatch(
+      /\(struct\.new \$voyd_struct_shape_/,
+    );
+  });
+
+  it("passes direct heap-object literals to non-escaping direct calls as lanes", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn sum_vec(vec: Vec2) -> i32
+  vec.x + vec.y
+
+pub fn main() -> i32
+  sum_vec(Vec2 { x: 7, y: 8 })
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(15);
+    expect(optimizedCodegen.module.emitText()).not.toMatch(
+      /\(struct\.new \$voyd_struct_shape_/,
+    );
+  });
+
+  it("preserves call argument side-effect order for scalar aggregate lanes", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn mutate_and_read(~box: Box) -> i32
+  box.value = 10
+  box.value
+
+fn combine(value: i32, vec: Vec2) -> i32
+  value + vec.x + vec.y
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  combine(mutate_and_read(box), Vec2 { x: box.value, y: 0 })
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(20);
+  });
+
+  it("keeps scalar object-literal call argument setup with the override", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+pub val Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn mutate_alias(box: Box) -> i32
+  let ~alias = box
+  alias.value = 20
+  box.value
+
+fn consume(vec: Vec2) -> i32
+  vec.x + vec.y
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  consume(Vec2 { x: mutate_alias(box), y: box.value })
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(40);
+  });
+
+  it("preserves block statements when heap-object call arguments fall back", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn sum_vec(vec: Vec2) -> i32
+  vec.x + vec.y
+
+pub fn main() -> i32
+  var marker = 0
+  let result = sum_vec(block
+    marker = 5
+    Vec2 { x: 1, y: 2 })
+  result + marker
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(8);
+  });
+
+  it("keeps effectful heap-object callees on the normal ABI", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+eff Local
+  next(tail) -> i32
+
+fn sum_vec(vec: Vec2): Local -> i32
+  vec.x + vec.y + Local::next()
+
+pub fn main(): () -> i32
+  try
+    let vec = Vec2 { x: 1, y: 2 }
+    sum_vec(vec)
+  Local::next(tail):
+    tail(4)
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(7);
+    expect(optimizedCodegen.module.emitText()).not.toMatch(/__scalar_agg__param/);
+  });
+
+  it("restores bindings after failed scalar heap-result probing", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn mutate_alias_return(box: Box) -> Box
+  let ~alias = box
+  alias.value = 7
+  let value = 2
+  Box { value: value }
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  let other = mutate_alias_return(box)
+  other.value * 10 + box.value
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(27);
+  });
+
+  it("preserves block statements when scalar aggregate reassignments fall back", () => {
+    const { optimizedCodegen } = compileOptimized(`
+pub val Vec2 {
+  x: i32,
+  y: i32
+}
+
+pub fn main() -> i32
+  var marker = 0
+  var vec = Vec2 { x: 1, y: 1 }
+  vec = block
+    marker = 5
+    Vec2 { x: 3, y: 4 }
+  vec.x + vec.y + marker
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(12);
+  });
+
+  it("reassigns mutable scalar value aggregate locals without materializing", () => {
+    const { optimizedCodegen } = compileOptimized(`
+pub val Vec2 {
+  x: i32,
+  y: i32
+}
+
+pub fn main() -> i32
+  var vec = Vec2 { x: 1, y: 2 }
+  vec = Vec2 { x: 5, y: 6 }
+  vec.x + vec.y
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(11);
+    expect(optimizedCodegen.module.emitText()).not.toMatch(
+      /\(struct\.new \$voyd_struct_shape_/,
+    );
+  });
+
+  it("extracts labeled call arguments from scalar aggregate locals", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+fn sum_vec({ x: i32, y: i32 }) -> i32
+  x + y
+
+pub fn main() -> i32
+  let vec = Vec2 { x: 4, y: 6 }
+  sum_vec(vec)
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(10);
+    expect(optimizedCodegen.module.emitText()).not.toMatch(
+      /\(struct\.new \$voyd_struct_shape_/,
+    );
+  });
+});

--- a/packages/compiler/src/codegen/context.ts
+++ b/packages/compiler/src/codegen/context.ts
@@ -110,6 +110,8 @@ export interface FunctionMetadata {
   effectful: boolean;
   effectRow?: EffectRowId;
   exactParameterTypes?: ReadonlyMap<SymbolId, TypeId>;
+  scalarAggregateParamIndexes?: readonly number[];
+  scalarAggregateResult?: boolean;
 }
 
 export interface StaticEffectHandlerCapture {
@@ -279,6 +281,13 @@ export interface LocalBindingLocal extends LocalBindingBase {
   index: number;
 }
 
+export interface LocalBindingScalarAggregate extends LocalBindingBase {
+  kind: "scalar-aggregate";
+  mutable: boolean;
+  structInfo: StructuralTypeInfo;
+  fields: ReadonlyMap<string, LocalBindingLocal>;
+}
+
 export interface LocalBindingCapture extends LocalBindingBase {
   kind: "capture";
   envIndex: number;
@@ -304,6 +313,7 @@ export interface LocalBindingProjectedElement extends LocalBindingBase {
 
 export type LocalBinding =
   | LocalBindingLocal
+  | LocalBindingScalarAggregate
   | LocalBindingCapture
   | LocalBindingStorageRef
   | LocalBindingProjectedElement;
@@ -367,6 +377,7 @@ export interface CompiledExpression {
   expr: binaryen.ExpressionRef;
   usedReturnCall: boolean;
   usedOutResultStorageRef?: boolean;
+  usedScalarAggregateResult?: boolean;
 }
 
 export interface CompileCallOptions {
@@ -374,6 +385,7 @@ export interface CompileCallOptions {
   expectedResultTypeId?: TypeId;
   typeInstanceId?: ProgramFunctionInstanceId;
   outResultStorageRef?: binaryen.ExpressionRef;
+  scalarAggregateResultTypeId?: TypeId;
 }
 
 export interface ExpressionCompilerParams {
@@ -384,6 +396,7 @@ export interface ExpressionCompilerParams {
   expectedResultTypeId?: TypeId;
   preserveStorageRefs?: boolean;
   outResultStorageRef?: binaryen.ExpressionRef;
+  scalarAggregateResultTypeId?: TypeId;
 }
 
 export type ExpressionCompiler = (

--- a/packages/compiler/src/codegen/effects/continuation-compiler/continuation-expression.ts
+++ b/packages/compiler/src/codegen/effects/continuation-compiler/continuation-expression.ts
@@ -22,6 +22,7 @@ import {
   compileBreakExpr,
   compileContinueExpr,
   compileIfExpr,
+  compileKnownMatchArmValue,
   compileLoopExpr,
   compileMatchExpr,
   compileWhileExpr,
@@ -251,10 +252,12 @@ const compileContinuationMatchExpr = ({
 
   const armWithTarget = expr.arms.find((arm) => exprContainsTarget(arm.value, resumeTarget, ctx));
   if (armWithTarget) {
-    const armExpr = compileExpr({
-      exprId: armWithTarget.value,
+    const armExpr = compileKnownMatchArmValue({
+      expr,
+      arm: armWithTarget,
       ctx,
       fnCtx,
+      compileExpr,
       tailPosition,
       expectedResultTypeId,
     });

--- a/packages/compiler/src/codegen/effects/continuation-compiler/grouped-expression.ts
+++ b/packages/compiler/src/codegen/effects/continuation-compiler/grouped-expression.ts
@@ -27,6 +27,7 @@ import {
   compileBreakExpr,
   compileContinueExpr,
   compileIfExpr,
+  compileKnownMatchArmValue,
   compileLoopExpr,
   compileMatchExpr,
   compileWhileExpr,
@@ -407,10 +408,12 @@ const compileGroupedContinuationMatchExpr = ({
       activeSiteOrder,
       ctx,
     });
-    const armExpr = compileExpr({
-      exprId: arm.value,
+    const armExpr = compileKnownMatchArmValue({
+      expr,
+      arm,
       ctx,
       fnCtx,
+      compileExpr,
       tailPosition,
       expectedResultTypeId,
     });

--- a/packages/compiler/src/codegen/expressions/blocks.ts
+++ b/packages/compiler/src/codegen/expressions/blocks.ts
@@ -494,7 +494,16 @@ const compileDefaultLetStatement = (
     fnCtx,
     ops,
     compileExpr,
-    options: { declare: true },
+    compileStatement: (nestedStmtId) =>
+      compileStatement(nestedStmtId, ctx, fnCtx, compileExpr),
+    compileBlockInitializer: (blockExpr, compileBody) =>
+      withBlockScope({
+        expr: blockExpr,
+        ctx,
+        fnCtx,
+        run: compileBody,
+      }),
+    options: { declare: true, mutable: stmt.mutable },
   });
   if (ops.length === 0) {
     return ctx.mod.nop();

--- a/packages/compiler/src/codegen/expressions/call/arguments.ts
+++ b/packages/compiler/src/codegen/expressions/call/arguments.ts
@@ -10,6 +10,7 @@ import type {
   FunctionMetadata,
   HirCallExpr,
   HirExprId,
+  LocalBindingScalarAggregate,
   SymbolId,
   TypeId,
 } from "../../context.js";
@@ -25,6 +26,7 @@ import {
   loadStructuralField,
 } from "../../structural.js";
 import {
+  abiTypeFor,
   getInlineHeapBoxType,
   getRequiredExprType,
   getStructuralTypeInfo,
@@ -37,19 +39,76 @@ import {
   loadLocalValue,
   loadBindingValue,
   loadBindingStorageRef,
+  materializeOwnedBinding,
   storeLocalValue,
+  loadScalarAggregateBindingField,
+  storeScalarAggregateBindingValue,
 } from "../../locals.js";
 import {
   materializeProjectedElementBinding,
   tryCompileProjectedElementStorageRefExpr,
 } from "../../projected-element-views.js";
 import { compileCallArgExpressionsWithTemps } from "./shared.js";
+import { captureMultivalueLanes } from "../../multivalue.js";
+import {
+  getOrCreateScalarAggregateCallSpecialization,
+  scalarAggregateParameterCanUseSpecializedAbi,
+} from "../../optimization/scalar-aggregate-calls.js";
+import {
+  canStoreScalarAggregateExpression,
+  createScalarAggregateTempBinding,
+  tryStoreScalarAggregateExpression,
+} from "../../optimization/scalar-aggregates.js";
 import type {
   CallParam,
   CompileCallArgumentOptions,
   CompiledCallArgumentsForParams,
   PlannedCallArguments,
 } from "./types.js";
+
+type ScalarAggregateCallArg =
+  | { kind: "binding"; symbol: SymbolId; typeId: TypeId }
+  | { kind: "expression"; exprId: HirExprId; typeId: TypeId };
+
+const heapObjectScalarArgumentNeedsProducerSpecialization = ({
+  exprId,
+  ctx,
+}: {
+  exprId: HirExprId;
+  ctx: CodegenContext;
+}): boolean => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  if (!expr) {
+    return true;
+  }
+  if (expr.exprKind === "call" || expr.exprKind === "method-call") {
+    return true;
+  }
+  if (expr.exprKind === "block") {
+    return typeof expr.value !== "number"
+      ? false
+      : heapObjectScalarArgumentNeedsProducerSpecialization({
+          exprId: expr.value,
+          ctx,
+        });
+  }
+  if (expr.exprKind === "if" || expr.exprKind === "cond") {
+    return (
+      expr.branches.some((branch) =>
+        heapObjectScalarArgumentNeedsProducerSpecialization({
+          exprId: branch.value,
+          ctx,
+        }),
+      ) ||
+      (typeof expr.defaultBranch === "number" &&
+        heapObjectScalarArgumentNeedsProducerSpecialization({
+          exprId: expr.defaultBranch,
+          ctx,
+        }))
+    );
+  }
+  return false;
+};
 
 export const compileCallArguments = ({
   call,
@@ -64,6 +123,28 @@ export const compileCallArguments = ({
   fnCtx: FunctionContext;
   compileExpr: ExpressionCompiler;
 }): binaryen.ExpressionRef[] => {
+  return compileCallArgumentsWithMetadata({
+    call,
+    meta,
+    ctx,
+    fnCtx,
+    compileExpr,
+  }).args;
+};
+
+export const compileCallArgumentsWithMetadata = ({
+  call,
+  meta,
+  ctx,
+  fnCtx,
+  compileExpr,
+}: {
+  call: HirCallExpr;
+  meta: FunctionMetadata;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+}): { args: binaryen.ExpressionRef[]; meta: FunctionMetadata } => {
   const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
   const typedPlan = resolveTypedCallArgumentPlan({
     callId: call.id,
@@ -71,10 +152,11 @@ export const compileCallArguments = ({
     ctx,
   });
 
-  return compileCallArgumentsForParams({
+  const compiled = compileCallArgumentsForParamsWithDetails({
     call,
     params: meta.parameters,
     paramAbiKinds: meta.paramAbiKinds,
+    meta,
     ctx,
     fnCtx,
     compileExpr,
@@ -83,12 +165,14 @@ export const compileCallArguments = ({
       typedPlan,
     },
   });
+  return { args: compiled.args, meta: compiled.meta ?? meta };
 };
 
 export const compileCallArgumentsForParams = ({
   call,
   params,
   paramAbiKinds,
+  meta,
   ctx,
   fnCtx,
   compileExpr,
@@ -97,6 +181,7 @@ export const compileCallArgumentsForParams = ({
   call: HirCallExpr;
   params: readonly CallParam[];
   paramAbiKinds?: readonly string[];
+  meta?: FunctionMetadata;
   ctx: CodegenContext;
   fnCtx: FunctionContext;
   compileExpr: ExpressionCompiler;
@@ -106,6 +191,7 @@ export const compileCallArgumentsForParams = ({
     call,
     params,
     paramAbiKinds,
+    meta,
     ctx,
     fnCtx,
     compileExpr,
@@ -116,6 +202,7 @@ export const compileCallArgumentsForParamsWithDetails = ({
   call,
   params,
   paramAbiKinds,
+  meta,
   ctx,
   fnCtx,
   compileExpr,
@@ -124,6 +211,7 @@ export const compileCallArgumentsForParamsWithDetails = ({
   call: HirCallExpr;
   params: readonly CallParam[];
   paramAbiKinds?: readonly string[];
+  meta?: FunctionMetadata;
   ctx: CodegenContext;
   fnCtx: FunctionContext;
   compileExpr: ExpressionCompiler;
@@ -162,6 +250,57 @@ export const compileCallArgumentsForParamsWithDetails = ({
         argIndexOffset,
       });
 
+  const scalarAggregateArgs = meta
+    ? collectScalarAggregateCallArgs({
+        plan: planned.plan,
+        callArgs: call.args,
+        meta,
+        ctx,
+        fnCtx,
+      })
+    : new Map<number, ScalarAggregateCallArg>();
+  const tempArgIndexes = new Set(
+    (ctx.effectLowering.callArgTemps.get(call.id) ?? [])
+      .filter((entry) => entry.argIndex >= 0)
+      .map((entry) => entry.argIndex),
+  );
+  const eligibleScalarAggregateArgs = new Map(
+    Array.from(scalarAggregateArgs.entries()).filter(([paramIndex]) => {
+      const entry = planned.plan[paramIndex];
+      return (
+        entry?.kind === "direct" &&
+        !tempArgIndexes.has(entry.argIndex + argIndexOffset)
+      );
+    }),
+  );
+  const resolvedMeta =
+    meta && eligibleScalarAggregateArgs.size > 0
+      ? getOrCreateScalarAggregateCallSpecialization({
+          ctx,
+          meta,
+          paramIndexes: new Set(eligibleScalarAggregateArgs.keys()),
+        }) ?? meta
+      : meta;
+  const selectedScalarParams = new Set(
+    resolvedMeta?.scalarAggregateParamIndexes ?? [],
+  );
+  const selectedScalarArgs = new Map(
+    Array.from(eligibleScalarAggregateArgs.entries()).filter(([paramIndex]) =>
+      selectedScalarParams.has(paramIndex),
+    ),
+  );
+  const selectedScalarArgsByArgIndex = new Map<number, ScalarAggregateCallArg>();
+  planned.plan.forEach((entry, paramIndex) => {
+    if (entry.kind !== "direct") {
+      return;
+    }
+    const scalarArg = selectedScalarArgs.get(paramIndex);
+    if (scalarArg) {
+      selectedScalarArgsByArgIndex.set(entry.argIndex, scalarArg);
+    }
+  });
+  const scalarOverrideArgIndexes = new Set(selectedScalarArgsByArgIndex.keys());
+
   const consumedArgs = call.args.slice(0, planned.consumedArgCount);
   const preservedArgIndexes = collectPreservedStorageRefArgIndexes({
     plan: planned.plan,
@@ -174,6 +313,21 @@ export const compileCallArgumentsForParamsWithDetails = ({
     allArgExprIds: allCallArgExprIds ?? call.args.map((arg) => arg.expr),
     expectedTypeIdAt: (index) => planned.expectedTypeByArgIndex.get(index),
     preserveStorageRefsAt: (index) => preservedArgIndexes.has(index + argIndexOffset),
+    compileOverrideAt: (_arg, index) => {
+      const scalarArg = selectedScalarArgsByArgIndex.get(index);
+      if (!scalarArg) {
+        return undefined;
+      }
+      return {
+        expr: scalarAggregateArgumentValueForCallArg({
+          arg: scalarArg,
+          ctx,
+          fnCtx,
+          compileExpr,
+        }),
+        skipCoercion: true,
+      };
+    },
     ctx,
     fnCtx,
     compileExpr,
@@ -183,15 +337,210 @@ export const compileCallArgumentsForParamsWithDetails = ({
     plan: planned.plan,
     compiledArgs,
     callArgs: call.args,
-    paramTypeIds: params.map((param) => param.typeId),
-    paramAbiKinds,
+    paramTypeIds: resolvedMeta?.paramTypeIds ?? params.map((param) => param.typeId),
+    paramAbiKinds: resolvedMeta?.paramAbiKinds ?? paramAbiKinds,
+    scalarOverrideArgIndexes,
     typeInstanceId,
     ctx,
     fnCtx,
     compileExpr,
   });
 
-  return { args, consumedArgCount: planned.consumedArgCount };
+  return {
+    args,
+    consumedArgCount: planned.consumedArgCount,
+    meta: resolvedMeta ?? meta,
+  };
+};
+
+const collectScalarAggregateCallArgs = ({
+  plan,
+  callArgs,
+  meta,
+  ctx,
+  fnCtx,
+}: {
+  plan: readonly CallArgumentPlanEntry[];
+  callArgs: readonly HirCallExpr["args"][number][];
+  meta: FunctionMetadata;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): Map<number, ScalarAggregateCallArg> => {
+  const bindings = new Map<number, ScalarAggregateCallArg>();
+  plan.forEach((entry, paramIndex) => {
+    if (
+      entry.kind !== "direct" ||
+      entry.argIndex !== 0 ||
+      meta.paramAbiKinds[paramIndex] !== "direct" ||
+      !scalarAggregateParameterCanUseSpecializedAbi({ meta, paramIndex, ctx })
+    ) {
+      return;
+    }
+    const argExprId = callArgs[entry.argIndex]?.expr;
+    const argExpr = ctx.module.hir.expressions.get(argExprId);
+    if (!argExpr) {
+      return;
+    }
+    if (argExpr.exprKind === "identifier") {
+      const binding = fnCtx.bindings.get(argExpr.symbol);
+      if (
+        binding?.kind === "scalar-aggregate" &&
+        binding.typeId === meta.paramTypeIds[paramIndex]
+      ) {
+        bindings.set(paramIndex, {
+          kind: "binding",
+          symbol: argExpr.symbol,
+          typeId: meta.paramTypeIds[paramIndex]!,
+        });
+      }
+      return;
+    }
+    const typeId = meta.paramTypeIds[paramIndex];
+    const structInfo =
+      typeof typeId === "number" ? getStructuralTypeInfo(typeId, ctx) : undefined;
+    if (
+      typeof argExprId !== "number" ||
+      typeof typeId !== "number" ||
+      !structInfo ||
+      (structInfo.layoutKind === "heap-object" &&
+        heapObjectScalarArgumentNeedsProducerSpecialization({
+          exprId: argExprId,
+          ctx,
+        })) ||
+      !canStoreScalarAggregateExpression({
+        exprId: argExprId,
+        targetTypeId: typeId,
+        structInfo,
+        ctx,
+      })
+    ) {
+      return;
+    }
+    bindings.set(paramIndex, { kind: "expression", exprId: argExprId, typeId });
+  });
+  return bindings;
+};
+
+const scalarAggregateArgumentValueForCallArg = ({
+  arg,
+  ctx,
+  fnCtx,
+  compileExpr,
+}: {
+  arg: ScalarAggregateCallArg;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+}): binaryen.ExpressionRef => {
+  if (arg.kind === "binding") {
+    const binding = getRequiredBinding(arg.symbol, ctx, fnCtx);
+    if (binding.kind === "scalar-aggregate" && binding.typeId === arg.typeId) {
+      return scalarAggregateArgumentValue({ binding, ctx, fnCtx });
+    }
+    const structInfo = getStructuralTypeInfo(arg.typeId, ctx);
+    if (!structInfo) {
+      throw new Error("scalar aggregate binding argument requires a structural type");
+    }
+    const scalarBinding = createScalarAggregateTempBinding({
+      typeId: arg.typeId,
+      structInfo,
+      ctx,
+      fnCtx,
+    });
+    const setup = [
+      storeScalarAggregateBindingValue({
+        binding: scalarBinding,
+        value: loadBindingValue(binding, ctx, fnCtx),
+        ctx,
+        fnCtx,
+      }),
+    ];
+    const value = scalarAggregateArgumentValue({
+      binding: scalarBinding,
+      ctx,
+      fnCtx,
+    });
+    return ctx.mod.block(
+      null,
+      [...setup, value],
+      binaryen.getExpressionType(value),
+    );
+  }
+  const structInfo = getStructuralTypeInfo(arg.typeId, ctx);
+  if (!structInfo) {
+    throw new Error("scalar aggregate call argument requires a structural type");
+  }
+  const binding = createScalarAggregateTempBinding({
+    typeId: arg.typeId,
+    structInfo,
+    ctx,
+    fnCtx,
+  });
+  const setup = tryStoreScalarAggregateExpression({
+    binding,
+    exprId: arg.exprId,
+    targetTypeId: arg.typeId,
+    ctx,
+    fnCtx,
+    compileExpr,
+  });
+  if (!setup) {
+    throw new Error("scalar aggregate call argument is not scalarizable");
+  }
+  const value = scalarAggregateArgumentValue({ binding, ctx, fnCtx });
+  return ctx.mod.block(
+    null,
+    [...setup, value],
+    binaryen.getExpressionType(value),
+  );
+};
+
+const scalarAggregateArgumentValue = ({
+  binding,
+  ctx,
+  fnCtx,
+}: {
+  binding: LocalBindingScalarAggregate;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  const setup: binaryen.ExpressionRef[] = [];
+  const lanes: binaryen.ExpressionRef[] = [];
+  const laneTypes: binaryen.Type[] = [];
+
+  binding.structInfo.fields.forEach((field) => {
+    const value = loadScalarAggregateBindingField({
+      binding,
+      fieldName: field.name,
+      ctx,
+    });
+    if (typeof value !== "number") {
+      throw new Error(`scalar aggregate missing field ${field.name}`);
+    }
+    const fieldAbiTypes = [...binaryen.expandType(field.wasmType)];
+    laneTypes.push(...fieldAbiTypes);
+    if (fieldAbiTypes.length <= 1) {
+      lanes.push(value);
+      return;
+    }
+    const captured = captureMultivalueLanes({
+      value,
+      abiTypes: fieldAbiTypes,
+      ctx,
+      fnCtx,
+    });
+    setup.push(...captured.setup);
+    lanes.push(...captured.lanes);
+  });
+
+  const value =
+    lanes.length === 1
+      ? lanes[0]!
+      : ctx.mod.tuple.make(lanes as binaryen.ExpressionRef[]);
+  if (setup.length === 0) {
+    return value;
+  }
+  return ctx.mod.block(null, [...setup, value], abiTypeFor(laneTypes));
 };
 
 export const resolveTypedCallArgumentPlan = ({
@@ -541,6 +890,7 @@ const materializeCallArgumentPlan = ({
   callArgs,
   paramTypeIds,
   paramAbiKinds,
+  scalarOverrideArgIndexes,
   typeInstanceId,
   ctx,
   fnCtx,
@@ -551,6 +901,7 @@ const materializeCallArgumentPlan = ({
   callArgs: readonly HirCallExpr["args"][number][];
   paramTypeIds: readonly TypeId[];
   paramAbiKinds?: readonly string[];
+  scalarOverrideArgIndexes?: ReadonlySet<number>;
   typeInstanceId: ProgramFunctionInstanceId | undefined;
   ctx: CodegenContext;
   fnCtx: FunctionContext;
@@ -575,6 +926,7 @@ const materializeCallArgumentPlan = ({
         argValue: compiledArgs[entry.argIndex]!,
         paramTypeId,
         abiKind,
+        scalarOverride: scalarOverrideArgIndexes?.has(entry.argIndex) ?? false,
         ctx,
         fnCtx,
         compileExpr,
@@ -627,6 +979,32 @@ const materializeCallArgumentPlan = ({
     const field = containerInfo.fieldMap.get(entry.fieldName);
     if (!field) {
       throw new Error(`missing field ${entry.fieldName} in labeled-argument container`);
+    }
+
+    const scalarFieldValue =
+      abiKind === "mutable_ref"
+        ? undefined
+        : loadScalarContainerFieldValue({
+            containerExprId: containerArg.expr,
+            fieldName: entry.fieldName,
+            ctx,
+            fnCtx,
+          });
+    if (typeof scalarFieldValue === "number") {
+      return lowerCallArgumentForAbi({
+        argValue: coerceValueToType({
+          value: scalarFieldValue,
+          actualType: field.typeId,
+          targetType: entry.targetTypeId,
+          ctx,
+          fnCtx,
+        }),
+        paramTypeId,
+        abiKind,
+        ctx,
+        fnCtx,
+        compileExpr,
+      });
     }
 
     const existingTemp = containerTemps.get(entry.containerArgIndex);
@@ -747,6 +1125,32 @@ const materializeCallArgumentPlan = ({
   });
 };
 
+const loadScalarContainerFieldValue = ({
+  containerExprId,
+  fieldName,
+  ctx,
+  fnCtx,
+}: {
+  containerExprId: HirExprId;
+  fieldName: string;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef | undefined => {
+  const expr = ctx.module.hir.expressions.get(containerExprId);
+  if (expr?.exprKind !== "identifier") {
+    return undefined;
+  }
+  const binding = fnCtx.bindings.get(expr.symbol);
+  if (binding?.kind !== "scalar-aggregate") {
+    return undefined;
+  }
+  return loadScalarAggregateBindingField({
+    binding,
+    fieldName,
+    ctx,
+  });
+};
+
 const collectPreservedStorageRefArgIndexes = ({
   plan,
   paramAbiKinds,
@@ -778,6 +1182,7 @@ const lowerCallArgumentForAbi = ({
   addressableValue,
   paramTypeId,
   abiKind,
+  scalarOverride = false,
   ctx,
   fnCtx,
   compileExpr,
@@ -787,11 +1192,36 @@ const lowerCallArgumentForAbi = ({
   addressableValue?: binaryen.ExpressionRef;
   paramTypeId?: TypeId;
   abiKind?: string;
+  scalarOverride?: boolean;
   ctx: CodegenContext;
   fnCtx: FunctionContext;
   compileExpr: ExpressionCompiler;
 }): binaryen.ExpressionRef => {
   if (abiKind !== "readonly_ref" && abiKind !== "mutable_ref") {
+    if (!scalarOverride && typeof argExprId === "number") {
+      const argExpr = ctx.module.hir.expressions.get(argExprId);
+      if (argExpr?.exprKind === "identifier") {
+        const binding = fnCtx.bindings.get(argExpr.symbol);
+        if (
+          binding?.kind === "scalar-aggregate" &&
+          binding.structInfo.layoutKind === "heap-object"
+        ) {
+          const materialized = materializeOwnedBinding({
+            symbol: argExpr.symbol,
+            ctx,
+            fnCtx,
+          });
+          const value = loadBindingValue(materialized.binding, ctx, fnCtx);
+          return materialized.setup.length === 0
+            ? value
+            : ctx.mod.block(
+                null,
+                [...materialized.setup, value],
+                binaryen.getExpressionType(value),
+              );
+        }
+      }
+    }
     return argValue;
   }
   if (typeof paramTypeId !== "number") {

--- a/packages/compiler/src/codegen/expressions/call/entrypoints.ts
+++ b/packages/compiler/src/codegen/expressions/call/entrypoints.ts
@@ -18,13 +18,16 @@ import type {
 import { compileIntrinsicCall } from "../../intrinsics.js";
 import { effectsFacade } from "../../effects/facade.js";
 import { getRequiredExprType } from "../../types.js";
-import { compileCallArguments } from "./arguments.js";
+import {
+  compileCallArgumentsWithMetadata,
+} from "./arguments.js";
 import { compileClosureCall, compileCurriedClosureCall } from "./closure.js";
 import { getFunctionMetadataForCall } from "./metadata.js";
 import { emitResolvedCall } from "./resolved-call.js";
 import { compileTraitDispatchCall } from "./trait-dispatch.js";
 import { compileCallArgExpressionsWithTemps } from "./shared.js";
 import { getOrCreateReceiverSpecialization } from "../../receiver-specialization.js";
+import { getOrCreateScalarAggregateCallSpecialization } from "../../optimization/scalar-aggregate-calls.js";
 
 export const compileCallExpr = (
   expr: HirCallExpr,
@@ -88,6 +91,7 @@ export const compileCallExpr = (
       expectedResultTypeId,
       typeInstanceId,
       outResultStorageRef,
+      scalarAggregateResultTypeId: options.scalarAggregateResultTypeId,
     });
   }
 
@@ -127,6 +131,7 @@ export const compileCallExpr = (
         expectedResultTypeId,
         typeInstanceId,
         outResultStorageRef,
+        scalarAggregateResultTypeId: options.scalarAggregateResultTypeId,
       });
     }
 
@@ -197,16 +202,21 @@ export const compileCallExpr = (
         ctx,
         fnCtx,
       });
-      const args = compileCallArguments({
+      const compiledArgs = compileCallArgumentsWithMetadata({
         call: expr,
         meta: resolvedMeta,
         ctx,
         fnCtx,
         compileExpr,
       });
+      const callMeta = scalarResultSpecializedMetaForCall({
+        meta: compiledArgs.meta,
+        scalarAggregateResultTypeId: options.scalarAggregateResultTypeId,
+        ctx,
+      });
       return emitResolvedCall({
-        meta: resolvedMeta,
-        args,
+        meta: callMeta,
+        args: compiledArgs.args,
         callId: expr.id,
         ctx,
         fnCtx,
@@ -312,16 +322,21 @@ export const compileMethodCallExpr = (
     fnCtx,
   });
 
-  const args = compileCallArguments({
+  const compiledArgs = compileCallArgumentsWithMetadata({
     call: callView,
     meta: resolvedMeta,
     ctx,
     fnCtx,
     compileExpr,
   });
+  const callMeta = scalarResultSpecializedMetaForCall({
+    meta: compiledArgs.meta,
+    scalarAggregateResultTypeId: options.scalarAggregateResultTypeId,
+    ctx,
+  });
   return emitResolvedCall({
-    meta: resolvedMeta,
-    args,
+    meta: callMeta,
+    args: compiledArgs.args,
     callId: expr.id,
     ctx,
     fnCtx,
@@ -417,6 +432,7 @@ const compileResolvedSymbolCall = ({
   expectedResultTypeId,
   typeInstanceId,
   outResultStorageRef,
+  scalarAggregateResultTypeId,
 }: {
   expr: HirCallExpr;
   symbol: number;
@@ -430,6 +446,7 @@ const compileResolvedSymbolCall = ({
   expectedResultTypeId?: TypeId;
   typeInstanceId: ProgramFunctionInstanceId | undefined;
   outResultStorageRef?: CompileCallOptions["outResultStorageRef"];
+  scalarAggregateResultTypeId?: TypeId;
 }): CompiledExpression => {
   const traitDispatch = traitDispatchEnabled
     ? compileTraitDispatchCall({
@@ -502,16 +519,21 @@ const compileResolvedSymbolCall = ({
     fnCtx,
   });
 
-  const args = compileCallArguments({
+  const compiledArgs = compileCallArgumentsWithMetadata({
     call: expr,
     meta: resolvedMeta,
     ctx,
     fnCtx,
     compileExpr,
   });
+  const callMeta = scalarResultSpecializedMetaForCall({
+    meta: compiledArgs.meta,
+    scalarAggregateResultTypeId,
+    ctx,
+  });
   return emitResolvedCall({
-    meta: resolvedMeta,
-    args,
+    meta: callMeta,
+    args: compiledArgs.args,
     callId: expr.id,
     ctx,
     fnCtx,
@@ -522,6 +544,26 @@ const compileResolvedSymbolCall = ({
       outResultStorageRef,
     },
   });
+};
+
+const scalarResultSpecializedMetaForCall = ({
+  meta,
+  scalarAggregateResultTypeId,
+  ctx,
+}: {
+  meta: FunctionMetadata;
+  scalarAggregateResultTypeId?: TypeId;
+  ctx: CodegenContext;
+}): FunctionMetadata => {
+  if (typeof scalarAggregateResultTypeId !== "number") {
+    return meta;
+  }
+  return getOrCreateScalarAggregateCallSpecialization({
+    ctx,
+    meta,
+    paramIndexes: new Set(meta.scalarAggregateParamIndexes ?? []),
+    scalarResultTypeId: scalarAggregateResultTypeId,
+  }) ?? meta;
 };
 
 const getCalleeTypeId = ({

--- a/packages/compiler/src/codegen/expressions/call/resolved-call.ts
+++ b/packages/compiler/src/codegen/expressions/call/resolved-call.ts
@@ -13,6 +13,7 @@ import {
   loadBindingStorageRef,
   loadBindingValue,
   loadLocalValue,
+  materializeOwnedBinding,
   storeLocalValue,
 } from "../../locals.js";
 import {
@@ -155,6 +156,7 @@ export const emitResolvedCall = ({
         })
       : undefined;
   const resolvedMeta = staticSpecializedMeta ?? meta;
+  const argSetups: binaryen.ExpressionRef[] = [];
   const staticCaptureArgs =
     staticSpecializedMeta && fnCtx.staticEffectContext
       ? fnCtx.staticEffectContext.captures.map((capture) => {
@@ -163,23 +165,34 @@ export const emitResolvedCall = ({
             throw new Error("missing static effect capture binding");
           }
           if (capture.mode === "storage-ref") {
-            const storageRef = loadBindingStorageRef(binding, ctx);
+            let storageRef = loadBindingStorageRef(binding, ctx);
+            if (!storageRef && binding.kind === "scalar-aggregate") {
+              const materialized = materializeOwnedBinding({
+                symbol: capture.symbol,
+                ctx,
+                fnCtx,
+              });
+              argSetups.push(...materialized.setup);
+              storageRef = loadBindingStorageRef(materialized.binding, ctx);
+            }
             if (!storageRef) {
               throw new Error("missing static effect capture storage ref");
             }
             return storageRef;
           }
           return loadBindingValue(binding, ctx, fnCtx);
-        })
+      })
       : [];
 
-  const argSetups: binaryen.ExpressionRef[] = [];
   const allArgs = [...args, ...staticCaptureArgs];
   const userArgs = allArgs.flatMap((arg, index) => {
+    const typeId = resolvedMeta.scalarAggregateParamIndexes?.includes(index)
+      ? undefined
+      : resolvedMeta.paramTypeIds[index];
     const flattened = flattenAbiArgument(
       arg,
       resolvedMeta.paramAbiTypes[index] ?? [binaryen.getExpressionType(arg)],
-      resolvedMeta.paramTypeIds[index],
+      typeId,
     );
     argSetups.push(...flattened.setup);
     return flattened.args;
@@ -326,6 +339,21 @@ export const emitResolvedCall = ({
     rawCall,
     resolvedMeta.resultAbiTypes,
   );
+  if (resolvedMeta.scalarAggregateResult) {
+    const callExpr =
+      argSetups.length === 0
+        ? stabilizedCall
+        : ctx.mod.block(
+            null,
+            [...argSetups, stabilizedCall],
+            binaryen.getExpressionType(stabilizedCall),
+          );
+    return {
+      expr: callExpr,
+      usedReturnCall: false,
+      usedScalarAggregateResult: true,
+    };
+  }
   const decodedCall =
     getSignatureSpillBoxType({ typeId: resolvedMeta.resultTypeId, ctx }) ===
     resolvedMeta.resultType

--- a/packages/compiler/src/codegen/expressions/call/shared.ts
+++ b/packages/compiler/src/codegen/expressions/call/shared.ts
@@ -95,6 +95,7 @@ export const compileCallArgExpressionsWithTemps = ({
   allArgExprIds,
   expectedTypeIdAt,
   preserveStorageRefsAt,
+  compileOverrideAt,
   ctx,
   fnCtx,
   compileExpr,
@@ -105,6 +106,10 @@ export const compileCallArgExpressionsWithTemps = ({
   allArgExprIds?: readonly HirExprId[];
   expectedTypeIdAt: (index: number) => TypeId | undefined;
   preserveStorageRefsAt?: (index: number) => boolean;
+  compileOverrideAt?: (
+    arg: { expr: HirExprId },
+    index: number,
+  ) => { expr: binaryen.ExpressionRef; skipCoercion?: boolean } | undefined;
   ctx: CodegenContext;
   fnCtx: FunctionContext;
   compileExpr: ExpressionCompiler;
@@ -141,15 +146,27 @@ export const compileCallArgExpressionsWithTemps = ({
 
   return args.map((arg, index) => {
     const expectedTypeId = expectedTypeIdAt(index);
-    const expr = ctx.module.hir.expressions.get(arg.expr);
-    const actualTypeId =
-      expr?.exprKind === "identifier"
-        ? (fnCtx.bindings.get(expr.symbol)?.typeId ??
-          getUnresolvedExprType(arg.expr, ctx, typeInstanceId))
-        : getUnresolvedExprType(arg.expr, ctx, typeInstanceId);
     const tempId = tempsByIndex.get(index + offset);
+    const compileValue = (): binaryen.ExpressionRef => {
+      const override = compileOverrideAt?.(arg, index);
+      if (override) {
+        return override.skipCoercion
+          ? override.expr
+          : coerceValueToType({
+              value: override.expr,
+              actualType: getUnresolvedExprType(arg.expr, ctx, typeInstanceId),
+              targetType: expectedTypeId,
+              ctx,
+              fnCtx,
+            });
+      }
 
-    if (typeof tempId !== "number") {
+      const expr = ctx.module.hir.expressions.get(arg.expr);
+      const actualTypeId =
+        expr?.exprKind === "identifier"
+          ? (fnCtx.bindings.get(expr.symbol)?.typeId ??
+            getUnresolvedExprType(arg.expr, ctx, typeInstanceId))
+          : getUnresolvedExprType(arg.expr, ctx, typeInstanceId);
       const value = compileExpr({
         exprId: arg.expr,
         ctx,
@@ -163,27 +180,19 @@ export const compileCallArgExpressionsWithTemps = ({
         ctx,
         fnCtx,
       });
+    };
+
+    if (typeof tempId !== "number") {
+      return compileValue();
     }
 
     const tempLocal = getOrCreateTempLocal({ tempId, ctx, fnCtx });
-    const value = compileExpr({
-      exprId: arg.expr,
-      ctx,
-      fnCtx,
-      preserveStorageRefs: preserveStorageRefsAt?.(index) ?? false,
-    });
-    const coerced = coerceValueToType({
-      value: value.expr,
-      actualType: actualTypeId,
-      targetType: expectedTypeId,
-      ctx,
-      fnCtx,
-    });
+    const value = compileValue();
 
     const compute = ctx.mod.block(
       null,
       [
-        storeLocalValue({ binding: tempLocal, value: coerced, ctx, fnCtx }),
+        storeLocalValue({ binding: tempLocal, value, ctx, fnCtx }),
         loadLocalValue(tempLocal, ctx),
       ],
       tempLocal.type

--- a/packages/compiler/src/codegen/expressions/call/types.ts
+++ b/packages/compiler/src/codegen/expressions/call/types.ts
@@ -2,6 +2,7 @@ import type binaryen from "binaryen";
 import type {
   HirCallExpr,
   HirExprId,
+  FunctionMetadata,
   TypeId,
 } from "../../context.js";
 import type { ProgramFunctionInstanceId } from "../../../semantics/ids.js";
@@ -26,6 +27,7 @@ export type CompileCallArgumentOptions = {
 export type CompiledCallArgumentsForParams = {
   args: binaryen.ExpressionRef[];
   consumedArgCount: number;
+  meta?: FunctionMetadata;
 };
 
 export type PlannedCallArguments = {

--- a/packages/compiler/src/codegen/expressions/control-flow.ts
+++ b/packages/compiler/src/codegen/expressions/control-flow.ts
@@ -86,6 +86,44 @@ const declarePatternLocals = (
   }
 };
 
+const ensurePatternLocals = (
+  pattern: HirPattern,
+  ctx: CodegenContext,
+  fnCtx: FunctionContext,
+): void => {
+  switch (pattern.kind) {
+    case "wildcard":
+      return;
+    case "identifier":
+      if (!fnCtx.bindings.has(pattern.symbol)) {
+        declareLocal(pattern.symbol, ctx, fnCtx);
+      }
+      return;
+    case "tuple":
+      pattern.elements.forEach((entry) =>
+        ensurePatternLocals(entry, ctx, fnCtx),
+      );
+      return;
+    case "destructure":
+      pattern.fields.forEach((field) =>
+        ensurePatternLocals(field.pattern, ctx, fnCtx),
+      );
+      if (pattern.spread) {
+        ensurePatternLocals(pattern.spread, ctx, fnCtx);
+      }
+      return;
+    case "type":
+      if (pattern.binding) {
+        ensurePatternLocals(pattern.binding, ctx, fnCtx);
+      }
+      return;
+    default: {
+      const unknownPattern = pattern as { kind: string };
+      throw new Error(`unsupported pattern kind ${unknownPattern.kind}`);
+    }
+  }
+};
+
 const getNominalComponent = (
   type: TypeId,
   ctx: CodegenContext,
@@ -234,6 +272,369 @@ const lowerToOutResultStorageIfNeeded = ({
     usedReturnCall: normalized.usedReturnCall,
     usedOutResultStorageRef: true,
   };
+};
+
+const getMatchPatternTypeIdForPattern = (
+  pattern: HirPattern,
+  ctx: CodegenContext,
+): TypeId | undefined => {
+  if (pattern.kind === "wildcard") return undefined;
+  if (pattern.kind === "type") {
+    return getMatchPatternTypeId(pattern, ctx);
+  }
+  if (typeof pattern.typeId === "number") {
+    return pattern.typeId;
+  }
+  return undefined;
+};
+
+interface MatchDiscriminantState {
+  typeId: TypeId;
+  temp: LocalBindingLocal;
+  init: binaryen.ExpressionRef;
+  load: () => binaryen.ExpressionRef;
+  symbol?: number;
+}
+
+const prepareMatchDiscriminant = ({
+  expr,
+  ctx,
+  fnCtx,
+  compileExpr,
+}: {
+  expr: HirMatchExpr;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+}): MatchDiscriminantState => {
+  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+  const discriminantTypeId = getRequiredExprType(
+    expr.discriminant,
+    ctx,
+    typeInstanceId,
+  );
+  const discriminantType = wasmTypeFor(discriminantTypeId, ctx);
+  const discriminantTemp = allocateTempLocal(
+    discriminantType,
+    fnCtx,
+    discriminantTypeId,
+    ctx,
+  );
+  const discriminantValue = coerceValueToType({
+    value: compileExpr({
+      exprId: expr.discriminant,
+      ctx,
+      fnCtx,
+      expectedResultTypeId: discriminantTypeId,
+    }).expr,
+    actualType: discriminantTypeId,
+    targetType: discriminantTypeId,
+    ctx,
+    fnCtx,
+  });
+  const inlineDiscriminantLayout = shouldInlineUnionLayout(discriminantTypeId, ctx)
+    ? getInlineUnionLayout(discriminantTypeId, ctx)
+    : undefined;
+  const discriminantLaneTemps =
+    inlineDiscriminantLayout && inlineDiscriminantLayout.abiTypes.length > 1
+      ? inlineDiscriminantLayout.abiTypes.map((type) =>
+          allocateTempLocal(type, fnCtx),
+        )
+      : undefined;
+  const loadStoredDiscriminant = (): binaryen.ExpressionRef => {
+    if (discriminantLaneTemps) {
+      const lanes = discriminantLaneTemps.map((lane) =>
+        loadLocalValue(lane, ctx),
+      );
+      return lanes.length === 1
+        ? lanes[0]!
+        : ctx.mod.tuple.make(lanes as binaryen.ExpressionRef[]);
+    }
+    return loadLocalValue(discriminantTemp, ctx);
+  };
+  const initDiscriminant = discriminantLaneTemps
+    ? (() => {
+        const captured = captureMultivalueLanes({
+          value: coerceExprToWasmType({
+            expr: discriminantValue,
+            targetType: inlineDiscriminantLayout!.interfaceType,
+            ctx,
+          }),
+          abiTypes: inlineDiscriminantLayout!.abiTypes,
+          ctx,
+          fnCtx,
+        });
+        return ctx.mod.block(
+          null,
+          [
+            ...captured.setup,
+            ...discriminantLaneTemps.map((lane, index) =>
+              storeLocalValue({
+                binding: lane,
+                value: captured.lanes[index]!,
+                ctx,
+                fnCtx,
+              }),
+            ),
+          ],
+          binaryen.none,
+        );
+      })()
+    : storeLocalValue({
+        binding: discriminantTemp,
+        value: discriminantValue,
+        ctx,
+        fnCtx,
+      });
+  const discriminantExpr = ctx.module.hir.expressions.get(expr.discriminant);
+  const discriminantSymbol =
+    discriminantExpr?.exprKind === "identifier" ? discriminantExpr.symbol : undefined;
+
+  return {
+    typeId: discriminantTypeId,
+    temp: discriminantTemp,
+    init: initDiscriminant,
+    load: loadStoredDiscriminant,
+    symbol: discriminantSymbol,
+  };
+};
+
+const compileMatchArmValueWithBindings = ({
+  matchExpr,
+  arm,
+  resultTypeId,
+  patternTypeId,
+  discriminant,
+  ctx,
+  fnCtx,
+  compileExpr,
+  tailPosition,
+  outResultStorageRef,
+}: {
+  matchExpr: HirMatchExpr;
+  arm: HirMatchExpr["arms"][number];
+  resultTypeId: TypeId;
+  patternTypeId: TypeId;
+  discriminant: MatchDiscriminantState;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+  tailPosition: boolean;
+  outResultStorageRef?: binaryen.ExpressionRef;
+}): CompiledExpression =>
+  withRestoredBindings(fnCtx, () => {
+    if (arm.pattern.kind === "type" && arm.pattern.binding) {
+      declarePatternLocals(arm.pattern.binding, ctx, fnCtx);
+    } else if (arm.pattern.kind !== "wildcard") {
+      declarePatternLocals(arm.pattern, ctx, fnCtx);
+    }
+
+    const discriminantOptionalInfo = shouldInlineUnionLayout(discriminant.typeId, ctx)
+      ? getOptionalLayoutInfo(discriminant.typeId, ctx)
+      : undefined;
+    const optionalSomePayload =
+      discriminantOptionalInfo &&
+      patternTypeId === discriminantOptionalInfo.someType
+        ? (() => {
+            const someLayout = getInlineUnionLayout(discriminant.typeId, ctx).members.find(
+              (member) => member.typeId === discriminantOptionalInfo.someType,
+            );
+            if (!someLayout) {
+              throw new Error("inline optional layout is missing Some member");
+            }
+            const discriminantValue = discriminant.load();
+            if (someLayout.abiTypes.length === 0) {
+              return ctx.mod.nop();
+            }
+            if (someLayout.abiTypes.length === 1) {
+              return ctx.mod.tuple.extract(discriminantValue, someLayout.abiStart);
+            }
+            return ctx.mod.tuple.make(
+              someLayout.abiTypes.map((_, index) =>
+                ctx.mod.tuple.extract(
+                  discriminantValue,
+                  someLayout.abiStart + index,
+                ),
+              ),
+            );
+          })()
+        : undefined;
+    const narrowedDiscriminant = (): binaryen.ExpressionRef =>
+      shouldInlineUnionLayout(discriminant.typeId, ctx)
+        ? coerceValueToType({
+            value: discriminant.load(),
+            actualType: discriminant.typeId,
+            targetType: patternTypeId,
+            ctx,
+            fnCtx,
+          })
+        : coerceExprToWasmType({
+            expr: discriminant.load(),
+            targetType: wasmTypeFor(patternTypeId, ctx),
+            ctx,
+          });
+
+    const bindingOps: binaryen.ExpressionRef[] = [];
+    if (arm.pattern.kind === "type" && arm.pattern.binding) {
+      const projectedOptionalPayloadOps =
+        typeof optionalSomePayload !== "undefined"
+          ? tryCompileProjectedOptionalPayloadBinding({
+              pattern: arm.pattern.binding,
+              optionalExprId: matchExpr.discriminant,
+              armValueExprId: arm.value,
+              ctx,
+              fnCtx,
+              compileExpr,
+            })
+          : undefined;
+      if (projectedOptionalPayloadOps) {
+        bindingOps.push(...projectedOptionalPayloadOps);
+      } else if (
+        typeof optionalSomePayload !== "undefined" &&
+        arm.pattern.binding.kind === "identifier"
+      ) {
+        compilePatternInitializationFromValue({
+          pattern: arm.pattern.binding,
+          value: optionalSomePayload,
+          valueTypeId: discriminantOptionalInfo!.innerType,
+          ctx,
+          fnCtx,
+          ops: bindingOps,
+          options: { declare: true },
+        });
+      } else if (
+        typeof optionalSomePayload !== "undefined" &&
+        arm.pattern.binding.kind === "destructure" &&
+        !arm.pattern.binding.spread &&
+        arm.pattern.binding.fields.length === 1 &&
+        arm.pattern.binding.fields[0]!.name === "value"
+      ) {
+        compilePatternInitializationFromValue({
+          pattern: arm.pattern.binding.fields[0]!.pattern,
+          value: optionalSomePayload,
+          valueTypeId: discriminantOptionalInfo!.innerType,
+          ctx,
+          fnCtx,
+          ops: bindingOps,
+          options: { declare: true },
+        });
+      } else {
+        compilePatternInitializationFromValue({
+          pattern: arm.pattern.binding,
+          value: narrowedDiscriminant(),
+          valueTypeId: patternTypeId,
+          ctx,
+          fnCtx,
+          ops: bindingOps,
+          options: { declare: true },
+        });
+      }
+    } else if (arm.pattern.kind !== "type") {
+      compilePatternInitializationFromValue({
+        pattern: arm.pattern,
+        value: narrowedDiscriminant(),
+        valueTypeId: patternTypeId,
+        ctx,
+        fnCtx,
+        ops: bindingOps,
+        options: { declare: true },
+      });
+    }
+
+    if (typeof discriminant.symbol === "number") {
+      const narrowedBinding = allocateTempLocal(
+        wasmTypeFor(patternTypeId, ctx),
+        fnCtx,
+        patternTypeId,
+        ctx,
+      );
+      bindingOps.push(
+        storeLocalValue({
+          binding: narrowedBinding,
+          value: coerceValueToType({
+            value: narrowedDiscriminant(),
+            actualType: patternTypeId,
+            targetType: patternTypeId,
+            ctx,
+            fnCtx,
+          }),
+          ctx,
+          fnCtx,
+        }),
+      );
+      fnCtx.bindings.set(discriminant.symbol, {
+        ...narrowedBinding,
+        kind: "local",
+        typeId: patternTypeId,
+      });
+    }
+
+    const armValue = lowerToOutResultStorageIfNeeded({
+      compiled: compileExpr({
+        exprId: arm.value,
+        ctx,
+        fnCtx,
+        tailPosition,
+        expectedResultTypeId: resultTypeId,
+        outResultStorageRef,
+      }),
+      exprId: arm.value,
+      resultTypeId,
+      outResultStorageRef,
+      ctx,
+      fnCtx,
+    });
+    return bindingOps.length === 0
+      ? armValue
+      : {
+          expr: ctx.mod.block(
+            null,
+            [...bindingOps, armValue.expr],
+            binaryen.getExpressionType(armValue.expr),
+          ),
+          usedReturnCall: armValue.usedReturnCall,
+          usedOutResultStorageRef: armValue.usedOutResultStorageRef,
+        };
+  });
+
+export const compileKnownMatchArmValue = ({
+  expr,
+  arm,
+  ctx,
+  fnCtx,
+  compileExpr,
+  tailPosition,
+  expectedResultTypeId,
+}: {
+  expr: HirMatchExpr;
+  arm: HirMatchExpr["arms"][number];
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+  tailPosition: boolean;
+  expectedResultTypeId?: TypeId;
+}): CompiledExpression => {
+  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+  const resultTypeId =
+    expectedResultTypeId ?? getRequiredExprType(expr.id, ctx, typeInstanceId);
+
+  return normalizeOutResultStorageForwarding({
+    compiled: withRestoredBindings(fnCtx, () => {
+      if (arm.pattern.kind === "type" && arm.pattern.binding) {
+        ensurePatternLocals(arm.pattern.binding, ctx, fnCtx);
+      } else if (arm.pattern.kind !== "wildcard") {
+        ensurePatternLocals(arm.pattern, ctx, fnCtx);
+      }
+
+      return compileExpr({
+        exprId: arm.value,
+        ctx,
+        fnCtx,
+        tailPosition,
+        expectedResultTypeId: resultTypeId,
+      });
+    }),
+  });
 };
 
 export const compileIfExpr = (
@@ -387,63 +788,14 @@ export const compileMatchExpr = (
   const resultTypeId =
     expectedResultTypeId ?? getRequiredExprType(expr.id, ctx, typeInstanceId);
   const resultType = wasmTypeFor(resultTypeId, ctx);
-  const discriminantTypeId = getRequiredExprType(expr.discriminant, ctx, typeInstanceId);
-  const discriminantType = wasmTypeFor(discriminantTypeId, ctx);
-  const discriminantTemp = allocateTempLocal(
-    discriminantType,
-    fnCtx,
-    discriminantTypeId,
-    ctx,
-  );
-  const discriminantValue = coerceValueToType({
-    value: compileExpr({
-      exprId: expr.discriminant,
-      ctx,
-      fnCtx,
-      expectedResultTypeId: discriminantTypeId,
-    }).expr,
-    actualType: discriminantTypeId,
-    targetType: discriminantTypeId,
-    ctx,
-    fnCtx,
-  });
-  const inlineDiscriminantLayout = shouldInlineUnionLayout(discriminantTypeId, ctx)
-    ? getInlineUnionLayout(discriminantTypeId, ctx)
-    : undefined;
-  const discriminantLaneTemps =
-    inlineDiscriminantLayout && inlineDiscriminantLayout.abiTypes.length > 1
-      ? inlineDiscriminantLayout.abiTypes.map((type) =>
-          allocateTempLocal(type, fnCtx),
-        )
-      : undefined;
-  const loadStoredDiscriminant = (): binaryen.ExpressionRef => {
-    if (discriminantLaneTemps) {
-      const lanes = discriminantLaneTemps.map((lane) =>
-        loadLocalValue(lane, ctx),
-      );
-      return lanes.length === 1
-        ? lanes[0]!
-        : ctx.mod.tuple.make(lanes as binaryen.ExpressionRef[]);
-    }
-    return loadLocalValue(discriminantTemp, ctx);
-  };
-
-  const patternTypeIdFor = (pattern: HirPattern): TypeId | undefined => {
-    if (pattern.kind === "wildcard") return undefined;
-    if (pattern.kind === "type") {
-      return getMatchPatternTypeId(pattern, ctx);
-    }
-    if (typeof pattern.typeId === "number") {
-      return pattern.typeId;
-    }
-    return undefined;
-  };
+  const discriminant = prepareMatchDiscriminant({ expr, ctx, fnCtx, compileExpr });
+  const discriminantTypeId = discriminant.typeId;
 
   const duplicateNominals = (() => {
     const seen = new Set<TypeId>();
     const dupes = new Set<TypeId>();
     expr.arms.forEach((arm) => {
-      const typeId = patternTypeIdFor(arm.pattern);
+      const typeId = getMatchPatternTypeIdForPattern(arm.pattern, ctx);
       if (typeof typeId !== "number") {
         return;
       }
@@ -459,44 +811,6 @@ export const compileMatchExpr = (
     });
     return dupes;
   })();
-
-  const initDiscriminant = discriminantLaneTemps
-    ? (() => {
-        const captured = captureMultivalueLanes({
-          value: coerceExprToWasmType({
-            expr: discriminantValue,
-            targetType: inlineDiscriminantLayout!.interfaceType,
-            ctx,
-          }),
-          abiTypes: inlineDiscriminantLayout!.abiTypes,
-          ctx,
-          fnCtx,
-        });
-        return ctx.mod.block(
-          null,
-          [
-            ...captured.setup,
-            ...discriminantLaneTemps.map((lane, index) =>
-              storeLocalValue({
-                binding: lane,
-                value: captured.lanes[index]!,
-                ctx,
-                fnCtx,
-              }),
-            ),
-          ],
-          binaryen.none,
-        );
-      })()
-    : storeLocalValue({
-        binding: discriminantTemp,
-        value: discriminantValue,
-        ctx,
-        fnCtx,
-      });
-  const discriminantExpr = ctx.module.hir.expressions.get(expr.discriminant);
-  const discriminantSymbol =
-    discriminantExpr?.exprKind === "identifier" ? discriminantExpr.symbol : undefined;
 
   let chain: CompiledExpression | undefined;
   for (let index = expr.arms.length - 1; index >= 0; index -= 1) {
@@ -547,7 +861,7 @@ export const compileMatchExpr = (
       continue;
     }
 
-    const patternTypeId = patternTypeIdFor(arm.pattern);
+    const patternTypeId = getMatchPatternTypeIdForPattern(arm.pattern, ctx);
     if (typeof patternTypeId !== "number") {
       throw new Error(
         `match pattern missing type annotation (${arm.pattern.kind})`,
@@ -557,185 +871,23 @@ export const compileMatchExpr = (
     const condition = compileMatchCondition(
       patternTypeId,
       discriminantTypeId,
-      loadStoredDiscriminant,
-      discriminantTemp,
+      discriminant.load,
+      discriminant.temp,
       ctx,
       duplicateNominals,
     );
 
-    const discriminantOptionalInfo = shouldInlineUnionLayout(discriminantTypeId, ctx)
-      ? getOptionalLayoutInfo(discriminantTypeId, ctx)
-      : undefined;
-    const optionalSomePayload =
-      discriminantOptionalInfo &&
-      patternTypeId === discriminantOptionalInfo.someType
-        ? (() => {
-            const someLayout = getInlineUnionLayout(discriminantTypeId, ctx).members.find(
-              (member) => member.typeId === discriminantOptionalInfo.someType,
-            );
-            if (!someLayout) {
-              throw new Error("inline optional layout is missing Some member");
-            }
-            const discriminantValue = loadStoredDiscriminant();
-            if (someLayout.abiTypes.length === 0) {
-              return ctx.mod.nop();
-            }
-            if (someLayout.abiTypes.length === 1) {
-              return ctx.mod.tuple.extract(discriminantValue, someLayout.abiStart);
-            }
-            return ctx.mod.tuple.make(
-              someLayout.abiTypes.map((_, index) =>
-                ctx.mod.tuple.extract(
-                  discriminantValue,
-                  someLayout.abiStart + index,
-                ),
-              ),
-            );
-          })()
-        : undefined;
-    const narrowedDiscriminant = (): binaryen.ExpressionRef =>
-      shouldInlineUnionLayout(discriminantTypeId, ctx)
-        ? coerceValueToType({
-            value: loadStoredDiscriminant(),
-            actualType: discriminantTypeId,
-            targetType: patternTypeId,
-            ctx,
-            fnCtx,
-          })
-        : coerceExprToWasmType({
-            expr: loadStoredDiscriminant(),
-            targetType: wasmTypeFor(patternTypeId, ctx),
-            ctx,
-          });
-
-    const armExpr = withRestoredBindings(fnCtx, () => {
-      if (arm.pattern.kind === "type" && arm.pattern.binding) {
-        declarePatternLocals(arm.pattern.binding, ctx, fnCtx);
-      } else if (arm.pattern.kind !== "wildcard") {
-        declarePatternLocals(arm.pattern, ctx, fnCtx);
-      }
-
-      const bindingOps: binaryen.ExpressionRef[] = [];
-      if (arm.pattern.kind === "type" && arm.pattern.binding) {
-        const projectedOptionalPayloadOps =
-          typeof optionalSomePayload !== "undefined"
-            ? tryCompileProjectedOptionalPayloadBinding({
-                pattern: arm.pattern.binding,
-                optionalExprId: expr.discriminant,
-                armValueExprId: arm.value,
-                ctx,
-                fnCtx,
-                compileExpr,
-              })
-            : undefined;
-        if (projectedOptionalPayloadOps) {
-          bindingOps.push(...projectedOptionalPayloadOps);
-        } else if (
-          typeof optionalSomePayload !== "undefined" &&
-          arm.pattern.binding.kind === "identifier"
-        ) {
-          compilePatternInitializationFromValue({
-            pattern: arm.pattern.binding,
-            value: optionalSomePayload,
-            valueTypeId: discriminantOptionalInfo!.innerType,
-            ctx,
-            fnCtx,
-            ops: bindingOps,
-            options: { declare: true },
-          });
-        } else if (
-          typeof optionalSomePayload !== "undefined" &&
-          arm.pattern.binding.kind === "destructure" &&
-          !arm.pattern.binding.spread &&
-          arm.pattern.binding.fields.length === 1 &&
-          arm.pattern.binding.fields[0]!.name === "value"
-        ) {
-          compilePatternInitializationFromValue({
-            pattern: arm.pattern.binding.fields[0]!.pattern,
-            value: optionalSomePayload,
-            valueTypeId: discriminantOptionalInfo!.innerType,
-            ctx,
-            fnCtx,
-            ops: bindingOps,
-            options: { declare: true },
-          });
-        } else {
-          compilePatternInitializationFromValue({
-            pattern: arm.pattern.binding,
-            value: narrowedDiscriminant(),
-            valueTypeId: patternTypeId,
-            ctx,
-            fnCtx,
-            ops: bindingOps,
-            options: { declare: true },
-          });
-        }
-      } else if (arm.pattern.kind !== "type") {
-        compilePatternInitializationFromValue({
-          pattern: arm.pattern,
-          value: narrowedDiscriminant(),
-          valueTypeId: patternTypeId,
-          ctx,
-          fnCtx,
-          ops: bindingOps,
-          options: { declare: true },
-        });
-      }
-
-      if (typeof discriminantSymbol === "number") {
-        const narrowedBinding = allocateTempLocal(
-          wasmTypeFor(patternTypeId, ctx),
-          fnCtx,
-          patternTypeId,
-          ctx,
-        );
-        bindingOps.push(
-          storeLocalValue({
-            binding: narrowedBinding,
-            value: coerceValueToType({
-              value: narrowedDiscriminant(),
-              actualType: patternTypeId,
-              targetType: patternTypeId,
-              ctx,
-              fnCtx,
-            }),
-            ctx,
-            fnCtx,
-          }),
-        );
-        fnCtx.bindings.set(discriminantSymbol, {
-          ...narrowedBinding,
-          kind: "local",
-          typeId: patternTypeId,
-        });
-      }
-
-      const armValue = lowerToOutResultStorageIfNeeded({
-        compiled: compileExpr({
-          exprId: arm.value,
-          ctx,
-          fnCtx,
-          tailPosition,
-          expectedResultTypeId: resultTypeId,
-          outResultStorageRef,
-        }),
-        exprId: arm.value,
-        resultTypeId,
-        outResultStorageRef,
-        ctx,
-        fnCtx,
-      });
-      return bindingOps.length === 0
-        ? armValue
-        : {
-            expr: ctx.mod.block(
-              null,
-              [...bindingOps, armValue.expr],
-              binaryen.getExpressionType(armValue.expr),
-            ),
-            usedReturnCall: armValue.usedReturnCall,
-            usedOutResultStorageRef: armValue.usedOutResultStorageRef,
-          };
+    const armExpr = compileMatchArmValueWithBindings({
+      matchExpr: expr,
+      arm,
+      resultTypeId,
+      patternTypeId,
+      discriminant,
+      ctx,
+      fnCtx,
+      compileExpr,
+      tailPosition,
+      outResultStorageRef,
     });
 
     const fallback =
@@ -789,7 +941,7 @@ export const compileMatchExpr = (
   return {
     expr: ctx.mod.block(
       null,
-      [initDiscriminant, finalExpr.expr],
+      [discriminant.init, finalExpr.expr],
       finalExpr.usedOutResultStorageRef ? binaryen.none : resultType,
     ),
     usedReturnCall: finalExpr.usedReturnCall,

--- a/packages/compiler/src/codegen/expressions/control-flow.ts
+++ b/packages/compiler/src/codegen/expressions/control-flow.ts
@@ -175,6 +175,18 @@ const normalizeOutResultStorageForwarding = ({
   return compiled;
 };
 
+const withRestoredBindings = <T>(
+  fnCtx: FunctionContext,
+  run: () => T,
+): T => {
+  const previousBindings = new Map(fnCtx.bindings);
+  try {
+    return run();
+  } finally {
+    fnCtx.bindings = previousBindings;
+  }
+};
+
 const lowerToOutResultStorageIfNeeded = ({
   compiled,
   exprId,
@@ -260,14 +272,16 @@ export const compileIfExpr = (
   };
   let fallback =
     typeof expr.defaultBranch === "number"
-      ? compileExpr({
-          exprId: expr.defaultBranch,
-          ctx,
-          fnCtx,
-          tailPosition,
-          expectedResultTypeId: resultTypeId,
-          outResultStorageRef,
-        })
+      ? withRestoredBindings(fnCtx, () =>
+          compileExpr({
+            exprId: expr.defaultBranch!,
+            ctx,
+            fnCtx,
+            tailPosition,
+            expectedResultTypeId: resultTypeId,
+            outResultStorageRef,
+          }),
+        )
       : undefined;
 
   if (!fallback && resultType !== binaryen.none) {
@@ -309,14 +323,16 @@ export const compileIfExpr = (
       ctx,
       fnCtx,
     }).expr;
-    const value = compileExpr({
-      exprId: branch.value,
-      ctx,
-      fnCtx,
-      tailPosition,
-      expectedResultTypeId: resultTypeId,
-      outResultStorageRef,
-    });
+    const value = withRestoredBindings(fnCtx, () =>
+      compileExpr({
+        exprId: branch.value,
+        ctx,
+        fnCtx,
+        tailPosition,
+        expectedResultTypeId: resultTypeId,
+        outResultStorageRef,
+      }),
+    );
     const loweredValue = lowerToOutResultStorageIfNeeded({
       compiled: value,
       exprId: branch.value,
@@ -485,22 +501,18 @@ export const compileMatchExpr = (
   let chain: CompiledExpression | undefined;
   for (let index = expr.arms.length - 1; index >= 0; index -= 1) {
     const arm = expr.arms[index]!;
-    if (arm.pattern.kind === "type" && arm.pattern.binding) {
-      declarePatternLocals(arm.pattern.binding, ctx, fnCtx);
-    } else if (arm.pattern.kind !== "wildcard") {
-      declarePatternLocals(arm.pattern, ctx, fnCtx);
-    }
-
     if (arm.pattern.kind === "wildcard") {
       const armValue = normalizeOutResultStorageForwarding({
-        compiled: compileExpr({
-          exprId: arm.value,
-          ctx,
-          fnCtx,
-          tailPosition,
-          expectedResultTypeId: resultTypeId,
-          outResultStorageRef,
-        }),
+        compiled: withRestoredBindings(fnCtx, () =>
+          compileExpr({
+            exprId: arm.value,
+            ctx,
+            fnCtx,
+            tailPosition,
+            expectedResultTypeId: resultTypeId,
+            outResultStorageRef,
+          }),
+        ),
       });
       if (armValue.usedOutResultStorageRef) {
         chain = {
@@ -581,7 +593,6 @@ export const compileMatchExpr = (
             );
           })()
         : undefined;
-    const bindingOps: binaryen.ExpressionRef[] = [];
     const narrowedDiscriminant = (): binaryen.ExpressionRef =>
       shouldInlineUnionLayout(discriminantTypeId, ctx)
         ? coerceValueToType({
@@ -596,52 +607,72 @@ export const compileMatchExpr = (
             targetType: wasmTypeFor(patternTypeId, ctx),
             ctx,
           });
-    if (arm.pattern.kind === "type" && arm.pattern.binding) {
-      const projectedOptionalPayloadOps =
-        typeof optionalSomePayload !== "undefined"
-          ? tryCompileProjectedOptionalPayloadBinding({
-              pattern: arm.pattern.binding,
-              optionalExprId: expr.discriminant,
-              armValueExprId: arm.value,
-              ctx,
-              fnCtx,
-              compileExpr,
-            })
-          : undefined;
-      if (projectedOptionalPayloadOps) {
-        bindingOps.push(...projectedOptionalPayloadOps);
-      } else if (
-        typeof optionalSomePayload !== "undefined" &&
-        arm.pattern.binding.kind === "identifier"
-      ) {
+
+    const armExpr = withRestoredBindings(fnCtx, () => {
+      if (arm.pattern.kind === "type" && arm.pattern.binding) {
+        declarePatternLocals(arm.pattern.binding, ctx, fnCtx);
+      } else if (arm.pattern.kind !== "wildcard") {
+        declarePatternLocals(arm.pattern, ctx, fnCtx);
+      }
+
+      const bindingOps: binaryen.ExpressionRef[] = [];
+      if (arm.pattern.kind === "type" && arm.pattern.binding) {
+        const projectedOptionalPayloadOps =
+          typeof optionalSomePayload !== "undefined"
+            ? tryCompileProjectedOptionalPayloadBinding({
+                pattern: arm.pattern.binding,
+                optionalExprId: expr.discriminant,
+                armValueExprId: arm.value,
+                ctx,
+                fnCtx,
+                compileExpr,
+              })
+            : undefined;
+        if (projectedOptionalPayloadOps) {
+          bindingOps.push(...projectedOptionalPayloadOps);
+        } else if (
+          typeof optionalSomePayload !== "undefined" &&
+          arm.pattern.binding.kind === "identifier"
+        ) {
+          compilePatternInitializationFromValue({
+            pattern: arm.pattern.binding,
+            value: optionalSomePayload,
+            valueTypeId: discriminantOptionalInfo!.innerType,
+            ctx,
+            fnCtx,
+            ops: bindingOps,
+            options: { declare: true },
+          });
+        } else if (
+          typeof optionalSomePayload !== "undefined" &&
+          arm.pattern.binding.kind === "destructure" &&
+          !arm.pattern.binding.spread &&
+          arm.pattern.binding.fields.length === 1 &&
+          arm.pattern.binding.fields[0]!.name === "value"
+        ) {
+          compilePatternInitializationFromValue({
+            pattern: arm.pattern.binding.fields[0]!.pattern,
+            value: optionalSomePayload,
+            valueTypeId: discriminantOptionalInfo!.innerType,
+            ctx,
+            fnCtx,
+            ops: bindingOps,
+            options: { declare: true },
+          });
+        } else {
+          compilePatternInitializationFromValue({
+            pattern: arm.pattern.binding,
+            value: narrowedDiscriminant(),
+            valueTypeId: patternTypeId,
+            ctx,
+            fnCtx,
+            ops: bindingOps,
+            options: { declare: true },
+          });
+        }
+      } else if (arm.pattern.kind !== "type") {
         compilePatternInitializationFromValue({
-          pattern: arm.pattern.binding,
-          value: optionalSomePayload,
-          valueTypeId: discriminantOptionalInfo!.innerType,
-          ctx,
-          fnCtx,
-          ops: bindingOps,
-          options: { declare: true },
-        });
-      } else if (
-        typeof optionalSomePayload !== "undefined" &&
-        arm.pattern.binding.kind === "destructure" &&
-        !arm.pattern.binding.spread &&
-        arm.pattern.binding.fields.length === 1 &&
-        arm.pattern.binding.fields[0]!.name === "value"
-      ) {
-        compilePatternInitializationFromValue({
-          pattern: arm.pattern.binding.fields[0]!.pattern,
-          value: optionalSomePayload,
-          valueTypeId: discriminantOptionalInfo!.innerType,
-          ctx,
-          fnCtx,
-          ops: bindingOps,
-          options: { declare: true },
-        });
-      } else {
-        compilePatternInitializationFromValue({
-          pattern: arm.pattern.binding,
+          pattern: arm.pattern,
           value: narrowedDiscriminant(),
           valueTypeId: patternTypeId,
           ctx,
@@ -650,79 +681,51 @@ export const compileMatchExpr = (
           options: { declare: true },
         });
       }
-    } else if (arm.pattern.kind !== "type") {
-      compilePatternInitializationFromValue({
-        pattern: arm.pattern,
-        value: narrowedDiscriminant(),
-        valueTypeId: patternTypeId,
-        ctx,
-        fnCtx,
-        ops: bindingOps,
-        options: { declare: true },
-      });
-    }
 
-    let restoreDiscriminantBinding: (() => void) | undefined;
-    if (typeof discriminantSymbol === "number") {
-      const narrowedBinding = allocateTempLocal(
-        wasmTypeFor(patternTypeId, ctx),
-        fnCtx,
-        patternTypeId,
-        ctx,
-      );
-      bindingOps.push(
-        storeLocalValue({
-          binding: narrowedBinding,
-          value: coerceValueToType({
-            value: narrowedDiscriminant(),
-            actualType: patternTypeId,
-            targetType: patternTypeId,
+      if (typeof discriminantSymbol === "number") {
+        const narrowedBinding = allocateTempLocal(
+          wasmTypeFor(patternTypeId, ctx),
+          fnCtx,
+          patternTypeId,
+          ctx,
+        );
+        bindingOps.push(
+          storeLocalValue({
+            binding: narrowedBinding,
+            value: coerceValueToType({
+              value: narrowedDiscriminant(),
+              actualType: patternTypeId,
+              targetType: patternTypeId,
+              ctx,
+              fnCtx,
+            }),
             ctx,
             fnCtx,
           }),
-          ctx,
-          fnCtx,
-        }),
-      );
-      const originalBinding = fnCtx.bindings.get(discriminantSymbol);
-      fnCtx.bindings.set(discriminantSymbol, {
-        ...narrowedBinding,
-        kind: "local",
-        typeId: patternTypeId,
-      });
-      restoreDiscriminantBinding = () => {
-        if (originalBinding) {
-          fnCtx.bindings.set(discriminantSymbol, originalBinding);
-          return;
-        }
-        fnCtx.bindings.delete(discriminantSymbol);
-      };
-    }
-
-    const armValue = (() => {
-      try {
-        return lowerToOutResultStorageIfNeeded({
-          compiled: compileExpr({
-            exprId: arm.value,
-            ctx,
-            fnCtx,
-            tailPosition,
-            expectedResultTypeId: resultTypeId,
-            outResultStorageRef,
-          }),
-          exprId: arm.value,
-          resultTypeId,
-          outResultStorageRef,
-          ctx,
-          fnCtx,
+        );
+        fnCtx.bindings.set(discriminantSymbol, {
+          ...narrowedBinding,
+          kind: "local",
+          typeId: patternTypeId,
         });
-      } finally {
-        restoreDiscriminantBinding?.();
       }
-    })();
 
-    const armExpr =
-      bindingOps.length === 0
+      const armValue = lowerToOutResultStorageIfNeeded({
+        compiled: compileExpr({
+          exprId: arm.value,
+          ctx,
+          fnCtx,
+          tailPosition,
+          expectedResultTypeId: resultTypeId,
+          outResultStorageRef,
+        }),
+        exprId: arm.value,
+        resultTypeId,
+        outResultStorageRef,
+        ctx,
+        fnCtx,
+      });
+      return bindingOps.length === 0
         ? armValue
         : {
             expr: ctx.mod.block(
@@ -733,6 +736,7 @@ export const compileMatchExpr = (
             usedReturnCall: armValue.usedReturnCall,
             usedOutResultStorageRef: armValue.usedOutResultStorageRef,
           };
+    });
 
     const fallback =
       chain ??

--- a/packages/compiler/src/codegen/expressions/index.ts
+++ b/packages/compiler/src/codegen/expressions/index.ts
@@ -35,6 +35,7 @@ export const compileExpression: ExpressionCompiler = ({
   expectedResultTypeId,
   preserveStorageRefs = false,
   outResultStorageRef,
+  scalarAggregateResultTypeId,
 }: ExpressionCompilerParams): CompiledExpression => {
   const expr = ctx.module.hir.expressions.get(exprId);
   if (!expr) {
@@ -69,6 +70,7 @@ export const compileExpression: ExpressionCompiler = ({
         tailPosition,
         expectedResultTypeId,
         outResultStorageRef,
+        scalarAggregateResultTypeId,
       });
     }
     case "method-call": {
@@ -96,6 +98,7 @@ export const compileExpression: ExpressionCompiler = ({
         tailPosition,
         expectedResultTypeId,
         outResultStorageRef,
+        scalarAggregateResultTypeId,
       });
     }
     case "block":

--- a/packages/compiler/src/codegen/expressions/mutations.ts
+++ b/packages/compiler/src/codegen/expressions/mutations.ts
@@ -12,6 +12,7 @@ import type {
   TypeId,
 } from "../context.js";
 import { compilePatternInitialization } from "../patterns.js";
+import { tryStoreScalarAggregateExpression } from "../optimization/scalar-aggregates.js";
 import {
   coerceValueToType,
   initStructuralValue,
@@ -25,6 +26,8 @@ import {
   getRequiredBinding,
   loadLocalValue,
   materializeOwnedBinding,
+  storeScalarAggregateBindingField,
+  storeScalarAggregateBindingValue,
   storeStorageRefBindingValue,
   storeLocalValue,
 } from "../locals.js";
@@ -87,6 +90,14 @@ const storeIntoBinding = ({
   }
   if (binding.kind === "projected-element-ref") {
     throw new Error("cannot assign to a projected element binding");
+  }
+  if (binding.kind === "scalar-aggregate") {
+    return storeScalarAggregateBindingValue({
+      binding,
+      value: coerced,
+      ctx,
+      fnCtx,
+    });
   }
 
   return storeLocalValue({ binding, value: coerced, ctx, fnCtx });
@@ -207,26 +218,59 @@ const compileFieldAssignment = ({
     ctx,
     typeInstanceId,
   });
-  const rootTypeId = getRequiredExprType(rootExprId, ctx, typeInstanceId);
-  const rootTemp = allocateTempLocal(
-    wasmTypeFor(rootTypeId, ctx),
-    fnCtx,
-    rootTypeId,
-    ctx,
-  );
-  const ops: binaryen.ExpressionRef[] = [
-    storeLocalValue({
-      binding: rootTemp,
-      value: compileExpr({
-        exprId: rootExprId,
+  const rootExpr = ctx.module.hir.expressions.get(rootExprId);
+  const rootBinding =
+    rootExpr?.exprKind === "identifier"
+      ? fnCtx.bindings.get(rootExpr.symbol)
+      : undefined;
+  if (rootBinding?.kind === "scalar-aggregate" && segments.length === 1) {
+    const field = rootBinding.structInfo.fieldMap.get(targetExpr.field);
+    if (!field) {
+      throw new Error(`object does not contain field ${targetExpr.field}`);
+    }
+    return storeScalarAggregateBindingField({
+      binding: rootBinding,
+      fieldName: targetExpr.field,
+      value: coerceValueToType({
+        value,
+        actualType: valueTypeId,
+        targetType: field.typeId,
         ctx,
         fnCtx,
-        expectedResultTypeId: rootTypeId,
-      }).expr,
+      }),
       ctx,
       fnCtx,
-    }),
-  ];
+    });
+  }
+  const rootTypeId = getRequiredExprType(rootExprId, ctx, typeInstanceId);
+  const materializedRoot =
+    rootBinding?.kind === "scalar-aggregate" &&
+    rootExpr?.exprKind === "identifier" &&
+    segments.length > 1
+      ? materializeOwnedBinding({
+          symbol: rootExpr.symbol,
+          ctx,
+          fnCtx,
+        })
+      : undefined;
+  const rootTemp =
+    materializedRoot?.binding ??
+    allocateTempLocal(wasmTypeFor(rootTypeId, ctx), fnCtx, rootTypeId, ctx);
+  const ops: binaryen.ExpressionRef[] = materializedRoot
+    ? [...materializedRoot.setup]
+    : [
+        storeLocalValue({
+          binding: rootTemp,
+          value: compileExpr({
+            exprId: rootExprId,
+            ctx,
+            fnCtx,
+            expectedResultTypeId: rootTypeId,
+          }).expr,
+          ctx,
+          fnCtx,
+        }),
+      ];
 
   const ownerTemps = [rootTemp];
   segments.slice(0, -1).forEach((segment, index) => {
@@ -296,7 +340,6 @@ const compileFieldAssignment = ({
     replacementTypeId = segment.ownerTypeId;
   }
 
-  const rootExpr = ctx.module.hir.expressions.get(rootExprId);
   if (rootExpr?.exprKind !== "identifier") {
     throw new Error(
       "inline value-object field assignment requires an addressable root binding",
@@ -401,6 +444,60 @@ export const compileAssignExpr = (
 
   const binding = getRequiredBinding(targetExpr.symbol, ctx, fnCtx);
   const targetTypeId = getSymbolTypeId(targetExpr.symbol, ctx, typeInstanceId);
+  if (binding.kind === "scalar-aggregate") {
+    const scalarStore = tryStoreScalarAggregateExpression({
+      binding,
+      exprId: expr.value,
+      targetTypeId,
+      ctx,
+      fnCtx,
+      compileExpr,
+    });
+    if (scalarStore) {
+      return {
+        expr: scalarStore.length === 1
+          ? scalarStore[0]!
+          : ctx.mod.block(null, scalarStore, binaryen.none),
+        usedReturnCall: false,
+      };
+    }
+    if (binding.structInfo.layoutKind === "heap-object") {
+      const materialized = materializeOwnedBinding({
+        symbol: targetExpr.symbol,
+        ctx,
+        fnCtx,
+      });
+      const valueExpr = compileExpr({
+        exprId: expr.value,
+        ctx,
+        fnCtx,
+        expectedResultTypeId: targetTypeId,
+      });
+      const coerced = coerceValueToType({
+        value: valueExpr.expr,
+        actualType: valueTypeId,
+        targetType: targetTypeId,
+        ctx,
+        fnCtx,
+      });
+      return {
+        expr: ctx.mod.block(
+          null,
+          [
+            ...materialized.setup,
+            storeLocalValue({
+              binding: materialized.binding,
+              value: coerced,
+              ctx,
+              fnCtx,
+            }),
+          ],
+          binaryen.none,
+        ),
+        usedReturnCall: false,
+      };
+    }
+  }
   const valueExpr = compileExpr({
     exprId: expr.value,
     ctx,
@@ -457,6 +554,17 @@ export const compileAssignExpr = (
   }
   if (binding.kind === "projected-element-ref") {
     throw new Error("cannot assign to a projected element binding");
+  }
+  if (binding.kind === "scalar-aggregate") {
+    return {
+      expr: storeScalarAggregateBindingValue({
+        binding,
+        value: coerced,
+        ctx,
+        fnCtx,
+      }),
+      usedReturnCall: false,
+    };
   }
 
   return {

--- a/packages/compiler/src/codegen/expressions/objects.ts
+++ b/packages/compiler/src/codegen/expressions/objects.ts
@@ -13,6 +13,7 @@ import type {
 import {
   allocateTempLocal,
   getRequiredBinding,
+  loadScalarAggregateBindingField,
   loadBindingStorageRef,
   loadBindingValue,
   loadLocalValue,
@@ -597,6 +598,37 @@ export const compileFieldAccessExpr = (
   }
 
   const targetExpr = ctx.module.hir.expressions.get(expr.target);
+  const scalarTargetBinding =
+    targetExpr?.exprKind === "identifier"
+      ? fnCtx.bindings.get(targetExpr.symbol)
+      : undefined;
+  if (scalarTargetBinding?.kind === "scalar-aggregate") {
+    const scalarField = scalarTargetBinding.structInfo.fieldMap.get(expr.field);
+    const scalarValue = scalarField
+      ? loadScalarAggregateBindingField({
+          binding: scalarTargetBinding,
+          fieldName: expr.field,
+          ctx,
+        })
+      : undefined;
+    if (scalarField && scalarValue) {
+      const coerced = coerceValueToType({
+        value: scalarValue,
+        actualType: scalarField.typeId,
+        targetType: expectedFieldTypeId,
+        ctx,
+        fnCtx,
+      });
+      return {
+        expr: coerceExprToWasmType({
+          expr: coerced,
+          targetType: expectedFieldWasmType,
+          ctx,
+        }),
+        usedReturnCall: false,
+      };
+    }
+  }
 
   const actualTargetTypeId = getUnresolvedExprType(expr.target, ctx, typeInstanceId);
   const bindingActualTargetTypeId =

--- a/packages/compiler/src/codegen/functions.ts
+++ b/packages/compiler/src/codegen/functions.ts
@@ -16,6 +16,7 @@ import {
   allocateTempLocal,
   createStorageRefBinding,
   loadBindingValue,
+  storeScalarAggregateBindingValue,
   storeLocalValue,
 } from "./locals.js";
 import {
@@ -79,6 +80,17 @@ import {
   takePendingReceiverSpecializations,
   type ReceiverSpecialization,
 } from "./receiver-specialization.js";
+import {
+  createScalarAggregateTempBinding,
+  loadScalarAggregateBindingAbiValue,
+  tryBindScalarAggregateParameter,
+  tryStoreScalarAggregateExpression,
+} from "./optimization/scalar-aggregates.js";
+import {
+  markScalarAggregateCallSpecializationCompiled,
+  takePendingScalarAggregateCallSpecializations,
+  type ScalarAggregateCallSpecialization,
+} from "./optimization/scalar-aggregate-calls.js";
 
 const REACHABILITY_STATE = Symbol.for("voyd.codegen.reachabilityState");
 const FUNCTION_METADATA_REGISTRATION_STATE = Symbol.for(
@@ -309,6 +321,24 @@ const bindRawFunctionParameters = ({
         }),
       );
     } else {
+      if (typeof typeId === "number") {
+        const scalarized = tryBindScalarAggregateParameter({
+          symbol: param.symbol,
+          typeId,
+          mutable: param.mutable,
+          abiValues,
+          scalarAggregateAbi:
+            meta.scalarAggregateParamIndexes?.includes(index) ?? false,
+          ctx,
+          fnCtx,
+        });
+        if (scalarized) {
+          ops.push(...scalarized);
+          abiIndex += abiTypes.length;
+          return;
+        }
+      }
+
       const localType = wasmTypeFor(typeId!, ctx);
       const binding = allocateTempLocal(
         localType,
@@ -957,17 +987,20 @@ export const registerFunctionMetadata = (ctx: CodegenContext): void => {
           );
         }
 
+        const parameterBindingKind = (index: number) =>
+          signature.parameters[index]?.bindingKind ??
+          (item.parameters[index]?.mutable ? "mutable-ref" : undefined);
         const paramAbiKinds = descriptor.parameters.map((param, index) =>
           getOptimizedParamAbiKind({
             typeId: param.type,
-            bindingKind: signature.parameters[index]?.bindingKind,
+            bindingKind: parameterBindingKind(index),
             ctx,
           }),
         );
         const paramAbiTypes = descriptor.parameters.map((param, index) =>
           getOptimizedAbiTypesForParam({
             typeId: param.type,
-            bindingKind: signature.parameters[index]?.bindingKind,
+            bindingKind: parameterBindingKind(index),
             ctx,
           }),
         );
@@ -1021,7 +1054,7 @@ export const registerFunctionMetadata = (ctx: CodegenContext): void => {
               typeof item.parameters[index]?.symbol === "number"
                 ? symbolName(ctx, ctx.moduleId, item.parameters[index]!.symbol)
                 : undefined,
-            bindingKind: signature.parameters[index]?.bindingKind,
+            bindingKind: parameterBindingKind(index),
             synthetic: signature.parameters[index]?.synthetic,
           })),
           paramAbiKinds,
@@ -1135,6 +1168,7 @@ export const compileFunctions = ({
   }
   compiledCount += compilePendingStaticEffectSpecializations(ctx);
   compiledCount += compilePendingReceiverSpecializations(ctx);
+  compiledCount += compilePendingScalarAggregateCallSpecializations(ctx);
   return compiledCount;
 };
 
@@ -1813,6 +1847,24 @@ const compileFunctionItem = (
     ctx,
     fnCtx,
   });
+  const scalarResultBody = compileScalarAggregateFunctionResult({
+    fn,
+    meta,
+    ctx,
+    fnCtx,
+    paramInitOps,
+    defaultInitOps,
+  });
+  if (scalarResultBody) {
+    ctx.mod.addFunction(
+      meta.wasmName,
+      binaryen.createType(meta.paramTypes as number[]),
+      meta.resultType,
+      fnCtx.locals,
+      scalarResultBody,
+    );
+    return;
+  }
 
   const body = compileExpression({
     exprId: fn.body,
@@ -1900,6 +1952,64 @@ const compileFunctionItem = (
     meta.resultType,
     fnCtx.locals,
     functionBody,
+  );
+};
+
+const compileScalarAggregateFunctionResult = ({
+  fn,
+  meta,
+  ctx,
+  fnCtx,
+  paramInitOps,
+  defaultInitOps,
+}: {
+  fn: HirFunction;
+  meta: FunctionMetadata;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  paramInitOps: readonly binaryen.ExpressionRef[];
+  defaultInitOps: readonly binaryen.ExpressionRef[];
+}): binaryen.ExpressionRef | undefined => {
+  if (!meta.scalarAggregateResult) {
+    return undefined;
+  }
+  const structInfo = getStructuralTypeInfo(meta.resultTypeId, ctx);
+  if (!structInfo) {
+    return undefined;
+  }
+  const binding = createScalarAggregateTempBinding({
+    typeId: meta.resultTypeId,
+    structInfo,
+    ctx,
+    fnCtx,
+  });
+  const scalarStores = tryStoreScalarAggregateExpression({
+    binding,
+    exprId: fn.body,
+    targetTypeId: meta.resultTypeId,
+    ctx,
+    fnCtx,
+    compileExpr: compileExpression,
+  });
+  const setup = scalarStores ?? [
+    storeScalarAggregateBindingValue({
+      binding,
+      value: compileExpression({
+        exprId: fn.body,
+        ctx,
+        fnCtx,
+        tailPosition: false,
+        expectedResultTypeId: meta.resultTypeId,
+      }).expr,
+      ctx,
+      fnCtx,
+    }),
+  ];
+  const result = loadScalarAggregateBindingAbiValue({ binding, ctx });
+  return ctx.mod.block(
+    null,
+    [...paramInitOps, ...defaultInitOps, ...setup, result],
+    meta.resultType,
   );
 };
 
@@ -2344,6 +2454,30 @@ const compilePendingReceiverSpecializations = (
   const pending = takePendingReceiverSpecializations(ctx);
   pending.forEach((specialization) =>
     compileReceiverSpecialization(specialization, ctx)
+  );
+  return pending.length;
+};
+
+const compileScalarAggregateCallSpecialization = (
+  specialization: ScalarAggregateCallSpecialization,
+  ctx: CodegenContext,
+): void => {
+  const { item, meta } = specialization;
+  if (ctx.mod.getFunction(meta.wasmName) === 0) {
+    compileFunctionItem(item, meta, ctx);
+  }
+  markScalarAggregateCallSpecializationCompiled({
+    ctx,
+    wasmName: meta.wasmName,
+  });
+};
+
+const compilePendingScalarAggregateCallSpecializations = (
+  ctx: CodegenContext,
+): number => {
+  const pending = takePendingScalarAggregateCallSpecializations(ctx);
+  pending.forEach((specialization) =>
+    compileScalarAggregateCallSpecialization(specialization, ctx),
   );
   return pending.length;
 };

--- a/packages/compiler/src/codegen/locals.ts
+++ b/packages/compiler/src/codegen/locals.ts
@@ -15,9 +15,11 @@ import {
 } from "@voyd-lang/lib/binaryen-gc/index.js";
 import {
   fixedArrayStorageElementType,
+  initStructuralValue,
   liftFixedArrayElementValue,
   liftHeapValueToInline,
   lowerValueForHeapField,
+  loadStructuralField,
   storeValueIntoStorageRef,
 } from "./structural.js";
 import {
@@ -277,6 +279,9 @@ export const loadBindingValue = (
       ctx,
     });
   }
+  if (binding.kind === "scalar-aggregate") {
+    return loadScalarAggregateBindingValue({ binding, ctx, fnCtx });
+  }
   if (binding.kind === "projected-element-ref") {
     return loadProjectedElementBindingValue(binding, ctx, fnCtx);
   }
@@ -325,6 +330,9 @@ export const loadBindingStorageRef = (
   if (binding.kind === "storage-ref") {
     return ctx.mod.local.get(binding.index, binding.storageType);
   }
+  if (binding.kind === "scalar-aggregate") {
+    return undefined;
+  }
   if (binding.kind === "projected-element-ref") {
     return loadProjectedElementBindingStorageRef(binding, ctx);
   }
@@ -371,6 +379,31 @@ export const materializeOwnedBinding = ({
   const existing = getRequiredBinding(symbol, ctx, fnCtx);
   if (existing.kind === "local") {
     return { binding: existing, setup: [] };
+  }
+  if (existing.kind === "scalar-aggregate") {
+    const owned =
+      typeof existing.typeId === "number" &&
+      typeof getInlineHeapBoxType({ typeId: existing.typeId, ctx }) === "number"
+        ? allocateAddressableLocal({
+            typeId: existing.typeId,
+            ctx,
+            fnCtx,
+          })
+        : allocateTempLocal(existing.type, fnCtx, existing.typeId, ctx);
+    const setup = [
+      storeLocalValue({
+        binding: owned,
+        value: loadBindingValue(existing, ctx, fnCtx),
+        ctx,
+        fnCtx,
+      }),
+    ];
+    fnCtx.bindings.set(symbol, {
+      ...owned,
+      kind: "local",
+      typeId: existing.typeId,
+    });
+    return { binding: owned, setup };
   }
   if (existing.kind === "capture") {
     throw new Error("cannot materialize capture binding into owned local storage");
@@ -456,5 +489,128 @@ export const storeStorageRefBindingValue = ({
     typeId: binding.typeId,
     ctx,
     fnCtx,
+  });
+};
+
+export const loadScalarAggregateBindingField = ({
+  binding,
+  fieldName,
+  ctx,
+}: {
+  binding: Extract<LocalBinding, { kind: "scalar-aggregate" }>;
+  fieldName: string;
+  ctx: CodegenContext;
+}): binaryen.ExpressionRef | undefined => {
+  const fieldBinding = binding.fields.get(fieldName);
+  return fieldBinding ? loadLocalValue(fieldBinding, ctx) : undefined;
+};
+
+export const storeScalarAggregateBindingField = ({
+  binding,
+  fieldName,
+  value,
+  ctx,
+  fnCtx,
+}: {
+  binding: Extract<LocalBinding, { kind: "scalar-aggregate" }>;
+  fieldName: string;
+  value: binaryen.ExpressionRef;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  if (!binding.mutable) {
+    throw new Error("cannot assign to immutable scalar aggregate binding");
+  }
+  const fieldBinding = binding.fields.get(fieldName);
+  if (!fieldBinding) {
+    throw new Error(`scalar aggregate missing field ${fieldName}`);
+  }
+  return storeLocalValue({
+    binding: fieldBinding,
+    value,
+    ctx,
+    fnCtx,
+  });
+};
+
+export const storeScalarAggregateBindingValue = ({
+  binding,
+  value,
+  ctx,
+  fnCtx,
+}: {
+  binding: Extract<LocalBinding, { kind: "scalar-aggregate" }>;
+  value: binaryen.ExpressionRef;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  const temp = allocateTempLocal(binding.type, fnCtx, binding.typeId, ctx);
+  const ops: binaryen.ExpressionRef[] = [
+    storeLocalValue({
+      binding: temp,
+      value,
+      ctx,
+      fnCtx,
+    }),
+  ];
+  binding.structInfo.fields.forEach((field) => {
+    const fieldBinding = binding.fields.get(field.name);
+    if (!fieldBinding) {
+      throw new Error(`scalar aggregate missing field ${field.name}`);
+    }
+    ops.push(
+      storeLocalValue({
+        binding: fieldBinding,
+        value: loadStructuralField({
+          structInfo: binding.structInfo,
+          field,
+          pointer: () => loadLocalValue(temp, ctx),
+          ctx,
+        }),
+        ctx,
+        fnCtx,
+      }),
+    );
+  });
+  return ctx.mod.block(null, ops, binaryen.none);
+};
+
+const loadScalarAggregateBindingValue = ({
+  binding,
+  ctx,
+  fnCtx,
+}: {
+  binding: Extract<LocalBinding, { kind: "scalar-aggregate" }>;
+  ctx: CodegenContext;
+  fnCtx?: FunctionContext;
+}): binaryen.ExpressionRef => {
+  const fieldValues = binding.structInfo.fields.map((field) => {
+    const fieldBinding = binding.fields.get(field.name);
+    if (!fieldBinding) {
+      throw new Error(`scalar aggregate missing field ${field.name}`);
+    }
+    const value = loadLocalValue(fieldBinding, ctx);
+    if (binding.structInfo.layoutKind === "value-object") {
+      return coerceExprToWasmType({
+        expr: value,
+        targetType: field.wasmType,
+        ctx,
+      });
+    }
+    if (!fnCtx) {
+      throw new Error("heap scalar aggregate rematerialization requires a function context");
+    }
+    return lowerValueForHeapField({
+      value,
+      typeId: field.typeId,
+      targetType: field.heapWasmType,
+      ctx,
+      fnCtx,
+    });
+  });
+  return initStructuralValue({
+    structInfo: binding.structInfo,
+    fieldValues,
+    ctx,
   });
 };

--- a/packages/compiler/src/codegen/optimization/scalar-aggregate-calls.ts
+++ b/packages/compiler/src/codegen/optimization/scalar-aggregate-calls.ts
@@ -1,0 +1,489 @@
+import binaryen from "binaryen";
+import type {
+  CodegenContext,
+  FunctionMetadata,
+} from "../context.js";
+import type { HirFunction } from "../../semantics/hir/index.js";
+import type { HirExprId, SymbolId, TypeId } from "../../semantics/ids.js";
+import { abiTypeFor, getStructuralTypeInfo } from "../types.js";
+import {
+  canStoreScalarAggregateExpression,
+  scalarAggregateAbiTypesForType,
+} from "./scalar-aggregates.js";
+import { walkHirExpression } from "../hir-walk.js";
+
+export interface ScalarAggregateCallSpecialization {
+  base: FunctionMetadata;
+  meta: FunctionMetadata;
+  item: HirFunction;
+  paramIndexes: readonly number[];
+  scalarResult: boolean;
+}
+
+type ScalarAggregateCallSpecializationState = {
+  byKey: Map<string, ScalarAggregateCallSpecialization>;
+  pending: ScalarAggregateCallSpecialization[];
+  compiled: Set<string>;
+};
+
+const SCALAR_AGGREGATE_CALL_SPECIALIZATION_STATE = Symbol(
+  "voyd.codegen.scalarAggregateCallSpecializationState",
+);
+
+const MAX_SCALAR_AGGREGATE_CALL_SPECIALIZATIONS_PER_FUNCTION = 8;
+
+const stateOf = (ctx: CodegenContext): ScalarAggregateCallSpecializationState =>
+  ctx.programHelpers.getHelperState<ScalarAggregateCallSpecializationState>(
+    SCALAR_AGGREGATE_CALL_SPECIALIZATION_STATE,
+    () => ({
+      byKey: new Map(),
+      pending: [],
+      compiled: new Set(),
+    }),
+  );
+
+const sanitize = (value: string): string =>
+  value.replace(/[^a-zA-Z0-9_]/g, "_");
+
+const functionItemFor = ({
+  ctx,
+  meta,
+}: {
+  ctx: CodegenContext;
+  meta: FunctionMetadata;
+}): HirFunction | undefined => {
+  const targetCtx = ctx.moduleContexts.get(meta.moduleId);
+  const targetModule = targetCtx?.module ?? ctx.program.modules.get(meta.moduleId);
+  return Array.from(targetModule?.hir.items.values() ?? []).find(
+    (item): item is HirFunction =>
+      item.kind === "function" && item.symbol === meta.symbol,
+  );
+};
+
+const assignmentTargetResolvesToSymbol = ({
+  exprId,
+  symbols,
+  ctx,
+}: {
+  exprId: HirExprId;
+  symbols: ReadonlySet<SymbolId>;
+  ctx: CodegenContext;
+}): boolean => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  if (!expr) {
+    return false;
+  }
+  if (expr.exprKind === "identifier") {
+    return symbols.has(expr.symbol);
+  }
+  if (expr.exprKind === "field-access") {
+    return assignmentTargetResolvesToSymbol({
+      exprId: expr.target,
+      symbols,
+      ctx,
+    });
+  }
+  return false;
+};
+
+const aliasSymbolsForParameter = ({
+  item,
+  symbol,
+  ctx,
+}: {
+  item: HirFunction;
+  symbol: SymbolId;
+  ctx: CodegenContext;
+}): ReadonlySet<SymbolId> => {
+  const adjacency = new Map<SymbolId, Set<SymbolId>>();
+  const link = (left: SymbolId, right: SymbolId): void => {
+    if (left === right) {
+      return;
+    }
+    const leftAliases = adjacency.get(left) ?? new Set<SymbolId>();
+    leftAliases.add(right);
+    adjacency.set(left, leftAliases);
+    const rightAliases = adjacency.get(right) ?? new Set<SymbolId>();
+    rightAliases.add(left);
+    adjacency.set(right, rightAliases);
+  };
+  const maybeLinkIdentifierAlias = ({
+    targetSymbol,
+    valueExprId,
+  }: {
+    targetSymbol: SymbolId;
+    valueExprId: HirExprId;
+  }): void => {
+    const valueExpr = ctx.module.hir.expressions.get(valueExprId);
+    if (valueExpr?.exprKind === "identifier") {
+      link(targetSymbol, valueExpr.symbol);
+    }
+  };
+
+  walkHirExpression({
+    exprId: item.body,
+    ctx,
+    visitor: {
+      onStmt: (_stmtId, stmt) => {
+        if (stmt.kind === "let" && stmt.pattern.kind === "identifier") {
+          maybeLinkIdentifierAlias({
+            targetSymbol: stmt.pattern.symbol,
+            valueExprId: stmt.initializer,
+          });
+        }
+        return undefined;
+      },
+      onExpr: (_exprId, expr) => {
+        if (expr.exprKind !== "assign") {
+          return undefined;
+        }
+        if (typeof expr.target === "number") {
+          const target = ctx.module.hir.expressions.get(expr.target);
+          if (target?.exprKind === "identifier") {
+            maybeLinkIdentifierAlias({
+              targetSymbol: target.symbol,
+              valueExprId: expr.value,
+            });
+          }
+        }
+        if (expr.pattern?.kind === "identifier") {
+          maybeLinkIdentifierAlias({
+            targetSymbol: expr.pattern.symbol,
+            valueExprId: expr.value,
+          });
+        }
+        return undefined;
+      },
+    },
+  });
+
+  const aliases = new Set<SymbolId>();
+  const queue = [symbol];
+  while (queue.length > 0) {
+    const current = queue.pop()!;
+    if (aliases.has(current)) {
+      continue;
+    }
+    aliases.add(current);
+    (adjacency.get(current) ?? new Set<SymbolId>()).forEach((next) => {
+      queue.push(next);
+    });
+  }
+  return aliases;
+};
+
+const parameterHasFieldAssignment = ({
+  item,
+  symbol,
+  ctx,
+}: {
+  item: HirFunction;
+  symbol: SymbolId;
+  ctx: CodegenContext;
+}): boolean => {
+  const aliases = aliasSymbolsForParameter({ item, symbol, ctx });
+  let hasAssignment = false;
+  walkHirExpression({
+    exprId: item.body,
+    ctx,
+    visitor: {
+      onExpr: (_exprId, expr) => {
+        if (
+          expr.exprKind === "assign" &&
+          typeof expr.target === "number" &&
+          assignmentTargetResolvesToSymbol({
+            exprId: expr.target,
+            symbols: aliases,
+            ctx,
+          })
+        ) {
+          hasAssignment = true;
+          return "stop";
+        }
+        return undefined;
+      },
+    },
+  });
+  return hasAssignment;
+};
+
+export const scalarAggregateParameterCanUseSpecializedAbi = ({
+  meta,
+  paramIndex,
+  ctx,
+}: {
+  meta: FunctionMetadata;
+  paramIndex: number;
+  ctx: CodegenContext;
+}): boolean => {
+  if (meta.effectful) {
+    return false;
+  }
+  const param = meta.parameters[paramIndex];
+  if (!param || typeof param.symbol !== "number") {
+    return false;
+  }
+  const structInfo = getStructuralTypeInfo(param.typeId, ctx);
+  if (!structInfo || structInfo.layoutKind !== "heap-object") {
+    return false;
+  }
+  const abiTypes = scalarAggregateAbiTypesForType({ typeId: param.typeId, ctx });
+  if (!abiTypes || abiTypes.length === 0) {
+    return false;
+  }
+  const item = functionItemFor({ ctx, meta });
+  if (item?.parameters[paramIndex]?.mutable) {
+    return false;
+  }
+  const targetCtx = ctx.moduleContexts.get(meta.moduleId) ?? ctx;
+  if (
+    item &&
+    parameterHasFieldAssignment({
+      item,
+      symbol: param.symbol,
+      ctx: targetCtx,
+    })
+  ) {
+    return false;
+  }
+  const fact = ctx.optimization?.escapeAnalysis.parameters
+    .get(meta.instanceId)
+    ?.get(param.symbol);
+  return Boolean(fact && !fact.escapes);
+};
+
+export const scalarAggregateResultCanUseSpecializedAbi = ({
+  meta,
+  resultTypeId,
+  item,
+  ctx,
+}: {
+  meta: FunctionMetadata;
+  resultTypeId: TypeId;
+  item?: HirFunction;
+  ctx: CodegenContext;
+}): boolean => {
+  if (
+    meta.effectful ||
+    meta.resultAbiKind !== "direct" ||
+    meta.resultTypeId !== resultTypeId
+  ) {
+    return false;
+  }
+  const structInfo = getStructuralTypeInfo(resultTypeId, ctx);
+  if (!structInfo || structInfo.layoutKind !== "heap-object") {
+    return false;
+  }
+  if (
+    !item ||
+    !heapObjectResultBodyIsFreshAggregate({
+      exprId: item.body,
+      resultTypeId,
+      ctx,
+    }) ||
+    !canStoreScalarAggregateExpression({
+      exprId: item.body,
+      targetTypeId: resultTypeId,
+      structInfo,
+      ctx,
+    })
+  ) {
+    return false;
+  }
+  const abiTypes = scalarAggregateAbiTypesForType({ typeId: resultTypeId, ctx });
+  return Boolean(abiTypes && abiTypes.length > 0);
+};
+
+const heapObjectResultBodyIsFreshAggregate = ({
+  exprId,
+  resultTypeId,
+  ctx,
+}: {
+  exprId: number;
+  resultTypeId: TypeId;
+  ctx: CodegenContext;
+}): boolean => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  if (!expr) {
+    return false;
+  }
+  if (expr.exprKind === "object-literal") {
+    const structInfo = getStructuralTypeInfo(resultTypeId, ctx);
+    return Boolean(
+      structInfo &&
+        canStoreScalarAggregateExpression({
+          exprId,
+          targetTypeId: resultTypeId,
+          structInfo,
+          ctx,
+        }),
+    );
+  }
+  if (expr.exprKind === "block") {
+    return (
+      expr.statements.length === 0 &&
+      typeof expr.value === "number" &&
+      heapObjectResultBodyIsFreshAggregate({
+        exprId: expr.value,
+        resultTypeId,
+        ctx,
+      })
+    );
+  }
+  if (expr.exprKind === "if" || expr.exprKind === "cond") {
+    return (
+      typeof expr.defaultBranch === "number" &&
+      expr.branches.every((branch) =>
+        heapObjectResultBodyIsFreshAggregate({
+          exprId: branch.value,
+          resultTypeId,
+          ctx,
+        }),
+      ) &&
+      heapObjectResultBodyIsFreshAggregate({
+        exprId: expr.defaultBranch,
+        resultTypeId,
+        ctx,
+      })
+    );
+  }
+  return false;
+};
+
+export const getOrCreateScalarAggregateCallSpecialization = ({
+  ctx,
+  meta,
+  paramIndexes,
+  scalarResultTypeId,
+}: {
+  ctx: CodegenContext;
+  meta: FunctionMetadata;
+  paramIndexes: ReadonlySet<number>;
+  scalarResultTypeId?: TypeId;
+}): FunctionMetadata | undefined => {
+  const item = functionItemFor({ ctx, meta });
+  const targetCtx = ctx.moduleContexts.get(meta.moduleId) ?? ctx;
+  const scalarResult =
+    typeof scalarResultTypeId === "number" &&
+    scalarAggregateResultCanUseSpecializedAbi({
+      meta,
+      resultTypeId: scalarResultTypeId,
+      item,
+      ctx: targetCtx,
+    });
+  if (!ctx.optimization || (paramIndexes.size === 0 && !scalarResult)) {
+    return undefined;
+  }
+  const selectedIndexes = Array.from(paramIndexes)
+    .filter((paramIndex) =>
+      scalarAggregateParameterCanUseSpecializedAbi({ meta, paramIndex, ctx }),
+    )
+    .sort((left, right) => left - right);
+  if (selectedIndexes.length === 0 && !scalarResult) {
+    return undefined;
+  }
+  if (!item) {
+    return undefined;
+  }
+
+  const key = `${meta.moduleId}:${meta.instanceId}:${selectedIndexes.join(",")}:result=${scalarResult ? "scalar" : "normal"}`;
+  const state = stateOf(ctx);
+  const existing = state.byKey.get(key);
+  if (existing) {
+    return existing.meta;
+  }
+  const existingForFunction = Array.from(state.byKey.values()).filter(
+    (specialization) =>
+      specialization.base.moduleId === meta.moduleId &&
+      specialization.base.instanceId === meta.instanceId,
+  );
+  if (
+    existingForFunction.length >=
+    MAX_SCALAR_AGGREGATE_CALL_SPECIALIZATIONS_PER_FUNCTION
+  ) {
+    return undefined;
+  }
+
+  const paramAbiTypes = meta.paramAbiTypes.map((abiTypes, index) =>
+    selectedIndexes.includes(index) && typeof meta.paramTypeIds[index] === "number"
+      ? (scalarAggregateAbiTypesForType({
+          typeId: meta.paramTypeIds[index]!,
+          ctx,
+        }) ?? abiTypes)
+      : abiTypes,
+  );
+  const userParamTypes = paramAbiTypes.flat();
+  const widened = ctx.effectsBackend.abi.widenSignature({
+    ctx,
+    effectful: meta.effectful,
+    userParamTypes: meta.outParamType
+      ? [meta.outParamType, ...userParamTypes]
+      : userParamTypes,
+    userResultType:
+      scalarResult
+        ? abiTypeFor(
+            scalarAggregateAbiTypesForType({
+              typeId: meta.resultTypeId,
+              ctx,
+            }) ?? [meta.resultType],
+          )
+        : meta.resultAbiKind === "out_ref" ? binaryen.none : meta.resultType,
+  });
+  const resultAbiTypes =
+    scalarResult
+      ? scalarAggregateAbiTypesForType({ typeId: meta.resultTypeId, ctx }) ??
+        meta.resultAbiTypes
+      : meta.resultAbiTypes;
+  const specializedMeta: FunctionMetadata = {
+    ...meta,
+    wasmName: `${meta.wasmName}__scalar_agg_${sanitize(
+      `${selectedIndexes.join("_")}${scalarResult ? "_result" : ""}`,
+    )}`,
+    paramTypes: widened.paramTypes,
+    paramAbiTypes,
+    userParamOffset: widened.userParamOffset,
+    firstUserParamIndex:
+      widened.userParamOffset + (meta.outParamType ? 1 : 0),
+    resultType: widened.resultType,
+    resultAbiTypes,
+    scalarAggregateParamIndexes: selectedIndexes,
+    scalarAggregateResult: scalarResult,
+  };
+  const specialization: ScalarAggregateCallSpecialization = {
+    base: meta,
+    meta: specializedMeta,
+    item,
+    paramIndexes: selectedIndexes,
+    scalarResult,
+  };
+  state.byKey.set(key, specialization);
+  state.pending.push(specialization);
+  return specializedMeta;
+};
+
+export const takePendingScalarAggregateCallSpecializations = (
+  ctx: CodegenContext,
+): ScalarAggregateCallSpecialization[] => {
+  const state = stateOf(ctx);
+  const pending = state.pending.filter(
+    (specialization) =>
+      specialization.meta.moduleId === ctx.moduleId &&
+      !state.compiled.has(specialization.meta.wasmName),
+  );
+  state.pending = state.pending.filter(
+    (specialization) =>
+      specialization.meta.moduleId !== ctx.moduleId &&
+      !state.compiled.has(specialization.meta.wasmName),
+  );
+  return pending;
+};
+
+export const markScalarAggregateCallSpecializationCompiled = ({
+  ctx,
+  wasmName,
+}: {
+  ctx: CodegenContext;
+  wasmName: string;
+}): void => {
+  stateOf(ctx).compiled.add(wasmName);
+};

--- a/packages/compiler/src/codegen/optimization/scalar-aggregates.ts
+++ b/packages/compiler/src/codegen/optimization/scalar-aggregates.ts
@@ -1,0 +1,1089 @@
+import binaryen from "binaryen";
+import type {
+  CodegenContext,
+  ExpressionCompiler,
+  FunctionContext,
+  HirExprId,
+  HirBlockExpr,
+  HirCondExpr,
+  HirObjectLiteralExpr,
+  HirExpression,
+  HirIfExpr,
+  LocalBindingScalarAggregate,
+  StructuralFieldInfo,
+  StructuralTypeInfo,
+  SymbolId,
+  TypeId,
+} from "../context.js";
+import {
+  allocateTempLocal,
+  loadLocalValue,
+  storeScalarAggregateBindingValue,
+  storeLocalValue,
+} from "../locals.js";
+import {
+  coerceValueToType,
+} from "../structural.js";
+import { compileOptionalNoneValue } from "../optionals.js";
+import { captureMultivalueLanes } from "../multivalue.js";
+import {
+  getRequiredExprType,
+  getStructuralTypeInfo,
+  wasmTypeFor,
+} from "../types.js";
+import { compileCallArgExpressionsWithTemps } from "../expressions/call/shared.js";
+
+const MAX_SCALAR_AGGREGATE_LANES = 4;
+const SCALAR_AGGREGATE_MATERIALIZATION_BOUNDARY_REASONS = new Set([
+  "assignment",
+  "return",
+]);
+
+export type ScalarAggregateStatementCompiler = (
+  stmtId: number,
+) => binaryen.ExpressionRef;
+
+export type ScalarAggregateBlockInitializerCompiler = (
+  expr: HirBlockExpr,
+  compileBody: () => binaryen.ExpressionRef[] | undefined,
+) => binaryen.ExpressionRef[] | undefined;
+
+const aggregateLaneCount = (structInfo: StructuralTypeInfo): number =>
+  structInfo.fields.reduce((count, field) => count + field.inlineArity, 0);
+
+const isSmallScalarAggregate = (structInfo: StructuralTypeInfo): boolean =>
+  structInfo.fields.length > 0 &&
+  aggregateLaneCount(structInfo) <= MAX_SCALAR_AGGREGATE_LANES;
+
+const symbolIsUsedAsMethodReceiver = ({
+  symbol,
+  ctx,
+}: {
+  symbol: SymbolId;
+  ctx: CodegenContext;
+}): boolean =>
+  Array.from(ctx.module.hir.expressions.values()).some((expr) => {
+    if (expr.exprKind !== "method-call") {
+      return false;
+    }
+    const target = ctx.module.hir.expressions.get(expr.target);
+    return target?.exprKind === "identifier" && target.symbol === symbol;
+  });
+
+const symbolIsCapturedByEffectHandler = ({
+  symbol,
+  ctx,
+}: {
+  symbol: SymbolId;
+  ctx: CodegenContext;
+}): boolean =>
+  Array.from(
+    ctx.optimization?.handlerClauseCaptures.get(ctx.moduleId)?.values() ?? [],
+  ).some((byClause) =>
+    Array.from(byClause.values()).some((symbols) => symbols.includes(symbol)),
+  );
+
+const symbolIsUsedAsMutableAliasInitializer = ({
+  symbol,
+  ctx,
+}: {
+  symbol: SymbolId;
+  ctx: CodegenContext;
+}): boolean =>
+  Array.from(ctx.module.hir.statements.values()).some((stmt) => {
+    if (
+      stmt.kind !== "let" ||
+      stmt.pattern.kind !== "identifier" ||
+      (!stmt.mutable && stmt.pattern.bindingKind !== "mutable-ref")
+    ) {
+      return false;
+    }
+    const initializer = ctx.module.hir.expressions.get(stmt.initializer);
+    return initializer?.exprKind === "identifier" && initializer.symbol === symbol;
+  });
+
+const fieldAccessRoot = ({
+  exprId,
+  ctx,
+}: {
+  exprId: HirExprId;
+  ctx: CodegenContext;
+}): { symbol?: SymbolId; depth: number } => {
+  let currentExprId = exprId;
+  let depth = 0;
+  while (true) {
+    const expr = ctx.module.hir.expressions.get(currentExprId);
+    if (expr?.exprKind === "field-access") {
+      depth += 1;
+      currentExprId = expr.target;
+      continue;
+    }
+    return {
+      symbol: expr?.exprKind === "identifier" ? expr.symbol : undefined,
+      depth,
+    };
+  }
+};
+
+const symbolIsUsedAsNestedFieldAssignmentRoot = ({
+  symbol,
+  ctx,
+}: {
+  symbol: SymbolId;
+  ctx: CodegenContext;
+}): boolean =>
+  Array.from(ctx.module.hir.expressions.values()).some((expr) => {
+    if (expr.exprKind !== "assign" || typeof expr.target !== "number") {
+      return false;
+    }
+    const root = fieldAccessRoot({ exprId: expr.target, ctx });
+    return root.symbol === symbol && root.depth > 1;
+  });
+
+const heapObjectSymbolNeedsStableIdentity = ({
+  symbol,
+  ctx,
+}: {
+  symbol: SymbolId;
+  ctx: CodegenContext;
+}): boolean =>
+  symbolIsUsedAsMutableAliasInitializer({ symbol, ctx });
+
+export const scalarAggregateAbiTypesForType = ({
+  typeId,
+  ctx,
+}: {
+  typeId: TypeId;
+  ctx: CodegenContext;
+}): readonly binaryen.Type[] | undefined => {
+  const structInfo = getStructuralTypeInfo(typeId, ctx);
+  if (!structInfo || !isSmallScalarAggregate(structInfo)) {
+    return undefined;
+  }
+  return structInfo.fields.flatMap((field) => [
+    ...binaryen.expandType(field.wasmType),
+  ]);
+};
+
+const nonEscapingOriginFactAllowsScalarization = ({
+  symbol,
+  exprId,
+  typeId,
+  ctx,
+}: {
+  symbol: SymbolId;
+  exprId: HirExprId;
+  typeId: TypeId;
+  ctx: CodegenContext;
+}): boolean => {
+  const fact = ctx.optimization?.escapeAnalysis.origins
+    .get(ctx.moduleId)
+    ?.get(exprId);
+  const structInfo = getStructuralTypeInfo(typeId, ctx);
+  return Boolean(
+    fact &&
+      fact.originKind === "aggregate" &&
+      fact.typeId === typeId &&
+      (!fact.escapes ||
+        fact.escapeReasons.every((reason) =>
+          reason === "assignment"
+            ? structInfo?.layoutKind === "value-object"
+            : SCALAR_AGGREGATE_MATERIALIZATION_BOUNDARY_REASONS.has(reason),
+        )) &&
+      fact.directLocalSymbols.includes(symbol),
+  );
+};
+
+const nonEscapingParameterFactAllowsScalarization = ({
+  symbol,
+  fnCtx,
+  ctx,
+}: {
+  symbol: SymbolId;
+  fnCtx: FunctionContext;
+  ctx: CodegenContext;
+}): boolean => {
+  if (typeof fnCtx.instanceId !== "number") {
+    return false;
+  }
+  const fact = ctx.optimization?.escapeAnalysis.parameters
+    .get(fnCtx.instanceId)
+    ?.get(symbol);
+  return Boolean(fact && !fact.escapes);
+};
+
+const createScalarAggregateBinding = ({
+  symbol,
+  typeId,
+  mutable,
+  structInfo,
+  ctx,
+  fnCtx,
+}: {
+  symbol?: SymbolId;
+  typeId: TypeId;
+  mutable: boolean;
+  structInfo: StructuralTypeInfo;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): LocalBindingScalarAggregate => {
+  const fields = new Map<string, ReturnType<typeof allocateTempLocal>>();
+  structInfo.fields.forEach((field) => {
+    fields.set(
+      field.name,
+      allocateTempLocal(field.wasmType, fnCtx, field.typeId, ctx),
+    );
+  });
+
+  const binding: LocalBindingScalarAggregate = {
+    kind: "scalar-aggregate",
+    mutable,
+    type: wasmTypeFor(typeId, ctx),
+    storageType: wasmTypeFor(typeId, ctx),
+    typeId,
+    structInfo,
+    fields,
+  };
+  if (typeof symbol === "number") {
+    fnCtx.bindings.set(symbol, binding);
+  }
+  return binding;
+};
+
+export const createScalarAggregateTempBinding = ({
+  typeId,
+  structInfo,
+  ctx,
+  fnCtx,
+}: {
+  typeId: TypeId;
+  structInfo: StructuralTypeInfo;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): LocalBindingScalarAggregate =>
+  createScalarAggregateBinding({
+    typeId,
+    mutable: false,
+    structInfo,
+    ctx,
+    fnCtx,
+  });
+
+const storeFieldValue = ({
+  binding,
+  field,
+  value,
+  actualTypeId,
+  ctx,
+  fnCtx,
+}: {
+  binding: LocalBindingScalarAggregate;
+  field: StructuralFieldInfo;
+  value: binaryen.ExpressionRef;
+  actualTypeId: TypeId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  const fieldBinding = binding.fields.get(field.name);
+  if (!fieldBinding) {
+    throw new Error(`scalar aggregate missing field ${field.name}`);
+  }
+  return storeLocalValue({
+    binding: fieldBinding,
+    value: coerceValueToType({
+      value,
+      actualType: actualTypeId,
+      targetType: field.typeId,
+      ctx,
+      fnCtx,
+    }),
+    ctx,
+    fnCtx,
+  });
+};
+
+const objectLiteralCanScalarize = (
+  expr: HirObjectLiteralExpr,
+  structInfo: StructuralTypeInfo,
+): boolean => {
+  if (expr.entries.some((entry) => entry.kind !== "field")) {
+    return false;
+  }
+  const initialized = new Set(
+    expr.entries
+      .filter((entry): entry is Extract<typeof entry, { kind: "field" }> =>
+        entry.kind === "field"
+      )
+      .map((entry) => entry.name),
+  );
+  return structInfo.fields.every((field) => initialized.has(field.name) || field.optional);
+};
+
+const compileObjectLiteralIntoScalarBinding = ({
+  binding,
+  expr,
+  structInfo,
+  ctx,
+  fnCtx,
+  compileExpr,
+}: {
+  binding: LocalBindingScalarAggregate;
+  expr: HirObjectLiteralExpr;
+  structInfo: StructuralTypeInfo;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+}): binaryen.ExpressionRef[] => {
+  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+  const values = compileCallArgExpressionsWithTemps({
+    callId: expr.id,
+    args: expr.entries.map((entry) => ({ expr: entry.value })),
+    expectedTypeIdAt: (index) => {
+      const entry = expr.entries[index];
+      return entry?.kind === "field"
+        ? structInfo.fieldMap.get(entry.name)?.typeId
+        : undefined;
+    },
+    ctx,
+    fnCtx,
+    compileExpr,
+  });
+  const ops: binaryen.ExpressionRef[] = [];
+  const initialized = new Set<string>();
+
+  expr.entries.forEach((entry, index) => {
+    if (entry.kind !== "field") {
+      throw new Error("scalar aggregate object literal unexpectedly contains a spread");
+    }
+    const field = structInfo.fieldMap.get(entry.name);
+    if (!field) {
+      throw new Error(`object literal cannot set unknown field ${entry.name}`);
+    }
+    ops.push(
+      storeFieldValue({
+        binding,
+        field,
+        value: values[index]!,
+        actualTypeId: getRequiredExprType(entry.value, ctx, typeInstanceId),
+        ctx,
+        fnCtx,
+      }),
+    );
+    initialized.add(entry.name);
+  });
+
+  structInfo.fields.forEach((field) => {
+    if (initialized.has(field.name)) {
+      return;
+    }
+    if (!field.optional) {
+      throw new Error(`missing initializer for field ${field.name}`);
+    }
+    ops.push(
+      storeFieldValue({
+        binding,
+        field,
+        value: compileOptionalNoneValue({
+          targetTypeId: field.typeId,
+          ctx,
+          fnCtx,
+        }),
+        actualTypeId: field.typeId,
+        ctx,
+        fnCtx,
+      }),
+    );
+  });
+
+  return ops;
+};
+
+const compileTupleIntoScalarBinding = ({
+  binding,
+  expr,
+  structInfo,
+  ctx,
+  fnCtx,
+  compileExpr,
+}: {
+  binding: LocalBindingScalarAggregate;
+  expr: HirExpression & { exprKind: "tuple"; elements: readonly HirExprId[] };
+  structInfo: StructuralTypeInfo;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+}): binaryen.ExpressionRef[] => {
+  const values = compileCallArgExpressionsWithTemps({
+    callId: expr.id,
+    args: expr.elements.map((element) => ({ expr: element })),
+    expectedTypeIdAt: (index) => structInfo.fieldMap.get(`${index}`)?.typeId,
+    ctx,
+    fnCtx,
+    compileExpr,
+  });
+  return expr.elements.map((element, index) => {
+    const field = structInfo.fieldMap.get(`${index}`);
+    if (!field) {
+      throw new Error(`tuple element ${index} missing corresponding field`);
+    }
+    return storeFieldValue({
+      binding,
+      field,
+      value: values[index]!,
+      actualTypeId: getRequiredExprType(element, ctx, fnCtx.typeInstanceId ?? fnCtx.instanceId),
+      ctx,
+      fnCtx,
+    });
+  });
+};
+
+const exprCanScalarizeAggregateAssignment = ({
+  symbol,
+  exprId,
+  targetTypeId,
+  structInfo,
+  requireOriginFact,
+  allowBlockStatements,
+  ctx,
+}: {
+  symbol?: SymbolId;
+  exprId: HirExprId;
+  targetTypeId: TypeId;
+  structInfo: StructuralTypeInfo;
+  requireOriginFact: boolean;
+  allowBlockStatements: boolean;
+  ctx: CodegenContext;
+}): boolean => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  if (!expr) {
+    return false;
+  }
+
+  if (expr.exprKind === "object-literal") {
+    return (
+      (!requireOriginFact ||
+        (typeof symbol === "number" &&
+          nonEscapingOriginFactAllowsScalarization({
+            symbol,
+            exprId,
+            typeId: targetTypeId,
+            ctx,
+          }))) &&
+      objectLiteralCanScalarize(expr, structInfo)
+    );
+  }
+
+  if (expr.exprKind === "tuple") {
+    return (
+      (!requireOriginFact ||
+        (typeof symbol === "number" &&
+          nonEscapingOriginFactAllowsScalarization({
+            symbol,
+            exprId,
+            typeId: targetTypeId,
+            ctx,
+          }))) &&
+      structInfo.fields.length === expr.elements.length
+    );
+  }
+
+  if (expr.exprKind === "block") {
+    return (
+      typeof expr.value === "number" &&
+      (expr.statements.length === 0 || allowBlockStatements) &&
+      exprCanScalarizeAggregateAssignment({
+        symbol,
+        exprId: expr.value,
+        targetTypeId,
+        structInfo,
+        requireOriginFact,
+        allowBlockStatements,
+        ctx,
+      })
+    );
+  }
+
+  if (expr.exprKind === "if" || expr.exprKind === "cond") {
+    return (
+      typeof expr.defaultBranch === "number" &&
+      expr.branches.every((branch) =>
+        exprCanScalarizeAggregateAssignment({
+          symbol,
+          exprId: branch.value,
+          targetTypeId,
+          structInfo,
+          requireOriginFact,
+          allowBlockStatements,
+          ctx,
+        }),
+      ) &&
+      exprCanScalarizeAggregateAssignment({
+        symbol,
+        exprId: expr.defaultBranch,
+        targetTypeId,
+        structInfo,
+        requireOriginFact,
+        allowBlockStatements,
+        ctx,
+      })
+    );
+  }
+
+  if (expr.exprKind === "call" || expr.exprKind === "method-call") {
+    return true;
+  }
+
+  return false;
+};
+
+const scalarAssignmentMayFailAfterBlockStatements = ({
+  exprId,
+  structInfo,
+  ctx,
+}: {
+  exprId: HirExprId;
+  structInfo: StructuralTypeInfo;
+  ctx: CodegenContext;
+}): boolean => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  if (!expr) {
+    return true;
+  }
+  if (expr.exprKind === "call" || expr.exprKind === "method-call") {
+    return structInfo.layoutKind === "heap-object";
+  }
+  if (expr.exprKind === "block") {
+    return typeof expr.value !== "number" ||
+      scalarAssignmentMayFailAfterBlockStatements({
+        exprId: expr.value,
+        structInfo,
+        ctx,
+      });
+  }
+  if (expr.exprKind === "if" || expr.exprKind === "cond") {
+    return (
+      typeof expr.defaultBranch !== "number" ||
+      expr.branches.some((branch) =>
+        scalarAssignmentMayFailAfterBlockStatements({
+          exprId: branch.value,
+          structInfo,
+          ctx,
+        }),
+      ) ||
+      scalarAssignmentMayFailAfterBlockStatements({
+        exprId: expr.defaultBranch,
+        structInfo,
+        ctx,
+      })
+    );
+  }
+  return false;
+};
+
+const asStatementBlock = (
+  ctx: CodegenContext,
+  ops: readonly binaryen.ExpressionRef[],
+): binaryen.ExpressionRef =>
+  ops.length === 0 ? ctx.mod.nop() : ctx.mod.block(null, [...ops], binaryen.none);
+
+const compileConditionalAssignment = ({
+  binding,
+  expr,
+  symbol,
+  targetTypeId,
+  structInfo,
+  ctx,
+  fnCtx,
+  compileExpr,
+  compileStatement,
+  compileBlockInitializer,
+}: {
+  binding: LocalBindingScalarAggregate;
+  expr: HirIfExpr | HirCondExpr;
+  symbol?: SymbolId;
+  targetTypeId: TypeId;
+  structInfo: StructuralTypeInfo;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+  compileStatement?: ScalarAggregateStatementCompiler;
+  compileBlockInitializer?: ScalarAggregateBlockInitializerCompiler;
+}): binaryen.ExpressionRef[] | undefined => {
+  if (typeof expr.defaultBranch !== "number") {
+    throw new Error("scalar aggregate conditional requires a default branch");
+  }
+
+  const defaultOps = compileScalarAggregateAssignment({
+      binding,
+      symbol,
+      exprId: expr.defaultBranch,
+      targetTypeId,
+      structInfo,
+      ctx,
+      fnCtx,
+      compileExpr,
+      compileStatement,
+      compileBlockInitializer,
+  });
+  if (!defaultOps) {
+    return undefined;
+  }
+  let fallback = asStatementBlock(ctx, defaultOps);
+
+  for (let index = expr.branches.length - 1; index >= 0; index -= 1) {
+    const branch = expr.branches[index]!;
+    const condition = compileExpr({ exprId: branch.condition, ctx, fnCtx }).expr;
+    const thenOps = compileScalarAggregateAssignment({
+      binding,
+      symbol,
+      exprId: branch.value,
+      targetTypeId,
+      structInfo,
+      ctx,
+      fnCtx,
+      compileExpr,
+      compileStatement,
+      compileBlockInitializer,
+    });
+    if (!thenOps) {
+      return undefined;
+    }
+    fallback = ctx.mod.if(condition, asStatementBlock(ctx, thenOps), fallback);
+  }
+
+  return [fallback];
+};
+
+const compileScalarAggregateAssignment = ({
+  binding,
+  symbol,
+  exprId,
+  targetTypeId,
+  structInfo,
+  ctx,
+  fnCtx,
+  compileExpr,
+  compileStatement,
+  compileBlockInitializer,
+}: {
+  binding: LocalBindingScalarAggregate;
+  symbol?: SymbolId;
+  exprId: HirExprId;
+  targetTypeId: TypeId;
+  structInfo: StructuralTypeInfo;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+  compileStatement?: ScalarAggregateStatementCompiler;
+  compileBlockInitializer?: ScalarAggregateBlockInitializerCompiler;
+}): binaryen.ExpressionRef[] | undefined => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  if (!expr) {
+    throw new Error(`missing scalar aggregate initializer expression ${exprId}`);
+  }
+
+  if (expr.exprKind === "object-literal") {
+    return compileObjectLiteralIntoScalarBinding({
+      binding,
+      expr,
+      structInfo,
+      ctx,
+      fnCtx,
+      compileExpr,
+    });
+  }
+
+  if (expr.exprKind === "tuple") {
+    return compileTupleIntoScalarBinding({
+      binding,
+      expr,
+      structInfo,
+      ctx,
+      fnCtx,
+      compileExpr,
+    });
+  }
+
+  if (expr.exprKind === "block") {
+    if (typeof expr.value !== "number") {
+      throw new Error("scalar aggregate block initializer requires a value");
+    }
+    if (
+      expr.statements.length > 0 &&
+      (!compileStatement || !compileBlockInitializer)
+    ) {
+      return undefined;
+    }
+    if (
+      expr.statements.length > 0 &&
+      scalarAssignmentMayFailAfterBlockStatements({
+        exprId: expr.value,
+        structInfo,
+        ctx,
+      })
+    ) {
+      return undefined;
+    }
+    const compileBody = () => {
+      const statementOps = compileStatement
+        ? expr.statements.map(compileStatement)
+        : [];
+      const valueOps = compileScalarAggregateAssignment({
+        binding,
+        symbol,
+        exprId: expr.value!,
+        targetTypeId,
+        structInfo,
+        ctx,
+        fnCtx,
+        compileExpr,
+        compileStatement,
+        compileBlockInitializer,
+      });
+      return valueOps ? [...statementOps, ...valueOps] : undefined;
+    };
+    return compileBlockInitializer
+      ? compileBlockInitializer(expr, compileBody)
+      : compileBody();
+  }
+
+  if (expr.exprKind === "if" || expr.exprKind === "cond") {
+    return compileConditionalAssignment({
+      binding,
+      expr,
+      symbol,
+      targetTypeId,
+      structInfo,
+      ctx,
+      fnCtx,
+      compileExpr,
+      compileStatement,
+      compileBlockInitializer,
+    });
+  }
+
+  if (expr.exprKind === "call" || expr.exprKind === "method-call") {
+    const previousBindings =
+      binding.structInfo.layoutKind === "heap-object"
+        ? new Map(fnCtx.bindings)
+        : undefined;
+    const value = compileExpr({
+      exprId,
+      ctx,
+      fnCtx,
+      expectedResultTypeId: targetTypeId,
+      scalarAggregateResultTypeId: targetTypeId,
+    });
+    if (value.usedScalarAggregateResult) {
+      return storeScalarAggregateBindingAbiValue({
+        binding,
+        value: value.expr,
+        ctx,
+        fnCtx,
+      });
+    }
+    if (binding.structInfo.layoutKind === "heap-object") {
+      if (previousBindings) {
+        fnCtx.bindings = previousBindings;
+      }
+      return undefined;
+    }
+    return [
+      storeScalarAggregateBindingValue({
+        binding,
+        value: value.expr,
+        ctx,
+        fnCtx,
+      }),
+    ];
+  }
+
+  return undefined;
+};
+
+export const tryScalarizeAggregateInitializer = ({
+  symbol,
+  initializer,
+  targetTypeId,
+  mutable,
+  ctx,
+  fnCtx,
+  compileExpr,
+  compileStatement,
+  compileBlockInitializer,
+}: {
+  symbol: SymbolId;
+  initializer: HirExprId;
+  targetTypeId: TypeId;
+  mutable: boolean;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+  compileStatement?: ScalarAggregateStatementCompiler;
+  compileBlockInitializer?: ScalarAggregateBlockInitializerCompiler;
+}): binaryen.ExpressionRef[] | undefined => {
+  if (fnCtx.effectful) {
+    return undefined;
+  }
+  const structInfo = getStructuralTypeInfo(targetTypeId, ctx);
+  if (!structInfo || !isSmallScalarAggregate(structInfo)) {
+    return undefined;
+  }
+  if (
+    mutable &&
+    symbolIsUsedAsMethodReceiver({ symbol, ctx })
+  ) {
+    return undefined;
+  }
+  if (
+    structInfo.layoutKind === "heap-object" &&
+    heapObjectSymbolNeedsStableIdentity({ symbol, ctx })
+  ) {
+    return undefined;
+  }
+  if (symbolIsUsedAsNestedFieldAssignmentRoot({ symbol, ctx })) {
+    return undefined;
+  }
+  if (symbolIsCapturedByEffectHandler({ symbol, ctx })) {
+    return undefined;
+  }
+
+  if (
+    !exprCanScalarizeAggregateAssignment({
+      symbol,
+      structInfo,
+      exprId: initializer,
+      targetTypeId,
+      requireOriginFact: true,
+      allowBlockStatements: Boolean(compileStatement && compileBlockInitializer),
+      ctx,
+    })
+  ) {
+    return undefined;
+  }
+
+  const previousBinding = fnCtx.bindings.get(symbol);
+  const binding = createScalarAggregateBinding({
+    symbol,
+    typeId: targetTypeId,
+    mutable,
+    structInfo,
+    ctx,
+    fnCtx,
+  });
+  const ops = compileScalarAggregateAssignment({
+    binding,
+    symbol,
+    exprId: initializer,
+    targetTypeId,
+    structInfo,
+    ctx,
+    fnCtx,
+    compileExpr,
+    compileStatement,
+    compileBlockInitializer,
+  });
+  if (!ops) {
+    if (previousBinding) {
+      fnCtx.bindings.set(symbol, previousBinding);
+    } else {
+      fnCtx.bindings.delete(symbol);
+    }
+    return undefined;
+  }
+  return ops;
+};
+
+export const canStoreScalarAggregateExpression = ({
+  exprId,
+  targetTypeId,
+  structInfo,
+  allowBlockStatements = false,
+  ctx,
+}: {
+  exprId: HirExprId;
+  targetTypeId: TypeId;
+  structInfo: StructuralTypeInfo;
+  allowBlockStatements?: boolean;
+  ctx: CodegenContext;
+}): boolean =>
+  exprCanScalarizeAggregateAssignment({
+    exprId,
+    targetTypeId,
+    structInfo,
+    requireOriginFact: false,
+    allowBlockStatements,
+    ctx,
+  });
+
+export const tryStoreScalarAggregateExpression = ({
+  binding,
+  exprId,
+  targetTypeId,
+  ctx,
+  fnCtx,
+  compileExpr,
+  compileStatement,
+  compileBlockInitializer,
+}: {
+  binding: LocalBindingScalarAggregate;
+  exprId: HirExprId;
+  targetTypeId: TypeId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+  compileStatement?: ScalarAggregateStatementCompiler;
+  compileBlockInitializer?: ScalarAggregateBlockInitializerCompiler;
+}): binaryen.ExpressionRef[] | undefined => {
+  const structInfo = binding.structInfo;
+  if (
+    binding.typeId !== targetTypeId ||
+    !exprCanScalarizeAggregateAssignment({
+      exprId,
+      targetTypeId,
+      structInfo,
+      requireOriginFact: false,
+      allowBlockStatements: Boolean(compileStatement && compileBlockInitializer),
+      ctx,
+    })
+  ) {
+    return undefined;
+  }
+  return compileScalarAggregateAssignment({
+    binding,
+    exprId,
+    targetTypeId,
+    structInfo,
+    ctx,
+    fnCtx,
+    compileExpr,
+    compileStatement,
+    compileBlockInitializer,
+  });
+};
+
+export const storeScalarAggregateBindingAbiValue = ({
+  binding,
+  value,
+  ctx,
+  fnCtx,
+}: {
+  binding: LocalBindingScalarAggregate;
+  value: binaryen.ExpressionRef;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef[] => {
+  const abiTypes = binding.structInfo.fields.flatMap((field) => [
+    ...binaryen.expandType(field.wasmType),
+  ]);
+  const captured = captureMultivalueLanes({
+    value,
+    abiTypes,
+    ctx,
+    fnCtx,
+  });
+  const stores = binding.structInfo.fields.map((field) => {
+    const laneValues = captured.lanes.slice(
+      field.inlineStart,
+      field.inlineStart + field.inlineArity,
+    );
+    const fieldValue =
+      laneValues.length === 1
+        ? laneValues[0]!
+        : ctx.mod.tuple.make(laneValues as binaryen.ExpressionRef[]);
+    return storeFieldValue({
+      binding,
+      field,
+      value: fieldValue,
+      actualTypeId: field.typeId,
+      ctx,
+      fnCtx,
+    });
+  });
+  return [...captured.setup, ...stores];
+};
+
+export const loadScalarAggregateBindingAbiValue = ({
+  binding,
+  ctx,
+}: {
+  binding: LocalBindingScalarAggregate;
+  ctx: CodegenContext;
+}): binaryen.ExpressionRef => {
+  const lanes = binding.structInfo.fields.flatMap((field) => {
+    const fieldBinding = binding.fields.get(field.name);
+    if (!fieldBinding) {
+      throw new Error(`scalar aggregate missing field ${field.name}`);
+    }
+    const value = loadLocalValue(fieldBinding, ctx);
+    const fieldAbiTypes = [...binaryen.expandType(field.wasmType)];
+    return fieldAbiTypes.length <= 1
+      ? [value]
+      : fieldAbiTypes.map((_, index) => ctx.mod.tuple.extract(value, index));
+  });
+  return lanes.length === 1
+    ? lanes[0]!
+    : ctx.mod.tuple.make(lanes as binaryen.ExpressionRef[]);
+};
+
+export const tryBindScalarAggregateParameter = ({
+  symbol,
+  typeId,
+  mutable,
+  abiValues,
+  scalarAggregateAbi,
+  ctx,
+  fnCtx,
+}: {
+  symbol: SymbolId;
+  typeId: TypeId;
+  mutable: boolean;
+  abiValues: readonly binaryen.ExpressionRef[];
+  scalarAggregateAbi?: boolean;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef[] | undefined => {
+  if (
+    fnCtx.effectful ||
+    mutable ||
+    !nonEscapingParameterFactAllowsScalarization({ symbol, fnCtx, ctx })
+  ) {
+    return undefined;
+  }
+  const structInfo = getStructuralTypeInfo(typeId, ctx);
+  if (
+    !structInfo ||
+    (structInfo.layoutKind !== "value-object" && scalarAggregateAbi !== true) ||
+    !isSmallScalarAggregate(structInfo) ||
+    abiValues.length !== aggregateLaneCount(structInfo)
+  ) {
+    return undefined;
+  }
+
+  const binding = createScalarAggregateBinding({
+    symbol,
+    typeId,
+    mutable: false,
+    structInfo,
+    ctx,
+    fnCtx,
+  });
+  return structInfo.fields.map((field) => {
+    const laneValues = abiValues.slice(
+      field.inlineStart,
+      field.inlineStart + field.inlineArity,
+    );
+    const value =
+      laneValues.length === 1
+        ? laneValues[0]!
+        : ctx.mod.tuple.make(laneValues as binaryen.ExpressionRef[]);
+    return storeFieldValue({
+      binding,
+      field,
+      value,
+      actualTypeId: field.typeId,
+      ctx,
+      fnCtx,
+    });
+  });
+};

--- a/packages/compiler/src/codegen/patterns.ts
+++ b/packages/compiler/src/codegen/patterns.ts
@@ -5,6 +5,7 @@ import type {
   FunctionContext,
   HirExprId,
   HirPattern,
+  LocalBindingScalarAggregate,
   TypeId,
 } from "./context.js";
 import {
@@ -12,8 +13,12 @@ import {
   declareLocal,
   declareLocalWithTypeId,
   getRequiredBinding,
+  loadBindingValue,
   loadBindingStorageRef,
   loadLocalValue,
+  loadScalarAggregateBindingField,
+  materializeOwnedBinding,
+  storeScalarAggregateBindingValue,
   storeStorageRefBindingValue,
   storeLocalValue,
 } from "./locals.js";
@@ -34,9 +39,15 @@ import {
   refCast,
   structSetFieldValue,
 } from "@voyd-lang/lib/binaryen-gc/index.js";
+import {
+  tryScalarizeAggregateInitializer,
+  type ScalarAggregateBlockInitializerCompiler,
+  type ScalarAggregateStatementCompiler,
+} from "./optimization/scalar-aggregates.js";
 
 export interface PatternInitOptions {
   declare: boolean;
+  mutable?: boolean;
 }
 
 interface PatternInitParams {
@@ -46,6 +57,8 @@ interface PatternInitParams {
   fnCtx: FunctionContext;
   ops: binaryen.ExpressionRef[];
   compileExpr: ExpressionCompiler;
+  compileStatement?: ScalarAggregateStatementCompiler;
+  compileBlockInitializer?: ScalarAggregateBlockInitializerCompiler;
   options: PatternInitOptions;
 }
 
@@ -103,6 +116,14 @@ const storeIntoBinding = ({
   }
   if (binding.kind === "projected-element-ref") {
     throw new Error("cannot assign to a projected element binding");
+  }
+  if (binding.kind === "scalar-aggregate") {
+    return storeScalarAggregateBindingValue({
+      binding,
+      value: coerced,
+      ctx,
+      fnCtx,
+    });
   }
   return storeLocalValue({ binding, value: coerced, ctx, fnCtx });
 };
@@ -228,6 +249,8 @@ export const compilePatternInitialization = ({
   fnCtx,
   ops,
   compileExpr,
+  compileStatement,
+  compileBlockInitializer,
   options,
 }: PatternInitParams): void => {
   const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
@@ -279,6 +302,34 @@ export const compilePatternInitialization = ({
   const targetTypeId = options.declare
     ? getDeclaredSymbolTypeId(pattern.symbol, ctx, typeInstanceId)
     : getSymbolTypeId(pattern.symbol, ctx, typeInstanceId);
+  const mutableBinding =
+    options.mutable === true || pattern.bindingKind === "mutable-ref";
+  const scalarized = options.declare
+    ? tryScalarizeAggregateInitializer({
+        symbol: pattern.symbol,
+        initializer,
+        targetTypeId,
+        mutable: mutableBinding,
+        ctx,
+        fnCtx,
+        compileExpr,
+        compileStatement,
+        compileBlockInitializer,
+      })
+    : undefined;
+  if (scalarized) {
+    ops.push(...scalarized);
+    return;
+  }
+
+  ops.push(
+    ...materializeScalarHeapInitializerAlias({
+      initializer,
+      ctx,
+      fnCtx,
+    }),
+  );
+
   const binding = options.declare
     ? declareLocalWithTypeId(pattern.symbol, targetTypeId, ctx, fnCtx)
     : getRequiredBinding(pattern.symbol, ctx, fnCtx);
@@ -423,6 +474,23 @@ const compileTuplePattern = ({
     ctx,
     typeInstanceId
   );
+  const scalarBinding = getScalarAggregateInitializerBinding({
+    initializer,
+    ctx,
+    fnCtx,
+  });
+  if (scalarBinding) {
+    compilePatternFromScalarAggregate({
+      pattern,
+      binding: scalarBinding,
+      typeId: initializerType,
+      ctx,
+      fnCtx,
+      ops,
+      options,
+    });
+    return;
+  }
   const initializerTemp = allocateTempLocal(
     wasmTypeFor(initializerType, ctx),
     fnCtx,
@@ -491,6 +559,23 @@ const compileDestructurePattern = ({
     ctx,
     typeInstanceId
   );
+  const scalarBinding = getScalarAggregateInitializerBinding({
+    initializer,
+    ctx,
+    fnCtx,
+  });
+  if (scalarBinding) {
+    compilePatternFromScalarAggregate({
+      pattern,
+      binding: scalarBinding,
+      typeId: initializerType,
+      ctx,
+      fnCtx,
+      ops,
+      options,
+    });
+    return;
+  }
   const initializerTemp = allocateTempLocal(
     wasmTypeFor(initializerType, ctx),
     fnCtx,
@@ -542,6 +627,204 @@ const compileDestructurePattern = ({
       })
     );
   });
+};
+
+const getScalarAggregateInitializerBinding = ({
+  initializer,
+  ctx,
+  fnCtx,
+}: {
+  initializer: HirExprId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): LocalBindingScalarAggregate | undefined => {
+  const expr = ctx.module.hir.expressions.get(initializer);
+  if (expr?.exprKind !== "identifier") {
+    return undefined;
+  }
+  const binding = fnCtx.bindings.get(expr.symbol);
+  return binding?.kind === "scalar-aggregate" ? binding : undefined;
+};
+
+const materializeScalarHeapInitializerAlias = ({
+  initializer,
+  ctx,
+  fnCtx,
+}: {
+  initializer: HirExprId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): readonly binaryen.ExpressionRef[] => {
+  const expr = ctx.module.hir.expressions.get(initializer);
+  if (expr?.exprKind !== "identifier") {
+    return [];
+  }
+  const binding = fnCtx.bindings.get(expr.symbol);
+  if (
+    binding?.kind !== "scalar-aggregate" ||
+    binding.structInfo.layoutKind !== "heap-object"
+  ) {
+    return [];
+  }
+  return materializeOwnedBinding({
+    symbol: expr.symbol,
+    ctx,
+    fnCtx,
+  }).setup;
+};
+
+const compilePatternFromScalarAggregate = ({
+  pattern,
+  binding,
+  typeId,
+  ctx,
+  fnCtx,
+  ops,
+  options,
+}: {
+  pattern: HirPattern;
+  binding: LocalBindingScalarAggregate;
+  typeId: TypeId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  ops: binaryen.ExpressionRef[];
+  options: PatternInitOptions;
+}): void => {
+  const pending = collectAssignmentsFromScalarAggregate({
+    pattern,
+    binding,
+    typeId,
+    ctx,
+    fnCtx,
+    ops,
+  });
+  pending.forEach(({ pattern: subPattern, temp, typeId: subPatternTypeId }) => {
+    const targetTypeId = subPatternTypeId;
+    const targetBinding = options.declare
+      ? declareLocalWithTypeId(subPattern.symbol, targetTypeId, ctx, fnCtx)
+      : getRequiredBinding(subPattern.symbol, ctx, fnCtx);
+    ops.push(
+      storeIntoBinding({
+        binding: targetBinding,
+        value: loadLocalValue(temp, ctx),
+        targetTypeId,
+        actualTypeId: subPatternTypeId,
+        ctx,
+        fnCtx,
+      }),
+    );
+  });
+};
+
+const collectAssignmentsFromScalarAggregate = ({
+  pattern,
+  binding,
+  typeId,
+  ctx,
+  fnCtx,
+  ops,
+}: {
+  pattern: HirPattern;
+  binding: LocalBindingScalarAggregate;
+  typeId: TypeId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  ops: binaryen.ExpressionRef[];
+}): PendingPatternAssignment[] => {
+  const structInfo = getStructuralTypeInfo(typeId, ctx);
+  if (!structInfo) {
+    throw new Error("scalar aggregate pattern requires a structural value");
+  }
+  const fieldPatterns =
+    pattern.kind === "tuple"
+      ? pattern.elements.map((subPattern, index) => ({
+          name: `${index}`,
+          pattern: subPattern,
+        }))
+      : pattern.kind === "destructure"
+        ? pattern.fields
+        : undefined;
+  if (!fieldPatterns) {
+    return collectAssignmentsFromScalarAggregateValue({
+      pattern,
+      binding,
+      typeId,
+      ctx,
+      fnCtx,
+      ops,
+    });
+  }
+  if (pattern.kind === "destructure" && pattern.spread && pattern.spread.kind !== "wildcard") {
+    throw new Error("destructure spread bindings are not supported yet");
+  }
+  if (pattern.kind === "tuple" && fieldPatterns.length !== structInfo.fields.length) {
+    throw new Error("tuple pattern arity mismatch");
+  }
+
+  return fieldPatterns.flatMap(({ name, pattern: subPattern }) => {
+    const field = structInfo.fieldMap.get(name);
+    if (!field) {
+      throw new Error(`structural value is missing field ${name}`);
+    }
+    const value = loadScalarAggregateBindingField({
+      binding,
+      fieldName: name,
+      ctx,
+    });
+    if (typeof value !== "number") {
+      throw new Error(`scalar aggregate missing field ${name}`);
+    }
+    const fieldTemp = allocateTempLocal(field.wasmType, fnCtx, field.typeId, ctx);
+    ops.push(
+      storeLocalValue({
+        binding: fieldTemp,
+        value,
+        ctx,
+        fnCtx,
+      }),
+    );
+    return collectAssignmentsFromValue({
+      pattern: subPattern,
+      temp: fieldTemp,
+      typeId: field.typeId,
+      ctx,
+      fnCtx,
+      ops,
+    });
+  });
+};
+
+const collectAssignmentsFromScalarAggregateValue = ({
+  pattern,
+  binding,
+  typeId,
+  ctx,
+  fnCtx,
+  ops,
+}: {
+  pattern: HirPattern;
+  binding: LocalBindingScalarAggregate;
+  typeId: TypeId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  ops: binaryen.ExpressionRef[];
+}): PendingPatternAssignment[] => {
+  if (pattern.kind === "wildcard") {
+    return [];
+  }
+  if (pattern.kind !== "identifier") {
+    throw new Error(`unsupported pattern kind ${pattern.kind}`);
+  }
+  const temp = allocateTempLocal(wasmTypeFor(typeId, ctx), fnCtx, typeId, ctx);
+  ops.push(
+    storeLocalValue({
+      binding: temp,
+      value: loadBindingValue(binding, ctx, fnCtx),
+      ctx,
+      fnCtx,
+    }),
+  );
+  return [{ pattern, temp, typeId }];
 };
 
 const collectAssignmentsFromValue = ({

--- a/packages/compiler/src/optimize/pipeline.ts
+++ b/packages/compiler/src/optimize/pipeline.ts
@@ -5,6 +5,7 @@ import type {
 } from "../semantics/hir/index.js";
 import { walkExpression } from "../semantics/hir/index.js";
 import type {
+  CodegenFunctionSignature,
   CallLoweringInfo,
   ModuleCodegenView,
   MonomorphizedInstanceInfo,
@@ -1836,6 +1837,50 @@ const mergeExactParameterCandidate = ({
   candidates.set(instanceId, bySymbol);
 };
 
+const resolveDirectIdentifierCallTarget = ({
+  moduleView,
+  expr,
+  typeArgs,
+  ir,
+}: {
+  moduleView: OptimizedModuleView;
+  expr: Extract<HirExpression, { exprKind: "call" | "method-call" }>;
+  typeArgs: readonly TypeId[];
+  ir: MutableOptimizationIr;
+}): readonly { functionId: ProgramFunctionId; instanceId?: ProgramFunctionInstanceId }[] => {
+  if (expr.exprKind !== "call") {
+    return [];
+  }
+  const callee = moduleView.hir.expressions.get(expr.callee);
+  if (callee?.exprKind !== "identifier") {
+    return [];
+  }
+  const resolved = resolveImportedSymbol({
+    moduleId: moduleView.moduleId,
+    symbol: callee.symbol,
+    ir,
+  });
+  const module = ir.modules.get(resolved.moduleId);
+  if (!module || !functionItemBySymbol({ moduleView: module, symbol: resolved.symbol })) {
+    return [];
+  }
+  const functionId = canonicalProgramSymbolIdOf({
+    moduleId: resolved.moduleId,
+    symbol: resolved.symbol,
+    ir,
+  });
+  return [
+    {
+      functionId,
+      instanceId: ir.baseProgram.functions.getInstanceId(
+        resolved.moduleId,
+        resolved.symbol,
+        typeArgs,
+      ),
+    },
+  ];
+};
+
 const resolveTargetsForExactPropagation = ({
   moduleView,
   exprId,
@@ -1858,38 +1903,11 @@ const resolveTargetsForExactPropagation = ({
   if (resolvedTargets.length > 0 || expr.exprKind !== "call") {
     return resolvedTargets;
   }
-  const callee = moduleView.hir.expressions.get(expr.callee);
-  if (callee?.exprKind !== "identifier") {
-    return [];
-  }
-  const resolved = resolveImportedSymbol({
-    moduleId: moduleView.moduleId,
-    symbol: callee.symbol,
-    ir,
-  });
-  const module = ir.modules.get(resolved.moduleId);
-  if (!module || !functionItemBySymbol({ moduleView: module, symbol: resolved.symbol })) {
-    return [];
-  }
-  const functionId = canonicalProgramSymbolIdOf({
-    moduleId: resolved.moduleId,
-    symbol: resolved.symbol,
-    ir,
-  });
   const callInfo = ir.calls.get(moduleView.moduleId)?.get(exprId);
   const typeArgs = callInfo
     ? resolveCallTypeArgs({ callInfo, callerInstanceId })
     : [];
-  return [
-    {
-      functionId,
-      instanceId: ir.baseProgram.functions.getInstanceId(
-        resolved.moduleId,
-        resolved.symbol,
-        typeArgs,
-      ),
-    },
-  ];
+  return resolveDirectIdentifierCallTarget({ moduleView, expr, typeArgs, ir });
 };
 
 const externallyCallableFunctionInstances = (
@@ -4294,6 +4312,12 @@ type EscapeUseContext = {
   traitBoundary?: boolean;
 };
 
+type StructuralEscapeField = {
+  name: string;
+  typeId: TypeId;
+  optional: boolean;
+};
+
 type EscapeAnalysisState = {
   ir: MutableOptimizationIr;
   moduleView: OptimizedModuleView;
@@ -4801,6 +4825,238 @@ const isTraitType = ({
     (desc.kind === "intersection" && (desc.traits?.length ?? 0) > 0);
 };
 
+const targetParameterIsMutable = ({
+  state,
+  moduleId,
+  symbol,
+  parameterIndex,
+  parameter,
+}: {
+  state: EscapeAnalysisState;
+  moduleId: string;
+  symbol: SymbolId;
+  parameterIndex: number;
+  parameter: CodegenFunctionSignature["parameters"][number];
+}): boolean => {
+  if (parameter.bindingKind === "mutable-ref") {
+    return true;
+  }
+  const moduleView = state.ir.modules.get(moduleId);
+  const item = moduleView
+    ? functionItemBySymbol({ moduleView, symbol })
+    : undefined;
+  return item?.parameters[parameterIndex]?.mutable === true;
+};
+
+const structuralEscapeFieldsForType = ({
+  typeId,
+  state,
+  seen = new Set<TypeId>(),
+}: {
+  typeId: TypeId;
+  state: EscapeAnalysisState;
+  seen?: Set<TypeId>;
+}): readonly StructuralEscapeField[] | undefined => {
+  if (seen.has(typeId)) {
+    return undefined;
+  }
+  seen.add(typeId);
+
+  const layout = state.ir.baseProgram.types.getStructuralLayout(typeId);
+  if (layout?.kind === "structural-object") {
+    return layout.fields;
+  }
+
+  const objectInfo = state.ir.baseProgram.objects.getInfoByNominal(typeId);
+  if (objectInfo) {
+    return objectInfo.fields.map((field) => ({
+      name: field.name,
+      typeId: field.type,
+      optional: field.optional === true,
+    }));
+  }
+
+  const desc = state.ir.baseProgram.types.getTypeDesc(typeId);
+  if (desc.kind === "intersection") {
+    const structural =
+      typeof desc.structural === "number"
+        ? structuralEscapeFieldsForType({
+            typeId: desc.structural,
+            state,
+            seen,
+          })
+        : undefined;
+    if (structural) {
+      return structural;
+    }
+    return typeof desc.nominal === "number"
+      ? structuralEscapeFieldsForType({ typeId: desc.nominal, state, seen })
+      : undefined;
+  }
+
+  return undefined;
+};
+
+const parameterCanBeOmittedAtCallSite = ({
+  parameter,
+  moduleId,
+  state,
+}: {
+  parameter: CodegenFunctionSignature["parameters"][number];
+  moduleId: string;
+  state: EscapeAnalysisState;
+}): boolean =>
+  parameter.optional === true ||
+  parameter.synthetic === "stable-callsite-id" ||
+  state.ir.baseProgram.optionals.getOptionalInfo(moduleId, parameter.typeId) !==
+    undefined;
+
+const callLabelsCompatible = ({
+  parameter,
+  argLabel,
+}: {
+  parameter: CodegenFunctionSignature["parameters"][number];
+  argLabel: string | undefined;
+}): boolean => (parameter.label ? argLabel === parameter.label : argLabel === undefined);
+
+const fallbackContainerFieldParameterIndexesForCallArgument = ({
+  expr,
+  argIndex,
+  signature,
+  moduleId,
+  state,
+}: {
+  expr: Extract<HirExpression, { exprKind: "call" | "method-call" }>;
+  argIndex: number;
+  signature: CodegenFunctionSignature;
+  moduleId: string;
+  state: EscapeAnalysisState;
+}): readonly number[] | undefined => {
+  if (expr.exprKind !== "call") {
+    return undefined;
+  }
+
+  const targetArg = expr.args[argIndex];
+  if (!targetArg || targetArg.label !== undefined) {
+    return undefined;
+  }
+
+  const targetArgTypeId = exprTypeFor({
+    moduleView: state.moduleView,
+    exprId: targetArg.expr,
+  });
+  if (typeof targetArgTypeId !== "number") {
+    return undefined;
+  }
+
+  const targetFields = structuralEscapeFieldsForType({
+    typeId: targetArgTypeId,
+    state,
+  });
+  if (!targetFields) {
+    return undefined;
+  }
+  const fieldsByName = new Map(targetFields.map((field) => [field.name, field]));
+
+  const parameterIndexes: number[] = [];
+  let cursorArgIndex = 0;
+  let cursorParameterIndex = 0;
+
+  while (cursorParameterIndex < signature.parameters.length) {
+    const parameter = signature.parameters[cursorParameterIndex]!;
+    const arg = expr.args[cursorArgIndex];
+
+    if (!arg) {
+      if (parameterCanBeOmittedAtCallSite({ parameter, moduleId, state })) {
+        cursorParameterIndex += 1;
+        continue;
+      }
+      return undefined;
+    }
+
+    if (parameter.label && arg.label === undefined) {
+      const argTypeId = exprTypeFor({
+        moduleView: state.moduleView,
+        exprId: arg.expr,
+      });
+      if (typeof argTypeId !== "number") {
+        return undefined;
+      }
+
+      const fields = structuralEscapeFieldsForType({ typeId: argTypeId, state });
+      const fieldMap = fields
+        ? new Map(fields.map((field) => [field.name, field]))
+        : undefined;
+      if (fieldMap) {
+        let nextParameterIndex = cursorParameterIndex;
+        const containerParameterIndexes: number[] = [];
+        while (nextParameterIndex < signature.parameters.length) {
+          const runParameter = signature.parameters[nextParameterIndex]!;
+          if (!runParameter.label) {
+            break;
+          }
+
+          if (fieldMap.has(runParameter.label)) {
+            containerParameterIndexes.push(nextParameterIndex);
+            nextParameterIndex += 1;
+            continue;
+          }
+
+          if (
+            parameterCanBeOmittedAtCallSite({
+              parameter: runParameter,
+              moduleId,
+              state,
+            })
+          ) {
+            nextParameterIndex += 1;
+            continue;
+          }
+
+          return undefined;
+        }
+
+        if (nextParameterIndex > cursorParameterIndex) {
+          if (cursorArgIndex === argIndex) {
+            if (containerParameterIndexes.length === 0) {
+              return undefined;
+            }
+            parameterIndexes.push(...containerParameterIndexes);
+          }
+          cursorParameterIndex = nextParameterIndex;
+          cursorArgIndex += 1;
+          continue;
+        }
+      }
+    }
+
+    if (callLabelsCompatible({ parameter, argLabel: arg.label })) {
+      if (cursorArgIndex === argIndex) {
+        return undefined;
+      }
+      cursorParameterIndex += 1;
+      cursorArgIndex += 1;
+      continue;
+    }
+
+    if (parameterCanBeOmittedAtCallSite({ parameter, moduleId, state })) {
+      cursorParameterIndex += 1;
+      continue;
+    }
+
+    return undefined;
+  }
+
+  if (cursorArgIndex < expr.args.length) {
+    return undefined;
+  }
+
+  return parameterIndexes.length > 0 &&
+      parameterIndexes.every((index) => fieldsByName.has(signature.parameters[index]!.label!))
+    ? parameterIndexes
+    : undefined;
+};
+
 const contextForCallArgument = ({
   moduleView,
   exprId,
@@ -4824,7 +5080,7 @@ const contextForCallArgument = ({
     };
   }
 
-  const targets =
+  const resolvedTargets =
     typeof state.callerInstanceId === "number"
       ? resolveTargetsForExactPropagation({
           moduleView,
@@ -4839,8 +5095,145 @@ const contextForCallArgument = ({
           callerInstanceId: state.callerInstanceId,
           ir: state.ir,
         });
+  const targets =
+    resolvedTargets.length > 0
+      ? resolvedTargets
+      : resolveDirectIdentifierCallTarget({
+          moduleView,
+          expr,
+          typeArgs: callInfo
+            ? resolveCallTypeArgs({
+                callInfo,
+                callerInstanceId: state.callerInstanceId,
+              })
+            : [],
+          ir: state.ir,
+        });
   if (targets.length === 0) {
     return { reason: "unknown" };
+  }
+
+  const argPlan = callInfo
+    ? resolveCallArgPlan({ callInfo, callerInstanceId: state.callerInstanceId })
+    : undefined;
+  const containerFieldEntries =
+    argPlan?.flatMap((entry, parameterIndex) =>
+      entry.kind === "container-field" && entry.containerArgIndex === argIndex
+        ? [{ entry, parameterIndex }]
+        : [],
+    ) ?? [];
+  const argIsOnlyContainerFields =
+    containerFieldEntries.length > 0 &&
+    argPlan?.every((entry) =>
+      entry.kind === "container-field"
+        ? entry.containerArgIndex === argIndex || entry.containerArgIndex !== argIndex
+        : entry.kind !== "direct" || entry.argIndex !== argIndex,
+    ) === true;
+  if (argIsOnlyContainerFields) {
+    let unsafeReason: EscapeAnalysisEscapeReason | undefined;
+    targets.forEach(({ instanceId }) => {
+      if (unsafeReason || typeof instanceId !== "number") {
+        unsafeReason = unsafeReason ?? "unknown";
+        return;
+      }
+      const target = state.ir.baseProgram.functions.getInstance(instanceId);
+      const signature = state.ir.baseProgram.functions.getSignature(
+        target.symbolRef.moduleId,
+        target.symbolRef.symbol,
+      );
+      if (!signature) {
+        unsafeReason = "unknown";
+        return;
+      }
+      if (!state.ir.baseProgram.effects.isEmpty(signature.effectRow)) {
+        unsafeReason = "effectful-call";
+        return;
+      }
+      containerFieldEntries.forEach(({ parameterIndex }) => {
+        if (unsafeReason) {
+          return;
+        }
+        const parameter = signature.parameters[parameterIndex];
+        if (!parameter || typeof parameter.symbol !== "number") {
+          unsafeReason = "unknown";
+          return;
+        }
+        if (
+          targetParameterIsMutable({
+            state,
+            moduleId: target.symbolRef.moduleId,
+            symbol: target.symbolRef.symbol,
+            parameterIndex,
+            parameter,
+          })
+        ) {
+          unsafeReason = "mutable-call-argument";
+          return;
+        }
+      });
+    });
+    if (!unsafeReason) {
+      return {};
+    }
+  }
+  if (!argPlan) {
+    let unsafeReason: EscapeAnalysisEscapeReason | undefined;
+    targets.forEach(({ instanceId }) => {
+      if (unsafeReason || typeof instanceId !== "number") {
+        unsafeReason = unsafeReason ?? "unknown";
+        return;
+      }
+      const target = state.ir.baseProgram.functions.getInstance(instanceId);
+      const signature = state.ir.baseProgram.functions.getSignature(
+        target.symbolRef.moduleId,
+        target.symbolRef.symbol,
+      );
+      if (!signature) {
+        unsafeReason = "unknown";
+        return;
+      }
+      if (!state.ir.baseProgram.effects.isEmpty(signature.effectRow)) {
+        unsafeReason = "effectful-call";
+        return;
+      }
+      const parameterIndexes =
+        fallbackContainerFieldParameterIndexesForCallArgument({
+          expr,
+          argIndex,
+          signature,
+          moduleId: target.symbolRef.moduleId,
+          state,
+        });
+      if (!parameterIndexes) {
+        unsafeReason = "unknown";
+        return;
+      }
+      parameterIndexes.forEach((parameterIndex) => {
+        if (unsafeReason) {
+          return;
+        }
+        const parameter = signature.parameters[parameterIndex];
+        if (!parameter || typeof parameter.symbol !== "number") {
+          unsafeReason = "unknown";
+          return;
+        }
+        if (
+          targetParameterIsMutable({
+            state,
+            moduleId: target.symbolRef.moduleId,
+            symbol: target.symbolRef.symbol,
+            parameterIndex,
+            parameter,
+          })
+        ) {
+          unsafeReason = "mutable-call-argument";
+          return;
+        }
+      });
+    });
+    if (!unsafeReason) {
+      return {};
+    }
   }
 
   let traitBoundary = false;
@@ -4882,7 +5275,15 @@ const contextForCallArgument = ({
       return;
     }
     traitBoundary = traitBoundary || isTraitType({ typeId: parameter.typeId, ir: state.ir });
-    if (parameter.bindingKind === "mutable-ref") {
+    if (
+      targetParameterIsMutable({
+        state,
+        moduleId: target.symbolRef.moduleId,
+        symbol: target.symbolRef.symbol,
+        parameterIndex,
+        parameter,
+      })
+    ) {
       unsafeReason = "mutable-call-argument";
       return;
     }

--- a/packages/compiler/src/semantics/hir/__tests__/walk.test.ts
+++ b/packages/compiler/src/semantics/hir/__tests__/walk.test.ts
@@ -102,6 +102,23 @@ const createTestBuilder = () => {
       captures: [],
     });
 
+  const addMatch = (
+    discriminant: number,
+    arms: readonly {
+      pattern: HirPattern;
+      guard?: number;
+      value: number;
+    }[],
+  ) =>
+    builder.addExpression({
+      kind: "expr",
+      exprKind: "match",
+      ast: nextAst(),
+      span,
+      discriminant,
+      arms,
+    });
+
   const addEffectHandler = (
     body: number,
     handlerBody: number,
@@ -135,6 +152,7 @@ const createTestBuilder = () => {
     addBlock,
     addAssign,
     addLambda,
+    addMatch,
     addEffectHandler,
   };
 };
@@ -297,6 +315,46 @@ describe("hir walk", () => {
       "identifier",
       "type",
       "identifier",
+    ]);
+  });
+
+  it("walks match arm patterns before guard and value expressions", () => {
+    const { builder, addIdentifier, addLiteral, addMatch } = createTestBuilder();
+    const discriminantId = addIdentifier(10);
+    const guardId = addIdentifier(20);
+    const valueId = addLiteral("1");
+    const pattern: HirPattern = {
+      kind: "destructure",
+      fields: [{ name: "value", pattern: { kind: "identifier", symbol: 30 } }],
+    };
+    const matchId = addMatch(discriminantId, [
+      {
+        pattern,
+        guard: guardId,
+        value: valueId,
+      },
+    ]);
+    const hir = builder.finalize();
+    const events: string[] = [];
+
+    walkExpression({
+      exprId: matchId,
+      hir,
+      onEnterExpression: (id, expr) => {
+        events.push(`expr:${expr.exprKind}:${id}`);
+      },
+      onEnterPattern: (node) => {
+        events.push(`pattern:${node.kind}`);
+      },
+    });
+
+    expect(events).toEqual([
+      `expr:match:${matchId}`,
+      `expr:identifier:${discriminantId}`,
+      "pattern:destructure",
+      "pattern:identifier",
+      `expr:identifier:${guardId}`,
+      `expr:literal:${valueId}`,
     ]);
   });
 

--- a/packages/compiler/src/semantics/hir/walk.ts
+++ b/packages/compiler/src/semantics/hir/walk.ts
@@ -206,6 +206,7 @@ export const walkExpression = ({
         case "match":
           if (visitExpression(expr.discriminant)) return true;
           for (const arm of expr.arms) {
+            if (shouldVisitPatterns && visitPattern(arm.pattern)) return true;
             if (typeof arm.guard === "number") {
               if (visitExpression(arm.guard)) return true;
             }

--- a/packages/sdk/src/__tests__/sdk-node.test.ts
+++ b/packages/sdk/src/__tests__/sdk-node.test.ts
@@ -601,6 +601,33 @@ pub fn main() -> i32
     }
   });
 
+  it("runs optimized serialized exports after scalar aggregate lowering", async () => {
+    const sdk = createSdk();
+    const result = expectCompileSuccess(
+      await sdk.compile({
+        optimize: true,
+        source: `
+obj Pair {
+  x: i32,
+  y: i32
+}
+
+pub fn main() -> i32
+  var i = 0
+  var total = 0
+  while i < 20:
+    let pair = Pair { x: i, y: i + 1 }
+    total = total + pair.x + pair.y
+    i = i + 1
+  total
+`,
+      }),
+    );
+    const host = await createVoydHost({ wasm: result.wasm });
+
+    await expect(host.run<number>("main")).resolves.toBe(400);
+  });
+
   it("omits runtime diagnostics by default", async () => {
     const sdk = createSdk();
     const result = expectCompileSuccess(

--- a/scripts/bench-v326.ts
+++ b/scripts/bench-v326.ts
@@ -1,0 +1,522 @@
+import fs from "node:fs";
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { gzipSync } from "node:zlib";
+import { createSdk, type CompileResult } from "@voyd-lang/sdk";
+import { createVoydHost } from "@voyd-lang/sdk/js-host";
+
+type Scenario = {
+  name: string;
+  iterations: number;
+  warmups: number;
+  optional?: boolean;
+  source?: string;
+  entryPath?: string;
+  entryName?: string;
+  expected?: number;
+};
+
+type ScenarioResult = {
+  revision: string;
+  name: string;
+  optimize: boolean;
+  compileMs: number;
+  wasmBytes: number;
+  gzipBytes: number;
+  wasmSha256: string;
+  wasmTextBytes: number;
+  structNewCount: number;
+  structNewDefaultCount: number;
+  tupleMakeCount: number;
+  medianMs?: number;
+  samplesMs: number[];
+};
+
+const focusedSource = `
+obj Pair {
+  x: i32,
+  y: i32
+}
+
+val Vec3 {
+  x: i32,
+  y: i32,
+  z: i32
+}
+
+fn sum_vec(vec: Vec3) -> i32
+  vec.x + vec.y + vec.z
+
+fn identity(pair: Pair) -> Pair
+  pair
+
+fn sum_pair(pair: Pair) -> i32
+  pair.x + pair.y
+
+fn make_pair(seed: i32) -> Pair
+  Pair { x: seed, y: seed + 1 }
+
+pub fn non_escaping_object_local() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    let pair = Pair { x: i, y: i + 1 }
+    total = total + pair.x + pair.y
+    i = i + 1
+  total
+
+pub fn mutable_object_temporary() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    let ~pair = Pair { x: i, y: i + 1 }
+    pair.x = pair.x + 1
+    total = total + pair.x + pair.y
+    i = i + 1
+  total
+
+pub fn direct_value_call_argument() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    total = total + sum_vec(Vec3 { x: i, y: i + 1, z: i + 2 })
+    i = i + 1
+  total
+
+pub fn direct_heap_call_argument() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    let pair = Pair { x: i, y: i + 1 }
+    total = total + sum_pair(pair)
+    i = i + 1
+  total
+
+pub fn direct_heap_call_literal() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    total = total + sum_pair(Pair { x: i, y: i + 1 })
+    i = i + 1
+  total
+
+pub fn direct_heap_call_return() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    let pair = make_pair(i)
+    total = total + pair.x + pair.y
+    i = i + 1
+  total
+
+pub fn escape_boundary_rematerialization() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    total = total + identity(Pair { x: i, y: i + 1 }).x
+    i = i + 1
+  total
+`;
+
+const defaultIterations = Number.parseInt(process.env.VOYD_BENCH_ITERATIONS ?? "7", 10);
+const representativeIterations = Number.parseInt(
+  process.env.VOYD_BENCH_REPRESENTATIVE_ITERATIONS ?? "3",
+  10,
+);
+const optimizeModes = (process.env.VOYD_BENCH_OPTIMIZE_MODES ?? "false,true")
+  .split(",")
+  .map((value) => value.trim().toLowerCase())
+  .filter((value) => value.length > 0)
+  .map((value) => {
+    if (value === "true" || value === "1") {
+      return true;
+    }
+    if (value === "false" || value === "0") {
+      return false;
+    }
+    throw new Error(`invalid VOYD_BENCH_OPTIMIZE_MODES entry ${value}`);
+  });
+const revisionLabel = process.env.VOYD_BENCH_REVISION ?? "worktree";
+
+const maybeFileScenario = (scenario: Scenario): Scenario[] =>
+  scenario.entryPath && !fs.existsSync(scenario.entryPath) ? [] : [scenario];
+
+const scenarios: Scenario[] = [
+  {
+    name: "focused/non-escaping-object-local",
+    source: focusedSource,
+    entryName: "non_escaping_object_local",
+    expected: 400_000_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/mutable-object-temporary",
+    source: focusedSource,
+    entryName: "mutable_object_temporary",
+    expected: 400_020_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/direct-value-call-argument",
+    source: focusedSource,
+    entryName: "direct_value_call_argument",
+    expected: 600_030_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/direct-heap-call-argument",
+    source: focusedSource,
+    entryName: "direct_heap_call_argument",
+    expected: 400_000_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/direct-heap-call-literal",
+    source: focusedSource,
+    entryName: "direct_heap_call_literal",
+    expected: 400_000_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/direct-heap-call-return",
+    source: focusedSource,
+    entryName: "direct_heap_call_return",
+    expected: 400_000_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/escape-boundary-rematerialization",
+    source: focusedSource,
+    entryName: "escape_boundary_rematerialization",
+    expected: 199_990_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "representative/vtrace-compute-main",
+    entryPath: path.join(
+      import.meta.dirname,
+      "..",
+      "apps",
+      "smoke",
+      "fixtures",
+      "vtrace-compute-benchmark.voyd",
+    ),
+    entryName: "main",
+    expected: 3_825_271,
+    iterations: representativeIterations,
+    warmups: 1,
+  },
+  {
+    name: "representative/scalar-aggregate-particle-step",
+    entryPath: path.join(
+      import.meta.dirname,
+      "..",
+      "apps",
+      "smoke",
+      "fixtures",
+      "scalar-aggregate-representative.voyd",
+    ),
+    entryName: "main",
+    expected: 1_100_340_000,
+    iterations: representativeIterations,
+    warmups: 1,
+  },
+  ...maybeFileScenario({
+    name: "voyd-examples/suite-compile",
+    entryPath: "/Users/drew/projects/voyd_examples/benchmarks/suite/voyd/benchmarks.voyd",
+    optional: true,
+    iterations: 0,
+    warmups: 0,
+  }),
+];
+
+const expectCompileSuccess = (
+  result: CompileResult,
+  name: string,
+): Extract<CompileResult, { success: true }> => {
+  if (result.success) {
+    return result;
+  }
+
+  throw new Error(
+    `${name} failed to compile:\n${result.diagnostics
+      .map((diagnostic) => diagnostic.message)
+      .join("\n")}`,
+  );
+};
+
+const median = (values: readonly number[]): number | undefined => {
+  if (values.length === 0) {
+    return undefined;
+  }
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1]! + sorted[middle]!) / 2
+    : sorted[middle];
+};
+
+const countMatches = (source: string, pattern: RegExp): number =>
+  source.match(pattern)?.length ?? 0;
+
+const runScenario = async ({
+  scenario,
+  optimize,
+}: {
+  scenario: Scenario;
+  optimize: boolean;
+}): Promise<ScenarioResult> => {
+  const sdk = createSdk();
+  const compileStartedAt = performance.now();
+  const compiled = expectCompileSuccess(
+    await sdk.compile({
+      entryPath: scenario.entryPath,
+      source: scenario.source,
+      optimize,
+      emitWasmText: true,
+    }),
+    scenario.name,
+  );
+  const compileMs = performance.now() - compileStartedAt;
+
+  const samplesMs: number[] = [];
+  if (scenario.entryName && typeof scenario.expected === "number") {
+    const host = await createVoydHost({ wasm: compiled.wasm });
+    for (let warmup = 0; warmup < scenario.warmups; warmup += 1) {
+      const result = await host.run<number>(scenario.entryName);
+      if (result !== scenario.expected) {
+        throw new Error(
+          `${scenario.name} returned ${result} during warmup, expected ${scenario.expected}`,
+        );
+      }
+    }
+    for (let iteration = 0; iteration < scenario.iterations; iteration += 1) {
+      const startedAt = performance.now();
+      const result = await host.run<number>(scenario.entryName);
+      if (result !== scenario.expected) {
+        throw new Error(
+          `${scenario.name} returned ${result}, expected ${scenario.expected}`,
+        );
+      }
+      samplesMs.push(performance.now() - startedAt);
+    }
+  }
+
+  return {
+    revision: revisionLabel,
+    name: scenario.name,
+    optimize,
+    compileMs,
+    wasmBytes: compiled.wasm.byteLength,
+    gzipBytes: gzipSync(compiled.wasm).byteLength,
+    wasmSha256: createHash("sha256").update(compiled.wasm).digest("hex"),
+    wasmTextBytes: new TextEncoder().encode(compiled.wasmText ?? "").byteLength,
+    structNewCount: countMatches(compiled.wasmText ?? "", /\(struct\.new /g),
+    structNewDefaultCount: countMatches(
+      compiled.wasmText ?? "",
+      /\(struct\.new_default /g,
+    ),
+    tupleMakeCount: countMatches(compiled.wasmText ?? "", /\(tuple\.make/g),
+    medianMs: median(samplesMs),
+    samplesMs,
+  };
+};
+
+const printResults = (results: readonly ScenarioResult[]): void => {
+  console.log(
+    "revision,name,optimize,compileMs,wasmBytes,gzipBytes,wasmTextBytes,structNewCount,structNewDefaultCount,tupleMakeCount,wasmSha256,medianMs,samplesMs",
+  );
+  results.forEach((result) => {
+    console.log(
+      [
+        result.revision,
+        result.name,
+        result.optimize ? "true" : "false",
+        result.compileMs.toFixed(3),
+        result.wasmBytes.toString(),
+        result.gzipBytes.toString(),
+        result.wasmTextBytes.toString(),
+        result.structNewCount.toString(),
+        result.structNewDefaultCount.toString(),
+        result.tupleMakeCount.toString(),
+        result.wasmSha256,
+        result.medianMs === undefined ? "" : result.medianMs.toFixed(3),
+        result.samplesMs.map((sample) => sample.toFixed(3)).join("|"),
+      ].join(","),
+    );
+  });
+};
+
+const parseResultsCsv = (filePath: string): ScenarioResult[] => {
+  const lines = fs
+    .readFileSync(filePath, "utf8")
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0);
+  const header = lines.shift()?.split(",");
+  if (!header) {
+    throw new Error(`${filePath} is empty`);
+  }
+  const revisionColumn = header[0] === "revision";
+  const index = (column: string): number => {
+    const columnIndex = header.indexOf(column);
+    if (columnIndex < 0) {
+      throw new Error(`${filePath} is missing ${column} column`);
+    }
+    return columnIndex;
+  };
+
+  const revisionIndex = revisionColumn ? index("revision") : undefined;
+  const nameIndex = index("name");
+  const optimizeIndex = index("optimize");
+  const compileMsIndex = index("compileMs");
+  const wasmBytesIndex = index("wasmBytes");
+  const gzipBytesIndex = index("gzipBytes");
+  const wasmTextBytesIndex = index("wasmTextBytes");
+  const structNewCountIndex = index("structNewCount");
+  const structNewDefaultCountIndex = index("structNewDefaultCount");
+  const tupleMakeCountIndex = index("tupleMakeCount");
+  const wasmSha256Index = index("wasmSha256");
+  const medianMsIndex = index("medianMs");
+  const samplesMsIndex = index("samplesMs");
+
+  return lines.map((line) => {
+    const columns = line.split(",");
+    return {
+      revision:
+        typeof revisionIndex === "number" ? columns[revisionIndex] ?? "" : "unknown",
+      name: columns[nameIndex] ?? "",
+      optimize: columns[optimizeIndex] === "true",
+      compileMs: Number.parseFloat(columns[compileMsIndex] ?? "0"),
+      wasmBytes: Number.parseInt(columns[wasmBytesIndex] ?? "0", 10),
+      gzipBytes: Number.parseInt(columns[gzipBytesIndex] ?? "0", 10),
+      wasmTextBytes: Number.parseInt(columns[wasmTextBytesIndex] ?? "0", 10),
+      structNewCount: Number.parseInt(columns[structNewCountIndex] ?? "0", 10),
+      structNewDefaultCount: Number.parseInt(
+        columns[structNewDefaultCountIndex] ?? "0",
+        10,
+      ),
+      tupleMakeCount: Number.parseInt(columns[tupleMakeCountIndex] ?? "0", 10),
+      wasmSha256: columns[wasmSha256Index] ?? "",
+      medianMs:
+        columns[medianMsIndex] && columns[medianMsIndex]!.length > 0
+          ? Number.parseFloat(columns[medianMsIndex]!)
+          : undefined,
+      samplesMs:
+        columns[samplesMsIndex]?.length
+          ? columns[samplesMsIndex]!.split("|").map((sample) =>
+              Number.parseFloat(sample),
+            )
+          : [],
+    };
+  });
+};
+
+const resultKey = (result: Pick<ScenarioResult, "name" | "optimize">): string =>
+  `${result.name}\0${result.optimize ? "true" : "false"}`;
+
+const percentDelta = (base: number, head: number): string =>
+  base === 0 ? "" : (((head - base) / base) * 100).toFixed(1);
+
+const formatMaybeMs = (value: number | undefined): string =>
+  value === undefined ? "" : value.toFixed(3);
+
+const printComparison = ({
+  baseResults,
+  headResults,
+}: {
+  baseResults: readonly ScenarioResult[];
+  headResults: readonly ScenarioResult[];
+}): void => {
+  const baseByKey = new Map(baseResults.map((result) => [resultKey(result), result]));
+  const matched = headResults
+    .map((head) => ({ head, base: baseByKey.get(resultKey(head)) }))
+    .filter(
+      (entry): entry is { head: ScenarioResult; base: ScenarioResult } =>
+        entry.base !== undefined,
+    );
+
+  console.log(
+    "name,optimize,baseRevision,headRevision,compileMsBase,compileMsHead,compileMsDeltaPct,medianMsBase,medianMsHead,medianMsDeltaPct,wasmBytesBase,wasmBytesHead,wasmBytesDeltaPct,gzipBytesBase,gzipBytesHead,gzipBytesDeltaPct,wasmTextBytesBase,wasmTextBytesHead,wasmTextBytesDeltaPct,structNewBase,structNewHead,structNewDelta,structNewDefaultBase,structNewDefaultHead,structNewDefaultDelta,tupleMakeBase,tupleMakeHead,tupleMakeDelta,baseWasmSha256,headWasmSha256",
+  );
+  matched.forEach(({ base, head }) => {
+    console.log(
+      [
+        head.name,
+        head.optimize ? "true" : "false",
+        base.revision,
+        head.revision,
+        base.compileMs.toFixed(3),
+        head.compileMs.toFixed(3),
+        percentDelta(base.compileMs, head.compileMs),
+        formatMaybeMs(base.medianMs),
+        formatMaybeMs(head.medianMs),
+        base.medianMs === undefined || head.medianMs === undefined
+          ? ""
+          : percentDelta(base.medianMs, head.medianMs),
+        base.wasmBytes.toString(),
+        head.wasmBytes.toString(),
+        percentDelta(base.wasmBytes, head.wasmBytes),
+        base.gzipBytes.toString(),
+        head.gzipBytes.toString(),
+        percentDelta(base.gzipBytes, head.gzipBytes),
+        base.wasmTextBytes.toString(),
+        head.wasmTextBytes.toString(),
+        percentDelta(base.wasmTextBytes, head.wasmTextBytes),
+        base.structNewCount.toString(),
+        head.structNewCount.toString(),
+        (head.structNewCount - base.structNewCount).toString(),
+        base.structNewDefaultCount.toString(),
+        head.structNewDefaultCount.toString(),
+        (head.structNewDefaultCount - base.structNewDefaultCount).toString(),
+        base.tupleMakeCount.toString(),
+        head.tupleMakeCount.toString(),
+        (head.tupleMakeCount - base.tupleMakeCount).toString(),
+        base.wasmSha256,
+        head.wasmSha256,
+      ].join(","),
+    );
+  });
+};
+
+const main = async (): Promise<void> => {
+  const [command, baseCsv, headCsv] = process.argv.slice(2);
+  if (command === "compare") {
+    if (!baseCsv || !headCsv) {
+      throw new Error("usage: bench-v326.ts compare <base.csv> <head.csv>");
+    }
+    printComparison({
+      baseResults: parseResultsCsv(baseCsv),
+      headResults: parseResultsCsv(headCsv),
+    });
+    return;
+  }
+  if (command) {
+    throw new Error(`unknown command ${command}`);
+  }
+
+  const results: ScenarioResult[] = [];
+  for (const scenario of scenarios) {
+    for (const optimize of optimizeModes) {
+      try {
+        results.push(await runScenario({ scenario, optimize }));
+      } catch (error) {
+        if (!scenario.optional) {
+          throw error;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`skipping optional scenario ${scenario.name}: ${message}`);
+      }
+    }
+  }
+  printResults(results);
+};
+
+await main();


### PR DESCRIPTION
## Summary
- Thread escape-fact information into scalar aggregate replacement decisions
- Update codegen and optimization pipeline logic to avoid unsafe scalarization across calls, blocks, and mutations
- Refresh the representative smoke fixture, compiler tests, SDK coverage, and architecture notes

## Testing
- Not run (not requested)