### PR TITLE
[codex] Fix safe array loop proof invalidation

### DIFF
--- a/packages/compiler/src/codegen/__tests__/__fixtures__/std_array_smoke.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/std_array_smoke.voyd
@@ -65,6 +65,13 @@ fn build_ints() -> Array<i32>
   arr.push(4)
   arr
 
+fn build_sparse_ints() -> Array<i32>
+  let ~arr = Array<i32>::with_capacity(4)
+  arr.push(1)
+  arr.push(2)
+  arr.push(3)
+  arr
+
 pub fn safe_while_sum() -> i32
   let values = build_ints()
   var index = 0
@@ -167,6 +174,27 @@ pub fn while_stale_length_sum() -> i32
   var index = 0
   var total = 0
   while index < length:
+    total = total + values.at(index)
+    index = index + 1
+  total
+
+pub fn while_increment_before_at_trap() -> i32
+  let values = build_sparse_ints()
+  var index = 0
+  var total = 0
+  while index < values.len():
+    index = index + 1
+    total = total + values.at(index)
+  total
+
+pub fn while_captured_call_mutation_trap() -> i32
+  let ~values = build_sparse_ints()
+  let clear_values = () -> void =>
+    values.clear()
+  var index = 0
+  var total = 0
+  while index < values.len():
+    clear_values()
     total = total + values.at(index)
     index = index + 1
   total

--- a/packages/compiler/src/codegen/__tests__/std-array-smoke.test.ts
+++ b/packages/compiler/src/codegen/__tests__/std-array-smoke.test.ts
@@ -78,6 +78,12 @@ describe("std::array compile smoke", () => {
     });
     const host = await createVoydHost({ wasm: result.wasm });
     await expect(host.run<number>("direct_at_out_of_bounds")).rejects.toThrow();
+    await expect(
+      host.run<number>("while_increment_before_at_trap"),
+    ).rejects.toThrow();
+    await expect(
+      host.run<number>("while_captured_call_mutation_trap"),
+    ).rejects.toThrow();
   });
 
   it("lowers optimized direct len/at access without dynamic dispatch", async () => {
@@ -125,6 +131,8 @@ describe("std::array compile smoke", () => {
       "while_mutates_array_sum",
       "while_alias_mutation_sum",
       "while_stale_length_sum",
+      "while_increment_before_at_trap",
+      "while_captured_call_mutation_trap",
     ]) {
       const functionWat = watForExport(wat, exportName);
       expect(functionWat).toContain("array.get");

--- a/packages/compiler/src/codegen/optimization/array-fast-paths.ts
+++ b/packages/compiler/src/codegen/optimization/array-fast-paths.ts
@@ -209,6 +209,7 @@ const callHasName = ({
   name: string;
   ctx: CodegenContext;
 }): boolean => {
+  const intrinsicName = callIntrinsicName({ expr, ctx });
   const callee = ctx.module.hir.expressions.get(expr.callee);
   if (callee?.exprKind !== "identifier") {
     return false;
@@ -216,8 +217,30 @@ const callHasName = ({
   const calleeId = ctx.program.symbols.canonicalIdOf(ctx.moduleId, callee.symbol);
   return (
     ctx.program.symbols.getName(calleeId) === name ||
-    ctx.program.symbols.getIntrinsicName(calleeId) === name
+    intrinsicName === name
   );
+};
+
+const callIntrinsicName = ({
+  expr,
+  ctx,
+}: {
+  expr: HirCallExpr;
+  ctx: CodegenContext;
+}): string | undefined => {
+  const callee = ctx.module.hir.expressions.get(expr.callee);
+  if (callee?.exprKind !== "identifier") {
+    return undefined;
+  }
+  const calleeId = ctx.program.symbols.canonicalIdOf(ctx.moduleId, callee.symbol);
+  const intrinsicName = ctx.program.symbols.getIntrinsicName(calleeId);
+  if (typeof intrinsicName === "string") {
+    return intrinsicName;
+  }
+  const intrinsicFlags = ctx.program.symbols.getIntrinsicFunctionFlags(calleeId);
+  return intrinsicFlags.intrinsic
+    ? ctx.program.symbols.getName(calleeId)
+    : undefined;
 };
 
 const isCallNamed = ({
@@ -323,6 +346,129 @@ const isSafeArrayLoopRead = ({
   return expressionSymbol({ exprId: expr.args[0]!.expr, ctx }) === indexSymbol;
 };
 
+const safeLoopIntrinsicCalls = new Set([
+  "+",
+  "-",
+  "*",
+  "/",
+  "%",
+  "<",
+  "<=",
+  ">",
+  ">=",
+  "==",
+  "!=",
+  "and",
+  "or",
+  "xor",
+  "not",
+]);
+
+const isSafeLoopIntrinsicCall = ({
+  expr,
+  ctx,
+  fnCtx,
+}: {
+  expr: HirCallExpr;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): boolean => {
+  const callee = ctx.module.hir.expressions.get(expr.callee);
+  if (callee?.exprKind !== "identifier") {
+    return false;
+  }
+  const calleeId = ctx.program.symbols.canonicalIdOf(ctx.moduleId, callee.symbol);
+  const callName =
+    ctx.program.symbols.getIntrinsicName(calleeId) ??
+    ctx.program.symbols.getName(calleeId);
+  if (typeof callName !== "string" || !safeLoopIntrinsicCalls.has(callName)) {
+    return false;
+  }
+  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+  return (
+    isSafeLoopPrimitiveType({
+      typeId: getRequiredExprType(expr.id, ctx, typeInstanceId),
+      ctx,
+    }) &&
+    expr.args.every((arg) =>
+      isSafeLoopPrimitiveType({
+        typeId: getRequiredExprType(arg.expr, ctx, typeInstanceId),
+        ctx,
+      }),
+    )
+  );
+};
+
+const isSafeLoopPrimitiveType = ({
+  typeId,
+  ctx,
+}: {
+  typeId: TypeId;
+  ctx: CodegenContext;
+}): boolean =>
+  typeId === ctx.program.primitives.bool ||
+  typeId === ctx.program.primitives.i32 ||
+  typeId === ctx.program.primitives.i64 ||
+  typeId === ctx.program.primitives.f32 ||
+  typeId === ctx.program.primitives.f64;
+
+const isIndexIncrementAssignment = ({
+  exprId,
+  indexSymbol,
+  ctx,
+}: {
+  exprId: HirExprId;
+  indexSymbol: SymbolId;
+  ctx: CodegenContext;
+}): boolean => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  if (expr?.exprKind !== "assign") {
+    return false;
+  }
+  const targetSymbol = targetIdentifierSymbol({
+    exprId: expr.target,
+    ctx,
+  });
+  return (
+    targetSymbol === indexSymbol &&
+    exprIsIndexIncrement({ exprId: expr.value, indexSymbol, ctx })
+  );
+};
+
+const bodyHasFinalIndexIncrement = ({
+  bodyExprId,
+  indexSymbol,
+  ctx,
+}: {
+  bodyExprId: HirExprId;
+  indexSymbol: SymbolId;
+  ctx: CodegenContext;
+}): boolean => {
+  const body = ctx.module.hir.expressions.get(bodyExprId);
+  if (body?.exprKind !== "block" || body.statements.length === 0) {
+    return false;
+  }
+  if (typeof body.value === "number") {
+    return isIndexIncrementAssignment({
+      exprId: body.value,
+      indexSymbol,
+      ctx,
+    });
+  }
+  const lastStatementId = body.statements.at(-1);
+  const lastStatement = typeof lastStatementId === "number"
+    ? ctx.module.hir.statements.get(lastStatementId)
+    : undefined;
+  return (
+    lastStatement?.kind === "expr-stmt" &&
+    isIndexIncrementAssignment({
+      exprId: lastStatement.expr,
+      indexSymbol,
+      ctx,
+    })
+  );
+};
+
 const bodyPreservesArrayLoopProof = ({
   bodyExprId,
   indexSymbol,
@@ -381,14 +527,18 @@ const bodyPreservesArrayLoopProof = ({
           if (
             typeof targetSymbol === "number" &&
             arrayAliases.has(targetSymbol) &&
-            !isSafeArrayLoopRead({ expr, indexSymbol, ctx })
+            isSafeArrayLoopRead({ expr, indexSymbol, ctx })
           ) {
+            return undefined;
+          }
+          valid = false;
+          return "stop";
+        }
+        if (expr.exprKind === "call") {
+          if (!isSafeLoopIntrinsicCall({ expr, ctx, fnCtx })) {
             valid = false;
             return "stop";
           }
-          return undefined;
-        }
-        if (expr.exprKind === "call") {
           if (
             expr.args.some((arg) => {
               const argSymbol = expressionSymbol({ exprId: arg.expr, ctx });
@@ -613,6 +763,15 @@ const tryAnalyzeSafeArrayWhileLoop = ({
     ctx,
   });
   if (!indexInit) {
+    return undefined;
+  }
+  if (
+    !bodyHasFinalIndexIncrement({
+      bodyExprId: whileExpr.body,
+      indexSymbol: indexInit.indexSymbol,
+      ctx,
+    })
+  ) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

Fixes two correctness holes in the V-369 safe array loop fast path proof:

- require `while` loop index increments to be the final top-level body expression/statement before eliding `Array.at` checks
- invalidate the safe-loop proof for opaque calls and non-read method calls so captured mutators cannot shrink or otherwise mutate the proven array/index behind the optimizer's back

The optimizer still allows primitive scalar intrinsic calls for ordinary arithmetic in proven-safe loop bodies.

## Tests

- `npx vitest run --config vitest.config.ts --testTimeout 60000 --hookTimeout 60000 --maxWorkers=1 --minWorkers=1 packages/compiler/src/codegen/__tests__/std-array-smoke.test.ts`
- `npm test`
- `npm run typecheck`

## Review

Ran one follow-up correctness review after the fix. No new material findings remained.