### PR TITLE
Preserve mutable scalar aggregates in call lowering

### DIFF
--- a/packages/compiler/src/codegen/__tests__/scalar-aggregate-replacement.test.ts
+++ b/packages/compiler/src/codegen/__tests__/scalar-aggregate-replacement.test.ts
@@ -162,6 +162,90 @@ pub fn main() -> i32
     );
   });
 
+  it("preserves mutable value-object locals passed by mutable reference", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+pub val Vec3 {
+  x: i32,
+  y: i32,
+  z: i32
+}
+
+impl Vec3
+  fn empty() -> Vec3
+    Vec3 { x: 0, y: 0, z: 0 }
+
+fn fill(~out: Vec3) -> bool
+  out.x = 1
+  out.y = 2
+  out.z = 3
+  true
+
+pub fn main() -> i32
+  let ~out = Vec3::empty()
+  if fill(out):
+    return out.x + out.y + out.z
+  0
+`);
+
+    expect(runMain(baselineCodegen.module)()).toBe(6);
+    expect(runMain(optimizedCodegen.module)()).toBe(6);
+  });
+
+  it("preserves multiple mutable value-object call outputs after value arguments", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+pub val Vec3 {
+  x: i32,
+  y: i32,
+  z: i32
+}
+
+pub val Ray {
+  origin: Vec3,
+  direction: Vec3
+}
+
+impl Vec3
+  fn empty() -> Vec3
+    Vec3 { x: 0, y: 0, z: 0 }
+
+  fn '*'(self, other: Vec3) -> Vec3
+    Vec3 { x: self.x * other.x, y: self.y * other.y, z: self.z * other.z }
+
+  fn apply(~self, vec: Vec3)
+    self.x = vec.x
+    self.y = vec.y
+    self.z = vec.z
+
+impl Ray
+  fn empty() -> Ray
+    Ray { origin: Vec3::empty(), direction: Vec3::empty() }
+
+fn fill(ray: Ray, ~out: Vec3, ~scattered: Ray) -> bool
+  out.apply(Vec3 { x: 1, y: 2, z: 3 })
+  scattered.direction.x = ray.origin.x + 4
+  true
+
+fn color(ray: Ray, depth: i32) -> Vec3
+  if depth <= 0:
+    return Vec3 { x: 1, y: 1, z: 1 }
+
+  let ~out = Vec3::empty()
+  let ~scattered = Ray::empty()
+  if fill(ray, out, scattered):
+    return out * color(scattered, depth - 1)
+
+  Vec3::empty()
+
+pub fn main() -> i32
+  let ray = Ray { origin: Vec3 { x: 5, y: 0, z: 0 }, direction: Vec3::empty() }
+  let result = color(ray, 1)
+  result.x + result.y + result.z
+`);
+
+    expect(runMain(baselineCodegen.module)()).toBe(6);
+    expect(runMain(optimizedCodegen.module)()).toBe(6);
+  });
+
   it("materializes scalar heap roots before nested value field mutation", () => {
     const { optimizedCodegen } = compileOptimized(`
 type Inner = { x: i32, y: i32 }

--- a/packages/compiler/src/codegen/expressions/call/arguments.ts
+++ b/packages/compiler/src/codegen/expressions/call/arguments.ts
@@ -1249,7 +1249,28 @@ const lowerCallArgumentForAbi = ({
               ctx,
               fnCtx,
             })
+          : existing.kind === "scalar-aggregate"
+            ? materializeOwnedBinding({
+                symbol: addressableSymbol,
+                ctx,
+                fnCtx,
+              })
           : undefined;
+      if (existing.kind === "scalar-aggregate" && materialized) {
+        const materializedPointer = loadBindingStorageRef(materialized.binding, ctx);
+        if (!materializedPointer) {
+          throw new Error(
+            `mutable ref call argument requires addressable temp storage (type ${paramTypeId})`,
+          );
+        }
+        return materialized.setup.length === 0
+          ? materializedPointer
+          : ctx.mod.block(
+              null,
+              [...materialized.setup, materializedPointer],
+              materialized.binding.storageType,
+            );
+      }
       const ownedValue = materialized
         ? loadBindingValue(materialized.binding, ctx, fnCtx)
         : argValue;

--- a/packages/compiler/src/codegen/functions.ts
+++ b/packages/compiler/src/codegen/functions.ts
@@ -989,6 +989,7 @@ export const registerFunctionMetadata = (ctx: CodegenContext): void => {
 
         const parameterBindingKind = (index: number) =>
           signature.parameters[index]?.bindingKind ??
+          item.parameters[index]?.pattern.bindingKind ??
           (item.parameters[index]?.mutable ? "mutable-ref" : undefined);
         const paramAbiKinds = descriptor.parameters.map((param, index) =>
           getOptimizedParamAbiKind({

--- a/packages/compiler/src/codegen/optimization/scalar-aggregates.ts
+++ b/packages/compiler/src/codegen/optimization/scalar-aggregates.ts
@@ -70,6 +70,23 @@ const symbolIsUsedAsMethodReceiver = ({
     return target?.exprKind === "identifier" && target.symbol === symbol;
   });
 
+const symbolIsUsedAsCallArgument = ({
+  symbol,
+  ctx,
+}: {
+  symbol: SymbolId;
+  ctx: CodegenContext;
+}): boolean =>
+  Array.from(ctx.module.hir.expressions.values()).some((expr) => {
+    if (expr.exprKind !== "call" && expr.exprKind !== "method-call") {
+      return false;
+    }
+    return expr.args.some((arg) => {
+      const argExpr = ctx.module.hir.expressions.get(arg.expr);
+      return argExpr?.exprKind === "identifier" && argExpr.symbol === symbol;
+    });
+  });
+
 const symbolIsCapturedByEffectHandler = ({
   symbol,
   ctx,
@@ -831,7 +848,8 @@ export const tryScalarizeAggregateInitializer = ({
   }
   if (
     mutable &&
-    symbolIsUsedAsMethodReceiver({ symbol, ctx })
+    (symbolIsUsedAsMethodReceiver({ symbol, ctx }) ||
+      symbolIsUsedAsCallArgument({ symbol, ctx }))
   ) {
     return undefined;
   }

--- a/packages/compiler/src/codegen/types.ts
+++ b/packages/compiler/src/codegen/types.ts
@@ -2320,17 +2320,22 @@ const synthesizeConcreteFunctionMeta = ({
       return;
     }
 
+    const parameterBindingKind = (index: number) =>
+      signature.parameters[index]?.bindingKind ??
+      functionItem.parameters[index]?.pattern.bindingKind ??
+      (functionItem.parameters[index]?.mutable ? "mutable-ref" : undefined);
+
     const paramAbiKinds = instantiatedTypeDesc.parameters.map((param, index) =>
       getOptimizedParamAbiKind({
         typeId: param.type,
-        bindingKind: signature.parameters[index]?.bindingKind,
+        bindingKind: parameterBindingKind(index),
         ctx,
       }),
     );
     const paramAbiTypes = instantiatedTypeDesc.parameters.map((param, index) =>
       getOptimizedAbiTypesForParam({
         typeId: param.type,
-        bindingKind: signature.parameters[index]?.bindingKind,
+        bindingKind: parameterBindingKind(index),
         ctx,
       }),
     );
@@ -2394,7 +2399,7 @@ const synthesizeConcreteFunctionMeta = ({
                 ctx,
               })
             : undefined,
-        bindingKind: signature.parameters[index]?.bindingKind,
+        bindingKind: parameterBindingKind(index),
       })),
       paramAbiKinds,
       resultTypeId: instantiatedTypeDesc.returnType,


### PR DESCRIPTION
## Summary
- Keep mutable value-object locals materialized when they are passed by mutable reference or used as call arguments
- Thread binding kind information from parameter patterns through function metadata synthesis
- Add regression coverage for mutable call outputs and mutable reference locals

## Testing
- Added compiler unit tests covering optimized vs baseline execution for the new regression cases