### PR TITLE
Document V-370 value-lane rejection

### DIFF
--- a/docs/architecture/compiler-optimization-pipeline.md
+++ b/docs/architecture/compiler-optimization-pipeline.md
@@ -374,6 +374,62 @@ scenario is included in the script when present, but the current local checkout
 uses older `while ... do:` syntax and is skipped with a warning by this
 compiler.
 
+### V-370 Value-Lane Forwarding Rejection
+
+V-370 prototyped a narrow scalar aggregate extension: when an initializer,
+assignment, direct-call argument, or direct function result was already available
+as scalarized value-object lanes with the same target shape, codegen forwarded
+those lanes instead of rebuilding a full aggregate only to split it again. The
+prototype targeted local copies, block/conditional wrappers, field reads from
+scalar locals, direct value-object call arguments, and direct value-object
+returns. During review, side-effecting block wrappers in direct call/result
+contexts were still identified as additional implementation surface, which
+reinforced the decision not to land the prototype without stronger benchmark
+evidence.
+
+The prototype did not land because it failed the ticket's complexity bar. It
+added new call-lowering metadata for flattened arguments, new scalar source
+classification in `scalar-aggregates.ts`, and a direct-result path in function
+codegen. Those concepts increased call/codegen coupling and evaluation-order
+risk, but optimized PR-base vs PR-head measurements did not show repeatable
+representative wins.
+
+The benchmark harness remains useful for future attempts:
+
+- `scripts/bench-v326.ts` includes focused V-370 scenarios for scalar local
+  copy, block-wrapped copy, reassignment, direct-call local arguments, direct
+  returns, field copy, field direct-call forwarding, and field direct-return
+  forwarding.
+- The script records `tuple.extract` and `struct.get` counts in addition to
+  `struct.new`, `tuple.make`, wasm size, gzip size, WAT size, compile time, and
+  runtime.
+- `VOYD_BENCH_FILTER=<substring>` can run only selected scenarios for longer
+  repeatability checks.
+
+The removed prototype produced useful shape changes in narrow compiler tests,
+but optimized focused benchmarks showed no final wasm/WAT size movement after
+Binaryen cleanup. In a short full comparison
+(`VOYD_BENCH_ITERATIONS=5`, representative scenarios at one iteration), the
+focused module stayed at 22,065 wasm bytes and 204,836 WAT bytes, with gzip only
+moving from 7079 to 7081 bytes.
+
+Representative measurements did not justify the added complexity:
+
+- `representative/vtrace-compute-main`, 7 iterations, run 1: 266.700 ms to
+  266.185 ms median (-0.2%), 60,613 to 60,662 wasm bytes (+0.1%),
+  `struct.new` 767 to 765, `tuple.extract` 269 to 266.
+- `representative/vtrace-compute-main`, 7 iterations, run 2: 266.622 ms to
+  266.831 ms median (+0.1%) with the same size and shape deltas.
+- `representative/scalar-aggregate-particle-step`, 7 iterations, run 1:
+  0.128 ms to 0.115 ms median; run 2: 0.142 ms to 0.130 ms median. Both runs
+  kept identical wasm hashes and WAT shape counts, so the timing deltas were
+  noise rather than evidence for the optimization.
+
+Conclusion: keep V-326's scalar aggregate/materialization rules as the active
+implementation. A future V-370 retry should first identify a representative
+workload with stable post-Binaryen runtime or wasm-size movement, then implement
+only the smallest codegen concept needed for that workload.
+
 ## Binaryen Optimization
 
 After Voyd codegen emits the Binaryen module, `CodegenOptions.optimize` runs

--- a/scripts/bench-v326.ts
+++ b/scripts/bench-v326.ts
@@ -29,6 +29,8 @@ type ScenarioResult = {
   structNewCount: number;
   structNewDefaultCount: number;
   tupleMakeCount: number;
+  tupleExtractCount: number;
+  structGetCount: number;
   medianMs?: number;
   samplesMs: number[];
 };
@@ -45,8 +47,32 @@ val Vec3 {
   z: i32
 }
 
+type Vec3Record = {
+  x: i32,
+  y: i32,
+  z: i32
+}
+
 fn sum_vec(vec: Vec3) -> i32
   vec.x + vec.y + vec.z
+
+fn add_vec(seed: i32, vec: Vec3) -> i32
+  seed + vec.x + vec.y + vec.z
+
+fn add_record(seed: i32, vec: Vec3Record) -> i32
+  seed + vec.x + vec.y + vec.z
+
+fn make_vec_copy(seed: i32) -> Vec3
+  let first = Vec3 { x: seed, y: seed + 1, z: seed + 2 }
+  let second = first
+  second
+
+fn make_record_field_copy(seed: i32) -> Vec3Record
+  let pair = {
+    first: { x: seed, y: seed + 1, z: seed + 2 },
+    second: { x: seed + 3, y: seed + 4, z: seed + 5 }
+  }
+  pair.first
 
 fn identity(pair: Pair) -> Pair
   pair
@@ -81,6 +107,91 @@ pub fn direct_value_call_argument() -> i32
   var total = 0
   while i < 20000:
     total = total + sum_vec(Vec3 { x: i, y: i + 1, z: i + 2 })
+    i = i + 1
+  total
+
+pub fn value_lane_local_copy() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    let first = Vec3 { x: i, y: i + 1, z: i + 2 }
+    let second = first
+    total = total + second.x + second.y + second.z
+    i = i + 1
+  total
+
+pub fn value_lane_block_copy() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    let first = Vec3 { x: i, y: i + 1, z: i + 2 }
+    let second = block
+      total = total + 1
+      first
+    total = total + second.x + second.y + second.z
+    i = i + 1
+  total
+
+pub fn value_lane_reassignment() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    var target = Vec3 { x: 0, y: 0, z: 0 }
+    let source = Vec3 { x: i, y: i + 1, z: i + 2 }
+    target = source
+    total = total + target.x + target.y + target.z
+    i = i + 1
+  total
+
+pub fn value_lane_direct_call_local() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    let vec = Vec3 { x: i, y: i + 1, z: i + 2 }
+    total = total + add_vec(1, vec)
+    i = i + 1
+  total
+
+pub fn value_lane_direct_return() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    let vec = make_vec_copy(i)
+    total = total + vec.x + vec.y + vec.z
+    i = i + 1
+  total
+
+pub fn value_lane_field_copy() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    let pair = {
+      first: { x: i, y: i + 1, z: i + 2 },
+      second: { x: i + 3, y: i + 4, z: i + 5 }
+    }
+    let vec = pair.first
+    total = total + vec.x + vec.y + vec.z
+    i = i + 1
+  total
+
+pub fn value_lane_field_direct_call() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    let pair = {
+      first: { x: i, y: i + 1, z: i + 2 },
+      second: { x: i + 3, y: i + 4, z: i + 5 }
+    }
+    total = total + add_record(1, pair.first)
+    i = i + 1
+  total
+
+pub fn value_lane_field_direct_return() -> i32
+  var i = 0
+  var total = 0
+  while i < 20000:
+    let vec = make_record_field_copy(i)
+    total = total + vec.x + vec.y + vec.z
     i = i + 1
   total
 
@@ -138,6 +249,10 @@ const optimizeModes = (process.env.VOYD_BENCH_OPTIMIZE_MODES ?? "false,true")
     throw new Error(`invalid VOYD_BENCH_OPTIMIZE_MODES entry ${value}`);
   });
 const revisionLabel = process.env.VOYD_BENCH_REVISION ?? "worktree";
+const scenarioFilters = (process.env.VOYD_BENCH_FILTER ?? "")
+  .split(",")
+  .map((filter) => filter.trim())
+  .filter((filter) => filter.length > 0);
 
 const maybeFileScenario = (scenario: Scenario): Scenario[] =>
   scenario.entryPath && !fs.existsSync(scenario.entryPath) ? [] : [scenario];
@@ -163,6 +278,70 @@ const scenarios: Scenario[] = [
     name: "focused/direct-value-call-argument",
     source: focusedSource,
     entryName: "direct_value_call_argument",
+    expected: 600_030_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/value-lane-local-copy",
+    source: focusedSource,
+    entryName: "value_lane_local_copy",
+    expected: 600_030_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/value-lane-block-copy",
+    source: focusedSource,
+    entryName: "value_lane_block_copy",
+    expected: 600_050_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/value-lane-reassignment",
+    source: focusedSource,
+    entryName: "value_lane_reassignment",
+    expected: 600_030_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/value-lane-direct-call-local",
+    source: focusedSource,
+    entryName: "value_lane_direct_call_local",
+    expected: 600_050_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/value-lane-direct-return",
+    source: focusedSource,
+    entryName: "value_lane_direct_return",
+    expected: 600_030_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/value-lane-field-copy",
+    source: focusedSource,
+    entryName: "value_lane_field_copy",
+    expected: 600_030_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/value-lane-field-direct-call",
+    source: focusedSource,
+    entryName: "value_lane_field_direct_call",
+    expected: 600_050_000,
+    iterations: defaultIterations,
+    warmups: 2,
+  },
+  {
+    name: "focused/value-lane-field-direct-return",
+    source: focusedSource,
+    entryName: "value_lane_field_direct_return",
     expected: 600_030_000,
     iterations: defaultIterations,
     warmups: 2,
@@ -237,6 +416,13 @@ const scenarios: Scenario[] = [
     warmups: 0,
   }),
 ];
+
+const selectedScenarios =
+  scenarioFilters.length === 0
+    ? scenarios
+    : scenarios.filter((scenario) =>
+        scenarioFilters.some((filter) => scenario.name.includes(filter)),
+      );
 
 const expectCompileSuccess = (
   result: CompileResult,
@@ -325,6 +511,8 @@ const runScenario = async ({
       /\(struct\.new_default /g,
     ),
     tupleMakeCount: countMatches(compiled.wasmText ?? "", /\(tuple\.make/g),
+    tupleExtractCount: countMatches(compiled.wasmText ?? "", /\(tuple\.extract/g),
+    structGetCount: countMatches(compiled.wasmText ?? "", /\(struct\.get/g),
     medianMs: median(samplesMs),
     samplesMs,
   };
@@ -332,7 +520,7 @@ const runScenario = async ({
 
 const printResults = (results: readonly ScenarioResult[]): void => {
   console.log(
-    "revision,name,optimize,compileMs,wasmBytes,gzipBytes,wasmTextBytes,structNewCount,structNewDefaultCount,tupleMakeCount,wasmSha256,medianMs,samplesMs",
+    "revision,name,optimize,compileMs,wasmBytes,gzipBytes,wasmTextBytes,structNewCount,structNewDefaultCount,tupleMakeCount,tupleExtractCount,structGetCount,wasmSha256,medianMs,samplesMs",
   );
   results.forEach((result) => {
     console.log(
@@ -347,6 +535,8 @@ const printResults = (results: readonly ScenarioResult[]): void => {
         result.structNewCount.toString(),
         result.structNewDefaultCount.toString(),
         result.tupleMakeCount.toString(),
+        result.tupleExtractCount.toString(),
+        result.structGetCount.toString(),
         result.wasmSha256,
         result.medianMs === undefined ? "" : result.medianMs.toFixed(3),
         result.samplesMs.map((sample) => sample.toFixed(3)).join("|"),
@@ -372,6 +562,10 @@ const parseResultsCsv = (filePath: string): ScenarioResult[] => {
     }
     return columnIndex;
   };
+  const optionalIndex = (column: string): number | undefined => {
+    const columnIndex = header.indexOf(column);
+    return columnIndex < 0 ? undefined : columnIndex;
+  };
 
   const revisionIndex = revisionColumn ? index("revision") : undefined;
   const nameIndex = index("name");
@@ -383,6 +577,8 @@ const parseResultsCsv = (filePath: string): ScenarioResult[] => {
   const structNewCountIndex = index("structNewCount");
   const structNewDefaultCountIndex = index("structNewDefaultCount");
   const tupleMakeCountIndex = index("tupleMakeCount");
+  const tupleExtractCountIndex = optionalIndex("tupleExtractCount");
+  const structGetCountIndex = optionalIndex("structGetCount");
   const wasmSha256Index = index("wasmSha256");
   const medianMsIndex = index("medianMs");
   const samplesMsIndex = index("samplesMs");
@@ -404,6 +600,18 @@ const parseResultsCsv = (filePath: string): ScenarioResult[] => {
         10,
       ),
       tupleMakeCount: Number.parseInt(columns[tupleMakeCountIndex] ?? "0", 10),
+      tupleExtractCount: Number.parseInt(
+        typeof tupleExtractCountIndex === "number"
+          ? columns[tupleExtractCountIndex] ?? "0"
+          : "0",
+        10,
+      ),
+      structGetCount: Number.parseInt(
+        typeof structGetCountIndex === "number"
+          ? columns[structGetCountIndex] ?? "0"
+          : "0",
+        10,
+      ),
       wasmSha256: columns[wasmSha256Index] ?? "",
       medianMs:
         columns[medianMsIndex] && columns[medianMsIndex]!.length > 0
@@ -444,7 +652,7 @@ const printComparison = ({
     );
 
   console.log(
-    "name,optimize,baseRevision,headRevision,compileMsBase,compileMsHead,compileMsDeltaPct,medianMsBase,medianMsHead,medianMsDeltaPct,wasmBytesBase,wasmBytesHead,wasmBytesDeltaPct,gzipBytesBase,gzipBytesHead,gzipBytesDeltaPct,wasmTextBytesBase,wasmTextBytesHead,wasmTextBytesDeltaPct,structNewBase,structNewHead,structNewDelta,structNewDefaultBase,structNewDefaultHead,structNewDefaultDelta,tupleMakeBase,tupleMakeHead,tupleMakeDelta,baseWasmSha256,headWasmSha256",
+    "name,optimize,baseRevision,headRevision,compileMsBase,compileMsHead,compileMsDeltaPct,medianMsBase,medianMsHead,medianMsDeltaPct,wasmBytesBase,wasmBytesHead,wasmBytesDeltaPct,gzipBytesBase,gzipBytesHead,gzipBytesDeltaPct,wasmTextBytesBase,wasmTextBytesHead,wasmTextBytesDeltaPct,structNewBase,structNewHead,structNewDelta,structNewDefaultBase,structNewDefaultHead,structNewDefaultDelta,tupleMakeBase,tupleMakeHead,tupleMakeDelta,tupleExtractBase,tupleExtractHead,tupleExtractDelta,structGetBase,structGetHead,structGetDelta,baseWasmSha256,headWasmSha256",
   );
   matched.forEach(({ base, head }) => {
     console.log(
@@ -479,6 +687,12 @@ const printComparison = ({
         base.tupleMakeCount.toString(),
         head.tupleMakeCount.toString(),
         (head.tupleMakeCount - base.tupleMakeCount).toString(),
+        base.tupleExtractCount.toString(),
+        head.tupleExtractCount.toString(),
+        (head.tupleExtractCount - base.tupleExtractCount).toString(),
+        base.structGetCount.toString(),
+        head.structGetCount.toString(),
+        (head.structGetCount - base.structGetCount).toString(),
         base.wasmSha256,
         head.wasmSha256,
       ].join(","),
@@ -502,8 +716,12 @@ const main = async (): Promise<void> => {
     throw new Error(`unknown command ${command}`);
   }
 
+  if (selectedScenarios.length === 0) {
+    throw new Error(`no scenarios match VOYD_BENCH_FILTER=${scenarioFilters.join(",")}`);
+  }
+
   const results: ScenarioResult[] = [];
-  for (const scenario of scenarios) {
+  for (const scenario of selectedScenarios) {
     for (const optimize of optimizeModes) {
       try {
         results.push(await runScenario({ scenario, optimize }));
@@ -515,6 +733,9 @@ const main = async (): Promise<void> => {
         console.warn(`skipping optional scenario ${scenario.name}: ${message}`);
       }
     }
+  }
+  if (results.length === 0) {
+    throw new Error("no benchmark results were produced");
   }
   printResults(results);
 };


### PR DESCRIPTION
## Summary

- Document the V-370 value-lane forwarding prototype rejection analysis in the compiler optimization architecture notes.
- Extend `scripts/bench-v326.ts` with V-370-focused benchmark scenarios, `tuple.extract`/`struct.get` shape counts, `VOYD_BENCH_FILTER`, and safer filtered-run behavior.
- Keep compiler implementation unchanged because the prototype did not produce repeatable representative wins.

## Validation

- `npm run typecheck`
- `npm test`
- `VOYD_BENCH_FILTER=scalar-aggregate-particle-step VOYD_BENCH_OPTIMIZE_MODES=true VOYD_BENCH_REPRESENTATIVE_ITERATIONS=1 node --conditions=development --import tsx scripts/bench-v326.ts`
- legacy CSV compare sanity check without `tupleExtractCount`/`structGetCount`
- current CSV round-trip compare with new columns
- `VOYD_BENCH_FILTER=voyd-examples VOYD_BENCH_OPTIMIZE_MODES=true node --conditions=development --import tsx scripts/bench-v326.ts` exits nonzero when the optional selected scenario is skipped

## Review Loop

- Implementation-gap reviewer: no findings on final diff.
- Correctness reviewer: no findings on final diff.