### PR TITLE
Implement web framework package phase 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ output/
 /sb
 /*.sb.*
 .turbo
+**/.turbo
 .tmp-voyd-sdk-*
 /tmp/
 DS_Store

--- a/apps/smoke/fixtures/web-framework.voyd
+++ b/apps/smoke/fixtures/web-framework.voyd
@@ -1,0 +1,290 @@
+use pkg::web::all
+use pkg::web::router
+use std::http::{ Body, Headers, HttpError, IncomingRequest, Method, QueryString, Response }
+use std::json::{ JsonBool, JsonValue }
+use std::optional::types::all
+use std::result::types::all
+use std::string::type::String
+
+type UserParams = {
+  id: String
+}
+
+type UserQuery = {
+  verbose: bool
+}
+
+type CreateUser = {
+  name: String,
+  active: bool
+}
+
+fn dsl_middleware(ctx: Context, next: Next) -> Response
+  next(ctx)
+
+fn serve_dsl_compile_probe()
+  serve(port: 3000) routes():
+    adopt(dsl_middleware)
+
+    get("/health") do:
+      "ok".as_slice().to_string()
+
+    group("/api") routes():
+      get("/nested") do:
+        "nested".as_slice().to_string()
+
+    get("/users/:id") do(params: UserParams, query: UserQuery):
+      let verbose = if query.verbose then: "true".as_slice().to_string() else: "false".as_slice().to_string()
+      params.id.concat(":".as_slice()).concat(verbose)
+
+    method_not_allowed() do(ctx: Context):
+      ctx
+      Response::method_not_allowed().text("custom method".as_slice())
+
+    on_rejection() do(rejection: Rejection, ctx: Context):
+      ctx
+      Response::new(status: rejection.status).text(rejection.message)
+
+    post("/echo", body: text_body()) do(input: String):
+      Response::ok().text(input)
+
+    post("/users", body: json_body()) do(input: CreateUser):
+      Response::ok().text(input.name)
+
+fn serve_options_dsl_compile_probe()
+  serve(port: 3001, host: "127.0.0.1", shutdown_timeout: 250) routes():
+    put("/replace", body: json_body()) do(input: CreateUser):
+      Response::ok().text(input.name)
+
+    patch("/update", body: text_body(), auth: required_session()) do(input: String, session: String):
+      Response::ok().text(session.concat(":".as_slice()).concat(input))
+
+    delete("/remove", body: text_body()) do(input: String):
+      Response::ok().text(input)
+
+    route("/manual", method: Method::Delete {}) do(ctx: Context):
+      ctx
+      Response::ok().text("manual".as_slice())
+
+    route("/manual-body", method: Method::Put {}, body: json_body()) do(input: CreateUser):
+      Response::ok().text(input.name)
+
+    route("/manual-query", method: Method::Get {}) do(query: UserQuery, ctx: Context):
+      ctx
+      if query.verbose then: "verbose".as_slice().to_string() else: "quiet".as_slice().to_string()
+
+    route("/manual-auth", method: Method::Get {}, auth: required_session()) do(session: String):
+      Response::ok().text(session)
+
+    get("/ctx-text") do(ctx: Context):
+      ctx.path()
+
+    get("/json") do:
+      let value: JsonValue = JsonBool { value: true }
+      value
+
+    get("/result") do:
+      let value: Result<String, Rejection> = Ok<String> { value: "result".as_slice().to_string() }
+      value
+
+    get("/option") do:
+      let value: Option<String> = Some<String> { value: "option".as_slice().to_string() }
+      value
+
+fn request(method: Method, path: String, { query?: QueryString }) -> IncomingRequest
+  IncomingRequest {
+    method: method,
+    path: path,
+    query: query,
+    headers: Headers::empty(),
+    body: Body::empty()
+  }
+
+fn request_with_body(method: Method, path: String, body: Body) -> IncomingRequest
+  IncomingRequest {
+    method: method,
+    path: path,
+    query: None {},
+    headers: Headers::empty(),
+    body: body
+  }
+
+fn response_text(response: Response): () -> String
+  match(response.text())
+    Ok<String> { value }:
+      value
+    Err<HttpError>:
+      "error".as_slice().to_string()
+
+pub fn route_probe() -> i32
+  let web_app = app()
+    .method_not_allowed((_ctx: Context) -> Response =>
+      Response::method_not_allowed().text("custom method".as_slice())
+    )
+    .get("/users/:id".as_slice(), handler: (ctx: Context) -> Response =>
+      let id = ctx.param("id".as_slice()) ?? "missing".as_slice().to_string()
+      let verbose = ctx.query_value("verbose".as_slice()) ?? "false".as_slice().to_string()
+      Response::ok().text(id.concat(":".as_slice()).concat(verbose))
+    )
+    .get("/users/new".as_slice(), handler: (_ctx: Context) -> Response =>
+      Response::ok().text("new".as_slice())
+    )
+    .get("/session".as_slice(), auth: required_session(), handler: (session: String) -> Response =>
+      Response::ok().text(session)
+    )
+
+  let static_response = web_app.handle(request(Method::Get {}, "/users/new".as_slice().to_string()))
+  if not response_text(static_response).equals("new"):
+    return -1
+
+  let params_response = web_app.handle(
+    request(
+      Method::Get {},
+      "/users/42".as_slice().to_string(),
+      query: QueryString { raw: "verbose=true".as_slice().to_string() }
+    )
+  )
+  if not response_text(params_response).equals("42:true"):
+    return -2
+
+  let authed = web_app.handle(
+    IncomingRequest {
+      method: Method::Get {},
+      path: "/session".as_slice().to_string(),
+      query: None {},
+      headers: Headers::empty().append(header: "authorization".as_slice(), value: "ada".as_slice()),
+      body: Body::empty()
+    }
+  )
+  if not response_text(authed).equals("ada"):
+    return -8
+
+  let wrong_method = web_app.handle(request(Method::Post {}, "/users/42".as_slice().to_string()))
+  if not response_text(wrong_method).equals("custom method"):
+    return -9
+  wrong_method.status.code()
+
+pub fn builder_probe() -> i32
+  let built = build_app do(base):
+    let with_health = get_context(base, "/health".as_slice()) do(_ctx: Context):
+      Response::ok().text("ok".as_slice())
+
+    let with_item = get(with_health, "/items/:id".as_slice()) do(params: UserParams):
+      Response::ok().text(params.id)
+
+    let with_query = route_query_context(with_item, "/items/search".as_slice(), method: Method::Get {}) do(query: UserQuery, _ctx: Context):
+      if query.verbose then: Response::ok().text("verbose".as_slice()) else: Response::ok().text("quiet".as_slice())
+
+    let with_verbose = get_params_query(with_query, "/items/:id/verbose".as_slice()) do(params: UserParams, query: UserQuery):
+      let verbose = if query.verbose then: "true".as_slice().to_string() else: "false".as_slice().to_string()
+      Response::ok().text(params.id.concat(":".as_slice()).concat(verbose))
+
+    let with_auth = get(with_verbose, "/session".as_slice(), auth: required_session()) do(session: String):
+      Response::ok().text(session)
+
+    let with_route_auth = route_auth(with_auth, "/manual-session".as_slice(), method: Method::Get {}, auth: required_session()) do(session: String):
+      Response::ok().text(session)
+
+    post(
+      with_route_auth,
+      "/echo".as_slice(),
+      body: text_body(),
+      handler: (input: String) -> Response => Response::ok().text(input)
+    )
+
+  let health = built.handle(request(Method::Get {}, "/health".as_slice().to_string()))
+  if not response_text(health).equals("ok"):
+    return -3
+
+  let item = built.handle(request(Method::Get {}, "/items/book".as_slice().to_string()))
+  if not response_text(item).equals("book"):
+    return -4
+
+  let query_only = built.handle(
+    request(
+      Method::Get {},
+      "/items/search".as_slice().to_string(),
+      query: QueryString { raw: "verbose=true".as_slice().to_string() }
+    )
+  )
+  if not response_text(query_only).equals("verbose"):
+    return -10
+
+  let typed_query = built.handle(
+    request(
+      Method::Get {},
+      "/items/book/verbose".as_slice().to_string(),
+      query: QueryString { raw: "verbose=true".as_slice().to_string() }
+    )
+  )
+  if not response_text(typed_query).equals("book:true"):
+    return -6
+
+  let authed = built.handle(
+    IncomingRequest {
+      method: Method::Get {},
+      path: "/session".as_slice().to_string(),
+      query: None {},
+      headers: Headers::empty().append(header: "authorization".as_slice(), value: "ada".as_slice()),
+      body: Body::empty()
+    }
+  )
+  if not response_text(authed).equals("ada"):
+    return -9
+
+  let route_authed = built.handle(
+    IncomingRequest {
+      method: Method::Get {},
+      path: "/manual-session".as_slice().to_string(),
+      query: None {},
+      headers: Headers::empty().append(header: "authorization".as_slice(), value: "grace".as_slice()),
+      body: Body::empty()
+    }
+  )
+  if not response_text(route_authed).equals("grace"):
+    return -11
+
+  let echo = built.handle(
+    request_with_body(
+      Method::Post {},
+      "/echo".as_slice().to_string(),
+      Body::text("hello".as_slice())
+    )
+  )
+  if not response_text(echo).equals("hello"):
+    return -5
+
+  echo.status.code()
+
+pub fn all_json_response_probe() -> i32
+  let value: JsonValue = JsonBool { value: true }
+  let response = response_json(value)
+  let header = response.header("content-type".as_slice()) ?? "missing".as_slice().to_string()
+  if not header.equals("application/json"):
+    return -7
+
+  response.status.code()
+
+pub fn option_response_probe() -> i32
+  let some_value: Option<String> = Some<String> { value: "some".as_slice().to_string() }
+  let some_response = to_response(some_value)
+  if some_response.status.code() != 200:
+    return some_response.status.code()
+  if not response_text(some_response).equals("some".as_slice().to_string()):
+    return -9
+
+  let none_value: Option<String> = None {}
+  let none_response = to_response(none_value)
+  none_response.status.code()
+
+pub fn router_export_probe() -> i32
+  let api = router::Router::init()
+    .get_unit("/health".as_slice().to_string(), handler: () -> Response =>
+      Response::ok().text("router".as_slice())
+    )
+  let built = app().mount("/api".as_slice(), api)
+  let response = built.handle(request(Method::Get {}, "/api/health".as_slice().to_string()))
+  if not response_text(response).equals("router"):
+    return -8
+
+  response.status.code()

--- a/apps/smoke/src/web-framework.test.ts
+++ b/apps/smoke/src/web-framework.test.ts
@@ -1,0 +1,372 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createSdk, type CompileResult } from "@voyd-lang/sdk";
+
+const fixtureRoot = path.resolve(import.meta.dirname, "../fixtures");
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+
+const expectCompileSuccess = (
+  result: CompileResult,
+): Extract<CompileResult, { success: true }> => {
+  if (!result.success) {
+    throw new Error(result.diagnostics.map((diagnostic) => diagnostic.message).join("\n"));
+  }
+  expect(result.success).toBe(true);
+  return result;
+};
+
+describe("smoke: pkg::web", () => {
+  it("routes requests and builds apps through the public package API", async () => {
+    const sdk = createSdk();
+    const entryPath = path.join(fixtureRoot, "web-framework.voyd");
+    const result = expectCompileSuccess(
+      await sdk.compile({
+        entryPath,
+        roots: {
+          src: fixtureRoot,
+          pkgDirs: [path.join(repoRoot, "packages")],
+        },
+      }),
+    );
+
+    await expect(result.run<number>({ entryName: "route_probe" })).resolves.toBe(405);
+    await expect(result.run<number>({ entryName: "builder_probe" })).resolves.toBe(200);
+    await expect(result.run<number>({ entryName: "all_json_response_probe" })).resolves.toBe(200);
+    await expect(result.run<number>({ entryName: "option_response_probe" })).resolves.toBe(404);
+    await expect(result.run<number>({ entryName: "router_export_probe" })).resolves.toBe(200);
+  });
+
+  it("converts option responses from extracted route handlers", async () => {
+    const sdk = createSdk();
+    const result = expectCompileSuccess(
+      await sdk.compile({
+        source: `
+use pkg::web::{
+  Body,
+  Context,
+  Headers,
+  IncomingRequest,
+  Method,
+  Response,
+  build_app,
+  route_params_context
+}
+use std::optional::types::all
+use std::result::types::all
+use std::string::type::String
+
+type UserParams = {
+  id: String
+}
+
+fn request(method: Method, path: String) -> IncomingRequest
+  IncomingRequest {
+    method: method,
+    path: path,
+    query: None {},
+    headers: Headers::empty(),
+    body: Body::empty()
+  }
+
+fn response_text(response: Response) -> String
+  match(response.text())
+    Ok<String> { value }:
+      value
+    Err:
+      "error".as_slice().to_string()
+
+pub fn route_option_response_probe() -> i32
+  let built = build_app do(base):
+    route_params_context(base, "/option/:id".as_slice(), method: Method::Get {}) do(params: UserParams, _ctx: Context):
+      let value: Option<String> = Some<String> { value: params.id }
+      value
+
+  let response = built.handle(request(Method::Get {}, "/option/ada".as_slice().to_string()))
+  if response.status.code() != 200:
+    return response.status.code()
+  if not response_text(response).equals("ada".as_slice().to_string()):
+    return -12
+
+  response.status.code()
+`,
+        roots: {
+          src: fixtureRoot,
+          pkgDirs: [path.join(repoRoot, "packages")],
+        },
+      }),
+    );
+
+    await expect(result.run<number>({ entryName: "route_option_response_probe" })).resolves.toBe(
+      200,
+    );
+  });
+
+  it("supports body and auth policies on method helpers", async () => {
+    const sdk = createSdk();
+    const result = expectCompileSuccess(
+      await sdk.compile({
+        source: `
+use pkg::web::{
+  Body,
+  Context,
+  Headers,
+  IncomingRequest,
+  Method,
+  Response,
+  build_app,
+  delete,
+  json_body,
+  patch,
+  put,
+  required_session,
+  route,
+  text_body
+}
+use std::optional::types::all
+use std::result::types::all
+use std::string::type::String
+
+type CreateUser = {
+  name: String,
+  active: bool
+}
+
+fn request_with_body(method: Method, path: String, body: Body) -> IncomingRequest
+  IncomingRequest {
+    method: method,
+    path: path,
+    query: None {},
+    headers: Headers::empty(),
+    body: body
+  }
+
+fn response_text(response: Response) -> String
+  match(response.text())
+    Ok<String> { value }:
+      value
+    Err:
+      "error".as_slice().to_string()
+
+fn replace_user(input: CreateUser) -> Response
+  let active = if input.active then: "active".as_slice().to_string() else: "inactive".as_slice().to_string()
+  Response::ok().text(input.name.concat(":".as_slice()).concat(active))
+
+fn patch_session(input: String, session: String) -> Response
+  Response::ok().text(session.concat(":".as_slice()).concat(input))
+
+fn delete_body(input: String) -> Response
+  Response::ok().text(input)
+
+fn manual_body(input: CreateUser) -> Response
+  Response::ok().text(input.name.concat(":manual".as_slice()))
+
+pub fn method_body_route_probe() -> i32
+  let built = build_app do(base):
+    let with_put = put(base, "/replace".as_slice(), body: json_body(), replace_user)
+    let with_patch = patch(with_put, "/session-patch".as_slice(), body: text_body(), auth: required_session(), patch_session)
+    let with_delete = delete(with_patch, "/remove".as_slice(), body: text_body(), delete_body)
+    route(with_delete, "/manual".as_slice(), method: Method::Put {}, body: json_body(), manual_body)
+
+  let put_response = built.handle(
+    request_with_body(
+      Method::Put {},
+      "/replace".as_slice().to_string(),
+      Body::text("{\\"name\\":\\"Ada\\",\\"active\\":true}".as_slice())
+    )
+  )
+  if not response_text(put_response).equals("Ada:active"):
+    return -20
+
+  let patch_response = built.handle(
+    IncomingRequest {
+      method: Method::Patch {},
+      path: "/session-patch".as_slice().to_string(),
+      query: None {},
+      headers: Headers::empty().append(header: "authorization".as_slice(), value: "grace".as_slice()),
+      body: Body::text("hello".as_slice())
+    }
+  )
+  if not response_text(patch_response).equals("grace:hello"):
+    return -21
+
+  let delete_response = built.handle(
+    request_with_body(
+      Method::Delete {},
+      "/remove".as_slice().to_string(),
+      Body::text("bye".as_slice())
+    )
+  )
+  if not response_text(delete_response).equals("bye"):
+    return -22
+
+  let manual_response = built.handle(
+    request_with_body(
+      Method::Put {},
+      "/manual".as_slice().to_string(),
+      Body::text("{\\"name\\":\\"Manual\\",\\"active\\":false}".as_slice())
+    )
+  )
+  if not response_text(manual_response).equals("Manual:manual"):
+    return -23
+
+  manual_response.status.code()
+`,
+        roots: {
+          src: fixtureRoot,
+          pkgDirs: [path.join(repoRoot, "packages")],
+        },
+      }),
+    );
+
+    await expect(result.run<number>({ entryName: "method_body_route_probe" })).resolves.toBe(200);
+  });
+
+  it("converts responses from free get helpers", async () => {
+    const sdk = createSdk();
+    const result = expectCompileSuccess(
+      await sdk.compile({
+        source: `
+use pkg::web::{
+  Body,
+  Context,
+  Headers,
+  IncomingRequest,
+  Method,
+  Response,
+  build_app,
+  get,
+  get_context
+}
+use std::json::{ JsonBool, JsonValue }
+use std::optional::types::all
+use std::result::types::all
+use std::string::type::String
+
+type UserParams = {
+  id: String
+}
+
+fn request(method: Method, path: String) -> IncomingRequest
+  IncomingRequest {
+    method: method,
+    path: path,
+    query: None {},
+    headers: Headers::empty(),
+    body: Body::empty()
+  }
+
+fn response_text(response: Response) -> String
+  match(response.text())
+    Ok<String> { value }:
+      value
+    Err:
+      "error".as_slice().to_string()
+
+fn json_from_context(_ctx: Context) -> JsonValue
+  let value: JsonValue = JsonBool { value: true }
+  value
+
+fn optional_user(params: UserParams) -> Option<String>
+  Some<String> { value: params.id }
+
+pub fn free_get_response_probe() -> i32
+  let built = build_app do(base):
+    let with_json = get_context(base, "/json".as_slice(), json_from_context)
+    get(with_json, "/users/:id".as_slice(), optional_user)
+
+  let json_response = built.handle(request(Method::Get {}, "/json".as_slice().to_string()))
+  if json_response.status.code() != 200:
+    return -30
+  let content_type = json_response.header("content-type".as_slice()) ?? "missing".as_slice().to_string()
+  if not content_type.equals("application/json"):
+    return -31
+
+  let user_response = built.handle(request(Method::Get {}, "/users/ada".as_slice().to_string()))
+  if user_response.status.code() != 200:
+    return -32
+  if not response_text(user_response).equals("ada"):
+    return -33
+
+  user_response.status.code()
+`,
+        roots: {
+          src: fixtureRoot,
+          pkgDirs: [path.join(repoRoot, "packages")],
+        },
+      }),
+    );
+
+    await expect(result.run<number>({ entryName: "free_get_response_probe" })).resolves.toBe(200);
+  });
+
+  it("exports the documented router submodule", async () => {
+    const sdk = createSdk();
+    const result = expectCompileSuccess(
+      await sdk.compile({
+        source: `
+use pkg::web::router
+use pkg::web::{ Body, Headers, IncomingRequest, Method, Response }
+use std::optional::types::all
+use std::string::type::String
+
+fn request(method: Method, path: String) -> IncomingRequest
+  IncomingRequest {
+    method: method,
+    path: path,
+    query: None {},
+    headers: Headers::empty(),
+    body: Body::empty()
+  }
+
+pub fn router_module_export_probe() -> i32
+  let built = router::app()
+    .get("/health".as_slice(), handler: (_ctx: router::Context) -> Response =>
+      Response::ok().text("ok".as_slice())
+    )
+  let response = built.handle(request(Method::Get {}, "/health".as_slice().to_string()))
+  response.status.code()
+`,
+        roots: {
+          src: fixtureRoot,
+          pkgDirs: [path.join(repoRoot, "packages")],
+        },
+      }),
+    );
+
+    await expect(result.run<number>({ entryName: "router_module_export_probe" })).resolves.toBe(
+      200,
+    );
+  });
+
+  it("rejects unknown route DSL extractor parameter names", async () => {
+    const sdk = createSdk();
+    const result = await sdk.compile({
+      source: `
+use pkg::web::all
+use std::string::type::String
+
+type UserParams = {
+  id: String
+}
+
+fn invalid_route_dsl()
+  serve(port: 3000) routes():
+    get("/users/:id") do(user: UserParams):
+      user.id
+`,
+      roots: {
+        src: fixtureRoot,
+        pkgDirs: [path.join(repoRoot, "packages")],
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("Expected unknown route DSL extractor name to fail compilation");
+    }
+
+    expect(result.diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain(
+      "web route handler extractor parameters must be named params, query, headers",
+    );
+  });
+});

--- a/docs/proposals/web-framework/voyd-web-framework.md
+++ b/docs/proposals/web-framework/voyd-web-framework.md
@@ -1,6 +1,6 @@
 # Voyd Web Framework
 
-Status: Proposed
+Status: Implemented (Phase 1)
 Owner: Std + Runtime + Framework
 Scope: new framework package, recommended `packages/web`; smoke tests; SDK/server integration
 
@@ -84,7 +84,7 @@ obj Session {
   api user_id: String
 }
 
-pub fn main(): (HttpServer, TaskRuntime, Db, Log) -> Result<Unit, ServeError>
+pub fn main(): (HttpServer, TaskRuntime, Db, Log) -> Result<Unit, HostError>
   serve(port: 3000) routes():
     adopt(request_logger)
 
@@ -97,7 +97,7 @@ pub fn main(): (HttpServer, TaskRuntime, Db, Log) -> Result<Unit, ServeError>
 
       post(
         "/",
-        body: json(),
+        body: json_body(),
         auth: required_session()
       ) do(input: CreateUser, session: Session):
         create_user(input, by: session.user_id)
@@ -171,8 +171,8 @@ get("/users/:id") do(params: UserParams, query: UserQuery):
 
 Use labels when they configure behavior, select a format, or resolve ambiguity:
 
-- `body: json()`
-- `body: text()`
+- `body: json_body()`
+- `body: text_body()`
 - `auth: required_session()`
 - `auth: optional_session()`
 - `timeout:`
@@ -225,6 +225,14 @@ Recommended public modules:
 `all` should be convenient but not enormous. Advanced escape hatches should stay
 in their owning modules.
 
+The package root reserves `pkg::web::router` for the module path. Voyd's current
+package import resolver binds modules and values in one namespace at this
+boundary, so Phase 1 does not also expose a same-name free `router()` function.
+Use `pkg::web::router::Router::init()` or import `pkg::web::router` and call
+`router::Router::init()`. Root-level builder constructors such as `app()`,
+`build_app()`, and `serve()` stay re-exported from `pkg::web`, and
+`pkg::web::all` remains the ergonomic import for the route DSL.
+
 ## Route DSL
 
 The primary documented API should be a trailing-callback DSL.
@@ -236,7 +244,7 @@ serve(port: 3000) routes():
 
   post(
     "/sessions",
-    body: json(),
+    body: json_body(),
     auth: optional_session()
   ) do(input: LoginInput, session: Option<Session>):
     create_session(input, existing: session)
@@ -254,7 +262,9 @@ Recommended top-level functions:
 - `group(prefix, routes:)`
 - `adopt(middleware)`
 - `not_found(handler)`
+- `method_not_allowed(handler)`
 - `on_error(handler)`
+- `on_rejection(handler)`
 
 Prefer the route DSL in examples and docs. Keep the builder API available for
 composition, generated code, and cases where explicit app values read better.
@@ -295,14 +305,27 @@ route declarations should feel like ordinary Voyd calls with trailing closures.
 
 ## Builder API
 
-The secondary builder surface should mirror the DSL:
+The secondary builder surface should preserve the DSL's composition model while
+using explicit names for extracted handler shapes. This avoids relying on
+same-name builder overloads that the compiler cannot currently disambiguate when
+the handler is an inline lambda.
+
+Phase 1 extracted builder methods should accept `Response`-returning handlers.
+The route DSL and free route helper functions remain the richer surface for
+`IntoResponse` handler returns until the compiler can disambiguate those builder
+overloads without making inline lambda handlers ambiguous.
+
+Auth and body policies keep their explicit labels on the builder surface, so
+builder calls such as `app.get("/me", auth: required_session(), handler: ...)`
+and `app.route("/me", method: Method::Get {}, auth: required_session(),
+handler: ...)` are supported without relying on structural trait extraction.
 
 ```voyd
 let app = web::app()
   .adopt(request_logger)
-  .get("/health", handler: health)
+  .get_unit("/health", handler: health)
   .group("/users") routes(router):
-    router.get("/:id", handler: show_user)
+    router.get_params("/:id", handler: show_user)
 
 web::serve(app, port: 3000)
 ```
@@ -310,9 +333,13 @@ web::serve(app, port: 3000)
 Recommended primitives:
 
 - `web::app() -> App`
-- `web::router() -> Router`
+- `router::Router::init() -> Router` from `pkg::web::router`
 - `App::adopt(self, middleware) -> App`
 - `App::get(self, path, ...) -> App`
+- `App::get_unit(self, path, handler:) -> App`
+- `App::get_params(self, path, handler:) -> App`
+- `App::get_params_query(self, path, handler:) -> App`
+- `App::get(self, path, auth:, handler:) -> App`
 - `App::post(self, path, ...) -> App`
 - `App::route(self, path, method: Method, ...) -> App`
 - `App::group(self, prefix, build:) -> App`
@@ -402,7 +429,7 @@ get("/users/:id") do(params: UserParams, query: UserQuery, headers: RequestHeade
 
 post(
   "/users",
-  body: json(),
+  body: json_body(),
   auth: required_session(),
   timeout: Duration::from_millis(500)
 ) do(input: CreateUser, session: Session, ctx: Context):
@@ -432,8 +459,8 @@ Initial inferred handler parameters:
 
 Initial route policies that supply handler parameters:
 
-- `body: json()` plus one typed body parameter
-- `body: text()` plus one `String` body parameter
+- `body: json_body()` plus one typed body parameter
+- `body: text_body()` plus one `String` body parameter
 - `body: bytes()` plus one `Bytes` body parameter
 - `auth: required_session()` plus one `Session` parameter
 - `auth: optional_session()` plus one `Option<Session>` parameter
@@ -453,23 +480,43 @@ parameters are matched by the explicit route policy that introduces them. If a
 handler shape is ambiguous, the compiler should produce a targeted diagnostic
 asking for a route label, a parameter rename, or an explicit wrapper type.
 
-### Extractor Traits
+### Extractor Contracts
 
-Use traits to keep extraction extensible.
+Phase 1 should decode path params, query values, and headers into structural
+records through the same boundary-compatible machinery used for host DTOs. Body
+and auth extraction use nominal policy values because they carry behavior.
+Query-only structural route handlers should include `Context` in Phase 1, for
+example `route_query_context(app, "/search", method: Method::Get {}) do(query:
+SearchQuery, ctx: Context): ...`. The no-context query-only builder mirror is
+deferred because the compiler currently mis-lowers that generic function-value
+shape for inline structural DTO handlers; params+query routes such as
+`get_params_query` do not hit that path.
+
+Implementation note: the current route helpers also avoid wrapping structural
+params/query/header decodes in synthetic `Result<T, Rejection>` values. While
+working through Phase 1, generic route-builder closures inside some effectful
+test-entry shapes were mis-lowered when structural extraction was encoded as an
+always-`Ok` result and immediately matched. Phase 1 therefore decodes
+boundary-compatible structural values directly and reserves strict per-field
+fallible extraction for Phase 2.
 
 ```voyd
-pub trait FromParams<T>
-  fn from_params(params: RouteParams) -> Result<T, Rejection>
-
-pub trait FromQuery<T>
-  fn from_query(query: QueryParams) -> Result<T, Rejection>
-
 pub trait FromBody<T>
-  fn from_body(ctx: Context) -> Result<T, Rejection>
+  fn extract_body(self, request: IncomingRequest) -> Result<T, Rejection>
 
-pub trait FromHeaders<T>
-  fn from_headers(headers: http::Headers) -> Result<T, Rejection>
+pub trait FromAuth<T>
+  fn extract_auth(self, request: IncomingRequest) -> Result<T, Rejection>
 ```
+
+Custom trait-based params/query/header extraction is a Phase 2 feature unless the
+compiler gains precise generic trait dispatch for that shape. Do not emulate it
+by applying traits to structural DTOs.
+
+Phase 1 structural extraction should keep the route pipeline deterministic and
+boundary-compatible. Strict per-field missing or wrong-type validation for
+params, query, and headers can land in Phase 2 with fallible structural decoding;
+JSON parse failures and nominal body/auth policy failures should already produce
+typed rejections.
 
 Structural records are ideal targets for params and query because names matter
 more than identity:
@@ -507,6 +554,11 @@ Default mapping:
 - auth required but absent: `401`
 - auth present but insufficient: `403`
 
+Phase 1 only guarantees this mapping for implemented fallible paths such as route
+matching, JSON parsing, and nominal body/auth policies. Strict structural
+params/query/header field validation should follow with fallible structural
+decoding in Phase 2.
+
 Each extractor should return a `Rejection` that implements `IntoResponse`, so
 applications can override formatting consistently.
 
@@ -531,8 +583,8 @@ Recommended helpers:
 - `ctx.param(name) -> Option<String>`
 - `ctx.query_value(name) -> Option<String>`
 - `ctx.body_bytes() -> Bytes`
-- `ctx.text() -> Result<String, BodyError>`
-- `ctx.json() -> Result<JsonValue, BodyError>`
+- `ctx.text() -> Result<String, HttpError>`
+- `ctx.json() -> Result<JsonValue, HttpError>`
 
 Avoid a dynamic `locals` bag as the primary design. If an escape hatch is needed,
 make it visibly secondary, for example `ctx.extensions()`, and do not use it in
@@ -555,15 +607,15 @@ Response::ok()
   .with(header: "cache-control", value: "no-store")
   .text("hello")
 
-Response::created().json(user)
+response_json(Response::created(), user_json)
 Response::no_content()
 ```
 
 Because `Response` is owned by `std::http`, framework-specific helpers such as
 generic DTO JSON and VX HTML can be provided as extension-style free functions
-with `Response` as their first parameter. With `pkg::web::all` imported, users
-should still be able to write natural dot-call code such as
-`Response::ok().json(user)` and `Response::ok().html(page)`.
+with `Response` as their first parameter. Phase 1 keeps these helpers explicit
+(`response_json(response, value)` and `html_response(response, value)`) so it
+does not require trait implementations for non-nominal DTO or VX values.
 
 Recommended builders:
 
@@ -582,9 +634,10 @@ Recommended builders:
 - `with(body:)`
 - `with(cookie:)`
 - `text(value)`
-- `json(value)`
+- `json(value: JsonValue)`
 - `bytes(value)`
-- `html(value)`
+- `response_json(response, value: JsonValue)`
+- `html_response(response, value)`
 
 `html` can be provided by `pkg::web::html` if std should stay free of VX
 dependencies.
@@ -604,15 +657,19 @@ Initial implementations:
 - `String`
 - `StringSlice`
 - `Bytes`
-- `JsonValue`
-- `vx::Html<Msg>` or the current VX node type
 - `(Status, String)`
-- `(Status, JsonValue)`
 - `(Status, Bytes)`
 - `Result<T, E>` where `T: IntoResponse` and `E: IntoResponse`
 - `Option<T>` where `T: IntoResponse`, mapping `None` to `404`
 
-For ordinary DTO-compatible objects, the desired DevX is:
+Do not require trait implementations for structural or otherwise non-nominal
+objects. `JsonValue` and status tuples should be supported through concrete
+route/helper overloads and explicit response helpers such as
+`response_json(value)`, not by relaxing the compiler's nominal trait target rule.
+Likewise, VX HTML is returned through explicit `html_response`/`html` helpers in
+Phase 1 because the current VX value is not a nominal web response type.
+
+For ordinary DTO-compatible objects, the desired Phase 2 DevX is:
 
 ```voyd
 fn show_user(params: UserParams) -> Result<UserDto, AppError>
@@ -636,24 +693,26 @@ Route authors should be able to choose the level of explicitness:
 
 ```voyd
 get("/version") do:
-  VersionDto { version: "0.3.0" }
+  response_json(version_json(version: "0.3.0"))
 
 get("/status") do:
-  Response::ok().json(StatusDto { healthy: true })
+  response_json(Response::ok(), status_json(healthy: true))
 
-post("/users", body: json()) do(input: CreateUser):
+post("/users", body: json_body()) do(input: CreateUser):
   create_user(input)
 ```
 
-The framework should default DTO-compatible object returns to JSON, while
-strings remain `text/plain` and bytes remain `application/octet-stream`.
+Phase 1 should keep DTO JSON explicit through `JsonValue` and encoder helpers.
+Default JSON for arbitrary DTO-compatible object returns can come later once the
+language/runtime has a stable nominal or boundary-compatible JSON path that does
+not require structural trait implementations.
 
-If default JSON for arbitrary objects proves too implicit, keep the concise
-alternative:
+If default JSON for arbitrary objects proves too implicit, keep a concise
+explicit alternative:
 
 ```voyd
 get("/version") do:
-  json(VersionDto { version: "0.3.0" })
+  response_json(version_json(version: "0.3.0"))
 ```
 
 That still keeps users away from low-level encoding.
@@ -664,7 +723,7 @@ Server-rendered HTML should use `std::vx` as the authoring model.
 
 ```voyd
 use std::vx
-use pkg::web::Response
+use pkg::web::{ Response, html_response }
 
 fn home_page(name: String) -> vx::Html<AppMsg>
   <main>
@@ -673,14 +732,15 @@ fn home_page(name: String) -> vx::Html<AppMsg>
   </main>
 
 fn home() -> Response
-  Response::ok().html(home_page("friend"))
+  html_response(Response::ok(), home_page("friend"))
 ```
 
 Recommended helpers:
 
 - `html::render(value) -> String`
 - `html::document(value) -> String`
-- `Response::html(value) -> Response`
+- `html::html_response(response, value) -> Response`
+- `html::html(response, value) -> Response`
 
 The framework should treat HTML syntax as the primary authoring path. Users
 should not hand-assemble render trees unless they want to.
@@ -699,7 +759,8 @@ Conceptual API shape:
 
 ```voyd
 fn home(model: HomeModel) -> Response
-  Response::ok().html(
+  html_response(
+    Response::ok(),
     html::document(
       view: home_page(model),
       hydrate: html::hydrate(
@@ -809,7 +870,7 @@ obj AppError {
 
 impl IntoResponse for AppError
   fn into_response(self) -> Response
-    Response::new(status: self.status).json(ErrorDto { message: self.message })
+    Response::new(status: self.status).text(self.message)
 
 fn show_user(params: UserParams) -> Result<UserDto, AppError>
   users::find(params.id)
@@ -825,7 +886,10 @@ Framework-level error hooks are still useful:
 ```voyd
 serve(port: 3000) routes():
   not_found() do(ctx: Context):
-    Response::not_found().html(not_found_page(ctx.path()))
+    html_response(Response::not_found(), not_found_page(ctx.path()))
+
+  method_not_allowed() do(ctx: Context):
+    Response::method_not_allowed().text("wrong method")
 
   on_rejection() do(rejection: Rejection, ctx: Context):
     rejection.into_response().with(header: "x-error", value: "request")

--- a/package-lock.json
+++ b/package-lock.json
@@ -2532,6 +2532,10 @@
       "resolved": "packages/vx-dom",
       "link": true
     },
+    "node_modules/@voyd-lang/web": {
+      "resolved": "packages/web",
+      "link": true
+    },
     "node_modules/@vscode/vsce": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.7.1.tgz",
@@ -9935,6 +9939,13 @@
       },
       "devDependencies": {
         "happy-dom": "^20.10.1"
+      }
+    },
+    "packages/web": {
+      "name": "@voyd-lang/web",
+      "version": "0.1.0",
+      "dependencies": {
+        "@voyd-lang/std": "^0.2.0"
       }
     }
   }

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/effects-export-open-row-no-perform.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/effects-export-open-row-no-perform.voyd
@@ -1,0 +1,5 @@
+eff Async
+  await(tail) -> i32
+
+pub fn main(): Async -> i32
+  7

--- a/packages/compiler/src/codegen/__tests__/effects-export.test.ts
+++ b/packages/compiler/src/codegen/__tests__/effects-export.test.ts
@@ -17,6 +17,11 @@ const msgpackFixturePath = resolve(
   "__fixtures__",
   "effects-msgpack.voyd"
 );
+const openRowNoPerformFixturePath = resolve(
+  import.meta.dirname,
+  "__fixtures__",
+  "effects-export-open-row-no-perform.voyd"
+);
 
 const compileFixture = async (fixture: string) => {
   const result = await compileEffectFixture({ entryPath: fixture });
@@ -87,6 +92,18 @@ describe("effectful exports & host boundary", () => {
     if (!effectTable) return;
     expect(asyncParsed.map((op) => op.resumeKind)).toEqual([1, 0]);
     expect(asyncTable?.map((op) => op.resumeKind)).toEqual([1, 0]);
+  });
+
+  it("emits init_effects for open-row exports without performs", async () => {
+    const { module } = await compileFixture(openRowNoPerformFixturePath);
+    const wat = module.emitText();
+    expect(wat).toContain(`(export "init_effects"`);
+    await expect(
+      runEffectfulExport<number>({
+        wasm: module,
+        entryName: "main_effectful",
+      })
+    ).resolves.toMatchObject({ value: 7 });
   });
 
   it("round-trips msgpack values for effect handlers", async () => {

--- a/packages/compiler/src/codegen/effects/gc-trampoline-abi-strategy.ts
+++ b/packages/compiler/src/codegen/effects/gc-trampoline-abi-strategy.ts
@@ -25,6 +25,7 @@ import {
 } from "./host-boundary/operation-filter.js";
 import type { EffectOpSignature } from "./host-boundary/types.js";
 import type { EffectsAbiStrategy } from "./codegen-backend.js";
+import { ensureEffectHandleTable } from "./handle-table.js";
 
 const hiddenHandlerParamType = (ctx: CodegenContext): binaryen.Type =>
   ctx.effectsRuntime.handlerFrameType;
@@ -187,6 +188,7 @@ const emitHostBoundary: EffectsAbiStrategy["emitHostBoundary"] = ({
     });
     return;
   }
+  ensureEffectHandleTable(entryCtx);
   const handleOutcome = createHandleOutcomeDynamic({
     ctx: entryCtx,
     runtime: entryCtx.effectsRuntime,

--- a/packages/compiler/src/codegen/expressions/lambdas.ts
+++ b/packages/compiler/src/codegen/expressions/lambdas.ts
@@ -55,18 +55,20 @@ type LambdaEnvInfo = NonNullable<
 
 const formatLambdaInstanceLabel = (
   exprId: number,
-  outerInstanceId?: ProgramFunctionInstanceId
+  outerInstanceId: ProgramFunctionInstanceId | undefined,
+  lambdaTypeId: number
 ): string =>
   typeof outerInstanceId === "number"
-    ? `inst${outerInstanceId}_lambda${exprId}`
-    : `lambda${exprId}`;
+    ? `inst${outerInstanceId}_type${lambdaTypeId}_lambda${exprId}`
+    : `type${lambdaTypeId}_lambda${exprId}`;
 
 const makeLambdaKey = (
   exprId: number,
   ctx: CodegenContext,
+  lambdaTypeId: number,
   outerInstanceId?: ProgramFunctionInstanceId
 ) =>
-  `${ctx.moduleId}::lambda${exprId}::${outerInstanceId ?? "root"}`;
+  `${ctx.moduleId}::lambda${exprId}::type${lambdaTypeId}::${outerInstanceId ?? "root"}`;
 
 const makeLambdaFunctionName = ({
   expr,
@@ -446,8 +448,12 @@ export const compileLambdaExpr = (
   const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
   const lambdaTypeId = getRequiredExprType(expr.id, ctx, typeInstanceId);
   const base = getClosureTypeInfo(lambdaTypeId, ctx);
-  const lambdaInstanceLabel = formatLambdaInstanceLabel(expr.id, fnCtx.instanceId);
-  const key = makeLambdaKey(expr.id, ctx, fnCtx.instanceId);
+  const lambdaInstanceLabel = formatLambdaInstanceLabel(
+    expr.id,
+    typeInstanceId,
+    lambdaTypeId
+  );
+  const key = makeLambdaKey(expr.id, ctx, lambdaTypeId, typeInstanceId);
 
   let envInfo = ctx.lambdaEnvs.get(key);
   if (!envInfo) {

--- a/packages/compiler/src/codegen/intrinsics.ts
+++ b/packages/compiler/src/codegen/intrinsics.ts
@@ -972,6 +972,37 @@ export const compileIntrinsicCall = ({
         fnCtx,
       });
     }
+    case "__boundary_msgpack_to_value": {
+      assertArgCount(name, args, 1);
+      const returnTypeId = getRequiredExprType(call.id, ctx, instanceId);
+      const serializer = findSerializerForType(returnTypeId, ctx);
+      if (serializer) {
+        if (serializer.formatId !== "msgpack") {
+          throw new Error(
+            `boundary value deserializer format ${serializer.formatId} is not supported`
+          );
+        }
+        const msgpack = ensureMsgPackFunctions(ctx);
+        return coerceValueToType({
+          value: args[0]!,
+          actualType: msgpack.msgPackTypeId,
+          targetType: returnTypeId,
+          ctx,
+          fnCtx,
+        });
+      }
+      return unpackBoundaryValueFromMsgPack({
+        value: args[0]!,
+        schema: deriveBoundarySchema({
+          typeId: returnTypeId,
+          ctx,
+          label: "__boundary_msgpack_to_value target",
+          options: { tagStandaloneVariants: true },
+        }),
+        ctx,
+        fnCtx,
+      });
+    }
     case "__shift_l":
     case "__shift_ru": {
       assertArgCount(name, args, 2);

--- a/packages/compiler/src/codegen/structural.ts
+++ b/packages/compiler/src/codegen/structural.ts
@@ -55,6 +55,7 @@ type StructuralMatchCache = {
   fieldTypes: Map<string, boolean>;
   layouts: Map<string, boolean>;
   conversions: Map<string, boolean>;
+  nextClosureCoercionWrapperIndex: number;
 };
 
 const structuralMatchCache = (ctx: CodegenContext): StructuralMatchCache =>
@@ -62,6 +63,7 @@ const structuralMatchCache = (ctx: CodegenContext): StructuralMatchCache =>
     fieldTypes: new Map(),
     layouts: new Map(),
     conversions: new Map(),
+    nextClosureCoercionWrapperIndex: 0,
   }));
 
 const symmetricTypePairKey = (left: TypeId, right: TypeId): string =>
@@ -2267,6 +2269,17 @@ const coerceClosureToTarget = ({
   if (actualDesc.kind !== "function" || targetDesc.kind !== "function") {
     throw new Error("expected function type for closure coercion");
   }
+  if (
+    !functionTypesCompatibleForClosureCoercion({
+      actualType,
+      targetType,
+      ctx,
+    })
+  ) {
+    throw new Error(
+      `cannot coerce incompatible function type ${actualType} to ${targetType}`,
+    );
+  }
   const actualEffectful =
     typeof actualDesc.effectRow === "number" &&
     !ctx.program.effects.isEmpty(actualDesc.effectRow);
@@ -2276,7 +2289,9 @@ const coerceClosureToTarget = ({
   if (actualEffectful && !targetEffectful) {
     return value;
   }
-  const wrapperIndex = cache.size;
+  const structuralCache = structuralMatchCache(ctx);
+  const wrapperIndex = structuralCache.nextClosureCoercionWrapperIndex;
+  structuralCache.nextClosureCoercionWrapperIndex += 1;
   const fnName = `__voyd_effect_closure_wrap_${wrapperIndex}_${actualType}_${targetType}`;
   const envType = defineStructType(ctx.mod, {
     name: `__voydEffectClosureWrapEnv_${wrapperIndex}`,
@@ -2376,6 +2391,57 @@ const coerceClosureToTarget = ({
   cache.set(key, { envType, fnName, fnRefType });
 
   return initStruct(ctx.mod, envType, [refFunc(ctx.mod, fnName, fnRefType), value]);
+};
+
+const functionTypesCompatibleForClosureCoercion = ({
+  actualType,
+  targetType,
+  ctx,
+}: {
+  actualType: TypeId;
+  targetType: TypeId;
+  ctx: CodegenContext;
+}): boolean => {
+  const actualDesc = ctx.program.types.getTypeDesc(actualType);
+  const targetDesc = ctx.program.types.getTypeDesc(targetType);
+  if (actualDesc.kind !== "function" || targetDesc.kind !== "function") {
+    return false;
+  }
+  if (actualDesc.parameters.length !== targetDesc.parameters.length) {
+    return false;
+  }
+  const location = ctx.module.hir.module.ast;
+  for (let index = 0; index < actualDesc.parameters.length; index += 1) {
+    const actualParam = actualDesc.parameters[index]!;
+    const targetParam = targetDesc.parameters[index]!;
+    if (actualParam.optional !== targetParam.optional) {
+      return false;
+    }
+    const paramCompatible = ctx.program.types.unify(
+      targetParam.type,
+      actualParam.type,
+      {
+        location,
+        reason: "function parameter closure coercion",
+        variance: "covariant",
+        allowUnknown: true,
+      },
+    );
+    if (!paramCompatible.ok) {
+      return false;
+    }
+  }
+  const returnCompatible = ctx.program.types.unify(
+    actualDesc.returnType,
+    targetDesc.returnType,
+    {
+      location,
+      reason: "function return closure coercion",
+      variance: "covariant",
+      allowUnknown: true,
+    },
+  );
+  return returnCompatible.ok;
 };
 
 const closureReturnTypeId = (typeId: TypeId, ctx: CodegenContext): TypeId => {

--- a/packages/compiler/src/modules/path.ts
+++ b/packages/compiler/src/modules/path.ts
@@ -259,6 +259,15 @@ const resolvePackageSourceRoots = async ({
         pathAdapter,
       }),
     );
+
+    if (!packageName.startsWith("@")) {
+      candidates.push(
+        ...packageSourceRootCandidates({
+          packageRoot: pathAdapter.join(packagesDir, "@voyd-lang", packageName),
+          pathAdapter,
+        }),
+      );
+    }
   });
 
   return dedupePaths(candidates);

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_constraint_fallback.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_constraint_fallback.voyd
@@ -1,0 +1,22 @@
+trait Marked
+  fn marker(self) -> i32
+
+obj MarkerValue {
+  value: i32
+}
+
+impl Marked for MarkerValue
+  fn marker(self) -> i32
+    self.value
+
+fn choose<T: Marked>(value: T) -> i32
+  value.marker()
+
+fn choose<T>(value: T) -> bool
+  value
+  true
+
+pub fn main() -> i32
+  let marked = choose(MarkerValue { value: 7 })
+  let fallback = choose(1)
+  if fallback then: marked else: 0

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/overload_lambda_callback_return_disambiguation.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/overload_lambda_callback_return_disambiguation.voyd
@@ -1,0 +1,78 @@
+obj Response {
+  code: i32
+}
+
+obj JsonBool {
+  value: bool
+}
+
+obj JsonString {
+  value: string
+}
+
+obj Text {
+  value: i32
+}
+
+obj Problem {
+  code: i32
+}
+
+obj Ok<T> {
+  value: T
+}
+
+obj Err<E> {
+  error: E
+}
+
+obj Some<T> {
+  value: T
+}
+
+obj None {}
+
+type JsonValue = JsonBool | JsonString
+type Result<T, E> = Ok<T> | Err<E>
+type Option<T> = Some<T> | None
+
+trait IntoResponse<T>
+  fn into_response(self) -> Response
+
+impl IntoResponse<Text> for Text
+  fn into_response(self) -> Response
+    Response { code: 200 }
+
+impl IntoResponse<Problem> for Problem
+  fn into_response(self) -> Response
+    Response { code: 500 }
+
+fn route(handler: fn() -> JsonValue) -> Response
+  handler()
+  Response { code: 201 }
+
+fn route<T: IntoResponse<T>, E: IntoResponse<E>>(handler: fn() -> Result<T, E>) -> Response
+  handler()
+  Response { code: 202 }
+
+fn route<T: IntoResponse<T>>(handler: fn() -> Option<T>) -> Response
+  handler()
+  Response { code: 203 }
+
+fn route<R: IntoResponse<R>>(handler: fn() -> R) -> Response
+  handler().into_response()
+
+pub fn main() -> i32
+  let json_response = route do:
+    let value: JsonValue = JsonBool { value: true }
+    value
+
+  let result_response = route do:
+    let value: Result<Text, Problem> = Ok<Text> { value: Text { value: 1 } }
+    value
+
+  let option_response = route do:
+    let value: Option<Text> = Some<Text> { value: Text { value: 2 } }
+    value
+
+  json_response.code + result_response.code + option_response.code

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/overload_lambda_method_parameter_shape_disambiguation.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/overload_lambda_method_parameter_shape_disambiguation.voyd
@@ -1,0 +1,39 @@
+obj App {}
+
+obj Context {
+  value: i32
+}
+
+type Params = {
+  id: i32
+}
+
+type Query = {
+  verbose: bool
+}
+
+impl App
+  api fn get<T>(self, path: i32, { handler: fn(Context) -> T }) -> i32
+    self
+    path
+    handler(Context { value: 1 })
+    1
+
+  api fn get<P, T>(self, path: i32, { handler: fn(P) -> T }) -> i32
+    self
+    path
+    2
+
+  api fn get<P, Q, T>(self, path: i32, { handler: fn(P, Q) -> T }) -> i32
+    self
+    path
+    3
+
+pub fn main() -> i32
+  let app = App {}
+  let context_route = app.get(1, handler: (ctx: Context) -> i32 => ctx.value)
+  let params_route = app.get(2, handler: (params: Params) -> i32 => params.id)
+  let query_route = app.get(3, handler: (params: Params, query: Query) -> i32 =>
+    if query.verbose then: params.id else: 0
+  )
+  context_route + params_route + query_route

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/overload_named_callback_return_disambiguation.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/overload_named_callback_return_disambiguation.voyd
@@ -1,0 +1,75 @@
+obj Response {
+  code: i32
+}
+
+obj JsonBool {
+  value: bool
+}
+
+obj JsonString {
+  value: string
+}
+
+obj Text {
+  value: i32
+}
+
+obj Problem {
+  code: i32
+}
+
+obj Ok<T> {
+  value: T
+}
+
+obj Err<E> {
+  error: E
+}
+
+obj Some<T> {
+  value: T
+}
+
+obj None {}
+
+type JsonValue = JsonBool | JsonString
+type Result<T, E> = Ok<T> | Err<E>
+type Option<T> = Some<T> | None
+
+trait IntoResponse<T>
+  fn into_response(self) -> Response
+
+impl IntoResponse<Text> for Text
+  fn into_response(self) -> Response
+    Response { code: 200 }
+
+impl IntoResponse<Problem> for Problem
+  fn into_response(self) -> Response
+    Response { code: 500 }
+
+fn route(handler: fn() -> JsonValue) -> Response
+  handler()
+  Response { code: 201 }
+
+fn route<T: IntoResponse<T>, E: IntoResponse<E>>(handler: fn() -> Result<T, E>) -> Response
+  handler()
+  Response { code: 202 }
+
+fn route<T: IntoResponse<T>>(handler: fn() -> Option<T>) -> Response
+  handler()
+  Response { code: 203 }
+
+fn route<R: IntoResponse<R>>(handler: fn() -> R) -> Response
+  handler().into_response()
+
+fn make_json() -> JsonValue
+  let value: JsonValue = JsonBool { value: true }
+  value
+
+fn make_option() -> Option<Text>
+  Some<Text> { value: Text { value: 2 } }
+
+pub fn main() -> i32
+  let json_response = route(make_json)
+  let option_response = route(make_option)
+  json_response.code + option_response.code

--- a/packages/compiler/src/semantics/__tests__/pipeline.test.ts
+++ b/packages/compiler/src/semantics/__tests__/pipeline.test.ts
@@ -1410,6 +1410,12 @@ describe("semanticsPipeline", () => {
     ).toBe(true);
   });
 
+  it("allows overloads that differ by generic constraints and falls back when unsatisfied", () => {
+    const ast = loadAst("function_overloads_constraint_fallback.voyd");
+    const result = semanticsPipeline(ast);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("rejects impls that target structural types", () => {
     const ast = loadAst("impl_structural_target.voyd");
     expect(() => semanticsPipeline(ast)).toThrow(

--- a/packages/compiler/src/semantics/binding/overloads.ts
+++ b/packages/compiler/src/semantics/binding/overloads.ts
@@ -7,6 +7,7 @@ import type {
   OverloadBucket,
   BoundParameter,
 } from "./types.js";
+import type { TypeParameterDecl } from "../decls.js";
 import { findNonOverloadNameCollision } from "./name-collisions.js";
 
 const makeOverloadBucketKey = (scope: ScopeId, name: string): string =>
@@ -107,13 +108,58 @@ const createOverloadSignature = (
     };
   });
   const returnAnnotation = formatTypeAnnotation(fn.returnTypeExpr);
+  const typeParameterConstraints = typeParameterConstraintKey(fn);
+  const constraintLabel =
+    typeParameterConstraints.length > 0 ? ` where ${typeParameterConstraints}` : "";
   return {
-    key: overloadSignatureKeyFromParams(fn.params, { includeLabels: true }),
+    key: `${overloadSignatureKeyFromParams(fn.params, {
+      includeLabels: true,
+    })}|${typeParameterConstraints}`,
     label: `${fn.name}(${params
       .map((param) => param.label)
-      .join(", ")}) -> ${returnAnnotation}`,
+      .join(", ")}) -> ${returnAnnotation}${constraintLabel}`,
   };
 };
+
+const typeParameterConstraintKey = (fn: BoundFunction): string => {
+  const params = fn.typeParameters ?? [];
+  if (params.length === 0) {
+    return "";
+  }
+  const signatureAnnotations = [
+    ...fn.params.map((param) => formatTypeAnnotation(param.typeExpr)),
+    formatTypeAnnotation(fn.returnTypeExpr),
+  ];
+  return params
+    .filter((param) =>
+      signatureAnnotations.some((annotation) =>
+        referencesTypeParameter(annotation, param.name)
+      )
+    )
+    .map((param) => {
+      const normalizedIndex = params.indexOf(param);
+      return param.constraint
+        ? normalizeTypeParameterNames(formatTypeAnnotation(param.constraint), params)
+        : `$${normalizedIndex}:_`;
+    })
+    .join(",");
+};
+
+const referencesTypeParameter = (annotation: string, name: string): boolean =>
+  new RegExp(`\\b${escapeRegExp(name)}\\b`).test(annotation);
+
+const normalizeTypeParameterNames = (
+  value: string,
+  params: readonly TypeParameterDecl[]
+): string =>
+  params.reduce(
+    (out, param, index) =>
+      out.replace(new RegExp(`\\b${escapeRegExp(param.name)}\\b`, "g"), `$${index}`),
+    value
+  );
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 const parameterLabel = (param: BoundParameter): string | undefined =>
   param.label;

--- a/packages/compiler/src/semantics/intrinsics.ts
+++ b/packages/compiler/src/semantics/intrinsics.ts
@@ -77,6 +77,10 @@ const VALUE_INTRINSICS = new Map<string, IntrinsicValueMetadata>([
     "__boundary_value_to_msgpack",
     { intrinsicUsesSignature: false, access: "std-only" },
   ],
+  [
+    "__boundary_msgpack_to_value",
+    { intrinsicUsesSignature: false, access: "std-only" },
+  ],
   ["__shift_l", { intrinsicUsesSignature: false, access: "std-only" }],
   ["__shift_ru", { intrinsicUsesSignature: false, access: "std-only" }],
   ["__bit_and", { intrinsicUsesSignature: false, access: "std-only" }],

--- a/packages/compiler/src/semantics/typing/__tests__/overload-lambda-return-hint.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/overload-lambda-return-hint.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import type { HirCallExpr, HirLambdaExpr } from "../../hir/index.js";
+import type {
+  HirCallExpr,
+  HirLambdaExpr,
+  HirMethodCallExpr,
+} from "../../hir/index.js";
 import { semanticsPipeline } from "../../pipeline.js";
 import { loadAst } from "../../__tests__/load-ast.js";
 
@@ -75,5 +79,46 @@ describe("overload lambda return hint", () => {
     expect(call).toBeDefined();
     if (!call) return;
     expect(typing.table.getExprType(call.id)).toBe(bool);
+  });
+
+  it("uses callback return types to disambiguate overloads before generic constraints", () => {
+    expect(() =>
+      semanticsPipeline(
+        loadAst("overload_lambda_callback_return_disambiguation.voyd"),
+      ),
+    ).not.toThrow();
+  });
+
+  it("uses named callback return types to reject incompatible generic overloads", () => {
+    expect(() =>
+      semanticsPipeline(
+        loadAst("overload_named_callback_return_disambiguation.voyd"),
+      ),
+    ).not.toThrow();
+  });
+
+  it("uses inline lambda parameter shape to disambiguate method overloads", () => {
+    const semantics = semanticsPipeline(
+      loadAst("overload_lambda_method_parameter_shape_disambiguation.voyd"),
+    );
+    const { hir, typing } = semantics;
+
+    const calls = Array.from(hir.expressions.values())
+      .filter(
+        (expr): expr is HirMethodCallExpr =>
+          expr.exprKind === "method-call" && expr.method === "get",
+      )
+      .sort((left, right) => (left.span?.start ?? 0) - (right.span?.start ?? 0));
+
+    expect(calls).toHaveLength(3);
+    const selectedTypeParamCounts = calls.map((call) => {
+      const targets = typing.callTargets.get(call.id);
+      const target = targets?.values().next().value;
+      expect(target).toBeDefined();
+      if (!target) return undefined;
+      return typing.functions.getSignature(target.symbol)?.typeParams?.length ?? 0;
+    });
+
+    expect(selectedTypeParamCounts).toEqual([1, 2, 3]);
   });
 });

--- a/packages/compiler/src/semantics/typing/__tests__/typecheck-budget.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/typecheck-budget.test.ts
@@ -30,7 +30,10 @@ const createNamedType = (
   span,
 });
 
-const createOverloadFanoutCase = (overloadCount: number) => {
+const createOverloadFanoutCase = (
+  overloadCount: number,
+  options?: { sameShape?: boolean },
+) => {
   const ctx = createModuleContext();
   const overloadSetId: OverloadSetId = 0;
   const functionScope = ctx.symbolTable.rootScope as ScopeId;
@@ -47,7 +50,7 @@ const createOverloadFanoutCase = (overloadCount: number) => {
     });
     overloadSymbols.push(symbol);
 
-    const paramCount = index === overloadCount - 1 ? 1 : 2;
+    const paramCount = options?.sameShape || index === overloadCount - 1 ? 1 : 2;
     const params = Array.from({ length: paramCount }, (_, paramIndex) => {
       const paramSymbol = ctx.symbolTable.declare({
         name: `value_${index}_${paramIndex}`,
@@ -110,6 +113,141 @@ const createOverloadFanoutCase = (overloadCount: number) => {
       span: ctx.span,
     }),
     args: [{ expr: ctx.createLiteral("i32", "1") }],
+    ast: ctx.nextNode(),
+    span: ctx.span,
+  });
+  const mainDecl = ctx.decls.registerFunction({
+    name: "main",
+    visibility: packageVisibility(),
+    symbol: mainSymbol,
+    scope: functionScope,
+    params: [],
+    body: fakeExpr(),
+    moduleIndex: ctx.nextModuleIndex(),
+  });
+  ctx.builder.addFunction({
+    kind: "function",
+    visibility: packageVisibility(),
+    symbol: mainSymbol,
+    decl: mainDecl.id,
+    parameters: [],
+    returnType: i32(),
+    body: callExpr,
+    ast: ctx.nextNode(),
+    span: ctx.span,
+  });
+
+  return {
+    inputs: {
+      symbolTable: ctx.symbolTable,
+      hir: ctx.builder.finalize(),
+      overloads: new Map<OverloadSetId, readonly SymbolId[]>([
+        [overloadSetId, overloadSymbols],
+      ]),
+      decls: ctx.decls,
+    },
+    callExpr,
+    mainSymbol,
+    selectedSymbol: overloadSymbols[overloadSymbols.length - 1]!,
+  };
+};
+
+const createLabeledShapeNarrowingCase = (overloadCount: number) => {
+  const ctx = createModuleContext();
+  const overloadSetId: OverloadSetId = 0;
+  const functionScope = ctx.symbolTable.rootScope as ScopeId;
+  const fakeExpr = (): Expr =>
+    ({ syntaxId: ctx.nextNode(), location: ctx.span } as unknown as Expr);
+  const i32 = () => createNamedType("i32", ctx.nextNode(), ctx.span);
+
+  const overloadSymbols: SymbolId[] = [];
+  for (let index = 0; index < overloadCount; index += 1) {
+    const symbol = ctx.symbolTable.declare({
+      name: "configure",
+      kind: "value",
+      declaredAt: ctx.nextNode(),
+    });
+    overloadSymbols.push(symbol);
+
+    const targetParam = ctx.symbolTable.declare({
+      name: `target_${index}`,
+      kind: "parameter",
+      declaredAt: ctx.nextNode(),
+    });
+    const valueParam = ctx.symbolTable.declare({
+      name: `value_${index}`,
+      kind: "parameter",
+      declaredAt: ctx.nextNode(),
+    });
+    const valueLabel = index === overloadCount - 1 ? "body" : `other_${index}`;
+
+    const decl = ctx.decls.registerFunction({
+      name: "configure",
+      visibility: moduleVisibility(),
+      symbol,
+      scope: functionScope,
+      params: [
+        { name: `target_${index}`, symbol: targetParam, ast: undefined },
+        {
+          name: `value_${index}`,
+          label: valueLabel,
+          symbol: valueParam,
+          ast: undefined,
+        },
+      ],
+      body: fakeExpr(),
+      moduleIndex: ctx.nextModuleIndex(),
+    });
+
+    ctx.builder.addFunction({
+      kind: "function",
+      visibility: moduleVisibility(),
+      symbol,
+      decl: decl.id,
+      parameters: [
+        {
+          symbol: targetParam,
+          pattern: { kind: "identifier", symbol: targetParam },
+          mutable: false,
+          span: ctx.span,
+          type: i32(),
+        },
+        {
+          symbol: valueParam,
+          pattern: { kind: "identifier", symbol: valueParam },
+          mutable: false,
+          label: valueLabel,
+          span: ctx.span,
+          type: i32(),
+        },
+      ],
+      returnType: i32(),
+      body: ctx.createLiteral("i32", `${index}`),
+      ast: ctx.nextNode(),
+      span: ctx.span,
+    });
+  }
+
+  const mainSymbol = ctx.symbolTable.declare({
+    name: "main",
+    kind: "value",
+    declaredAt: ctx.nextNode(),
+  });
+  const callExpr = ctx.builder.addExpression({
+    kind: "expr",
+    exprKind: "call",
+    callee: ctx.builder.addExpression({
+      kind: "expr",
+      exprKind: "overload-set",
+      name: "configure",
+      set: overloadSetId,
+      ast: ctx.nextNode(),
+      span: ctx.span,
+    }),
+    args: [
+      { expr: ctx.createLiteral("i32", "1") },
+      { label: "body", expr: ctx.createLiteral("i32", "2") },
+    ],
     ast: ctx.nextNode(),
     span: ctx.span,
   });
@@ -1201,7 +1339,7 @@ const expectDiagnosticError = (run: () => unknown): DiagnosticError => {
 
 describe("type-check budgets", () => {
   it("reports TY0041 when overload fanout exceeds the candidate budget", () => {
-    const fanout = createOverloadFanoutCase(18);
+    const fanout = createOverloadFanoutCase(18, { sameShape: true });
     const error = expectDiagnosticError(() =>
       runTypingPipeline({
         ...fanout.inputs,
@@ -1217,6 +1355,25 @@ describe("type-check budgets", () => {
     const typing = runTypingPipeline({
       ...fanout.inputs,
       typeCheckBudget: { maxOverloadCandidates: 18 },
+    });
+
+    const callType = typing.table.getExprType(fanout.callExpr);
+    expect(callType).toBeDefined();
+    const callDesc = typing.arena.get(callType!);
+    expect(callDesc).toMatchObject({ kind: "primitive", name: "i32" });
+
+    const callTargets = typing.callTargets.get(fanout.callExpr);
+    expect(callTargets?.get(`${fanout.mainSymbol}<>`)).toEqual({
+      moduleId: "local",
+      symbol: fanout.selectedSymbol,
+    });
+  });
+
+  it("applies labeled argument shape before overload candidate budget checks", () => {
+    const fanout = createLabeledShapeNarrowingCase(18);
+    const typing = runTypingPipeline({
+      ...fanout.inputs,
+      typeCheckBudget: { maxOverloadCandidates: 5 },
     });
 
     const callType = typing.table.getExprType(fanout.callExpr);

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -883,6 +883,20 @@ const uniqueOverloadSymbols = (
     return undefined;
   }
 
+  let needsCanonicalization = false;
+  const localSeen = new Set<SymbolId>();
+  for (const symbol of symbols) {
+    if (localSeen.has(symbol) || ctx.importsByLocal.has(symbol)) {
+      needsCanonicalization = true;
+      break;
+    }
+    localSeen.add(symbol);
+  }
+
+  if (!needsCanonicalization) {
+    return symbols;
+  }
+
   const seen = new Set<string>();
   return symbols.filter((symbol) => {
     const key = symbolRefKey(canonicalSymbolRefForTypingContext(symbol, ctx));

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -56,6 +56,7 @@ import {
   bindCallArgumentTypeParams,
   buildCallArgumentHintSubstitution,
   expectedCallArgType,
+  type CallArgInput,
   typeCallArgsWithSignatureContext,
 } from "./call-arg-context.js";
 import {
@@ -67,9 +68,11 @@ import {
   applyExplicitTypeArguments,
   enforceOverloadCandidateBudget,
   findOverloadMatches,
+  narrowOverloadMatches,
   selectHintedOverloadCandidates,
+  specializeOverloadParameters,
 } from "./overload-resolution.js";
-import { typeExpression } from "../expressions.js";
+import { typeExpression, withSpeculativeExprTyping } from "../expressions.js";
 import { applyCurrentSubstitution } from "./shared.js";
 import { getValueType } from "./identifier.js";
 import { assertMutableObjectBinding, findBindingSymbol } from "./mutability.js";
@@ -872,6 +875,26 @@ export const typeMethodCallExpr = (
   });
 };
 
+const uniqueOverloadSymbols = (
+  symbols: readonly SymbolId[] | undefined,
+  ctx: TypingContext,
+): readonly SymbolId[] | undefined => {
+  if (!symbols) {
+    return undefined;
+  }
+
+  const seen = new Set<string>();
+  return symbols.filter((symbol) => {
+    const key = symbolRefKey(canonicalSymbolRefForTypingContext(symbol, ctx));
+    if (seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+};
+
 const getExpectedCallParameters = ({
   callee,
   typeArguments,
@@ -892,7 +915,7 @@ const getExpectedCallParameters = ({
     typeof expectedReturnType === "number" &&
     expectedReturnType !== ctx.primitives.unknown
   ) {
-    const overloads = ctx.overloads.get(callee.set);
+    const overloads = uniqueOverloadSymbols(ctx.overloads.get(callee.set), ctx);
     if (!overloads) {
       return {};
     }
@@ -916,6 +939,9 @@ const getExpectedCallParameters = ({
       ctx,
       state,
     });
+    if (matchingReturn.length === explicitTypeMatches.length) {
+      return {};
+    }
     enforceOverloadCandidateBudget({
       name: callee.name,
       candidateCount: matchingReturn.length,
@@ -1021,6 +1047,7 @@ const findMatchingOverloadCandidates = <
   state,
   typeArguments,
   argsForCandidate,
+  refineMatches,
 }: {
   candidates: readonly T[];
   args: readonly Arg[];
@@ -1028,8 +1055,9 @@ const findMatchingOverloadCandidates = <
   state: TypingState;
   typeArguments?: readonly TypeId[];
   argsForCandidate?: (candidate: T) => readonly Arg[];
-}): T[] =>
-  candidates.filter((candidate) =>
+  refineMatches?: (matches: readonly T[]) => readonly T[];
+}): readonly T[] => {
+  const matches = candidates.filter((candidate) =>
     matchesOverloadSignature(
       candidate.symbol,
       candidate.signature,
@@ -1039,6 +1067,9 @@ const findMatchingOverloadCandidates = <
       typeArguments,
     ),
   );
+  const refined = refineMatches ? refineMatches(matches) : matches;
+  return narrowOverloadMatches({ matches: refined, typeArguments, ctx, state });
+};
 
 const expectedCalleeType = (args: readonly Arg[], ctx: TypingContext): TypeId =>
   ctx.arena.internFunction({
@@ -1910,6 +1941,91 @@ const callArgumentsSatisfyParams = ({
           }) && typeSatisfies(match.matchedType, match.param.type, ctx, state),
     onSkipOptionalParam: () => true,
   }).kind === "ok";
+
+const callArgumentFunctionReturnsSatisfyParams = ({
+  args,
+  params,
+  signatureTypeParams,
+  ctx,
+  state,
+}: {
+  args: readonly Arg[];
+  params: readonly ParamSignature[];
+  signatureTypeParams: readonly FunctionTypeParam[];
+  ctx: TypingContext;
+  state: TypingState;
+}): boolean => {
+  const signatureTypeParamIds = new Set(
+    signatureTypeParams.map((param) => param.typeParam),
+  );
+  const result = walkCallArguments({
+    args,
+    params,
+    ctx,
+    state,
+    onMatch: (match) =>
+      functionReturnSatisfiesParameterReturn({
+        actual: match.matchedType,
+        expected: match.param.type,
+        signatureTypeParamIds,
+        ctx,
+        state,
+      }),
+    onSkipOptionalParam: () => true,
+  });
+  return result.kind === "ok";
+};
+
+const functionReturnSatisfiesParameterReturn = ({
+  actual,
+  expected,
+  signatureTypeParamIds,
+  ctx,
+  state,
+}: {
+  actual: TypeId;
+  expected: TypeId;
+  signatureTypeParamIds: ReadonlySet<TypeParamId>;
+  ctx: TypingContext;
+  state: TypingState;
+}): boolean => {
+  const actualDesc = ctx.arena.get(unfoldRecursiveTypeId(actual, ctx));
+  const expectedDesc = ctx.arena.get(unfoldRecursiveTypeId(expected, ctx));
+  if (actualDesc.kind !== "function" || expectedDesc.kind !== "function") {
+    return true;
+  }
+
+  const actualReturn = unfoldRecursiveTypeId(actualDesc.returnType, ctx);
+  const expectedReturn = unfoldRecursiveTypeId(expectedDesc.returnType, ctx);
+  if (
+    actualReturn === ctx.primitives.unknown ||
+    expectedReturn === ctx.primitives.unknown
+  ) {
+    return true;
+  }
+
+  if (!containsTypeParamRefFrom(expectedReturn, signatureTypeParamIds, ctx)) {
+    return typeSatisfies(actualReturn, expectedReturn, ctx, state);
+  }
+
+  const returnBindings = new Map<TypeParamId, TypeId>();
+  bindTypeParamsFromType(
+    expectedReturn,
+    actualReturn,
+    returnBindings,
+    ctx,
+    state,
+  );
+  const boundExpectedReturn = unfoldRecursiveTypeId(
+    ctx.arena.substitute(expectedReturn, returnBindings),
+    ctx,
+  );
+  if (containsTypeParamRefFrom(boundExpectedReturn, signatureTypeParamIds, ctx)) {
+    return false;
+  }
+
+  return typeSatisfies(actualReturn, boundExpectedReturn, ctx, state);
+};
 
 const MAX_OVERLOAD_DIAGNOSTIC_CANDIDATES = 12;
 
@@ -3177,6 +3293,15 @@ const selectMethodCallCandidate = ({
     state,
     typeArguments,
     argsForCandidate,
+    refineMatches: (rawMatches) =>
+      narrowOverloadMatchesByLambdaCompatibility({
+        matches: rawMatches,
+        args: probeArgs,
+        argsForCandidate,
+        typeArguments,
+        ctx,
+        state,
+      }),
   });
 
   let traitDispatch =
@@ -3229,6 +3354,15 @@ const selectMethodCallCandidate = ({
         state,
         typeArguments,
         argsForCandidate,
+        refineMatches: (rawMatches) =>
+          narrowOverloadMatchesByLambdaCompatibility({
+            matches: rawMatches,
+            args: probeArgs,
+            argsForCandidate,
+            typeArguments,
+            ctx,
+            state,
+          }),
       });
     }
   }
@@ -4417,6 +4551,7 @@ const typeFunctionCall = ({
   calleeExprId,
   calleeModuleId,
   nameForSymbol,
+  seedSubstitution,
 }: {
   args: readonly Arg[];
   signature: FunctionSignature;
@@ -4429,6 +4564,7 @@ const typeFunctionCall = ({
   calleeExprId?: HirExprId;
   calleeModuleId?: string;
   nameForSymbol?: SymbolNameResolver;
+  seedSubstitution?: ReadonlyMap<TypeParamId, TypeId>;
 }): { returnType: TypeId; effectRow: number } => {
   const callerInstanceKey = state.currentFunction?.instanceKey;
   if (!callerInstanceKey) {
@@ -4448,7 +4584,7 @@ const typeFunctionCall = ({
   const resolveName = (symbol: SymbolId): string =>
     resolveSymbolName(symbol, ctx, nameForSymbol);
   const hasTypeParams = signature.typeParams && signature.typeParams.length > 0;
-  const prefilledSubstitution =
+  const traitSubstitution =
     hasTypeParams && args.length > 0
       ? getTraitMethodTypeBindings({
           calleeSymbol,
@@ -4459,6 +4595,10 @@ const typeFunctionCall = ({
           state,
         })
       : undefined;
+  const prefilledSubstitution = mergeInitialCallSubstitutions(
+    seedSubstitution,
+    traitSubstitution,
+  );
   const instantiation = hasTypeParams
     ? instantiateFunctionCall({
         signature,
@@ -5218,7 +5358,7 @@ const typeOverloadedCall = (
   typeArguments?: readonly TypeId[],
   expectedReturnCandidates?: ReadonlySet<SymbolId>,
 ): { returnType: TypeId; effectRow: number } => {
-  const options = ctx.overloads.get(callee.set);
+  const options = uniqueOverloadSymbols(ctx.overloads.get(callee.set), ctx);
   if (!options) {
     throw new Error(
       `missing overload metadata for ${callee.name} (set ${callee.set})`,
@@ -5265,6 +5405,22 @@ const typeOverloadedCall = (
         state,
         typeArguments,
       ),
+    refineMatches: (rawMatches) => {
+      const lambdaCompatible = narrowOverloadMatchesByLambdaCompatibility({
+        matches: rawMatches,
+        args: probeArgs,
+        typeArguments,
+        ctx,
+        state,
+      });
+      return narrowOverloadMatchesByLambdaReturn({
+        matches: lambdaCompatible,
+        callArgs: call.args,
+        typeArguments,
+        ctx,
+        state,
+      });
+    },
   });
   if (matches.length === 0 && fallbackCandidates) {
     // Expected-return narrowing is a hint. If it removes all valid matches,
@@ -5287,6 +5443,22 @@ const typeOverloadedCall = (
           state,
           typeArguments,
         ),
+      refineMatches: (rawMatches) => {
+        const lambdaCompatible = narrowOverloadMatchesByLambdaCompatibility({
+          matches: rawMatches,
+          args: probeArgs,
+          typeArguments,
+          ctx,
+          state,
+        });
+        return narrowOverloadMatchesByLambdaReturn({
+          matches: lambdaCompatible,
+          callArgs: call.args,
+          typeArguments,
+          ctx,
+          state,
+        });
+      },
     });
   }
 
@@ -5392,6 +5564,13 @@ const typeOverloadedCall = (
     ctx.callResolution.targets.get(call.id) ?? new Map<string, SymbolRef>();
   targets.set(instanceKey, selectedRef);
   ctx.callResolution.targets.set(call.id, targets);
+  const lambdaReturnSubstitution = inferLambdaReturnSubstitutionForCandidate({
+    candidate: selected,
+    callArgs: call.args,
+    typeArguments,
+    ctx,
+    state,
+  })?.substitution;
   const hintSubstitution = buildCallArgumentHintSubstitution({
     signature: selected.signature,
     probeArgs,
@@ -5400,6 +5579,7 @@ const typeOverloadedCall = (
       signature: selected.signature,
       typeArguments,
       calleeSymbol: selected.symbol,
+      seedSubstitution: lambdaReturnSubstitution,
       ctx,
     }),
     ctx,
@@ -5425,7 +5605,610 @@ const typeOverloadedCall = (
     state,
     calleeExprId: callee.id,
     calleeModuleId: selectedRef.moduleId,
+    seedSubstitution: lambdaReturnSubstitution,
   });
+};
+
+const mergeInitialCallSubstitutions = (
+  seed: ReadonlyMap<TypeParamId, TypeId> | undefined,
+  traitBindings: ReadonlyMap<TypeParamId, TypeId> | undefined,
+): ReadonlyMap<TypeParamId, TypeId> | undefined => {
+  if ((!seed || seed.size === 0) && (!traitBindings || traitBindings.size === 0)) {
+    return undefined;
+  }
+
+  const merged = new Map<TypeParamId, TypeId>();
+  seed?.forEach((value, key) => merged.set(key, value));
+  traitBindings?.forEach((value, key) => merged.set(key, value));
+  return merged;
+};
+
+const narrowOverloadMatchesByLambdaReturn = <
+  T extends { symbol: SymbolId; signature: FunctionSignature },
+>({
+  matches,
+  callArgs,
+  typeArguments,
+  ctx,
+  state,
+}: {
+  matches: readonly T[];
+  callArgs: readonly { expr: HirExprId; label?: string }[];
+  typeArguments: readonly TypeId[] | undefined;
+  ctx: TypingContext;
+  state: TypingState;
+}): readonly T[] => {
+  if (matches.length <= 1) {
+    return matches;
+  }
+
+  const lambdaArgIndexes = callArgs
+    .map((arg, index) => ({ arg, index }))
+    .filter(({ arg }) => ctx.hir.expressions.get(arg.expr)?.exprKind === "lambda")
+    .map(({ index }) => index);
+  if (lambdaArgIndexes.length === 0) {
+    return matches;
+  }
+
+  const checkedMatches = matches
+    .map((candidate) => ({
+      candidate,
+      result: inferLambdaReturnSubstitutionForCandidate({
+        candidate,
+        callArgs,
+        typeArguments,
+        ctx,
+        state,
+      }),
+    }))
+    .filter(({ result }) => result?.checked === true && result.ok);
+
+  const concreteCheckedMatches = checkedMatches.filter(
+    ({ candidate }) => (candidate.signature.typeParams?.length ?? 0) === 0,
+  );
+  if (concreteCheckedMatches.length > 0) {
+    return concreteCheckedMatches.map(({ candidate }) => candidate);
+  }
+
+  if (
+    checkedMatches.length > 0 &&
+    checkedMatches.length < matches.length
+  ) {
+    return checkedMatches.map(({ candidate }) => candidate);
+  }
+  return matches;
+};
+
+const inferLambdaReturnSubstitutionForCandidate = <
+  T extends { symbol: SymbolId; signature: FunctionSignature },
+>({
+  candidate,
+  callArgs,
+  typeArguments,
+  ctx,
+  state,
+}: {
+  candidate: T;
+  callArgs: readonly { expr: HirExprId; label?: string }[];
+  typeArguments: readonly TypeId[] | undefined;
+  ctx: TypingContext;
+  state: TypingState;
+}):
+  | {
+      checked: true;
+      ok: boolean;
+      substitution: ReadonlyMap<TypeParamId, TypeId>;
+    }
+  | { checked: false; ok: true; substitution: undefined } => {
+  const substitution = new Map<TypeParamId, TypeId>(
+    applyExplicitTypeArguments({
+      signature: candidate.signature,
+      typeArguments,
+      calleeSymbol: candidate.symbol,
+      ctx,
+    }),
+  );
+  const lambdaArgIndexes = callArgs
+    .map((arg, index) => ({ arg, index }))
+    .filter(({ arg }) => ctx.hir.expressions.get(arg.expr)?.exprKind === "lambda")
+    .map(({ index }) => index);
+
+  let checked = false;
+  for (const index of lambdaArgIndexes) {
+    const arg = callArgs[index];
+    if (!arg) {
+      continue;
+    }
+    const params = publicCallParametersFor({ signature: candidate.signature }).map(
+      (param) => ({
+        ...param,
+        type: ctx.arena.substitute(param.type, substitution),
+      }),
+    );
+    const expected = expectedCallArgType({
+      args: callArgs,
+      index,
+      argIndex: index,
+      params,
+      hintSubstitution: undefined,
+      ctx,
+    });
+    if (typeof expected !== "number") {
+      continue;
+    }
+    const expectedFunctionType = unfoldRecursiveTypeId(expected, ctx);
+    const expectedDesc = ctx.arena.get(expectedFunctionType);
+    if (expectedDesc.kind !== "function") {
+      continue;
+    }
+    const expectedReturnType = unfoldRecursiveTypeId(expectedDesc.returnType, ctx);
+    if (expectedReturnType === ctx.primitives.unknown) {
+      continue;
+    }
+    const actualReturnType = inferLambdaReturnType({
+      lambdaExpr: arg.expr,
+      expectedFunctionType,
+      ctx,
+      state,
+    });
+    if (actualReturnType === undefined) {
+      return { checked: true, ok: false, substitution };
+    }
+    checked = true;
+    bindTypeParamsFromType(
+      expectedReturnType,
+      actualReturnType,
+      substitution,
+      ctx,
+      state,
+    );
+    const boundExpectedReturnType = unfoldRecursiveTypeId(
+      ctx.arena.substitute(expectedReturnType, substitution),
+      ctx,
+    );
+    if (
+      !typeSatisfies(actualReturnType, boundExpectedReturnType, ctx, state) ||
+      !typeSatisfies(boundExpectedReturnType, actualReturnType, ctx, state)
+    ) {
+      return { checked: true, ok: false, substitution };
+    }
+  }
+
+  if (!checked) {
+    return { checked: false, ok: true, substitution: undefined };
+  }
+
+  try {
+    (candidate.signature.typeParams ?? []).forEach((param) =>
+      enforceTypeParamConstraint(param, substitution, ctx, state),
+    );
+  } catch {
+    return { checked: true, ok: false, substitution };
+  }
+
+  return { checked: true, ok: true, substitution };
+};
+
+const narrowOverloadMatchesByLambdaCompatibility = <
+  T extends { symbol: SymbolId; signature: FunctionSignature },
+>({
+  matches,
+  args,
+  argsForCandidate,
+  typeArguments,
+  ctx,
+  state,
+}: {
+  matches: readonly T[];
+  args: readonly Arg[];
+  argsForCandidate?: (candidate: T) => readonly Arg[];
+  typeArguments: readonly TypeId[] | undefined;
+  ctx: TypingContext;
+  state: TypingState;
+}): readonly T[] => {
+  if (matches.length <= 1) {
+    return matches;
+  }
+
+  const hasInlineLambda = args.some(
+    (arg) =>
+      typeof arg.exprId === "number" &&
+      ctx.hir.expressions.get(arg.exprId)?.exprKind === "lambda",
+  );
+  if (!hasInlineLambda) {
+    return matches;
+  }
+
+  const compatible = matches.filter((candidate) =>
+    candidateAcceptsInlineLambdas({
+      candidate,
+      args: argsForCandidate ? argsForCandidate(candidate) : args,
+      typeArguments,
+      ctx,
+      state,
+    }),
+  );
+  const candidatesForScoring = compatible.length > 0 ? compatible : matches;
+  if (candidatesForScoring.length === 1) {
+    return candidatesForScoring;
+  }
+  if (candidatesForScoring.length > 1) {
+    const scored = candidatesForScoring.map((candidate) => ({
+      candidate,
+      penalty: inlineLambdaExpectedTypeParamPenalty({
+        candidate,
+        args: argsForCandidate ? argsForCandidate(candidate) : args,
+        typeArguments,
+        ctx,
+        state,
+      }),
+    }));
+    const minPenalty = Math.min(...scored.map(({ penalty }) => penalty));
+    const leastGeneric = scored
+      .filter(({ penalty }) => penalty === minPenalty)
+      .map(({ candidate }) => candidate);
+    if (
+      leastGeneric.length > 0 &&
+      leastGeneric.length < candidatesForScoring.length
+    ) {
+      return leastGeneric;
+    }
+  }
+  return candidatesForScoring.length < matches.length
+    ? candidatesForScoring
+    : matches;
+};
+
+const candidateAcceptsInlineLambdas = <
+  T extends { symbol: SymbolId; signature: FunctionSignature },
+>({
+  candidate,
+  args,
+  typeArguments,
+  ctx,
+  state,
+}: {
+  candidate: T;
+  args: readonly Arg[];
+  typeArguments: readonly TypeId[] | undefined;
+  ctx: TypingContext;
+  state: TypingState;
+}): boolean => {
+  const params = specializeOverloadParameters({
+    symbol: candidate.symbol,
+    signature: candidate.signature,
+    typeArguments,
+    ctx,
+  }).filter((param) => !isStableCallsiteIdParam(param));
+  const callArgs = callArgInputsFromArgs(args);
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    if (typeof arg.exprId !== "number") {
+      continue;
+    }
+    const lambdaExpr = ctx.hir.expressions.get(arg.exprId);
+    if (!lambdaExpr || lambdaExpr.exprKind !== "lambda") {
+      continue;
+    }
+    const expected = expectedCallArgType({
+      args: callArgs,
+      index,
+      argIndex: index,
+      params,
+      hintSubstitution: undefined,
+      ctx,
+    });
+    if (typeof expected !== "number") {
+      continue;
+    }
+    const expectedDesc = ctx.arena.get(unfoldRecursiveTypeId(expected, ctx));
+    if (expectedDesc.kind !== "function") {
+      continue;
+    }
+    if (expectedDesc.parameters.length !== lambdaExpr.parameters.length) {
+      return false;
+    }
+    for (let paramIndex = 0; paramIndex < lambdaExpr.parameters.length; paramIndex += 1) {
+      const actualParam = lambdaExpr.parameters[paramIndex]!;
+      if (!actualParam.type) {
+        continue;
+      }
+      const expectedParam = expectedDesc.parameters[paramIndex];
+      if (!expectedParam || containsTypeParamRef(expectedParam.type, ctx)) {
+        continue;
+      }
+      let actualType: TypeId | undefined;
+      try {
+        actualType = resolveTypeExpr(
+          actualParam.type,
+          ctx,
+          state,
+          ctx.primitives.unknown,
+        );
+      } catch {
+        continue;
+      }
+      if (
+        typeof actualType === "number" &&
+        !typeSatisfies(actualType, expectedParam.type, ctx, state) &&
+        !typeSatisfies(expectedParam.type, actualType, ctx, state)
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+const inlineLambdaExpectedTypeParamPenalty = <
+  T extends { symbol: SymbolId; signature: FunctionSignature },
+>({
+  candidate,
+  args,
+  typeArguments,
+  ctx,
+  state,
+}: {
+  candidate: T;
+  args: readonly Arg[];
+  typeArguments: readonly TypeId[] | undefined;
+  ctx: TypingContext;
+  state: TypingState;
+}): number => {
+  const params = specializeOverloadParameters({
+    symbol: candidate.symbol,
+    signature: candidate.signature,
+    typeArguments,
+    ctx,
+  }).filter((param) => !isStableCallsiteIdParam(param));
+  const callArgs = callArgInputsFromArgs(args);
+
+  let penalty = 0;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    if (typeof arg.exprId !== "number") {
+      continue;
+    }
+    const lambdaExpr = ctx.hir.expressions.get(arg.exprId);
+    if (!lambdaExpr || lambdaExpr.exprKind !== "lambda") {
+      continue;
+    }
+    const expected = expectedCallArgType({
+      args: callArgs,
+      index,
+      argIndex: index,
+      params,
+      hintSubstitution: undefined,
+      ctx,
+    });
+    if (typeof expected !== "number") {
+      continue;
+    }
+    const expectedDesc = ctx.arena.get(unfoldRecursiveTypeId(expected, ctx));
+    if (expectedDesc.kind !== "function") {
+      continue;
+    }
+    expectedDesc.parameters.forEach((param, paramIndex) => {
+      const lambdaParam = lambdaExpr.parameters[paramIndex];
+      const annotationPenalty =
+        lambdaParam?.type !== undefined
+          ? inlineLambdaAnnotationPenalty({
+              expected: param.type,
+              annotation: lambdaParam.type,
+              ctx,
+              state,
+            })
+          : undefined;
+      if (typeof annotationPenalty === "number") {
+        penalty += annotationPenalty;
+        return;
+      }
+
+      const paramDesc = ctx.arena.get(unfoldRecursiveTypeId(param.type, ctx));
+      if (paramDesc.kind === "type-param-ref") {
+        penalty += 1;
+      }
+    });
+  }
+  return penalty;
+};
+
+const inlineLambdaAnnotationPenalty = ({
+  expected,
+  annotation,
+  ctx,
+  state,
+}: {
+  expected: TypeId;
+  annotation: HirTypeExpr;
+  ctx: TypingContext;
+  state: TypingState;
+}): number | undefined => {
+  let actualType: TypeId | undefined;
+  try {
+    actualType = resolveTypeExpr(
+      annotation,
+      ctx,
+      state,
+      ctx.primitives.unknown,
+    );
+  } catch {
+    return undefined;
+  }
+
+  const expectedType = unfoldRecursiveTypeId(expected, ctx);
+  const expectedDesc = ctx.arena.get(expectedType);
+  if (expectedDesc.kind === "type-param-ref") {
+    return 10;
+  }
+
+  if (
+    typeSatisfies(actualType, expected, ctx, state) ||
+    typeSatisfies(expected, actualType, ctx, state)
+  ) {
+    return 0;
+  }
+
+  return containsTypeParamRef(expected, ctx) ? 100 : 1_000;
+};
+
+const callArgInputsFromArgs = (args: readonly Arg[]): readonly CallArgInput[] =>
+  args.map((arg) => ({
+    label: arg.label,
+    expr:
+      typeof arg.exprId === "number"
+        ? arg.exprId
+        : (-1 as unknown as HirExprId),
+  }));
+
+const inferLambdaReturnType = ({
+  lambdaExpr,
+  expectedFunctionType,
+  ctx,
+  state,
+}: {
+  lambdaExpr: HirExprId;
+  expectedFunctionType: TypeId;
+  ctx: TypingContext;
+  state: TypingState;
+}): TypeId | undefined => {
+  const expectedDesc = ctx.arena.get(expectedFunctionType);
+  if (expectedDesc.kind !== "function") {
+    return undefined;
+  }
+  const parameterContext = ctx.arena.internFunction({
+    parameters: expectedDesc.parameters,
+    returnType: ctx.primitives.unknown,
+    effectRow: expectedDesc.effectRow,
+  });
+  try {
+    const actualFunction = withSpeculativeExprTyping(ctx, () =>
+      typeExpression(lambdaExpr, ctx, state, { expectedType: parameterContext }),
+    );
+    const actualDesc = ctx.arena.get(actualFunction);
+    const actualReturnType =
+      actualDesc.kind === "function"
+        ? unfoldRecursiveTypeId(actualDesc.returnType, ctx)
+        : ctx.primitives.unknown;
+    return actualDesc.kind === "function" &&
+      actualReturnType !== ctx.primitives.unknown
+      ? actualReturnType
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const containsTypeParamRef = (
+  type: TypeId,
+  ctx: TypingContext,
+  seen = new Set<TypeId>(),
+): boolean => {
+  if (seen.has(type)) {
+    return false;
+  }
+  seen.add(type);
+  const desc = ctx.arena.get(unfoldRecursiveTypeId(type, ctx));
+  switch (desc.kind) {
+    case "type-param-ref":
+      return true;
+    case "recursive":
+      return containsTypeParamRef(desc.body, ctx, seen);
+    case "fixed-array":
+      return containsTypeParamRef(desc.element, ctx, seen);
+    case "union":
+      return desc.members.some((member) => containsTypeParamRef(member, ctx, seen));
+    case "intersection":
+      return (
+        (typeof desc.nominal === "number" &&
+          containsTypeParamRef(desc.nominal, ctx, seen)) ||
+        (typeof desc.structural === "number" &&
+          containsTypeParamRef(desc.structural, ctx, seen)) ||
+        (desc.traits?.some((trait) => containsTypeParamRef(trait, ctx, seen)) ?? false)
+      );
+    case "trait":
+    case "nominal-object":
+    case "value-object":
+      return desc.typeArgs.some((arg) => containsTypeParamRef(arg, ctx, seen));
+    case "structural-object":
+      return desc.fields.some((field) => containsTypeParamRef(field.type, ctx, seen));
+    case "function":
+      return (
+        desc.parameters.some((param) => containsTypeParamRef(param.type, ctx, seen)) ||
+        containsTypeParamRef(desc.returnType, ctx, seen)
+      );
+    case "primitive":
+      return false;
+  }
+};
+
+const containsTypeParamRefFrom = (
+  type: TypeId,
+  targetParams: ReadonlySet<TypeParamId>,
+  ctx: TypingContext,
+  seen = new Set<TypeId>(),
+): boolean => {
+  if (seen.has(type)) {
+    return false;
+  }
+  seen.add(type);
+  const desc = ctx.arena.get(unfoldRecursiveTypeId(type, ctx));
+  switch (desc.kind) {
+    case "type-param-ref":
+      return targetParams.has(desc.param);
+    case "recursive":
+      return containsTypeParamRefFrom(desc.body, targetParams, ctx, seen);
+    case "fixed-array":
+      return containsTypeParamRefFrom(desc.element, targetParams, ctx, seen);
+    case "union":
+      return desc.members.some((member) =>
+        containsTypeParamRefFrom(member, targetParams, ctx, seen),
+      );
+    case "intersection":
+      return (
+        (typeof desc.nominal === "number" &&
+          containsTypeParamRefFrom(desc.nominal, targetParams, ctx, seen)) ||
+        (typeof desc.structural === "number" &&
+          containsTypeParamRefFrom(desc.structural, targetParams, ctx, seen)) ||
+        (desc.traits?.some((trait) =>
+          containsTypeParamRefFrom(trait, targetParams, ctx, seen),
+        ) ?? false)
+      );
+    case "trait":
+    case "nominal-object":
+    case "value-object":
+      return desc.typeArgs.some((arg) =>
+        containsTypeParamRefFrom(arg, targetParams, ctx, seen),
+      );
+    case "structural-object":
+      return desc.fields.some((field) =>
+        containsTypeParamRefFrom(field.type, targetParams, ctx, seen),
+      );
+    case "function":
+      return (
+        desc.parameters.some((param) =>
+          containsTypeParamRefFrom(param.type, targetParams, ctx, seen),
+        ) || containsTypeParamRefFrom(desc.returnType, targetParams, ctx, seen)
+      );
+    case "primitive":
+      return false;
+  }
+};
+
+const unfoldRecursiveTypeId = (
+  type: TypeId,
+  ctx: TypingContext,
+  seen = new Set<TypeId>(),
+): TypeId => {
+  if (seen.has(type)) {
+    return type;
+  }
+  seen.add(type);
+  const desc = ctx.arena.get(type);
+  return desc.kind === "recursive"
+    ? unfoldRecursiveTypeId(desc.body, ctx, seen)
+    : type;
 };
 
 const resolveTraitDispatchOverload = <
@@ -5641,6 +6424,18 @@ const matchesOverloadSignature = (
     return false;
   }
 
+  if (
+    !callArgumentFunctionReturnsSatisfyParams({
+      args,
+      params,
+      signatureTypeParams: signature.typeParams ?? [],
+      ctx,
+      state,
+    })
+  ) {
+    return false;
+  }
+
   params.forEach(({ type }) => {
     if (type === ctx.primitives.unknown) {
       throw new Error(
@@ -5822,6 +6617,11 @@ const typeIntrinsicCall = (
         ctx,
         typeArguments,
         expectedReturnType,
+      });
+    case "__boundary_msgpack_to_value":
+      return typeBoundaryMsgPackToValueIntrinsic({
+        args,
+        typeArguments,
       });
     case "__shift_l":
     case "__shift_ru":
@@ -6653,6 +7453,26 @@ const typeBoundaryValueToMsgPackIntrinsic = ({
   });
   assertNoIntrinsicTypeArgs("__boundary_value_to_msgpack", typeArguments);
   return expectedReturnType ?? ctx.primitives.unknown;
+};
+
+const typeBoundaryMsgPackToValueIntrinsic = ({
+  args,
+  typeArguments,
+}: {
+  args: readonly Arg[];
+  typeArguments?: readonly TypeId[];
+}): TypeId => {
+  assertIntrinsicArgCount({
+    name: "__boundary_msgpack_to_value",
+    args,
+    expected: 1,
+    detail: "MessagePack value",
+  });
+  return requireSingleTypeArgument({
+    name: "__boundary_msgpack_to_value",
+    typeArguments,
+    detail: "target type",
+  });
 };
 
 const typeTaskTakeValueIntrinsic = ({

--- a/packages/compiler/src/semantics/typing/expressions/overload-resolution.ts
+++ b/packages/compiler/src/semantics/typing/expressions/overload-resolution.ts
@@ -119,9 +119,9 @@ export const findOverloadMatches = <T extends OverloadResolutionCandidate>({
   refineMatches?: (matches: readonly T[]) => readonly T[];
 }): readonly T[] => {
   const shapeCompatibleCandidates = candidates.filter((candidate) =>
-    callShapeCouldMatch({
+    signatureCallShapeCouldMatch({
       args,
-      params: publicCallParametersForShape(candidate.signature),
+      signature: candidate.signature,
       ctx,
       state,
     }),
@@ -139,10 +139,63 @@ export const findOverloadMatches = <T extends OverloadResolutionCandidate>({
   return narrowOverloadMatches({ matches: refined, typeArguments, ctx, state });
 };
 
+const signatureCallShapeCouldMatch = ({
+  args,
+  signature,
+  ctx,
+  state,
+}: {
+  args: readonly Arg[];
+  signature: FunctionSignature;
+  ctx: TypingContext;
+  state: TypingState;
+}): boolean => {
+  const positional = positionalCallShapeCouldMatch(args, signature.parameters);
+  if (typeof positional === "boolean") {
+    return positional;
+  }
+
+  return callShapeCouldMatch({
+    args,
+    params: publicCallParametersForShape(signature),
+    ctx,
+    state,
+  });
+};
+
 const publicCallParametersForShape = (
   signature: FunctionSignature,
 ): readonly ParamSignature[] =>
   signature.parameters.filter((param) => param.synthetic !== "stable-callsite-id");
+
+const positionalCallShapeCouldMatch = (
+  args: readonly Arg[],
+  params: readonly ParamSignature[],
+): boolean | undefined => {
+  let required = 0;
+  let total = 0;
+
+  for (const arg of args) {
+    if (arg.label !== undefined) {
+      return undefined;
+    }
+  }
+
+  for (const param of params) {
+    if (param.synthetic === "stable-callsite-id") {
+      continue;
+    }
+    if (param.label !== undefined) {
+      return undefined;
+    }
+    total += 1;
+    if (!param.optional) {
+      required += 1;
+    }
+  }
+
+  return args.length >= required && args.length <= total;
+};
 
 const callShapeCouldMatch = ({
   args,
@@ -172,7 +225,12 @@ const callShapeCouldMatch = ({
     const arg = args[argIndex];
 
     if (!arg) {
-      return params.slice(paramIndex).every((remaining) => remaining.optional);
+      for (let index = paramIndex; index < params.length; index += 1) {
+        if (!params[index]!.optional) {
+          return false;
+        }
+      }
+      return true;
     }
 
     if (param.label && arg.label === undefined) {

--- a/packages/compiler/src/semantics/typing/expressions/overload-resolution.ts
+++ b/packages/compiler/src/semantics/typing/expressions/overload-resolution.ts
@@ -7,7 +7,7 @@ import type {
   TypingContext,
   TypingState,
 } from "../types.js";
-import { getSymbolName } from "../type-system.js";
+import { getStructuralFields, getSymbolName } from "../type-system.js";
 import { satisfies as typeSatisfies } from "../type-relations.js";
 import {
   filterCandidatesByExpectedReturnType,
@@ -105,6 +105,7 @@ export const findOverloadMatches = <T extends OverloadResolutionCandidate>({
   state,
   matchesCandidate,
   argsForCandidate,
+  refineMatches,
 }: {
   name: string;
   candidates: readonly T[];
@@ -115,17 +116,146 @@ export const findOverloadMatches = <T extends OverloadResolutionCandidate>({
   state: TypingState;
   matchesCandidate: (candidate: T, args: readonly Arg[]) => boolean;
   argsForCandidate?: (candidate: T) => readonly Arg[];
+  refineMatches?: (matches: readonly T[]) => readonly T[];
 }): readonly T[] => {
+  const shapeCompatibleCandidates = candidates.filter((candidate) =>
+    callShapeCouldMatch({
+      args,
+      params: publicCallParametersForShape(candidate.signature),
+      ctx,
+      state,
+    }),
+  );
   enforceOverloadCandidateBudget({
     name,
-    candidateCount: candidates.length,
+    candidateCount: shapeCompatibleCandidates.length,
     ctx,
     span,
   });
-  const matches = candidates.filter((candidate) =>
+  const matches = shapeCompatibleCandidates.filter((candidate) =>
     matchesCandidate(candidate, argsForCandidate ? argsForCandidate(candidate) : args),
   );
-  return narrowOverloadMatches({ matches, typeArguments, ctx, state });
+  const refined = refineMatches ? refineMatches(matches) : matches;
+  return narrowOverloadMatches({ matches: refined, typeArguments, ctx, state });
+};
+
+const publicCallParametersForShape = (
+  signature: FunctionSignature,
+): readonly ParamSignature[] =>
+  signature.parameters.filter((param) => param.synthetic !== "stable-callsite-id");
+
+const callShapeCouldMatch = ({
+  args,
+  params,
+  ctx,
+  state,
+}: {
+  args: readonly Arg[];
+  params: readonly ParamSignature[];
+  ctx: TypingContext;
+  state: TypingState;
+}): boolean => {
+  if (
+    args.length > 0 &&
+    args.every((arg) => arg.label !== undefined) &&
+    params.length > 0 &&
+    params.every((param) => param.label !== undefined)
+  ) {
+    return allLabeledCallShapeCouldMatch({ args, params });
+  }
+
+  let argIndex = 0;
+  let paramIndex = 0;
+
+  while (paramIndex < params.length) {
+    const param = params[paramIndex]!;
+    const arg = args[argIndex];
+
+    if (!arg) {
+      return params.slice(paramIndex).every((remaining) => remaining.optional);
+    }
+
+    if (param.label && arg.label === undefined) {
+      const structuralFields = getStructuralFields(arg.type, ctx, state);
+      if (!structuralFields) {
+        return false;
+      }
+
+      let cursor = paramIndex;
+      while (cursor < params.length) {
+        const runParam = params[cursor]!;
+        if (!runParam.label) {
+          break;
+        }
+        const hasField = structuralFields.some((field) => field.name === runParam.label);
+        if (hasField || runParam.optional) {
+          cursor += 1;
+          continue;
+        }
+        return false;
+      }
+
+      if (cursor === paramIndex) {
+        return false;
+      }
+
+      argIndex += 1;
+      paramIndex = cursor;
+      continue;
+    }
+
+    if (labelsCompatibleForShape(param, arg.label)) {
+      argIndex += 1;
+      paramIndex += 1;
+      continue;
+    }
+
+    if (param.optional) {
+      paramIndex += 1;
+      continue;
+    }
+
+    return false;
+  }
+
+  return argIndex === args.length;
+};
+
+const allLabeledCallShapeCouldMatch = ({
+  args,
+  params,
+}: {
+  args: readonly Arg[];
+  params: readonly ParamSignature[];
+}): boolean => {
+  const argLabels = new Set(
+    args
+      .map((arg) => arg.label)
+      .filter((label): label is string => typeof label === "string"),
+  );
+  const paramLabels = new Set(
+    params
+      .map((param) => param.label)
+      .filter((label): label is string => typeof label === "string"),
+  );
+
+  const hasUnknownArgLabel = [...argLabels].some((label) => !paramLabels.has(label));
+  if (hasUnknownArgLabel) {
+    return false;
+  }
+
+  return params.every((param) => param.optional || argLabels.has(param.label!));
+};
+
+const labelsCompatibleForShape = (
+  param: ParamSignature,
+  argLabel: string | undefined,
+): boolean => {
+  if (!param.label) {
+    return argLabel === undefined;
+  }
+
+  return argLabel === param.label;
 };
 
 export const applyExplicitTypeArguments = ({
@@ -247,6 +377,15 @@ const overloadDominates = ({
     ) {
       return false;
     }
+    const candidateBareTypeParam = isBareTypeParamRef(candidateParam.type, ctx);
+    const otherBareTypeParam = isBareTypeParamRef(otherParam.type, ctx);
+    if (!candidateBareTypeParam && otherBareTypeParam) {
+      strictlyMoreSpecific = true;
+      continue;
+    }
+    if (candidateBareTypeParam && !otherBareTypeParam) {
+      return false;
+    }
     if (!typeSatisfies(candidateParam.type, otherParam.type, ctx, state)) {
       return false;
     }
@@ -257,6 +396,9 @@ const overloadDominates = ({
 
   return strictlyMoreSpecific;
 };
+
+const isBareTypeParamRef = (type: TypeId, ctx: TypingContext): boolean =>
+  ctx.arena.get(type).kind === "type-param-ref";
 
 const unresolvedTypeParamPenalty = ({
   type,
@@ -349,8 +491,24 @@ const overloadGenericityPenalty = ({
     typeArguments,
     ctx,
   }).reduce(
-    (sum, param) => sum + unresolvedTypeParamPenalty({ type: param.type, ctx }),
+    (sum, param) =>
+      sum +
+      unresolvedTypeParamPenalty({ type: param.type, ctx }) +
+      bareFunctionReturnTypeParamPenalty(param.type, ctx),
     0,
+  );
+
+const bareFunctionReturnTypeParamPenalty = (type: TypeId, ctx: TypingContext): number => {
+  const desc = ctx.arena.get(type);
+  return desc.kind === "function" && isBareTypeParamRef(desc.returnType, ctx) ? 2 : 0;
+};
+
+const overloadConstraintSpecificity = (
+  candidate: OverloadResolutionCandidate
+): number =>
+  (candidate.signature.typeParams ?? []).reduce(
+    (sum, param) => sum + (param.constraint ? 1 : 0),
+    0
   );
 
 export const narrowOverloadMatches = <T extends OverloadResolutionCandidate>({
@@ -404,5 +562,16 @@ export const narrowOverloadMatches = <T extends OverloadResolutionCandidate>({
       }) === minPenalty,
   );
 
-  return leastGenericMatches.length === 1 ? leastGenericMatches : matches;
+  if (leastGenericMatches.length === 1) {
+    return leastGenericMatches;
+  }
+
+  const maxConstraintSpecificity = Math.max(
+    ...leastGenericMatches.map(overloadConstraintSpecificity)
+  );
+  const mostConstrainedMatches = leastGenericMatches.filter(
+    (candidate) => overloadConstraintSpecificity(candidate) === maxConstraintSpecificity
+  );
+
+  return mostConstrainedMatches.length === 1 ? mostConstrainedMatches : matches;
 };

--- a/packages/reference/docs/README.md
+++ b/packages/reference/docs/README.md
@@ -44,6 +44,7 @@ The installed command is `voyd`.
 - [Control Flow](./control-flow.md)
 - [Tasks and Time](./tasks-and-time.md)
 - [VX](./vx.md)
+- [Web](./web.md)
 - [Modules](./modules.md)
 - [Types Overview](./types/overview.md)
 
@@ -54,5 +55,7 @@ The installed command is `voyd`.
 - Algebraic effects with typed handlers.
 - Same-run task concurrency and timer APIs built on the event loop.
 - Built-in VX render frames for browser/server UI runtimes.
+- Value-returning HTTP routes, typed request extraction, middleware, static
+  files, and VX-backed HTML responses through `pkg::web`.
 - Macros for surface-language features such as `enum` and `for`.
 - A package/module system built around `src/` and `pkg.voyd`.

--- a/packages/reference/docs/web.md
+++ b/packages/reference/docs/web.md
@@ -1,0 +1,697 @@
+---
+order: 9
+---
+
+# Web
+
+The `pkg::web` package is Voyd's HTTP application framework. It builds on
+`std::http` and gives you routing, middleware, typed request extraction,
+response conversion, static-file middleware, and server-side HTML helpers.
+
+Use the web framework when you want to write HTTP handlers as ordinary Voyd
+functions that return ordinary values. The framework owns the route table and
+request pipeline; `std::http` still owns the underlying request and response
+types.
+
+```voyd
+use pkg::web::all
+use std::error::HostError
+use std::http::server
+use std::result::types::all
+use std::task
+
+pub fn main(): (server::HttpServer, task::TaskRuntime) -> Result<Unit, HostError>
+  serve(port: 3000) routes():
+    get("/health") do:
+      "ok".as_slice().to_string()
+```
+
+Most applications should import `pkg::web::all`. Larger packages can import
+from the narrower modules:
+
+- `pkg::web::router` for `App`, `Router`, `Context`, middleware, and serving.
+- `pkg::web::routes` for builder-style route helper functions.
+- `pkg::web::extract` for body, auth, params, query, headers, and rejections.
+- `pkg::web::response` for `IntoResponse`, `to_response`, and response helpers.
+- `pkg::web::html` for VX server rendering.
+- `pkg::web::static_files` for `serve_dir`.
+
+## Routes
+
+Routes are declared inside `serve(...) routes():` or inside `build_app do(...)`.
+Use HTTP verb helpers for common routes and `route(..., method:)` when the
+method is dynamic or uncommon.
+
+```voyd
+use pkg::web::all
+use std::http::Method
+use std::error::HostError
+use std::http::server
+use std::result::types::all
+use std::task
+
+pub fn main(): (server::HttpServer, task::TaskRuntime) -> Result<Unit, HostError>
+  serve(port: 3000, host: "127.0.0.1", shutdown_timeout: 250) routes():
+    get("/health") do:
+      "ok".as_slice().to_string()
+
+    post("/events") do(ctx: Context):
+      ctx
+      status(code: 202, reason: "Accepted".as_slice()).empty()
+
+    route("/resource", method: Method::Delete {}) do:
+      Response::ok().text("deleted".as_slice())
+```
+
+Path segments that begin with `:` are path parameters.
+
+```voyd
+use pkg::web::all
+use std::error::HostError
+use std::http::server
+use std::result::types::all
+use std::string::type::String
+use std::task
+
+type UserParams = {
+  id: String
+}
+
+pub fn main(): (server::HttpServer, task::TaskRuntime) -> Result<Unit, HostError>
+  serve(port: 3000) routes():
+    get("/users/:id") do(params: UserParams):
+      params.id
+```
+
+Static routes are preferred over parameterized routes when both match. For
+example, `/users/new` wins over `/users/:id` even if the parameterized route was
+registered first.
+
+```voyd
+serve(port: 3000) routes():
+  get("/users/:id") do(params: UserParams):
+    Response::ok().text(params.id)
+
+  get("/users/new") do:
+    Response::ok().text("new".as_slice())
+```
+
+Group related routes with a prefix. Middleware adopted before a group applies
+inside the group; middleware adopted inside the group stays scoped to that
+group.
+
+```voyd
+serve(port: 3000) routes():
+  group("/api") routes():
+    get("/health") do:
+      "ok".as_slice().to_string()
+
+    group("/users") routes():
+      get("/:id") do(params: UserParams):
+        params.id
+```
+
+## Handlers
+
+Handlers return values. They do not receive a mutable response writer. The
+framework converts supported values with `IntoResponse`.
+
+```voyd
+get("/text") do:
+  "hello".as_slice().to_string()
+
+get("/raw") do:
+  Response::ok().text("already a response".as_slice())
+
+get("/created") do:
+  (Status::created(), "created".as_slice().to_string())
+```
+
+Useful return shapes include:
+
+- `Response`, returned unchanged.
+- `String` and `StringSlice`, returned as `200 OK` text.
+- `Bytes`, returned as `200 OK` bytes.
+- `JsonValue`, returned as `200 OK` JSON.
+- `(Status, String)`, `(Status, StringSlice)`, `(Status, Bytes)`, and
+  `(Status, JsonValue)`.
+- `Result<T, E>` when both `T` and `E` can become a response.
+- `Option<T>`, where `None` becomes `404 Not Found`.
+
+```voyd
+use pkg::web::all
+use std::json::{ JsonBool, JsonValue }
+use std::optional::types::all
+use std::result::types::all
+use std::string::type::String
+
+fn feature_flag() -> JsonValue
+  JsonBool { value: true }
+
+fn find_name(id: String) -> Option<String>
+  if id.equals("1") then:
+    Some<String> { value: "Ada".as_slice().to_string() }
+  else:
+    None {}
+
+fn create_name(name: String) -> Result<(Status, String), Rejection>
+  if name.is_empty() then:
+    Err<Rejection> { error: Rejection::bad_request("missing name".as_slice()) }
+  else:
+    Ok<(Status, String)> { value: (Status::created(), name) }
+
+serve(port: 3000) routes():
+  get("/flag") do:
+    feature_flag()
+
+  get("/users/:id") do(params: UserParams):
+    find_name(params.id)
+
+  post("/users", body: text_body()) do(input: String):
+    create_name(input)
+```
+
+Use `response_json(...)` when you want to create a JSON response explicitly.
+The shorter `json()` name is reserved in `pkg::web::all` for the JSON body
+policy, so `response_json(...)` is the clearest root-level response helper.
+
+```voyd
+let value: JsonValue = JsonBool { value: true }
+let response = response_json(value)
+```
+
+## Context
+
+Request handlers can ask for `ctx: Context` when they need the raw request,
+headers, path values, query values, or explicit rejection handling.
+
+```voyd
+get("/inspect/:id") do(ctx: Context):
+  let id = ctx.param("id".as_slice()) ?? "missing".as_slice().to_string()
+  let mode = ctx.query_value("mode".as_slice()) ?? "default".as_slice().to_string()
+  Response::ok().text(id.concat(":".as_slice()).concat(mode))
+```
+
+Common `Context` methods:
+
+- `ctx.method()` returns the request `Method`.
+- `ctx.path()` returns the request path.
+- `ctx.header(name)` returns an optional header value.
+- `ctx.param(name)` returns an optional path parameter.
+- `ctx.query()` returns all parsed query parameters.
+- `ctx.query_value(name)` returns one query value.
+- `ctx.body_bytes()` returns the raw request body bytes.
+- `ctx.text()` reads the request body as text.
+- `ctx.json()` reads the request body as `JsonValue`.
+- `ctx.reject(rejection)` runs the current rejection handler.
+
+## Params, Query, And Headers
+
+The DSL uses handler parameter names to decide which extractor to use:
+
+- `params: T` decodes path parameters into `T`.
+- `query: T` decodes the query string into `T`.
+- `headers: T` decodes request headers into `T`.
+- `ctx: Context` passes the full request context.
+
+Use structural types for request-shaped data.
+
+```voyd
+use pkg::web::all
+use std::string::type::String
+
+type SearchParams = {
+  org: String
+}
+
+type SearchQuery = {
+  q: String,
+  page: i32,
+  exact: bool
+}
+
+type RequestHeaders = {
+  authorization: String
+}
+
+serve(port: 3000) routes():
+  get("/orgs/:org/search") do(
+    params: SearchParams,
+    query: SearchQuery,
+    headers: RequestHeaders,
+    ctx: Context
+  ):
+    let request_id = ctx.header("x-request-id".as_slice()) ?? "missing".as_slice().to_string()
+    Response::ok().text(
+      params.org
+        .concat(":".as_slice())
+        .concat(query.q)
+        .concat(":".as_slice())
+        .concat(headers.authorization)
+        .concat(":".as_slice())
+        .concat(request_id)
+    )
+```
+
+Path params and headers decode as strings. Query values decode booleans from
+`true` and `false`, integers from canonical integer strings, and all other
+values as strings.
+
+Use the explicit `route_*` helpers in builder-style code when the parameter
+shape cannot be inferred from a free route helper name.
+
+```voyd
+let app = build_app do(base):
+  route_query_context(base, "/search".as_slice(), method: Method::Get {}) do(
+    query: SearchQuery,
+    _ctx: Context
+  ):
+    if query.exact then:
+      Response::ok().text("exact".as_slice())
+    else:
+      Response::ok().text("fuzzy".as_slice())
+```
+
+## Request Bodies
+
+Body policies are explicit route labels. Use `json_body()` for typed JSON,
+`text_body()` for text, and `bytes()` for raw bytes.
+
+```voyd
+use pkg::web::all
+use std::bytes::Bytes
+use std::string::type::String
+
+type CreateUser = {
+  name: String,
+  active: bool
+}
+
+serve(port: 3000) routes():
+  post("/users", body: json_body()) do(input: CreateUser):
+    Response::created().text(input.name)
+
+  post("/echo", body: text_body()) do(input: String):
+    Response::ok().text(input)
+
+  put("/upload", body: bytes()) do(input: Bytes):
+    Response::ok().bytes(input)
+```
+
+`json_body()` accepts `application/json` and media types ending in `+json`.
+When the content type is not JSON, the route rejects with `415 Unsupported
+Media Type`. Invalid body text or invalid JSON rejects with `400 Bad Request`.
+
+The concise aliases `json()` and `text()` are also available for body policies,
+but `json_body()` and `text_body()` read better in route declarations because
+`json` and `text` are common response concepts too.
+
+## Auth
+
+Auth is also an explicit route label. The default `required_session()` and
+`optional_session()` policies read the `authorization` header.
+
+```voyd
+use pkg::web::all
+use std::optional::types::all
+use std::string::type::String
+
+serve(port: 3000) routes():
+  get("/me", auth: required_session()) do(session: String):
+    Response::ok().text(session)
+
+  get("/maybe-me", auth: optional_session()) do(session: Option<String>):
+    match(session)
+      Some<String> { value }:
+        Response::ok().text(value)
+      None:
+        Response::unauthorized().empty()
+```
+
+Use a custom `AuthPolicy<T>` when your application has a typed session value.
+The extractor can perform effects because `AuthExtractor<T>` has an open effect
+row.
+
+```voyd
+use pkg::web::all
+use std::http::IncomingRequest
+use std::result::types::all
+use std::string::type::String
+
+obj Session {
+  api user_id: String,
+  api role: String
+}
+
+fn extract_session(request: IncomingRequest) -> Result<Session, Rejection>
+  match(request.header("authorization".as_slice()))
+    Some<String> { value }:
+      Ok<Session> {
+        value: Session { user_id: value, role: "member".as_slice().to_string() }
+      }
+    None:
+      Err<Rejection> { error: Rejection::unauthorized("missing auth".as_slice()) }
+
+serve(port: 3000) routes():
+  get(
+    "/account",
+    auth: required_session<Session>(extract: extract_session)
+  ) do(session: Session):
+    Response::ok().text(session.user_id)
+```
+
+## Middleware
+
+Middleware receives a `Context` and `next`. It returns a `Response`. Call
+`next(ctx)` to continue to the next middleware or the matched route handler, or
+return a response early.
+
+```voyd
+use pkg::web::all
+use std::http::Response
+use std::optional::types::all
+use std::string::type::String
+
+fn require_request_id(ctx: Context, next: Next) -> Response
+  match(ctx.header("x-request-id".as_slice()))
+    Some<String>:
+      next(ctx)
+    None:
+      Response::bad_request().text("missing request id".as_slice())
+
+serve(port: 3000) routes():
+  adopt(require_request_id)
+
+  get("/health") do:
+    "ok".as_slice().to_string()
+```
+
+Middleware is ordered by registration. Middleware adopted before a route applies
+to that route. Middleware adopted later does not affect earlier routes.
+
+```voyd
+serve(port: 3000) routes():
+  get("/public") do:
+    "public".as_slice().to_string()
+
+  adopt(require_request_id)
+
+  get("/private") do:
+    "private".as_slice().to_string()
+```
+
+The package includes `request_id_required`, which rejects requests that do not
+include `x-request-id`.
+
+```voyd
+serve(port: 3000) routes():
+  adopt(request_id_required)
+  get("/work") do:
+    Response::ok().empty()
+```
+
+## Errors And Rejections
+
+Route matching failures and extractor failures are handled separately.
+
+- No matching path returns the not-found handler.
+- A matching path with the wrong method returns the method-not-allowed handler.
+- Body, auth, params, query, and header extraction failures produce a
+  `Rejection`.
+- `on_error` and `on_rejection` both install an `ErrorHandler`.
+
+```voyd
+serve(port: 3000) routes():
+  not_found() do(ctx: Context):
+    ctx
+    Response::not_found().text("custom 404".as_slice())
+
+  method_not_allowed() do(ctx: Context):
+    ctx
+    Response::method_not_allowed().text("custom method".as_slice())
+
+  on_rejection() do(rejection: Rejection, ctx: Context):
+    ctx
+    Response::new(status: rejection.status).text(rejection.message)
+
+  post("/json", body: json_body()) do(input: CreateUser):
+    Response::ok().text(input.name)
+```
+
+Return `Result<T, Rejection>` from handlers when normal application validation
+should use the same response shape as extraction failures.
+
+```voyd
+fn validate_name(input: CreateUser) -> Result<CreateUser, Rejection>
+  if input.name.is_empty() then:
+    Err<Rejection> { error: Rejection::bad_request("name is required".as_slice()) }
+  else:
+    Ok<CreateUser> { value: input }
+
+post("/users", body: json_body()) do(input: CreateUser):
+  match(validate_name(input))
+    Ok<CreateUser> { value }:
+      Response::created().text(value.name)
+    Err<Rejection> { error }:
+      error
+```
+
+## Static Files
+
+Use `serve_dir(root)` as middleware. It serves `GET` and `HEAD`, prevents
+`..` path traversal, serves `index.html` for `/`, and falls through to `next`
+when the file is missing or cannot be read.
+
+```voyd
+use pkg::web::all
+
+serve(port: 3000) routes():
+  adopt(serve_dir("./public".as_slice()))
+
+  get("/api/health") do:
+    "ok".as_slice().to_string()
+```
+
+Static files infer common content types for `.html`, `.css`, `.js`, `.json`,
+`.png`, `.jpg`, `.jpeg`, and `.svg`. Other files use
+`application/octet-stream`.
+
+Place static middleware before dynamic fallback routes when files should win.
+Place it after API routes when the API should win.
+
+```voyd
+serve(port: 3000) routes():
+  get("/api/health") do:
+    "ok".as_slice().to_string()
+
+  adopt(serve_dir("./public".as_slice()))
+
+  get("/:slug") do(params: PageParams):
+    render_page(params.slug)
+```
+
+## HTML Responses
+
+`pkg::web::html` renders `std::vx` HTML values to strings for server-side
+responses. Use `html_response` or the `html` alias to attach
+`text/html; charset=utf-8`.
+
+```voyd
+use pkg::web::all
+use std::vx::all
+
+fn home() -> Response
+  html_response(
+    Response::ok(),
+    <main>
+      <h1>Voyd</h1>
+      <p>Hello from the server.</p>
+    </main>
+  )
+
+serve(port: 3000) routes():
+  get("/") do:
+    home()
+```
+
+Use `render(...)` when you need the HTML string and `document(...)` when you
+want a complete document string with `<!doctype html>`.
+
+```voyd
+let body = render(<span>Saved</span>)
+let full = document(
+  <html>
+    <body>
+      <h1>Saved</h1>
+    </body>
+  </html>
+)
+```
+
+## Builder API
+
+The route DSL is the default surface for applications. The builder API is useful
+for generated routes, package-level composition, and tests.
+
+```voyd
+use pkg::web::all
+use std::http::Response
+
+fn health() -> Response
+  Response::ok().text("ok".as_slice())
+
+let web_app = app()
+  .get_unit("/health".as_slice(), handler: health)
+  .get("/debug".as_slice(), handler: (ctx: Context) -> Response =>
+    Response::ok().text(ctx.path())
+  )
+```
+
+Use explicit builder method names for extracted handler shapes. The names make
+the extracted data visible and avoid ambiguous same-name overloads for inline
+lambdas.
+
+```voyd
+let web_app = app()
+  .get_params("/users/:id".as_slice(), handler: (params: UserParams) -> Response =>
+    Response::ok().text(params.id)
+  )
+  .get_params_query(
+    "/users/:id/activity".as_slice(),
+    handler: (params: UserParams, query: UserQuery) -> Response =>
+      let verbose = if query.verbose then: "true".as_slice().to_string() else: "false".as_slice().to_string()
+      Response::ok().text(params.id.concat(":".as_slice()).concat(verbose))
+  )
+```
+
+`build_app` gives builder helpers a threaded `AppBuild` value.
+
+```voyd
+let web_app = build_app do(base):
+  let with_health = get_context(base, "/health".as_slice()) do(_ctx: Context):
+    Response::ok().text("ok".as_slice())
+
+  let with_item = get(with_health, "/items/:id".as_slice()) do(params: UserParams):
+    Response::ok().text(params.id)
+
+  post(
+    with_item,
+    "/echo".as_slice(),
+    body: text_body(),
+    handler: (input: String) -> Response => Response::ok().text(input)
+  )
+```
+
+`Router` wraps an `App` for reusable subrouters. Import the module when you need
+the constructor, then call `router::Router::init()`.
+
+```voyd
+use pkg::web::all
+use pkg::web::router
+
+let api = router::Router::init()
+  .get_unit("/health".as_slice(), handler: () -> Response =>
+    Response::ok().text("router".as_slice())
+  )
+
+let web_app = app().mount("/api".as_slice(), api)
+```
+
+The package root reserves `pkg::web::router` for the module path, so there is no
+root-level `web::router()` constructor. This keeps imports predictable when a
+module and function would otherwise share the same package-boundary name.
+
+## Serving
+
+Use `serve(...) routes():` for the shortest application entrypoint.
+
+```voyd
+use pkg::web::all
+use std::error::HostError
+use std::http::server
+use std::result::types::all
+use std::task
+
+pub fn main(): (server::HttpServer, task::TaskRuntime) -> Result<Unit, HostError>
+  serve(port: 3000) routes():
+    get("/health") do:
+      "ok".as_slice().to_string()
+```
+
+Use `serve(app, port:)` or `serve_app(...)` when you already have an `App`.
+
+```voyd
+use pkg::web::all
+use std::error::HostError
+use std::http::server
+use std::result::types::all
+use std::task
+
+fn make_app() -> App
+  app().get_unit("/health".as_slice(), handler: () -> Response =>
+    Response::ok().text("ok".as_slice())
+  )
+
+pub fn main(): (server::HttpServer, task::TaskRuntime) -> Result<Unit, HostError>
+  serve(make_app(), port: 3000)
+```
+
+Use `serve_build(...)` when you want build-style composition and server options
+in one call.
+
+```voyd
+use pkg::web::all
+use std::error::HostError
+use std::http::server
+use std::result::types::all
+use std::task
+
+pub fn main(): (server::HttpServer, task::TaskRuntime) -> Result<Unit, HostError>
+  serve_build(port: 3000, host: "127.0.0.1") do(base):
+    get_unit(base, "/health".as_slice()) do:
+      "ok".as_slice().to_string()
+```
+
+`serve` is backed by `std::http::server`, so the surrounding function must
+provide the server and task-runtime effects required by that package.
+Application-specific effects used by handlers also remain visible in the
+entrypoint effect row.
+
+## Developer Notes
+
+The web package intentionally keeps a split between data and behavior:
+
+- Structural records model request data such as params, query, headers, and JSON
+  DTO bodies.
+- Nominal objects model behavior and policies such as `App`, `Router`,
+  `Context`, `JsonBody`, `TextBody`, `RequiredSession`, and `AuthPolicy<T>`.
+- Traits are implemented for nominal policy and response types. Do not rely on
+  applying traits to structural DTOs.
+
+Route registration stores erased `Handler`, `Middleware`, and `ErrorHandler`
+function values internally, but the public route helpers keep typed handler
+parameters long enough to derive extraction before wrapping the handler.
+
+When adding a new extractor family:
+
+- Add a nominal policy type when extraction carries behavior.
+- Keep route labels explicit for behavior-changing policy, such as `body:` and
+  `auth:`.
+- Prefer structural input records for decoded request data.
+- Add both DSL helpers and builder/helper mirrors when the shape is useful in
+  generated or composed code.
+- Keep route helper names explicit when inline lambda overload resolution would
+  otherwise be ambiguous.
+
+When adding a new response type:
+
+- Implement or reuse `IntoResponse<T>`.
+- Add `to_response(...)` overloads for common tuple, result, or option shapes
+  only when they improve call-site clarity.
+- Keep response helpers in `pkg::web::response`, and re-export root-level names
+  from `pkg::web` only when they do not conflict with common policy names.
+
+The framework should not hide effects in ambient state. Handler, middleware,
+auth, and body extraction callbacks use open effect rows where appropriate, and
+serving exposes the effects required by `std::http::server` and the application
+code it runs.

--- a/packages/sdk/src/__tests__/sdk-node.test.ts
+++ b/packages/sdk/src/__tests__/sdk-node.test.ts
@@ -517,6 +517,60 @@ pub fn main() -> i32
     }
   });
 
+  it("resolves scoped Voyd packages through bare pkg imports", async () => {
+    const sdk = createSdk();
+    const repoRoot = process.cwd();
+    const projectRoot = await fs.mkdtemp(
+      path.join(repoRoot, ".tmp-voyd-sdk-scoped-node-modules-"),
+    );
+    const srcDir = path.join(projectRoot, "src");
+    const entryPath = path.join(srcDir, "main.voyd");
+    const packageSrcDir = path.join(
+      projectRoot,
+      "node_modules",
+      "@voyd-lang",
+      "web",
+      "src",
+    );
+
+    await fs.mkdir(srcDir, { recursive: true });
+    await fs.mkdir(packageSrcDir, { recursive: true });
+    await fs.writeFile(
+      entryPath,
+      `use pkg::web::all
+
+pub fn main() -> i32
+  status(code: 204, reason: "No Content".as_slice()).status.code()
+`,
+    );
+    await fs.writeFile(
+      path.join(packageSrcDir, "pkg.voyd"),
+      `pub use src::response::status
+`,
+    );
+    await fs.writeFile(
+      path.join(packageSrcDir, "response.voyd"),
+      `use std::http::{ Response, Status }
+use std::string::type::StringSlice
+
+pub fn status({ code: i32, reason: StringSlice }) -> Response
+  match(Status::custom(code: code, reason: reason))
+    Ok<Status> { value }:
+      Response::new(status: value)
+    Err:
+      Response::internal_server_error()
+`,
+    );
+
+    try {
+      const result = expectCompileSuccess(await sdk.compile({ entryPath }));
+      const output = await result.run<number>({ entryName: "main" });
+      expect(output).toBe(204);
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   it("resolves packages from additional configured pkgDirs", async () => {
     const sdk = createSdk();
     const repoRoot = process.cwd();

--- a/packages/std/src/msgpack.voyd
+++ b/packages/std/src/msgpack.voyd
@@ -21,6 +21,7 @@ use std::number::cast::CastError
 use std::result::types::all
 use std::string::type::{ String, StringSlice, new_string }
 pub use self::fns::MsgPack
+pub use self::fns::MsgPackMap
 pub use self::errors::MsgPackError
 pub use self::types::{ Binary, Bool, F32, F64, I32, I64, Null, Numeric }
 
@@ -61,6 +62,14 @@ pub fn make_i64(value: i64): () -> MsgPack
 /// Constructs a MessagePack map from string keys to values.
 pub fn make_map(value: Dict<String, MsgPack>): () -> MsgPack
   msgpack_fns::make_map(value)
+
+/// Encodes a boundary-compatible DTO value as MessagePack.
+pub fn pack_boundary_value<T>(value: T): () -> MsgPack
+  boundary_value_to_msgpack(value)
+
+/// Decodes a boundary-compatible DTO value from MessagePack.
+pub fn unpack_boundary_value<T>(value: MsgPack): () -> T
+  boundary_msgpack_to_value<T>(value)
 
 pub fn unpack_bool(value: MsgPack): () -> Result<bool, MsgPackError>
   value.match(decoded)
@@ -185,6 +194,14 @@ fn msgpack_map_tag_is(map: Dict<String, MsgPack>, expected: String): () -> bool
 
 fn msgpack_make_string(value: String): () -> MsgPack
   msgpack_fns::make_string(value)
+
+@intrinsic(name: "__boundary_value_to_msgpack")
+fn boundary_value_to_msgpack<T>(value: T): () -> MsgPack
+  __boundary_value_to_msgpack(value)
+
+@intrinsic(name: "__boundary_msgpack_to_value")
+fn boundary_msgpack_to_value<T>(value: MsgPack): () -> T
+  __boundary_msgpack_to_value<T>(value)
 
 /// Encodes `value` into the caller-provided memory region `[ptr, ptr + len)`.
 ///

--- a/packages/std/src/msgpack/fns.voyd
+++ b/packages/std/src/msgpack/fns.voyd
@@ -210,6 +210,19 @@ pub fn unpack_bool(value: MsgPack): () -> bool
 /// Extracts a string from a MessagePack value.
 pub fn unpack_string(value: MsgPack): () -> String
   value.match(decoded)
+    Bool:
+      if decoded.value:
+        "true".as_slice().to_string()
+      else:
+        "false".as_slice().to_string()
+    I32:
+      cast::to_string(decoded.value)
+    I64:
+      cast::to_string(decoded.value)
+    F32:
+      cast::to_string(decoded.value)
+    F64:
+      cast::to_string(decoded.value)
     String:
       decoded
     else:

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@voyd-lang/web",
+  "version": "0.1.0",
+  "private": false,
+  "description": "Voyd web framework source package",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyd-lang/voyd"
+  },
+  "files": [
+    "src",
+    "dist"
+  ],
+  "scripts": {
+    "build": "node -e \"const fs=require('node:fs');fs.mkdirSync('dist',{recursive:true});fs.writeFileSync('dist/.placeholder','web framework source bundle');\"",
+    "clean": "rm -rf dist",
+    "typecheck": "echo 'no types for voyd web'",
+    "test": "VOYD_USE_SRC=1 node ../../scripts/voyd test ./src --fail-empty-tests",
+    "lint": "echo 'no lint configured'",
+    "prepack": "npm run clean && npm run build",
+    "prepublishOnly": "node ../../scripts/release/enforce-workspace-release.mjs"
+  },
+  "dependencies": {
+    "@voyd-lang/std": "^0.2.0"
+  }
+}

--- a/packages/web/src/all.voyd
+++ b/packages/web/src/all.voyd
@@ -1,0 +1,146 @@
+//! Convenient web framework imports.
+
+use super::extract::{
+  bytes as bytes_policy,
+  json as json_policy,
+  optional_session as optional_session_policy,
+  required_session as required_session_policy,
+  text as text_policy
+}
+use super::response::{ json as response_json_value }
+use std::json::JsonValue
+
+pub use super::extract::{
+  AuthExtractor,
+  AuthPolicy,
+  BodyError,
+  BytesBody,
+  extract_headers,
+  extract_params,
+  extract_query,
+  FromAuth,
+  FromBody,
+  JsonBody,
+  OptionalSession,
+  QueryParams,
+  Rejection,
+  RequiredSession,
+  RouteParams,
+  TextBody
+}
+pub use super::html::{ document, html, html_response, render }
+pub use super::middleware::request_id_required
+pub use super::response::{
+  Body,
+  Header,
+  HeaderName,
+  Headers,
+  HttpError,
+  IncomingRequest,
+  IntoResponse,
+  Method,
+  QueryString,
+  Response,
+  Status,
+  status,
+  to_response
+}
+pub use super::router::{
+  App,
+  AppBuild,
+  AuthError,
+  Context,
+  ErrorHandler,
+  Handler,
+  MatchedRoute,
+  Middleware,
+  Next,
+  Router,
+  TrailingSlashPolicy,
+  app,
+  build_app,
+  ignore_trailing_slash,
+  serve,
+  serve_app,
+  serve_build,
+  strict_trailing_slash
+}
+pub use super::routes::{
+  adopt,
+  get,
+  get_context,
+  get_params_query,
+  get_unit,
+  group,
+  method_not_allowed,
+  not_found,
+  on_error,
+  on_rejection,
+  patch,
+  patch_context,
+  patch_params_query,
+  patch_unit,
+  post,
+  post_context,
+  post_params_query,
+  post_unit,
+  put,
+  put_context,
+  put_params_query,
+  put_unit,
+  delete,
+  delete_context,
+  delete_params_query,
+  delete_unit,
+  route,
+  route_auth,
+  route_context,
+  route_headers,
+  route_headers_context,
+  route_params,
+  route_params_context,
+  route_params_headers,
+  route_params_headers_context,
+  route_params_query_headers,
+  route_params_query_headers_context,
+  route_unit,
+  route_params_query,
+  route_params_query_context,
+  route_query_context,
+  route_query_headers,
+  route_query_headers_context
+}
+pub use super::static_files::serve_dir
+
+pub fn json() -> JsonBody
+  json_policy()
+
+pub fn json_body() -> JsonBody
+  json_policy()
+
+pub fn response_json(value: JsonValue) -> Response
+  response_json_value(value)
+
+pub fn response_json(response: Response, value: JsonValue) -> Response
+  response_json_value(response, value)
+
+pub fn text() -> TextBody
+  text_policy()
+
+pub fn text_body() -> TextBody
+  text_policy()
+
+pub fn bytes() -> BytesBody
+  bytes_policy()
+
+pub fn required_session<T>({ extract: AuthExtractor<T> }) -> AuthPolicy<T>
+  required_session_policy<T>(extract: extract)
+
+pub fn required_session() -> RequiredSession
+  required_session_policy()
+
+pub fn optional_session<T>({ extract: AuthExtractor<Option<T>> }) -> AuthPolicy<Option<T>>
+  optional_session_policy<T>(extract: extract)
+
+pub fn optional_session() -> OptionalSession
+  optional_session_policy()

--- a/packages/web/src/extract.voyd
+++ b/packages/web/src/extract.voyd
@@ -1,0 +1,463 @@
+//! Request extractors and rejection values.
+
+use std::array::Array
+use std::bytes::Bytes
+use std::dict::Dict
+use std::http::self as http
+use std::http::{ Header, Headers, HttpError, IncomingRequest, QueryString, Response, Status }
+use std::json::{ JsonArray, JsonBool, JsonNull, JsonNumber, JsonObject, JsonString, JsonValue, parse as parse_json }
+use std::msgpack::MsgPack
+use std::msgpack::self as msgpack
+use std::number::cast::self as cast
+use std::optional::types::all
+use std::result::types::all
+use std::string::type::{ String, StringSlice, from_utf8, ParseIntError, Utf8Error }
+use super::response::IntoResponse
+
+pub type NameValue = {
+  name: String,
+  value: String
+}
+
+pub obj RouteParams {
+  api entries: Array<NameValue>
+}
+
+pub obj QueryParams {
+  api entries: Array<NameValue>
+}
+
+pub obj Rejection {
+  api status: Status,
+  api message: String
+}
+
+pub obj BodyError {
+  api message: String
+}
+
+pub obj JsonBody {}
+pub obj TextBody {}
+pub obj BytesBody {}
+pub obj RequiredSession {}
+pub obj OptionalSession {}
+
+pub type AuthExtractor<T> = fn(IncomingRequest) : (open) -> Result<T, Rejection>
+
+pub obj AuthPolicy<T> {
+  extractor: AuthExtractor<T>
+}
+
+pub trait FromBody<T>
+  fn extract_body(self, request: IncomingRequest) : (open) -> Result<T, Rejection>
+
+pub trait FromAuth<T>
+  fn extract_auth(self, request: IncomingRequest) : (open) -> Result<T, Rejection>
+
+impl RouteParams
+  api fn empty() -> RouteParams
+    RouteParams { entries: Array<NameValue>::init() }
+
+  api fn append(self, { name: String, value: String }) -> RouteParams
+    let ~next = self.entries.copied(1)
+    next.push({ name: name, value: value })
+    RouteParams { entries: next }
+
+  api fn get(self, name: StringSlice) -> Option<String>
+    find_value(self.entries, name)
+
+  api fn get(self, name: String) -> Option<String>
+    self.get(name.as_slice())
+
+impl QueryParams
+  api fn empty() -> QueryParams
+    QueryParams { entries: Array<NameValue>::init() }
+
+  api fn append(self, { name: String, value: String }) -> QueryParams
+    let ~next = self.entries.copied(1)
+    next.push({ name: name, value: value })
+    QueryParams { entries: next }
+
+  api fn get(self, name: StringSlice) -> Option<String>
+    find_value(self.entries, name)
+
+  api fn get(self, name: String) -> Option<String>
+    self.get(name.as_slice())
+
+impl Rejection
+  api fn bad_request(message: StringSlice) -> Rejection
+    Rejection { status: Status::bad_request(), message: message.to_string() }
+
+  api fn not_found(message: StringSlice) -> Rejection
+    Rejection { status: Status::not_found(), message: message.to_string() }
+
+  api fn payload_too_large(message: StringSlice) -> Rejection
+    match(Status::from(413))
+      Ok<Status> { value }:
+        Rejection { status: value, message: message.to_string() }
+      Err:
+        Rejection::bad_request(message)
+
+  api fn unsupported_media_type(message: StringSlice) -> Rejection
+    match(Status::from(415))
+      Ok<Status> { value }:
+        Rejection { status: value, message: message.to_string() }
+      Err:
+        Rejection::bad_request(message)
+
+  api fn unauthorized(message: StringSlice) -> Rejection
+    Rejection { status: Status::unauthorized(), message: message.to_string() }
+
+  api fn forbidden(message: StringSlice) -> Rejection
+    Rejection { status: Status::forbidden(), message: message.to_string() }
+
+impl IntoResponse<Rejection> for Rejection
+  fn into_response(self) -> Response
+    Response::new(status: self.status).text(self.message)
+
+impl<T> AuthPolicy<T>
+  api fn extract(self, request: IncomingRequest) : (open) -> Result<T, Rejection>
+    let extractor = self.extractor
+    extractor(request)
+
+impl FromBody<JsonValue> for JsonBody
+  fn extract_body(self, request: IncomingRequest) : (open) -> Result<JsonValue, Rejection>
+    self
+    json_body_value(request)
+
+impl FromBody<String> for TextBody
+  fn extract_body(self, request: IncomingRequest) : (open) -> Result<String, Rejection>
+    self
+    text_body(request)
+
+impl FromBody<Bytes> for BytesBody
+  fn extract_body(self, request: IncomingRequest) : (open) -> Result<Bytes, Rejection>
+    self
+    bytes_body(request)
+
+pub fn text_body(request: IncomingRequest) -> Result<String, Rejection>
+  match(request.text())
+    Ok<String> { value }:
+      Ok<String> { value: value }
+    Err<HttpError> { error }:
+      Err<Rejection> { error: Rejection::bad_request(error.message.as_slice()) }
+
+pub fn bytes_body(request: IncomingRequest) -> Result<Bytes, Rejection>
+  Ok<Bytes> { value: request.body_bytes() }
+
+pub fn extract_params<T>(params: RouteParams) -> Result<T, Rejection>
+  Ok<T> { value: decode_params<T>(params) }
+
+pub fn extract_query<T>(query: QueryParams) -> Result<T, Rejection>
+  Ok<T> { value: decode_query<T>(query) }
+
+pub fn extract_headers<T>(headers: Headers) -> Result<T, Rejection>
+  Ok<T> { value: decode_headers<T>(headers) }
+
+pub fn decode_params<T>(params: RouteParams) -> T
+  msgpack::unpack_boundary_value<T>(name_values_to_msgpack(params.entries))
+
+pub fn decode_query<T>(query: QueryParams) -> T
+  msgpack::unpack_boundary_value<T>(query_values_to_msgpack(query.entries))
+
+pub fn decode_headers<T>(headers: Headers) -> T
+  msgpack::unpack_boundary_value<T>(headers_to_msgpack(headers))
+
+pub fn decode_json_value<T>(value: JsonValue) -> T
+  msgpack::unpack_boundary_value<T>(json_to_msgpack(value))
+
+pub fn extract_json_body<T>(body: JsonBody, request: IncomingRequest) : (open) -> Result<T, Rejection>
+  body
+  match(json_body_value(request))
+    Ok<JsonValue> { value }:
+      Ok<T> { value: decode_json_value<T>(value) }
+    Err<Rejection> { error }:
+      Err<Rejection> { error: error }
+
+pub fn json_body_value(request: IncomingRequest) -> Result<JsonValue, Rejection>
+  match(json_content_type_rejection(request))
+    Some<Rejection> { value }:
+      Err<Rejection> { error: value }
+    None:
+      match(request.json())
+        Ok<JsonValue> { value }:
+          Ok<JsonValue> { value: value }
+        Err<HttpError> { error }:
+          Err<Rejection> { error: Rejection::bad_request(error.message.as_slice()) }
+
+pub fn json() -> JsonBody
+  JsonBody {}
+
+pub fn json_body() -> JsonBody
+  JsonBody {}
+
+pub fn text() -> TextBody
+  TextBody {}
+
+pub fn text_body() -> TextBody
+  TextBody {}
+
+pub fn bytes() -> BytesBody
+  BytesBody {}
+
+pub fn required_session<T>({ extract: AuthExtractor<T> }) -> AuthPolicy<T>
+  AuthPolicy<T> { extractor: extract }
+
+pub fn required_session() -> RequiredSession
+  RequiredSession {}
+
+pub fn optional_session<T>({ extract: AuthExtractor<Option<T>> }) -> AuthPolicy<Option<T>>
+  AuthPolicy<Option<T>> { extractor: extract }
+
+pub fn optional_session() -> OptionalSession
+  OptionalSession {}
+
+impl<T> FromAuth<T> for AuthPolicy<T>
+  fn extract_auth(self, request: IncomingRequest) : (open) -> Result<T, Rejection>
+    self.extract(request)
+
+pub fn query_from(request: IncomingRequest) -> QueryParams
+  match(request.query)
+    Some<QueryString> { value }:
+      parse_query(value.raw)
+    None:
+      QueryParams::empty()
+
+pub fn parse_query(raw: String) -> QueryParams
+  parse_query(raw.as_slice())
+
+pub fn parse_query(raw: StringSlice) -> QueryParams
+  let parts = raw.split(on: 38, keep_empty: false)
+  var out = QueryParams::empty()
+  var index = 0
+  while index < parts.len():
+    match(parts.get(index))
+      Some<StringSlice> { value }:
+        out = append_query_part(out, value)
+      None:
+        void
+    index = index + 1
+  out
+
+pub fn percent_decode(value: StringSlice, { plus_as_space?: bool }) -> String
+  let plus = plus_as_space ?? false
+  let ~bytes = Array<i32>::with_capacity(value.byte_len())
+  var index = 0
+  while index < value.byte_len():
+    let current = byte_at(value, index)
+    if current == 37 and index + 2 < value.byte_len():
+      let high = hex_value(byte_at(value, index + 1))
+      let low = hex_value(byte_at(value, index + 2))
+      if high >= 0 and low >= 0:
+        bytes.push(high * 16 + low)
+        index = index + 3
+        continue
+    if plus and current == 43:
+      bytes.push(32)
+    else:
+      bytes.push(current)
+    index = index + 1
+
+  match(from_utf8(bytes))
+    Ok<String> { value }:
+      value
+    Err<Utf8Error>:
+      value.to_string()
+
+fn append_query_part(params: QueryParams, part: StringSlice): () -> QueryParams
+  match(part.split_once(on: 61))
+    Some<(StringSlice, StringSlice)> { value }:
+      params.append(
+        name: percent_decode(value.0, plus_as_space: true),
+        value: percent_decode(value.1, plus_as_space: true)
+      )
+    None:
+      params.append(
+        name: percent_decode(part, plus_as_space: true),
+        value: String::init()
+      )
+
+pub fn default_required_session(request: IncomingRequest) -> Result<String, Rejection>
+  match(request.header("authorization".as_slice()))
+    Some<String> { value }:
+      Ok<String> { value: value }
+    None:
+      Err<Rejection> { error: Rejection::unauthorized("missing auth".as_slice()) }
+
+pub fn default_required_session_as<T>(request: IncomingRequest) -> Result<T, Rejection>
+  match(request.header("authorization".as_slice()))
+    Some<String> { value }:
+      Ok<T> { value: msgpack::unpack_boundary_value<T>(authorization_to_msgpack(value)) }
+    None:
+      Err<Rejection> { error: Rejection::unauthorized("missing auth".as_slice()) }
+
+fn json_content_type_rejection(request: IncomingRequest): () -> Option<Rejection>
+  match(request.header("content-type".as_slice()))
+    Some<String> { value }:
+      if json_content_type_allowed(value):
+        None {}
+      else:
+        Some<Rejection> {
+          value: Rejection::unsupported_media_type("expected application/json request body".as_slice())
+        }
+    None:
+      None {}
+
+fn json_content_type_allowed(value: String): () -> bool
+  let normalized = value.lowered()
+  let parts = normalized.as_slice().split(on: 59, max_splits: 1)
+  match(parts.get(0))
+    Some<StringSlice> { value: media }:
+      let media_type = media.trimmed()
+      media_type.to_string().equals("application/json") or media_type.ends_with("+json")
+    None:
+      false
+
+fn name_values_to_msgpack(entries: Array<NameValue>): () -> MsgPack
+  let ~out = Dict<String, MsgPack>::with_capacity(entries.len())
+  var index = 0
+  while index < entries.len():
+    match(entries.get(index))
+      Some<NameValue> { value }:
+        out.set(value.name, msgpack::make_string(value.value))
+      None:
+        void
+    index = index + 1
+  msgpack::make_map(out)
+
+fn query_values_to_msgpack(entries: Array<NameValue>): () -> MsgPack
+  let ~out = Dict<String, MsgPack>::with_capacity(entries.len())
+  var index = 0
+  while index < entries.len():
+    match(entries.get(index))
+      Some<NameValue> { value }:
+        out.set(value.name, query_value_to_msgpack(value.value))
+      None:
+        void
+    index = index + 1
+  msgpack::make_map(out)
+
+fn query_value_to_msgpack(value: String): () -> MsgPack
+  if value.equals("true"):
+    return msgpack::make_bool(true)
+  if value.equals("false"):
+    return msgpack::make_bool(false)
+  match(value.as_slice().parse_i64())
+    Ok<i64> { value: parsed }:
+      if cast::to_string(parsed).equals(value):
+        return msgpack::make_i64(parsed)
+      else:
+        return msgpack::make_string(value)
+    Err<ParseIntError>:
+      msgpack::make_string(value)
+
+fn headers_to_msgpack(headers: Headers): () -> MsgPack
+  let entries = headers.entries()
+  let ~out = Dict<String, MsgPack>::with_capacity(entries.len())
+  var index = 0
+  while index < entries.len():
+    match(entries.get(index))
+      Some<Header> { value }:
+        out.set(value.name.normalized(), msgpack::make_string(value.value))
+      None:
+        void
+    index = index + 1
+  msgpack::make_map(out)
+
+fn json_to_msgpack(value: JsonValue): () -> MsgPack
+  value.match(decoded)
+    JsonNull:
+      msgpack::make_null()
+    JsonBool:
+      msgpack::make_bool(decoded.value)
+    JsonNumber:
+      json_number_to_msgpack(decoded.value)
+    JsonString:
+      msgpack::make_string(decoded.value)
+    JsonArray:
+      json_array_to_msgpack(decoded.value)
+    JsonObject:
+      json_object_to_msgpack(decoded.value)
+
+fn json_number_to_msgpack(value: f64): () -> MsgPack
+  match(cast::to_i64_checked(value))
+    Ok<i64> { value: integer }:
+      if cast::to_f64(integer) == value:
+        return msgpack::make_i64(integer)
+      msgpack::make_f64(value)
+    Err:
+      msgpack::make_f64(value)
+
+fn json_array_to_msgpack(values: Array<JsonValue>): () -> MsgPack
+  let ~out = Array<MsgPack>::with_capacity(values.len())
+  var index = 0
+  while index < values.len():
+    match(values.get(index))
+      Some<JsonValue> { value }:
+        out.push(json_to_msgpack(value))
+      None:
+        void
+    index = index + 1
+  msgpack::make_array(out)
+
+fn json_object_to_msgpack(values: Dict<String, JsonValue>): () -> MsgPack
+  let entries = values.entries()
+  let ~out = Dict<String, MsgPack>::with_capacity(entries.len())
+  var index = 0
+  while index < entries.len():
+    match(entries.get(index))
+      Some<(String, JsonValue)> { value }:
+        out.set(value.0, json_to_msgpack(value.1))
+      None:
+        void
+    index = index + 1
+  msgpack::make_map(out)
+
+pub fn default_optional_session(request: IncomingRequest) -> Result<Option<String>, Rejection>
+  Ok<Option<String>> { value: request.header("authorization".as_slice()) }
+
+pub fn default_optional_session_as<T>(request: IncomingRequest) -> Result<Option<T>, Rejection>
+  match(request.header("authorization".as_slice()))
+    Some<String> { value }:
+      Ok<Option<T>> {
+        value: Some<T> {
+          value: msgpack::unpack_boundary_value<T>(authorization_to_msgpack(value))
+        }
+      }
+    None:
+      Ok<Option<T>> { value: None {} }
+
+fn authorization_to_msgpack(value: String): () -> MsgPack
+  match(parse_json(value))
+    Ok<JsonValue> { value: parsed }:
+      json_to_msgpack(parsed)
+    Err:
+      msgpack::make_string(value)
+
+fn find_value(entries: Array<NameValue>, name: StringSlice): () -> Option<String>
+  var index = 0
+  while index < entries.len():
+    match(entries.get(index))
+      Some<NameValue> { value }:
+        if value.name.equals(name.to_string()):
+          return Some<String> { value: value.value }
+      None:
+        void
+    index = index + 1
+  None {}
+
+fn byte_at(value: StringSlice, index: i32): () -> i32
+  match(value.get_byte(index))
+    Some<i32> { value }:
+      value
+    None:
+      -1
+
+fn hex_value(byte: i32): () -> i32
+  if byte >= 48 and byte <= 57:
+    return byte - 48
+  if byte >= 65 and byte <= 70:
+    return byte - 55
+  if byte >= 97 and byte <= 102:
+    return byte - 87
+  -1

--- a/packages/web/src/html.voyd
+++ b/packages/web/src/html.voyd
@@ -1,0 +1,195 @@
+//! Server-side rendering helpers for current `std::vx` HTML values.
+
+use std::array::Array
+use std::dict::Dict
+use std::http::Response
+use std::msgpack::{ MsgPack, MsgPackError }
+use std::msgpack::self as msgpack
+use std::number::cast::to_string
+use std::optional::types::all
+use std::string::type::{ String, StringSlice }
+use std::vx
+
+pub fn render<Msg>(value: vx::Html<Msg>) -> String
+  render_node(value)
+
+pub fn document<Msg>(value: vx::Html<Msg>) -> String
+  "<!doctype html>".as_slice().to_string().concat(render<Msg>(value))
+
+pub fn html_response<Msg>(response: Response, value: vx::Html<Msg>) -> Response
+  response
+    .with(headers: response.headers.set(header: "content-type".as_slice(), value: "text/html; charset=utf-8".as_slice()))
+    .text(render<Msg>(value))
+
+pub fn html<Msg>(response: Response, value: vx::Html<Msg>) -> Response
+  html_response<Msg>(response, value)
+
+fn render_node(value: MsgPack): () -> String
+  match(msgpack::unpack_string(value))
+    Ok<String> { value }:
+      return escape_text(value.as_slice())
+    Err<MsgPackError>:
+      void
+
+  match(msgpack::unpack_array(value))
+    Ok<Array<MsgPack>> { value }:
+      return render_children(value)
+    Err<MsgPackError>:
+      void
+
+  match(msgpack::unpack_map(value))
+    Ok<Dict<String, MsgPack>> { value: map }:
+      match(read_string(map, "kind".as_slice()))
+        Some<String> { value: kind }:
+          if kind.equals("element"):
+            return render_element(map)
+          if kind.equals("fragment"):
+            return render_node_children(map)
+          if kind.equals("text"):
+            match(read_string(map, "value".as_slice()))
+              Some<String> { value }:
+                return escape_text(value.as_slice())
+              None:
+                return String::init()
+          String::init()
+        None:
+          String::init()
+    Err<MsgPackError>:
+      String::init()
+
+fn render_element(map: Dict<String, MsgPack>): () -> String
+  let tag = read_string_or(map, "tag".as_slice(), "div".as_slice())
+  let attrs = render_attrs(map)
+  let children = render_node_children(map)
+  "<".as_slice()
+    .to_string()
+    .concat(tag)
+    .concat(attrs)
+    .concat(">".as_slice())
+    .concat(children)
+    .concat("</".as_slice())
+    .concat(tag)
+    .concat(">".as_slice())
+
+fn render_node_children(map: Dict<String, MsgPack>): () -> String
+  match(map.get("children".as_slice().to_string()))
+    Some<MsgPack> { value }:
+      match(msgpack::unpack_array(value))
+        Ok<Array<MsgPack>> { value }:
+          render_children(value)
+        Err<MsgPackError>:
+          String::init()
+    None:
+      String::init()
+
+fn render_children(children: Array<MsgPack>): () -> String
+  var out = String::init()
+  var index = 0
+  while index < children.len():
+    match(children.get(index))
+      Some<MsgPack> { value }:
+        out = out.concat(render_node(value))
+      None:
+        void
+    index = index + 1
+  out
+
+fn render_attrs(map: Dict<String, MsgPack>): () -> String
+  var out = String::init()
+  match(map.get("attrs".as_slice().to_string()))
+    Some<MsgPack> { value }:
+      match(msgpack::unpack_map(value))
+        Ok<Dict<String, MsgPack>> { value: attrs }:
+          let entries = attrs.entries()
+          var index = 0
+          while index < entries.len():
+            match(entries.get(index))
+              Some<(String, MsgPack)> { value }:
+                out = out.concat(render_attr(value.0, value.1))
+              None:
+                void
+            index = index + 1
+        Err<MsgPackError>:
+          void
+    None:
+      void
+  out
+
+fn render_attr(name: String, value: MsgPack): () -> String
+  match(msgpack::unpack_bool(value))
+    Ok<bool> { value }:
+      if value:
+        return " ".as_slice().to_string().concat(name)
+      return String::init()
+    Err<MsgPackError>:
+      void
+
+  match(msgpack::unpack_string(value))
+    Ok<String> { value }:
+      return " ".as_slice()
+        .to_string()
+        .concat(name)
+        .concat("=\"".as_slice())
+        .concat(escape_attr(value.as_slice()))
+        .concat("\"".as_slice())
+    Err<MsgPackError>:
+      void
+
+  match(msgpack::unpack_i32(value))
+    Ok<i32> { value }:
+      return " ".as_slice()
+        .to_string()
+        .concat(name)
+        .concat("=\"".as_slice())
+        .concat(to_string(value))
+        .concat("\"".as_slice())
+    Err<MsgPackError>:
+      String::init()
+
+fn read_string(map: Dict<String, MsgPack>, key: StringSlice): () -> Option<String>
+  match(map.get(key.to_string()))
+    Some<MsgPack> { value }:
+      match(msgpack::unpack_string(value))
+        Ok<String> { value }:
+          Some<String> { value: value }
+        Err<MsgPackError>:
+          None {}
+    None:
+      None {}
+
+fn read_string_or(map: Dict<String, MsgPack>, key: StringSlice, fallback: StringSlice): () -> String
+  match(read_string(map, key))
+    Some<String> { value }:
+      value
+    None:
+      fallback.to_string()
+
+fn escape_text(value: StringSlice): () -> String
+  escape(value, true)
+
+fn escape_attr(value: StringSlice): () -> String
+  escape(value, false)
+
+fn escape(value: StringSlice, text: bool): () -> String
+  var out = String::init()
+  var index = 0
+  while index < value.byte_len():
+    match(value.get_byte(index))
+      Some<i32> { value: byte }:
+        if byte == 38:
+          out = out.concat("&amp;".as_slice())
+        else:
+          if byte == 60:
+            out = out.concat("&lt;".as_slice())
+          else:
+            if byte == 62:
+              out = out.concat("&gt;".as_slice())
+            else:
+              if not text and byte == 34:
+                out = out.concat("&quot;".as_slice())
+              else:
+                out = out.concat(value.slice(bytes: index, len: 1))
+      None:
+        void
+    index = index + 1
+  out

--- a/packages/web/src/middleware.voyd
+++ b/packages/web/src/middleware.voyd
@@ -1,0 +1,13 @@
+//! Common middleware helpers.
+
+use std::http::Response
+use std::optional::types::all
+use std::string::type::String
+use super::router::{ Context, Next }
+
+pub fn request_id_required(ctx: Context, next: Next) -> Response
+  match(ctx.header("x-request-id".as_slice()))
+    Some<String> { value }:
+      next(ctx)
+    None:
+      Response::bad_request().text("missing request id".as_slice())

--- a/packages/web/src/pkg.voyd
+++ b/packages/web/src/pkg.voyd
@@ -1,0 +1,120 @@
+//! Voyd web framework package root.
+
+pub src::all
+pub src::extract
+pub src::html
+pub src::middleware
+pub src::response
+pub src::router
+pub src::routes
+pub src::static_files
+
+pub use src::extract::{
+  AuthExtractor,
+  AuthPolicy,
+  BodyError,
+  BytesBody,
+  extract_headers,
+  extract_params,
+  extract_query,
+  FromAuth,
+  FromBody,
+  JsonBody,
+  OptionalSession,
+  QueryParams,
+  Rejection,
+  RequiredSession,
+  RouteParams,
+  TextBody,
+  bytes,
+  json,
+  json_body,
+  optional_session,
+  required_session,
+  text,
+  text_body
+}
+pub use src::html::{ document, html_response, render }
+pub use src::middleware::request_id_required
+pub use src::response::{
+  Body,
+  Header,
+  HeaderName,
+  Headers,
+  HttpError,
+  IncomingRequest,
+  IntoResponse,
+  Method,
+  QueryString,
+  Response,
+  Status,
+  response_json,
+  status,
+  to_response
+}
+pub use src::router::{
+  App,
+  AppBuild,
+  AuthError,
+  Context,
+  ErrorHandler,
+  Handler,
+  MatchedRoute,
+  Middleware,
+  Next,
+  Router,
+  TrailingSlashPolicy,
+  app,
+  build_app,
+  ignore_trailing_slash,
+  serve,
+  serve_app,
+  serve_build,
+  strict_trailing_slash
+}
+pub use src::routes::{
+  adopt,
+  get,
+  get_context,
+  get_params_query,
+  get_unit,
+  group,
+  method_not_allowed,
+  not_found,
+  on_error,
+  on_rejection,
+  patch,
+  patch_context,
+  patch_params_query,
+  patch_unit,
+  post,
+  post_context,
+  post_params_query,
+  post_unit,
+  put,
+  put_context,
+  put_params_query,
+  put_unit,
+  delete,
+  delete_context,
+  delete_params_query,
+  delete_unit,
+  route,
+  route_auth,
+  route_context,
+  route_headers,
+  route_headers_context,
+  route_params,
+  route_params_context,
+  route_params_headers,
+  route_params_headers_context,
+  route_params_query_headers,
+  route_params_query_headers_context,
+  route_unit,
+  route_params_query,
+  route_params_query_context,
+  route_query_context,
+  route_query_headers,
+  route_query_headers_context
+}
+pub use src::static_files::serve_dir

--- a/packages/web/src/response.voyd
+++ b/packages/web/src/response.voyd
@@ -1,0 +1,146 @@
+//! Response conversion helpers for web handlers.
+
+use std::bytes::Bytes
+use std::http::{ Body, Response, Status }
+use std::json::{
+  JsonError,
+  JsonValue,
+  stringify as stringify_json
+}
+use std::optional::types::{ Option, Some, None }
+use std::result::types::{ Result, Ok, Err }
+use std::string::type::{ String, StringSlice }
+
+pub use std::http::{ Body, Header, HeaderName, Headers, HttpError, IncomingRequest, Method, QueryString, Response, Status }
+
+pub trait IntoResponse<T>
+  fn into_response(self) -> Response
+
+impl IntoResponse<Response> for Response
+  fn into_response(self) -> Response
+    self
+
+impl IntoResponse<String> for String
+  fn into_response(self) -> Response
+    Response::ok().text(self)
+
+impl IntoResponse<StringSlice> for StringSlice
+  fn into_response(self) -> Response
+    Response::ok().text(self)
+
+impl IntoResponse<Bytes> for Bytes
+  fn into_response(self) -> Response
+    Response::ok().bytes(self)
+
+pub fn to_response<T: IntoResponse<T>>(value: T) -> Response
+  into_response_value<T>(value)
+
+pub fn to_response(value: JsonValue) -> Response
+  json_value_response(Response::ok(), value)
+
+pub fn to_response(value: (Status, String)) -> Response
+  Response::new(status: value.0).text(value.1)
+
+pub fn to_response(value: (Status, StringSlice)) -> Response
+  Response::new(status: value.0).text(value.1)
+
+pub fn to_response(value: (Status, Bytes)) -> Response
+  Response::new(status: value.0).bytes(value.1)
+
+pub fn to_response(value: (Status, JsonValue)) -> Response
+  json_value_response(Response::new(status: value.0), value.1)
+
+pub fn to_response<T: IntoResponse<T>, E: IntoResponse<E>>(value: Result<T, E>) -> Response
+  match(value)
+    Ok<T> { value }:
+      into_response_value<T>(value)
+    Err<E> { error }:
+      into_response_value<E>(error)
+
+pub fn to_response(value: Option<Response>) -> Response
+  match(value)
+    Some<Response> { value: response }:
+      response
+    None:
+      Response::not_found().empty()
+
+pub fn to_response(value: Option<String>) -> Response
+  match(value)
+    Some<String> { value: inner }:
+      Response::ok().text(inner.as_slice())
+    None:
+      Response::not_found().empty()
+
+pub fn to_response(value: Option<StringSlice>) -> Response
+  match(value)
+    Some<StringSlice> { value: inner }:
+      Response::ok().text(inner)
+    None:
+      Response::not_found().empty()
+
+pub fn to_response(value: Option<Bytes>) -> Response
+  match(value)
+    Some<Bytes> { value: inner }:
+      Response::ok().bytes(inner)
+    None:
+      Response::not_found().empty()
+
+pub fn to_response(value: Option<JsonValue>) -> Response
+  match(value)
+    Some<JsonValue> { value: inner }:
+      json_value_response(Response::ok(), inner)
+    None:
+      Response::not_found().empty()
+
+pub fn to_response<T: IntoResponse<T>>(value: Option<T>) -> Response
+  match(value)
+    Some<T> { value: inner }:
+      into_response_value<T>(inner)
+    None:
+      Response::not_found().empty()
+
+pub fn text(value: StringSlice) -> Response
+  Response::ok().text(value)
+
+pub fn text(value: String) -> Response
+  Response::ok().text(value)
+
+pub fn json(value: JsonValue) -> Response
+  json_value_response(Response::ok(), value)
+
+pub fn response_json(value: JsonValue) -> Response
+  json_value_response(Response::ok(), value)
+
+pub fn json_value(value: JsonValue) -> Response
+  json_value_response(Response::ok(), value)
+
+pub fn json(response: Response, value: JsonValue) -> Response
+  json_value_response(response, value)
+
+pub fn response_json(response: Response, value: JsonValue) -> Response
+  json_value_response(response, value)
+
+pub fn bytes(value: Bytes) -> Response
+  Response::ok().bytes(value)
+
+pub fn status(status: Status) -> Response
+  Response::new(status: status)
+
+pub fn status({ code: i32, reason: StringSlice }) -> Response
+  match(Status::custom(code: code, reason: reason))
+    Ok<Status> { value }:
+      Response::new(status: value)
+    Err:
+      Response::internal_server_error()
+
+fn into_response_value<T: IntoResponse<T>>(value: T): () -> Response
+  value.into_response()
+
+fn json_value_response(response: Response, value: JsonValue): () -> Response
+  match(stringify_json(value))
+    Ok<String> { value }:
+      response
+        .with(headers: response.headers.set(header: "content-type".as_slice(), value: "application/json".as_slice()))
+        .with(body: Body::text(value))
+    Err<JsonError> { error }:
+      Response::internal_server_error().text(error.message)

--- a/packages/web/src/router.voyd
+++ b/packages/web/src/router.voyd
@@ -1,0 +1,1835 @@
+//! Value-returning router and `std::http::server` integration.
+
+use std::array::Array
+use std::bytes::Bytes
+use std::error::HostError
+use std::http::self as http
+use std::http::{ IncomingRequest, Method, Response }
+use std::http::server::self as server
+use std::json::JsonValue
+use std::optional::types::all
+use std::result::types::all
+use std::string::type::{ String, StringSlice }
+use std::task
+use super::extract::{
+  FromAuth,
+  FromBody,
+  JsonBody,
+  OptionalSession,
+  QueryParams,
+  Rejection,
+  RequiredSession,
+  RouteParams,
+  decode_json_value,
+  decode_params,
+  decode_query,
+  default_optional_session_as,
+  default_required_session_as,
+  extract_params,
+  extract_query,
+  json_body_value,
+  percent_decode,
+  query_from
+}
+use super::response::{ IntoResponse, json_value, to_response }
+
+pub type Handler = fn(Context) : (open) -> Response
+pub type Next = fn(Context) : (open) -> Response
+pub type Middleware = fn(Context, Next) : (open) -> Response
+pub type ErrorHandler = fn(Rejection, Context) : (open) -> Response
+
+pub obj AuthError {
+  api message: String
+}
+
+pub obj MatchedRoute {
+  api path: String,
+  api params: RouteParams
+}
+
+pub obj Context {
+  api request: IncomingRequest,
+  api route: MatchedRoute,
+  error_handler: ErrorHandler
+}
+
+pub obj TrailingSlashPolicy {
+  kind: i32
+}
+
+obj RouteSegment {
+  kind: i32,
+  value: String
+}
+
+pub obj Route {
+  method: Method,
+  path: String,
+  segments: Array<RouteSegment>,
+  middleware: Array<Middleware>,
+  handler: Handler,
+  error_handler: ErrorHandler,
+  order: i32
+}
+
+obj RouteMatch {
+  route: Route,
+  params: RouteParams,
+  score: i32
+}
+
+pub obj App {
+  routes: Array<Route>,
+  current_middleware: Array<Middleware>,
+  prefix: String,
+  next_order: i32,
+  not_found_handler: Handler,
+  method_not_allowed_handler: Handler,
+  error_handler: ErrorHandler,
+  trailing_slash_policy: TrailingSlashPolicy
+}
+
+pub obj Router {
+  app: App
+}
+
+pub type AppBuild = App
+
+impl AuthError
+  api fn init(message: StringSlice) -> AuthError
+    AuthError { message: message.to_string() }
+
+impl Context
+  api fn method(self) -> Method
+    self.request.method
+
+  api fn path(self) -> String
+    self.request.path
+
+  api fn header(self, name: StringSlice) -> Option<String>
+    self.request.header(name)
+
+  api fn header(self, name: String) -> Option<String>
+    self.request.header(name)
+
+  api fn param(self, name: StringSlice) -> Option<String>
+    self.route.params.get(name)
+
+  api fn param(self, name: String) -> Option<String>
+    self.param(name.as_slice())
+
+  api fn query(self) -> QueryParams
+    query_from(self.request)
+
+  api fn query_value(self, name: StringSlice) -> Option<String>
+    self.query().get(name)
+
+  api fn query_value(self, name: String) -> Option<String>
+    self.query_value(name.as_slice())
+
+  api fn body_bytes(self) -> Bytes
+    self.request.body_bytes()
+
+  api fn text(self) -> Result<String, http::HttpError>
+    self.request.text()
+
+  api fn json(self) -> Result<JsonValue, http::HttpError>
+    self.request.json()
+
+  api fn reject(self, rejection: Rejection) -> Response
+    let handler = self.error_handler
+    handler(rejection, self)
+
+impl TrailingSlashPolicy
+  api fn strict() -> TrailingSlashPolicy
+    TrailingSlashPolicy { kind: 0 }
+
+  api fn ignore() -> TrailingSlashPolicy
+    TrailingSlashPolicy { kind: 1 }
+
+impl App
+  api fn init() -> App
+    App {
+      routes: Array<Route>::init(),
+      current_middleware: Array<Middleware>::init(),
+      prefix: String::init(),
+      next_order: 0,
+      not_found_handler: (ctx: Context) -> Response => default_not_found(ctx),
+      method_not_allowed_handler: (ctx: Context) -> Response => default_method_not_allowed(ctx),
+      error_handler: (rejection: Rejection, ctx: Context) -> Response => default_rejection(rejection, ctx),
+      trailing_slash_policy: TrailingSlashPolicy::strict()
+    }
+
+  api fn adopt(self, middleware: Middleware) -> App
+    let ~next_middleware = self.current_middleware.copied(1)
+    next_middleware.push(middleware)
+    App {
+      routes: self.routes,
+      current_middleware: next_middleware,
+      prefix: self.prefix,
+      next_order: self.next_order,
+      not_found_handler: self.not_found_handler,
+      method_not_allowed_handler: self.method_not_allowed_handler,
+      error_handler: self.error_handler,
+      trailing_slash_policy: self.trailing_slash_policy
+    }
+
+  api fn with(self, { trailing_slash: TrailingSlashPolicy }) -> App
+    App {
+      routes: self.routes,
+      current_middleware: self.current_middleware,
+      prefix: self.prefix,
+      next_order: self.next_order,
+      not_found_handler: self.not_found_handler,
+      method_not_allowed_handler: self.method_not_allowed_handler,
+      error_handler: self.error_handler,
+      trailing_slash_policy: trailing_slash
+    }
+
+  api fn get(self, path: StringSlice, { handler: Handler }) -> App
+    self.with_route(path, Method::Get {}, handler)
+
+  api fn get(self, path: String, { handler: Handler }) -> App
+    self.get(path.as_slice(), handler: handler)
+
+  api fn get_context<T: IntoResponse<T>>(self, path: StringSlice, { handler: fn(Context) : (open) -> T }) -> App
+    self.with_route(path, Method::Get {}, (ctx: Context) -> Response => to_response<T>(handler(ctx)))
+
+  api fn get_unit(self, path: StringSlice, { handler: fn() : (open) -> Response }) -> App
+    self.with_unit_response_route(path, Method::Get {}, handler)
+
+  api fn get_unit(self, path: String, { handler: fn() : (open) -> Response }) -> App
+    self.get_unit(path.as_slice(), handler: handler)
+
+  api fn get_params<P>(self, path: StringSlice, { handler: fn(P) : (open) -> Response }) -> App
+    self.with_params_response_route(path, Method::Get {}, handler)
+
+  api fn get_params<P>(self, path: String, { handler: fn(P) : (open) -> Response }) -> App
+    self.get_params<P>(path.as_slice(), handler: handler)
+
+  api fn get_params_query<P, Q>(self, path: StringSlice, { handler: fn(P, Q) : (open) -> Response }) -> App
+    self.with_params_query_response_route(path, Method::Get {}, handler)
+
+  api fn get_params_query<P, Q>(self, path: String, { handler: fn(P, Q) : (open) -> Response }) -> App
+    self.get_params_query<P, Q>(path.as_slice(), handler: handler)
+
+  api fn get<S, A: FromAuth<S>>(self, path: StringSlice, { auth: A, handler: fn(S) : (open) -> Response }) -> App
+    self.with_route(path, Method::Get {}, (ctx: Context) -> Response =>
+      match(auth.extract_auth(ctx.request))
+        Ok<S> { value }:
+          handler(value)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn get<S, A: FromAuth<S>>(self, path: StringSlice, { auth: A, handler: fn(S, Context) : (open) -> Response }) -> App
+    self.with_route(path, Method::Get {}, (ctx: Context) -> Response =>
+      match(auth.extract_auth(ctx.request))
+        Ok<S> { value }:
+          handler(value, ctx)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn get<S>(self, path: StringSlice, { auth: RequiredSession, handler: fn(S) : (open) -> Response }) -> App
+    auth
+    self.with_route(path, Method::Get {}, (ctx: Context) -> Response =>
+      match(default_required_session_as<S>(ctx.request))
+        Ok<S> { value }:
+          handler(value)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn get<S>(self, path: StringSlice, { auth: RequiredSession, handler: fn(S, Context) : (open) -> Response }) -> App
+    auth
+    self.with_route(path, Method::Get {}, (ctx: Context) -> Response =>
+      match(default_required_session_as<S>(ctx.request))
+        Ok<S> { value }:
+          handler(value, ctx)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn get<S>(self, path: StringSlice, { auth: OptionalSession, handler: fn(Option<S>) : (open) -> Response }) -> App
+    auth
+    self.with_route(path, Method::Get {}, (ctx: Context) -> Response =>
+      match(default_optional_session_as<S>(ctx.request))
+        Ok<Option<S>> { value }:
+          handler(value)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn get<S>(self, path: StringSlice, { auth: OptionalSession, handler: fn(Option<S>, Context) : (open) -> Response }) -> App
+    auth
+    self.with_route(path, Method::Get {}, (ctx: Context) -> Response =>
+      match(default_optional_session_as<S>(ctx.request))
+        Ok<Option<S>> { value }:
+          handler(value, ctx)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn post(self, path: StringSlice, { handler: Handler }) -> App
+    self.with_route(path, Method::Post {}, handler)
+
+  api fn post_context<T: IntoResponse<T>>(self, path: StringSlice, { handler: fn(Context) : (open) -> T }) -> App
+    self.with_route(path, Method::Post {}, (ctx: Context) -> Response => to_response<T>(handler(ctx)))
+
+  api fn post_unit(self, path: StringSlice, { handler: fn() : (open) -> Response }) -> App
+    self.with_unit_response_route(path, Method::Post {}, handler)
+
+  api fn post_unit(self, path: String, { handler: fn() : (open) -> Response }) -> App
+    self.post_unit(path.as_slice(), handler: handler)
+
+  api fn post_params<P>(self, path: StringSlice, { handler: fn(P) : (open) -> Response }) -> App
+    self.with_params_response_route(path, Method::Post {}, handler)
+
+  api fn post_params<P>(self, path: String, { handler: fn(P) : (open) -> Response }) -> App
+    self.post_params<P>(path.as_slice(), handler: handler)
+
+  api fn post_params_query<P, Q>(self, path: StringSlice, { handler: fn(P, Q) : (open) -> Response }) -> App
+    self.with_params_query_response_route(path, Method::Post {}, handler)
+
+  api fn post_params_query<P, Q>(self, path: String, { handler: fn(P, Q) : (open) -> Response }) -> App
+    self.post_params_query<P, Q>(path.as_slice(), handler: handler)
+
+  api fn post<I, P: FromBody<I>>(
+    self,
+    path: StringSlice,
+    { body: P, handler: fn(I) : (open) -> Response }
+  ) -> App
+    self.with_route(path, Method::Post {}, (ctx: Context) -> Response =>
+      match(body.extract_body(ctx.request))
+        Ok<I> { value }:
+          handler(value)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn post<I, P: FromBody<I>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { body: P, handler: fn(I) : (open) -> T }
+  ) -> App
+    self.with_route(path, Method::Post {}, (ctx: Context) -> Response =>
+      match(body.extract_body(ctx.request))
+        Ok<I> { value }:
+          to_response<T>(handler(value))
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn post<I>(
+    self,
+    path: StringSlice,
+    { body: JsonBody, handler: fn(I) : (open) -> Response }
+  ) -> App
+    self.with_route(path, Method::Post {}, (ctx: Context) -> Response =>
+      body
+      match(json_body_value(ctx.request))
+        Ok<JsonValue> { value }:
+          handler(decode_json_value<I>(value))
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn post<I, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { body: JsonBody, handler: fn(I) : (open) -> T }
+  ) -> App
+    self.with_route(path, Method::Post {}, (ctx: Context) -> Response =>
+      body
+      match(json_body_value(ctx.request))
+        Ok<JsonValue> { value }:
+          to_response<T>(handler(decode_json_value<I>(value)))
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn post<I, P: FromBody<I>, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { body: P, auth: A, handler: fn(I, S) : (open) -> T }
+  ) -> App
+    self.with_route(path, Method::Post {}, (ctx: Context) -> Response =>
+      match(body.extract_body(ctx.request))
+        Err<Rejection> { error }:
+          ctx.reject(error)
+        Ok<I> { value: input }:
+          match(auth.extract_auth(ctx.request))
+            Ok<S> { value: session }:
+              to_response<T>(handler(input, session))
+            Err<Rejection> { error }:
+              ctx.reject(error)
+    )
+
+  api fn post<I, P: FromBody<I>, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { body: P, auth: A, handler: fn(I, S, Context) : (open) -> T }
+  ) -> App
+    self.with_route(path, Method::Post {}, (ctx: Context) -> Response =>
+      match(body.extract_body(ctx.request))
+        Err<Rejection> { error }:
+          ctx.reject(error)
+        Ok<I> { value: input }:
+          match(auth.extract_auth(ctx.request))
+            Ok<S> { value: session }:
+              to_response<T>(handler(input, session, ctx))
+            Err<Rejection> { error }:
+              ctx.reject(error)
+    )
+
+  api fn post<I, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { body: JsonBody, auth: A, handler: fn(I, S) : (open) -> T }
+  ) -> App
+    self.with_route(path, Method::Post {}, (ctx: Context) -> Response =>
+      body
+      match(json_body_value(ctx.request))
+        Err<Rejection> { error }:
+          ctx.reject(error)
+        Ok<JsonValue> { value }:
+          let input = decode_json_value<I>(value)
+          match(auth.extract_auth(ctx.request))
+            Ok<S> { value: session }:
+              to_response<T>(handler(input, session))
+            Err<Rejection> { error }:
+              ctx.reject(error)
+    )
+
+  api fn post<I, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { body: JsonBody, auth: A, handler: fn(I, S, Context) : (open) -> T }
+  ) -> App
+    self.with_route(path, Method::Post {}, (ctx: Context) -> Response =>
+      body
+      match(json_body_value(ctx.request))
+        Err<Rejection> { error }:
+          ctx.reject(error)
+        Ok<JsonValue> { value }:
+          let input = decode_json_value<I>(value)
+          match(auth.extract_auth(ctx.request))
+            Ok<S> { value: session }:
+              to_response<T>(handler(input, session, ctx))
+            Err<Rejection> { error }:
+              ctx.reject(error)
+    )
+
+  api fn put(self, path: StringSlice, { handler: Handler }) -> App
+    self.with_route(path, Method::Put {}, handler)
+
+  api fn put_context<T: IntoResponse<T>>(self, path: StringSlice, { handler: fn(Context) : (open) -> T }) -> App
+    self.with_route(path, Method::Put {}, (ctx: Context) -> Response => to_response<T>(handler(ctx)))
+
+  api fn put_unit(self, path: StringSlice, { handler: fn() : (open) -> Response }) -> App
+    self.with_unit_response_route(path, Method::Put {}, handler)
+
+  api fn put_unit(self, path: String, { handler: fn() : (open) -> Response }) -> App
+    self.put_unit(path.as_slice(), handler: handler)
+
+  api fn put_params<P>(self, path: StringSlice, { handler: fn(P) : (open) -> Response }) -> App
+    self.with_params_response_route(path, Method::Put {}, handler)
+
+  api fn put_params<P>(self, path: String, { handler: fn(P) : (open) -> Response }) -> App
+    self.put_params<P>(path.as_slice(), handler: handler)
+
+  api fn put_params_query<P, Q>(self, path: StringSlice, { handler: fn(P, Q) : (open) -> Response }) -> App
+    self.with_params_query_response_route(path, Method::Put {}, handler)
+
+  api fn put_params_query<P, Q>(self, path: String, { handler: fn(P, Q) : (open) -> Response }) -> App
+    self.put_params_query<P, Q>(path.as_slice(), handler: handler)
+
+  api fn patch(self, path: StringSlice, { handler: Handler }) -> App
+    self.with_route(path, Method::Patch {}, handler)
+
+  api fn patch_context<T: IntoResponse<T>>(self, path: StringSlice, { handler: fn(Context) : (open) -> T }) -> App
+    self.with_route(path, Method::Patch {}, (ctx: Context) -> Response => to_response<T>(handler(ctx)))
+
+  api fn patch_unit(self, path: StringSlice, { handler: fn() : (open) -> Response }) -> App
+    self.with_unit_response_route(path, Method::Patch {}, handler)
+
+  api fn patch_unit(self, path: String, { handler: fn() : (open) -> Response }) -> App
+    self.patch_unit(path.as_slice(), handler: handler)
+
+  api fn patch_params<P>(self, path: StringSlice, { handler: fn(P) : (open) -> Response }) -> App
+    self.with_params_response_route(path, Method::Patch {}, handler)
+
+  api fn patch_params<P>(self, path: String, { handler: fn(P) : (open) -> Response }) -> App
+    self.patch_params<P>(path.as_slice(), handler: handler)
+
+  api fn patch_params_query<P, Q>(self, path: StringSlice, { handler: fn(P, Q) : (open) -> Response }) -> App
+    self.with_params_query_response_route(path, Method::Patch {}, handler)
+
+  api fn patch_params_query<P, Q>(self, path: String, { handler: fn(P, Q) : (open) -> Response }) -> App
+    self.patch_params_query<P, Q>(path.as_slice(), handler: handler)
+
+  api fn delete(self, path: StringSlice, { handler: Handler }) -> App
+    self.with_route(path, Method::Delete {}, handler)
+
+  api fn delete_context<T: IntoResponse<T>>(self, path: StringSlice, { handler: fn(Context) : (open) -> T }) -> App
+    self.with_route(path, Method::Delete {}, (ctx: Context) -> Response => to_response<T>(handler(ctx)))
+
+  api fn delete_unit(self, path: StringSlice, { handler: fn() : (open) -> Response }) -> App
+    self.with_unit_response_route(path, Method::Delete {}, handler)
+
+  api fn delete_unit(self, path: String, { handler: fn() : (open) -> Response }) -> App
+    self.delete_unit(path.as_slice(), handler: handler)
+
+  api fn delete_params<P>(self, path: StringSlice, { handler: fn(P) : (open) -> Response }) -> App
+    self.with_params_response_route(path, Method::Delete {}, handler)
+
+  api fn delete_params<P>(self, path: String, { handler: fn(P) : (open) -> Response }) -> App
+    self.delete_params<P>(path.as_slice(), handler: handler)
+
+  api fn delete_params_query<P, Q>(self, path: StringSlice, { handler: fn(P, Q) : (open) -> Response }) -> App
+    self.with_params_query_response_route(path, Method::Delete {}, handler)
+
+  api fn delete_params_query<P, Q>(self, path: String, { handler: fn(P, Q) : (open) -> Response }) -> App
+    self.delete_params_query<P, Q>(path.as_slice(), handler: handler)
+
+  api fn route<T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, handler: fn(Context) : (open) -> T }
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response => to_response<T>(handler(ctx)))
+
+  api fn route<T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, handler: fn() : (open) -> T }
+  ) -> App
+    self.with_unit_route(path, method, handler)
+
+  api fn route<S, A: FromAuth<S>>(self, path: StringSlice, { method: Method, auth: A, handler: fn(S) : (open) -> Response }) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(auth.extract_auth(ctx.request))
+        Ok<S> { value }:
+          handler(value)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn route<S, A: FromAuth<S>>(self, path: StringSlice, { method: Method, auth: A, handler: fn(S, Context) : (open) -> Response }) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(auth.extract_auth(ctx.request))
+        Ok<S> { value }:
+          handler(value, ctx)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn route<S>(self, path: StringSlice, { method: Method, auth: RequiredSession, handler: fn(S) : (open) -> Response }) -> App
+    auth
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(default_required_session_as<S>(ctx.request))
+        Ok<S> { value }:
+          handler(value)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn route<S>(self, path: StringSlice, { method: Method, auth: RequiredSession, handler: fn(S, Context) : (open) -> Response }) -> App
+    auth
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(default_required_session_as<S>(ctx.request))
+        Ok<S> { value }:
+          handler(value, ctx)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn route<S>(self, path: StringSlice, { method: Method, auth: OptionalSession, handler: fn(Option<S>) : (open) -> Response }) -> App
+    auth
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(default_optional_session_as<S>(ctx.request))
+        Ok<Option<S>> { value }:
+          handler(value)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn route<S>(self, path: StringSlice, { method: Method, auth: OptionalSession, handler: fn(Option<S>, Context) : (open) -> Response }) -> App
+    auth
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(default_optional_session_as<S>(ctx.request))
+        Ok<Option<S>> { value }:
+          handler(value, ctx)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn route_context(
+    self,
+    path: StringSlice,
+    { method: Method, handler: Handler }
+  ) -> App
+    self.with_route(path, method, handler)
+
+  api fn route<I, P: FromBody<I>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, body: P, handler: fn(I) : (open) -> T }
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(body.extract_body(ctx.request))
+        Ok<I> { value }:
+          to_response<T>(handler(value))
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn route<I, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, body: JsonBody, handler: fn(I) : (open) -> T }
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      body
+      match(json_body_value(ctx.request))
+        Ok<JsonValue> { value }:
+          to_response<T>(handler(decode_json_value<I>(value)))
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  api fn route<I, P: FromBody<I>, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, body: P, auth: A, handler: fn(I, S) : (open) -> T }
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(body.extract_body(ctx.request))
+        Err<Rejection> { error }:
+          ctx.reject(error)
+        Ok<I> { value: input }:
+          match(auth.extract_auth(ctx.request))
+            Ok<S> { value: session }:
+              to_response<T>(handler(input, session))
+            Err<Rejection> { error }:
+              ctx.reject(error)
+    )
+
+  api fn route<I, P: FromBody<I>, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, body: P, auth: A, handler: fn(I, S, Context) : (open) -> T }
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(body.extract_body(ctx.request))
+        Err<Rejection> { error }:
+          ctx.reject(error)
+        Ok<I> { value: input }:
+          match(auth.extract_auth(ctx.request))
+            Ok<S> { value: session }:
+              to_response<T>(handler(input, session, ctx))
+            Err<Rejection> { error }:
+              ctx.reject(error)
+    )
+
+  api fn route<I, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, body: JsonBody, auth: A, handler: fn(I, S) : (open) -> T }
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      body
+      match(json_body_value(ctx.request))
+        Err<Rejection> { error }:
+          ctx.reject(error)
+        Ok<JsonValue> { value }:
+          let input = decode_json_value<I>(value)
+          match(auth.extract_auth(ctx.request))
+            Ok<S> { value: session }:
+              to_response<T>(handler(input, session))
+            Err<Rejection> { error }:
+              ctx.reject(error)
+    )
+
+  api fn route<I, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, body: JsonBody, auth: A, handler: fn(I, S, Context) : (open) -> T }
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      body
+      match(json_body_value(ctx.request))
+        Err<Rejection> { error }:
+          ctx.reject(error)
+        Ok<JsonValue> { value }:
+          let input = decode_json_value<I>(value)
+          match(auth.extract_auth(ctx.request))
+            Ok<S> { value: session }:
+              to_response<T>(handler(input, session, ctx))
+            Err<Rejection> { error }:
+              ctx.reject(error)
+    )
+
+  api fn group(self, prefix: StringSlice, { routes build: fn(App) : (open) -> App }) -> App
+    let child = App {
+      routes: Array<Route>::init(),
+      current_middleware: self.current_middleware.copied(),
+      prefix: join_route_paths(self.prefix.as_slice(), prefix),
+      next_order: self.next_order,
+      not_found_handler: self.not_found_handler,
+      method_not_allowed_handler: self.method_not_allowed_handler,
+      error_handler: self.error_handler,
+      trailing_slash_policy: self.trailing_slash_policy
+    }
+    let built = build(child)
+    self.merge_routes(built.routes, next_order: built.next_order)
+
+  api fn mount(self, prefix: StringSlice, router: Router) -> App
+    self.mount(prefix, router.app)
+
+  api fn mount(self, prefix: StringSlice, app: App) -> App
+    let routes = app.routes
+    var out = self
+    var index = 0
+    while index < routes.len():
+      match(routes.get(index))
+        Some<Route> { value }:
+          out = out.with_mounted_route(prefix, value)
+        None:
+          void
+      index = index + 1
+    out
+
+  api fn not_found(self, handler: Handler) -> App
+    App {
+      routes: self.routes,
+      current_middleware: self.current_middleware,
+      prefix: self.prefix,
+      next_order: self.next_order,
+      not_found_handler: handler,
+      method_not_allowed_handler: self.method_not_allowed_handler,
+      error_handler: self.error_handler,
+      trailing_slash_policy: self.trailing_slash_policy
+    }
+
+  api fn method_not_allowed(self, handler: Handler) -> App
+    App {
+      routes: self.routes,
+      current_middleware: self.current_middleware,
+      prefix: self.prefix,
+      next_order: self.next_order,
+      not_found_handler: self.not_found_handler,
+      method_not_allowed_handler: handler,
+      error_handler: self.error_handler,
+      trailing_slash_policy: self.trailing_slash_policy
+    }
+
+  api fn on_error(self, handler: ErrorHandler) -> App
+    App {
+      routes: self.routes,
+      current_middleware: self.current_middleware,
+      prefix: self.prefix,
+      next_order: self.next_order,
+      not_found_handler: self.not_found_handler,
+      method_not_allowed_handler: self.method_not_allowed_handler,
+      error_handler: handler,
+      trailing_slash_policy: self.trailing_slash_policy
+    }
+
+  api fn on_rejection(self, handler: ErrorHandler) -> App
+    self.on_error(handler)
+
+  api fn handle(self, request: IncomingRequest): (open) -> Response
+    let path = normalized_request_path(request.path, self.trailing_slash_policy)
+    match(best_match(self.routes, request.method, path.as_slice(), self.trailing_slash_policy))
+      Some<RouteMatch> { value }:
+        let ctx = Context {
+          request: request,
+          route: MatchedRoute { path: value.route.path, params: value.params },
+          error_handler: value.route.error_handler
+        }
+        run_middleware(value.route.middleware, 0, ctx, value.route.handler)
+      None:
+        let ctx = Context {
+          request: request,
+          route: MatchedRoute { path: path, params: RouteParams::empty() },
+          error_handler: self.error_handler
+        }
+        if path_matches_different_method(self.routes, path.as_slice(), self.trailing_slash_policy):
+          let handler = self.method_not_allowed_handler
+          run_middleware(self.current_middleware, 0, ctx, handler)
+        else:
+          let handler = self.not_found_handler
+          run_middleware(self.current_middleware, 0, ctx, handler)
+
+  fn with_params_route<P, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    method: Method,
+    handler: fn(P) : (open) -> T
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(extract_params<P>(ctx.route.params))
+        Ok<P> { value }:
+          to_response<T>(handler(value))
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  fn with_params_response_route<P>(
+    self,
+    path: StringSlice,
+    method: Method,
+    handler: fn(P) : (open) -> Response
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(extract_params<P>(ctx.route.params))
+        Ok<P> { value }:
+          handler(value)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  fn with_unit_route<T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    method: Method,
+    handler: fn() : (open) -> T
+  ) -> App
+    self.with_route(path, method, (_ctx: Context) -> Response =>
+      to_response<T>(handler())
+    )
+
+  fn with_unit_response_route(
+    self,
+    path: StringSlice,
+    method: Method,
+    handler: fn() : (open) -> Response
+  ) -> App
+    self.with_route(path, method, (_ctx: Context) -> Response =>
+      handler()
+    )
+
+  fn with_params_query_route<P, Q, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    method: Method,
+    handler: fn(P, Q) : (open) -> T
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      let params = decode_params<P>(ctx.route.params)
+      let query = decode_query<Q>(query_from(ctx.request))
+      to_response<T>(handler(params, query))
+    )
+
+  fn with_params_query_response_route<P, Q>(
+    self,
+    path: StringSlice,
+    method: Method,
+    handler: fn(P, Q) : (open) -> Response
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      let params = decode_params<P>(ctx.route.params)
+      let query = decode_query<Q>(query_from(ctx.request))
+      handler(params, query)
+    )
+
+  fn with_auth_response_route<S, A: FromAuth<S>>(
+    self,
+    path: StringSlice,
+    method: Method,
+    auth: A,
+    handler: fn(S) : (open) -> Response
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(auth.extract_auth(ctx.request))
+        Ok<S> { value }:
+          handler(value)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  fn with_auth_context_response_route<S, A: FromAuth<S>>(
+    self,
+    path: StringSlice,
+    method: Method,
+    auth: A,
+    handler: fn(S, Context) : (open) -> Response
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(auth.extract_auth(ctx.request))
+        Ok<S> { value }:
+          handler(value, ctx)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  fn with_required_session_response_route<S>(
+    self,
+    path: StringSlice,
+    method: Method,
+    handler: fn(S) : (open) -> Response
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(default_required_session_as<S>(ctx.request))
+        Ok<S> { value }:
+          handler(value)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  fn with_required_session_context_response_route<S>(
+    self,
+    path: StringSlice,
+    method: Method,
+    handler: fn(S, Context) : (open) -> Response
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(default_required_session_as<S>(ctx.request))
+        Ok<S> { value }:
+          handler(value, ctx)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  fn with_optional_session_response_route<S>(
+    self,
+    path: StringSlice,
+    method: Method,
+    handler: fn(Option<S>) : (open) -> Response
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(default_optional_session_as<S>(ctx.request))
+        Ok<Option<S>> { value }:
+          handler(value)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  fn with_optional_session_context_response_route<S>(
+    self,
+    path: StringSlice,
+    method: Method,
+    handler: fn(Option<S>, Context) : (open) -> Response
+  ) -> App
+    self.with_route(path, method, (ctx: Context) -> Response =>
+      match(default_optional_session_as<S>(ctx.request))
+        Ok<Option<S>> { value }:
+          handler(value, ctx)
+        Err<Rejection> { error }:
+          ctx.reject(error)
+    )
+
+  fn with_route(self, path: StringSlice, method: Method, handler: Handler) -> App
+    let full_path = join_route_paths(self.prefix.as_slice(), path)
+    let route = Route {
+      method: method,
+      path: full_path,
+      segments: parse_route_segments(full_path.as_slice()),
+      middleware: self.current_middleware.copied(),
+      handler: handler,
+      error_handler: self.error_handler,
+      order: self.next_order
+    }
+    let ~routes = self.routes.copied(1)
+    routes.push(route)
+    App {
+      routes: routes,
+      current_middleware: self.current_middleware,
+      prefix: self.prefix,
+      next_order: self.next_order + 1,
+      not_found_handler: self.not_found_handler,
+      method_not_allowed_handler: self.method_not_allowed_handler,
+      error_handler: self.error_handler,
+      trailing_slash_policy: self.trailing_slash_policy
+    }
+
+  fn merge_routes(self, routes: Array<Route>, { next_order: i32 }) -> App
+    let ~merged = self.routes.copied(routes.len())
+    var index = 0
+    while index < routes.len():
+      match(routes.get(index))
+        Some<Route> { value }:
+          merged.push(value)
+        None:
+          void
+      index = index + 1
+    App {
+      routes: merged,
+      current_middleware: self.current_middleware,
+      prefix: self.prefix,
+      next_order: next_order,
+      not_found_handler: self.not_found_handler,
+      method_not_allowed_handler: self.method_not_allowed_handler,
+      error_handler: self.error_handler,
+      trailing_slash_policy: self.trailing_slash_policy
+    }
+
+  fn with_mounted_route(self, prefix: StringSlice, route: Route) -> App
+    let full_path = join_route_paths(prefix, route.path.as_slice())
+    let mounted = Route {
+      method: route.method,
+      path: full_path,
+      segments: parse_route_segments(full_path.as_slice()),
+      middleware: combine_middleware(self.current_middleware, route.middleware),
+      handler: route.handler,
+      error_handler: route.error_handler,
+      order: self.next_order
+    }
+    let ~routes = self.routes.copied(1)
+    routes.push(mounted)
+    App {
+      routes: routes,
+      current_middleware: self.current_middleware,
+      prefix: self.prefix,
+      next_order: self.next_order + 1,
+      not_found_handler: self.not_found_handler,
+      method_not_allowed_handler: self.method_not_allowed_handler,
+      error_handler: self.error_handler,
+      trailing_slash_policy: self.trailing_slash_policy
+    }
+
+impl Router
+  api fn init() -> Router
+    Router { app: App::init() }
+
+  api fn to_app(self) -> App
+    self.app
+
+  api fn adopt(self, middleware: Middleware) -> Router
+    Router { app: self.app.adopt(middleware) }
+
+  api fn with(self, { trailing_slash: TrailingSlashPolicy }) -> Router
+    Router { app: self.app.with(trailing_slash: trailing_slash) }
+
+  api fn get(self, path: StringSlice, { handler: Handler }) -> Router
+    Router { app: self.app.get(path, handler: handler) }
+
+  api fn get(self, path: String, { handler: Handler }) -> Router
+    self.get(path.as_slice(), handler: handler)
+
+  api fn get_context<T: IntoResponse<T>>(self, path: StringSlice, { handler: fn(Context) : (open) -> T }) -> Router
+    Router { app: self.app.get_context<T>(path, handler: handler) }
+
+  api fn get_unit(self, path: StringSlice, { handler: fn() : (open) -> Response }) -> Router
+    Router { app: self.app.with_unit_response_route(path, Method::Get {}, handler) }
+
+  api fn get_unit(self, path: String, { handler: fn() : (open) -> Response }) -> Router
+    self.get_unit(path.as_slice(), handler: handler)
+
+  api fn get_params<P>(self, path: StringSlice, { handler: fn(P) : (open) -> Response }) -> Router
+    Router { app: self.app.with_params_response_route(path, Method::Get {}, handler) }
+
+  api fn get_params<P>(self, path: String, { handler: fn(P) : (open) -> Response }) -> Router
+    self.get_params<P>(path.as_slice(), handler: handler)
+
+  api fn get_params_query<P, Q>(self, path: StringSlice, { handler: fn(P, Q) : (open) -> Response }) -> Router
+    Router { app: self.app.with_params_query_response_route(path, Method::Get {}, handler) }
+
+  api fn get_params_query<P, Q>(self, path: String, { handler: fn(P, Q) : (open) -> Response }) -> Router
+    self.get_params_query<P, Q>(path.as_slice(), handler: handler)
+
+  api fn get<S, A: FromAuth<S>>(self, path: StringSlice, { auth: A, handler: fn(S) : (open) -> Response }) -> Router
+    Router { app: self.app.get<S, A>(path, auth: auth, handler: handler) }
+
+  api fn get<S, A: FromAuth<S>>(self, path: StringSlice, { auth: A, handler: fn(S, Context) : (open) -> Response }) -> Router
+    Router { app: self.app.get<S, A>(path, auth: auth, handler: handler) }
+
+  api fn get<S>(self, path: StringSlice, { auth: RequiredSession, handler: fn(S) : (open) -> Response }) -> Router
+    Router { app: self.app.get<S>(path, auth: auth, handler: handler) }
+
+  api fn get<S>(self, path: StringSlice, { auth: RequiredSession, handler: fn(S, Context) : (open) -> Response }) -> Router
+    Router { app: self.app.get<S>(path, auth: auth, handler: handler) }
+
+  api fn get<S>(self, path: StringSlice, { auth: OptionalSession, handler: fn(Option<S>) : (open) -> Response }) -> Router
+    Router { app: self.app.get<S>(path, auth: auth, handler: handler) }
+
+  api fn get<S>(self, path: StringSlice, { auth: OptionalSession, handler: fn(Option<S>, Context) : (open) -> Response }) -> Router
+    Router { app: self.app.get<S>(path, auth: auth, handler: handler) }
+
+  api fn post(self, path: StringSlice, { handler: Handler }) -> Router
+    Router { app: self.app.post(path, handler: handler) }
+
+  api fn post_context<T: IntoResponse<T>>(self, path: StringSlice, { handler: fn(Context) : (open) -> T }) -> Router
+    Router { app: self.app.post_context<T>(path, handler: handler) }
+
+  api fn post_unit(self, path: StringSlice, { handler: fn() : (open) -> Response }) -> Router
+    Router { app: self.app.with_unit_response_route(path, Method::Post {}, handler) }
+
+  api fn post_unit(self, path: String, { handler: fn() : (open) -> Response }) -> Router
+    self.post_unit(path.as_slice(), handler: handler)
+
+  api fn post_params<P>(self, path: StringSlice, { handler: fn(P) : (open) -> Response }) -> Router
+    Router { app: self.app.with_params_response_route(path, Method::Post {}, handler) }
+
+  api fn post_params<P>(self, path: String, { handler: fn(P) : (open) -> Response }) -> Router
+    self.post_params<P>(path.as_slice(), handler: handler)
+
+  api fn post_params_query<P, Q>(self, path: StringSlice, { handler: fn(P, Q) : (open) -> Response }) -> Router
+    Router { app: self.app.with_params_query_response_route(path, Method::Post {}, handler) }
+
+  api fn post_params_query<P, Q>(self, path: String, { handler: fn(P, Q) : (open) -> Response }) -> Router
+    self.post_params_query<P, Q>(path.as_slice(), handler: handler)
+
+  api fn post<I, P: FromBody<I>>(
+    self,
+    path: StringSlice,
+    { body: P, handler: fn(I) : (open) -> Response }
+  ) -> Router
+    Router { app: self.app.post<I, P>(path, body: body, handler: handler) }
+
+  api fn post<I, P: FromBody<I>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { body: P, handler: fn(I) : (open) -> T }
+  ) -> Router
+    Router { app: self.app.post<I, P, T>(path, body: body, handler: handler) }
+
+  api fn post<I>(
+    self,
+    path: StringSlice,
+    { body: JsonBody, handler: fn(I) : (open) -> Response }
+  ) -> Router
+    Router { app: self.app.post<I>(path, body: body, handler: handler) }
+
+  api fn post<I, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { body: JsonBody, handler: fn(I) : (open) -> T }
+  ) -> Router
+    Router { app: self.app.post<I, T>(path, body: body, handler: handler) }
+
+  api fn post<I, P: FromBody<I>, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { body: P, auth: A, handler: fn(I, S) : (open) -> T }
+  ) -> Router
+    Router { app: self.app.post<I, P, S, A, T>(path, body: body, auth: auth, handler: handler) }
+
+  api fn post<I, P: FromBody<I>, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { body: P, auth: A, handler: fn(I, S, Context) : (open) -> T }
+  ) -> Router
+    Router { app: self.app.post<I, P, S, A, T>(path, body: body, auth: auth, handler: handler) }
+
+  api fn post<I, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { body: JsonBody, auth: A, handler: fn(I, S) : (open) -> T }
+  ) -> Router
+    Router { app: self.app.post<I, S, A, T>(path, body: body, auth: auth, handler: handler) }
+
+  api fn post<I, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { body: JsonBody, auth: A, handler: fn(I, S, Context) : (open) -> T }
+  ) -> Router
+    Router { app: self.app.post<I, S, A, T>(path, body: body, auth: auth, handler: handler) }
+
+  api fn put(self, path: StringSlice, { handler: Handler }) -> Router
+    Router { app: self.app.put(path, handler: handler) }
+
+  api fn put_context<T: IntoResponse<T>>(self, path: StringSlice, { handler: fn(Context) : (open) -> T }) -> Router
+    Router { app: self.app.put_context<T>(path, handler: handler) }
+
+  api fn put_unit(self, path: StringSlice, { handler: fn() : (open) -> Response }) -> Router
+    Router { app: self.app.with_unit_response_route(path, Method::Put {}, handler) }
+
+  api fn put_unit(self, path: String, { handler: fn() : (open) -> Response }) -> Router
+    self.put_unit(path.as_slice(), handler: handler)
+
+  api fn put_params<P>(self, path: StringSlice, { handler: fn(P) : (open) -> Response }) -> Router
+    Router { app: self.app.with_params_response_route(path, Method::Put {}, handler) }
+
+  api fn put_params<P>(self, path: String, { handler: fn(P) : (open) -> Response }) -> Router
+    self.put_params<P>(path.as_slice(), handler: handler)
+
+  api fn put_params_query<P, Q>(self, path: StringSlice, { handler: fn(P, Q) : (open) -> Response }) -> Router
+    Router { app: self.app.with_params_query_response_route(path, Method::Put {}, handler) }
+
+  api fn put_params_query<P, Q>(self, path: String, { handler: fn(P, Q) : (open) -> Response }) -> Router
+    self.put_params_query<P, Q>(path.as_slice(), handler: handler)
+
+  api fn patch(self, path: StringSlice, { handler: Handler }) -> Router
+    Router { app: self.app.patch(path, handler: handler) }
+
+  api fn patch_context<T: IntoResponse<T>>(self, path: StringSlice, { handler: fn(Context) : (open) -> T }) -> Router
+    Router { app: self.app.patch_context<T>(path, handler: handler) }
+
+  api fn patch_unit(self, path: StringSlice, { handler: fn() : (open) -> Response }) -> Router
+    Router { app: self.app.with_unit_response_route(path, Method::Patch {}, handler) }
+
+  api fn patch_unit(self, path: String, { handler: fn() : (open) -> Response }) -> Router
+    self.patch_unit(path.as_slice(), handler: handler)
+
+  api fn patch_params<P>(self, path: StringSlice, { handler: fn(P) : (open) -> Response }) -> Router
+    Router { app: self.app.with_params_response_route(path, Method::Patch {}, handler) }
+
+  api fn patch_params<P>(self, path: String, { handler: fn(P) : (open) -> Response }) -> Router
+    self.patch_params<P>(path.as_slice(), handler: handler)
+
+  api fn patch_params_query<P, Q>(self, path: StringSlice, { handler: fn(P, Q) : (open) -> Response }) -> Router
+    Router { app: self.app.with_params_query_response_route(path, Method::Patch {}, handler) }
+
+  api fn patch_params_query<P, Q>(self, path: String, { handler: fn(P, Q) : (open) -> Response }) -> Router
+    self.patch_params_query<P, Q>(path.as_slice(), handler: handler)
+
+  api fn delete(self, path: StringSlice, { handler: Handler }) -> Router
+    Router { app: self.app.delete(path, handler: handler) }
+
+  api fn delete_context<T: IntoResponse<T>>(self, path: StringSlice, { handler: fn(Context) : (open) -> T }) -> Router
+    Router { app: self.app.delete_context<T>(path, handler: handler) }
+
+  api fn delete_unit(self, path: StringSlice, { handler: fn() : (open) -> Response }) -> Router
+    Router { app: self.app.with_unit_response_route(path, Method::Delete {}, handler) }
+
+  api fn delete_unit(self, path: String, { handler: fn() : (open) -> Response }) -> Router
+    self.delete_unit(path.as_slice(), handler: handler)
+
+  api fn delete_params<P>(self, path: StringSlice, { handler: fn(P) : (open) -> Response }) -> Router
+    Router { app: self.app.with_params_response_route(path, Method::Delete {}, handler) }
+
+  api fn delete_params<P>(self, path: String, { handler: fn(P) : (open) -> Response }) -> Router
+    self.delete_params<P>(path.as_slice(), handler: handler)
+
+  api fn delete_params_query<P, Q>(self, path: StringSlice, { handler: fn(P, Q) : (open) -> Response }) -> Router
+    Router { app: self.app.with_params_query_response_route(path, Method::Delete {}, handler) }
+
+  api fn delete_params_query<P, Q>(self, path: String, { handler: fn(P, Q) : (open) -> Response }) -> Router
+    self.delete_params_query<P, Q>(path.as_slice(), handler: handler)
+
+  api fn route<T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, handler: fn(Context) : (open) -> T }
+  ) -> Router
+    Router { app: self.app.route<T>(path, method: method, handler: handler) }
+
+  api fn route<T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, handler: fn() : (open) -> T }
+  ) -> Router
+    Router { app: self.app.with_unit_route(path, method, handler) }
+
+  api fn route<S, A: FromAuth<S>>(self, path: StringSlice, { method: Method, auth: A, handler: fn(S) : (open) -> Response }) -> Router
+    Router { app: self.app.route<S, A>(path, method: method, auth: auth, handler: handler) }
+
+  api fn route<S, A: FromAuth<S>>(self, path: StringSlice, { method: Method, auth: A, handler: fn(S, Context) : (open) -> Response }) -> Router
+    Router { app: self.app.route<S, A>(path, method: method, auth: auth, handler: handler) }
+
+  api fn route<S>(self, path: StringSlice, { method: Method, auth: RequiredSession, handler: fn(S) : (open) -> Response }) -> Router
+    Router { app: self.app.route<S>(path, method: method, auth: auth, handler: handler) }
+
+  api fn route<S>(self, path: StringSlice, { method: Method, auth: RequiredSession, handler: fn(S, Context) : (open) -> Response }) -> Router
+    Router { app: self.app.route<S>(path, method: method, auth: auth, handler: handler) }
+
+  api fn route<S>(self, path: StringSlice, { method: Method, auth: OptionalSession, handler: fn(Option<S>) : (open) -> Response }) -> Router
+    Router { app: self.app.route<S>(path, method: method, auth: auth, handler: handler) }
+
+  api fn route<S>(self, path: StringSlice, { method: Method, auth: OptionalSession, handler: fn(Option<S>, Context) : (open) -> Response }) -> Router
+    Router { app: self.app.route<S>(path, method: method, auth: auth, handler: handler) }
+
+  api fn route<I, P: FromBody<I>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, body: P, handler: fn(I) : (open) -> T }
+  ) -> Router
+    Router { app: self.app.route<I, P, T>(path, method: method, body: body, handler: handler) }
+
+  api fn route<I, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, body: JsonBody, handler: fn(I) : (open) -> T }
+  ) -> Router
+    Router { app: self.app.route<I, T>(path, method: method, body: body, handler: handler) }
+
+  api fn route<I, P: FromBody<I>, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, body: P, auth: A, handler: fn(I, S) : (open) -> T }
+  ) -> Router
+    Router { app: self.app.route<I, P, S, A, T>(path, method: method, body: body, auth: auth, handler: handler) }
+
+  api fn route<I, P: FromBody<I>, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, body: P, auth: A, handler: fn(I, S, Context) : (open) -> T }
+  ) -> Router
+    Router { app: self.app.route<I, P, S, A, T>(path, method: method, body: body, auth: auth, handler: handler) }
+
+  api fn route<I, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, body: JsonBody, auth: A, handler: fn(I, S) : (open) -> T }
+  ) -> Router
+    Router { app: self.app.route<I, S, A, T>(path, method: method, body: body, auth: auth, handler: handler) }
+
+  api fn route<I, S, A: FromAuth<S>, T: IntoResponse<T>>(
+    self,
+    path: StringSlice,
+    { method: Method, body: JsonBody, auth: A, handler: fn(I, S, Context) : (open) -> T }
+  ) -> Router
+    Router { app: self.app.route<I, S, A, T>(path, method: method, body: body, auth: auth, handler: handler) }
+
+  api fn group(self, prefix: StringSlice, { routes build: fn(Router) : (open) -> Router }) -> Router
+    Router {
+      app: self.app.group(prefix, routes: (child: App) -> App =>
+        build(Router { app: child }).app
+      )
+    }
+
+  api fn mount(self, prefix: StringSlice, router: Router) -> Router
+    Router { app: self.app.mount(prefix, router) }
+
+  api fn mount(self, prefix: StringSlice, app: App) -> Router
+    Router { app: self.app.mount(prefix, app) }
+
+  api fn not_found(self, handler: Handler) -> Router
+    Router { app: self.app.not_found(handler) }
+
+  api fn method_not_allowed(self, handler: Handler) -> Router
+    Router { app: self.app.method_not_allowed(handler) }
+
+  api fn on_error(self, handler: ErrorHandler) -> Router
+    Router { app: self.app.on_error(handler) }
+
+  api fn on_rejection(self, handler: ErrorHandler) -> Router
+    Router { app: self.app.on_rejection(handler) }
+
+  api fn handle(self, request: IncomingRequest): (open) -> Response
+    self.app.handle(request)
+
+pub fn app() -> App
+  App::init()
+
+pub fn strict_trailing_slash() -> TrailingSlashPolicy
+  TrailingSlashPolicy::strict()
+
+pub fn ignore_trailing_slash() -> TrailingSlashPolicy
+  TrailingSlashPolicy::ignore()
+
+pub fn build_app(routes: fn(AppBuild) : (open) -> AppBuild) -> App
+  routes(App::init())
+
+pub fn serve({
+  port: i32,
+  host?: String,
+  shutdown_timeout?: i32,
+  routes: fn(AppBuild) : (open) -> AppBuild
+}): (server::HttpServer, task::TaskRuntime, open) -> Result<Unit, HostError>
+  serve_build(
+    port: port,
+    host: host,
+    shutdown_timeout: shutdown_timeout,
+    routes: routes
+  )
+
+pub fn serve_build({
+  port: i32,
+  host?: String,
+  shutdown_timeout?: i32,
+  routes: fn(AppBuild) : (open) -> AppBuild
+}): (server::HttpServer, task::TaskRuntime, open) -> Result<Unit, HostError>
+  serve(
+    build_app(routes),
+    port: port,
+    host: host,
+    shutdown_timeout: shutdown_timeout
+  )
+
+pub fn serve(
+  app: App,
+  { port: i32, host?: String, shutdown_timeout?: i32 }
+): (server::HttpServer, task::TaskRuntime, open) -> Result<Unit, HostError>
+  serve_app(
+    app,
+    port: port,
+    host: host,
+    shutdown_timeout: shutdown_timeout
+  )
+
+pub fn serve_app(
+  app: App,
+  { port: i32, host?: String, shutdown_timeout?: i32 }
+): (server::HttpServer, task::TaskRuntime, open) -> Result<Unit, HostError>
+  server::serve_each(
+    config: server::ServerConfig::init(
+      port: port,
+      host: host,
+      response_timeout_millis: shutdown_timeout
+    ),
+    policy: server::ServeTaskPolicy::detached(),
+    handle: (request: IncomingRequest) -> Response => app.handle(request)
+  )
+
+pub macro serve(first, second)
+  let all_args = body
+  let routes_arg = all_args.get(all_args.length - 1)
+  if is_list(routes_arg) and routes_arg.calls(:):
+    let routes_callback = routes_arg.get(2)
+    if is_list(routes_callback) and routes_callback.calls(=>):
+      let callback_params = routes_callback.get(1)
+      if is_list(callback_params) and callback_params.length == 0:
+        let serve_args = all_args.slice(0, all_args.length - 1)
+        let handler_param_count = (handler) =>
+          if is_list(handler) and handler.calls(=>):
+            let handler_params = handler.get(1)
+            if is_list(handler_params):
+              if handler_params.length == 0:
+                0
+              else:
+                if handler_params.calls(:) and handler_params.length == 3:
+                  1
+                else:
+                  handler_params.length
+            else:
+              0
+          else:
+            -1
+        let handler_param_at = (handler, index) =>
+          if is_list(handler) and handler.calls(=>):
+            let handler_params = handler.get(1)
+            if is_list(handler_params):
+              if handler_params.calls(:) and handler_params.length == 3:
+                if index == 0:
+                  handler_params
+                else:
+                  void
+              else:
+                handler_params.get(index)
+            else:
+              void
+          else:
+            void
+        let handler_param_name_at = (handler, index) =>
+          let param = handler_param_at(handler, index)
+          if is_list(param) and param.calls(:):
+            param.get(1)
+          else:
+            param
+        let is_context_handler = (handler) =>
+          if is_list(handler) and handler.calls(=>):
+            let handler_params = handler.get(1)
+            if is_list(handler_params) and handler_params.calls(:) and handler_params.length == 3:
+              handler_params.get(1) == ctx
+            else:
+              false
+          else:
+            false
+        let handler_has_final_ctx = (handler) =>
+          let count = handler_param_count(handler)
+          if count > 0:
+            handler_param_name_at(handler, count - 1) == ctx
+          else:
+            false
+        let lower_named_method_route = (builder, name, path, args, method_expr, handler) =>
+          let invalid_handler = () =>
+            panic("web route handler extractor parameters must be named params, query, headers, and optional final ctx")
+          let query_requires_context = () =>
+            panic("web query-only route handlers must include a final ctx parameter in Phase 1; use do(query: Query, ctx: Context): ...")
+          let count = handler_param_count(handler)
+          let final_ctx = handler_has_final_ctx(handler)
+          let extraction_count =
+            if final_ctx:
+              count - 1
+            else:
+              count
+          let first = handler_param_name_at(handler, 0)
+          let second = handler_param_name_at(handler, 1)
+          let third = handler_param_name_at(handler, 2)
+          if count == 0:
+            `(route_unit $builder ($path).as_slice() method: $method_expr $$args)
+          else:
+            if count == 1 and final_ctx:
+              `(route_context $builder ($path).as_slice() method: $method_expr $$args)
+            else:
+              if extraction_count == 1:
+                if first == params:
+                  if final_ctx:
+                    `(route_params_context $builder ($path).as_slice() method: $method_expr $$args)
+                  else:
+                    `(route_params $builder ($path).as_slice() method: $method_expr $$args)
+                else:
+                  if first == query:
+                    if final_ctx:
+                      `(route_query_context $builder ($path).as_slice() method: $method_expr $$args)
+                    else:
+                      query_requires_context()
+                  else:
+                    if first == headers:
+                      if final_ctx:
+                        `(route_headers_context $builder ($path).as_slice() method: $method_expr $$args)
+                      else:
+                        `(route_headers $builder ($path).as_slice() method: $method_expr $$args)
+                    else:
+                      invalid_handler()
+              else:
+                if extraction_count == 2:
+                  if first == params and second == query:
+                    if final_ctx:
+                      `(route_params_query_context $builder ($path).as_slice() method: $method_expr $$args)
+                    else:
+                      `(route_params_query $builder ($path).as_slice() method: $method_expr $$args)
+                  else:
+                    if first == params and second == headers:
+                      if final_ctx:
+                        `(route_params_headers_context $builder ($path).as_slice() method: $method_expr $$args)
+                      else:
+                        `(route_params_headers $builder ($path).as_slice() method: $method_expr $$args)
+                    else:
+                      if first == query and second == headers:
+                        if final_ctx:
+                          `(route_query_headers_context $builder ($path).as_slice() method: $method_expr $$args)
+                        else:
+                          `(route_query_headers $builder ($path).as_slice() method: $method_expr $$args)
+                      else:
+                        invalid_handler()
+                else:
+                  if extraction_count == 3 and first == params and second == query and third == headers and final_ctx:
+                    `(route_params_query_headers_context $builder ($path).as_slice() method: $method_expr $$args)
+                  else:
+                    if extraction_count == 3 and first == params and second == query and third == headers:
+                      `(route_params_query_headers $builder ($path).as_slice() method: $method_expr $$args)
+                    else:
+                      invalid_handler()
+        let lower_method_route = (builder, statement, method_expr) =>
+          let name = statement.get(0)
+          let path = statement.get(1)
+          let args = statement.slice(2)
+          let handler = statement.get(statement.length - 1)
+          if args.length == 1:
+            lower_named_method_route(builder, name, path, args, method_expr, handler)
+          else:
+            `($name $builder ($path).as_slice() $$args)
+        let lower_route = (builder, statement) =>
+          let invalid_handler = () =>
+            panic("web route handler extractor parameters must be named params, query, headers, and optional final ctx")
+          let query_requires_context = () =>
+            panic("web query-only route handlers must include a final ctx parameter in Phase 1; use do(query: Query, ctx: Context): ...")
+          let path = statement.get(1)
+          let args = statement.slice(2)
+          let handler = statement.get(statement.length - 1)
+          let count = handler_param_count(handler)
+          let final_ctx = handler_has_final_ctx(handler)
+          let extraction_count =
+            if final_ctx:
+              count - 1
+            else:
+              count
+          let first = handler_param_name_at(handler, 0)
+          let second = handler_param_name_at(handler, 1)
+          let third = handler_param_name_at(handler, 2)
+          if count == 0:
+            `(route_unit $builder ($path).as_slice() $$args)
+          else:
+            if count == 1 and final_ctx:
+              `(route_context $builder ($path).as_slice() $$args)
+            else:
+              if extraction_count == 1:
+                if first == params:
+                  if final_ctx:
+                    `(route_params_context $builder ($path).as_slice() $$args)
+                  else:
+                    `(route_params $builder ($path).as_slice() $$args)
+                else:
+                  if first == query:
+                    if final_ctx:
+                      `(route_query_context $builder ($path).as_slice() $$args)
+                    else:
+                      query_requires_context()
+                  else:
+                    if first == headers:
+                      if final_ctx:
+                        `(route_headers_context $builder ($path).as_slice() $$args)
+                      else:
+                        `(route_headers $builder ($path).as_slice() $$args)
+                    else:
+                      invalid_handler()
+              else:
+                if extraction_count == 2:
+                  if first == params and second == query:
+                    if final_ctx:
+                      `(route_params_query_context $builder ($path).as_slice() $$args)
+                    else:
+                      `(route_params_query $builder ($path).as_slice() $$args)
+                  else:
+                    if first == params and second == headers:
+                      if final_ctx:
+                        `(route_params_headers_context $builder ($path).as_slice() $$args)
+                      else:
+                        `(route_params_headers $builder ($path).as_slice() $$args)
+                    else:
+                      if first == query and second == headers:
+                        if final_ctx:
+                          `(route_query_headers_context $builder ($path).as_slice() $$args)
+                        else:
+                          `(route_query_headers $builder ($path).as_slice() $$args)
+                      else:
+                        invalid_handler()
+                else:
+                  if extraction_count == 3 and first == params and second == query and third == headers and final_ctx:
+                    `(route_params_query_headers_context $builder ($path).as_slice() $$args)
+                  else:
+                    if extraction_count == 3 and first == params and second == query and third == headers:
+                      `(route_params_query_headers $builder ($path).as_slice() $$args)
+                    else:
+                      invalid_handler()
+        let build_routes = (initial, route_statements) =>
+          route_statements.reduce(initial, (builder, statement) =>
+            if statement.calls(adopt):
+              let args = statement.slice(1)
+              `(adopt $builder $$args)
+            else:
+              if statement.calls(not_found) or statement.calls(method_not_allowed) or statement.calls(on_error) or statement.calls(on_rejection):
+                let args = statement.slice(1)
+                let name = statement.get(0)
+                `($name $builder $$args)
+              else:
+                if statement.calls(group):
+                  let prefix = statement.get(1)
+                  let group_routes_arg = statement.get(2)
+                  if is_list(group_routes_arg) and group_routes_arg.calls(:):
+                    let group_callback = group_routes_arg.get(2)
+                    if is_list(group_callback) and group_callback.calls(=>):
+                      let group_params = group_callback.get(1)
+                      if is_list(group_params) and group_params.length == 0:
+                        let group_body = group_callback.get(2)
+                        let group_statements = group_body.slice(1)
+                        `(group $builder ($prefix).as_slice() routes: (child: AppBuild) -> AppBuild =>
+                          $(build_routes(`(child), group_statements))
+                        )
+                      else:
+                        `(group $builder ($prefix).as_slice() $$((statement.slice(2))))
+                    else:
+                      `(group $builder ($prefix).as_slice() $$((statement.slice(2))))
+                  else:
+                    `(group $builder ($prefix).as_slice() $$((statement.slice(2))))
+                else:
+                  if statement.calls(get):
+                    lower_method_route(builder, statement, `(Method::Get {}))
+                  else:
+                    if statement.calls(post):
+                      lower_method_route(builder, statement, `(Method::Post {}))
+                    else:
+                      if statement.calls(put):
+                        lower_method_route(builder, statement, `(Method::Put {}))
+                      else:
+                        if statement.calls(patch):
+                          lower_method_route(builder, statement, `(Method::Patch {}))
+                        else:
+                          if statement.calls(delete):
+                            lower_method_route(builder, statement, `(Method::Delete {}))
+                          else:
+                            if statement.calls(route):
+                              let path = statement.get(1)
+                              let args = statement.slice(2)
+                              if args.length > 2:
+                                `(route $builder ($path).as_slice() $$args)
+                              else:
+                                lower_route(builder, statement)
+                            else:
+                              let name = statement.get(0)
+                              let path = statement.get(1)
+                              let args = statement.slice(2)
+                              `($name $builder ($path).as_slice() $$args)
+          )
+        let route_body = routes_callback.get(2)
+        let statements = route_body.slice(1)
+        let app_expr = build_routes(`(app()), statements)
+        `(serve_app($app_expr, $$serve_args))
+      else:
+        if is_list(first) and first.calls(:):
+          `(serve_build($$all_args))
+        else:
+          `(serve_app($$all_args))
+    else:
+      if is_list(first) and first.calls(:):
+        `(serve_build($$all_args))
+      else:
+        `(serve_app($$all_args))
+  else:
+    if is_list(first) and first.calls(:):
+      `(serve_build($$all_args))
+    else:
+      `(serve_app($$all_args))
+
+
+pub fn make_route(path: StringSlice, method: Method, handler: Handler): () -> Route
+  let route_path = canonical_route_path(path)
+  Route {
+    method: method,
+    path: route_path,
+    segments: parse_route_segments(route_path.as_slice()),
+    middleware: Array<Middleware>::init(),
+    handler: handler,
+    error_handler: (rejection: Rejection, ctx: Context) -> Response => default_rejection(rejection, ctx),
+    order: 0
+  }
+
+fn run_middleware(middleware: Array<Middleware>, index: i32, ctx: Context, handler: Handler): (open) -> Response
+  if index >= middleware.len():
+    return handler(ctx)
+  match(middleware.get(index))
+    Some<Middleware> { value }:
+      value(ctx, (next_ctx: Context) -> Response => run_middleware(middleware, index + 1, next_ctx, handler))
+    None:
+      handler(ctx)
+
+fn combine_middleware(outer: Array<Middleware>, inner: Array<Middleware>): () -> Array<Middleware>
+  let ~combined = outer.copied(inner.len())
+  var index = 0
+  while index < inner.len():
+    match(inner.get(index))
+      Some<Middleware> { value }:
+        combined.push(value)
+      None:
+        void
+    index = index + 1
+  combined
+
+fn default_not_found(ctx: Context) -> Response
+  ctx
+  Response::not_found().text("not found".as_slice())
+
+fn default_method_not_allowed(ctx: Context) -> Response
+  ctx
+  Response::method_not_allowed().text("method not allowed".as_slice())
+
+fn default_rejection(rejection: Rejection, ctx: Context) -> Response
+  ctx
+  Response::new(status: rejection.status).text(rejection.message)
+
+fn rejection_response(error: Rejection): () -> Response
+  Response::new(status: error.status).text(error.message)
+
+fn best_match(routes: Array<Route>, method: Method, path: StringSlice, policy: TrailingSlashPolicy): () -> Option<RouteMatch>
+  var best_score = -1
+  var best_order = 2147483647
+  var best: Option<RouteMatch> = None<RouteMatch> {}
+  var index = 0
+  while index < routes.len():
+    match(routes.get(index))
+      Some<Route> { value }:
+        if methods_equal(value.method, method):
+          match(match_route(value, path, policy))
+            Some<RouteMatch> { value: candidate }:
+              if candidate.score > best_score or (candidate.score == best_score and candidate.route.order < best_order):
+                best_score = candidate.score
+                best_order = candidate.route.order
+                best = Some<RouteMatch> { value: candidate }
+            None:
+              void
+      None:
+        void
+    index = index + 1
+  best
+
+fn path_matches_different_method(routes: Array<Route>, path: StringSlice, policy: TrailingSlashPolicy): () -> bool
+  var index = 0
+  while index < routes.len():
+    match(routes.get(index))
+      Some<Route> { value }:
+        match(match_route(value, path, policy))
+          Some<RouteMatch> { value }:
+            return true
+          None:
+            void
+      None:
+        void
+    index = index + 1
+  false
+
+fn match_route(route: Route, path: StringSlice, policy: TrailingSlashPolicy): () -> Option<RouteMatch>
+  let request_segments = split_path(path)
+  let route_segments = route_segments_for_policy(route, policy)
+  if request_segments.len() != route_segments.len():
+    return None {}
+  var params = RouteParams::empty()
+  var score = 0
+  var index = 0
+  while index < route_segments.len():
+    let route_segment = route_segments.at(index)
+    let request_segment = request_segments.at(index)
+    if route_segment.kind == 0:
+      if not route_segment.value.equals(request_segment):
+        return None {}
+      score = score + 10
+    else:
+      if request_segment.is_empty():
+        return None {}
+      params = params.append(
+        name: route_segment.value,
+        value: percent_decode(request_segment.as_slice(), plus_as_space: false)
+      )
+      score = score + 1
+    index = index + 1
+  Some<RouteMatch> { value: RouteMatch { route: route, params: params, score: score } }
+
+fn route_segments_for_policy(route: Route, policy: TrailingSlashPolicy): () -> Array<RouteSegment>
+  if policy.kind == 0:
+    return route.segments
+  parse_route_segments(normalized_request_path(route.path, policy).as_slice())
+
+fn parse_route_segments(path: StringSlice): () -> Array<RouteSegment>
+  let source = split_path(path)
+  let ~segments = Array<RouteSegment>::with_capacity(source.len())
+  var index = 0
+  while index < source.len():
+    let value = source.at(index)
+    if value.as_slice().starts_with(":".as_slice()):
+      segments.push(RouteSegment { kind: 1, value: value.slice(bytes: 1, len: value.byte_len() - 1).to_string() })
+    else:
+      segments.push(RouteSegment { kind: 0, value: value })
+    index = index + 1
+  segments
+
+fn split_path(path: StringSlice): () -> Array<String>
+  let source = path.split(on: 47, keep_empty: true)
+  let ~segments = Array<String>::with_capacity(source.len())
+  var index = 0
+  while index < source.len():
+    let value = source.at(index)
+    if index == 0 and path.starts_with("/".as_slice()) and value.is_empty():
+      void
+    else:
+      segments.push(value.to_string())
+    index = index + 1
+  segments
+
+fn methods_equal(left: Method, right: Method): () -> bool
+  http::method_as_string(left).equals(http::method_as_string(right))
+
+fn normalized_request_path(path: String, policy: TrailingSlashPolicy): () -> String
+  if policy.kind == 0:
+    return path
+  if path.byte_len() > 1 and path.as_slice().ends_with("/".as_slice()):
+    return path.slice(bytes: 0, len: path.byte_len() - 1).to_string()
+  path
+
+fn canonical_route_path(path: StringSlice): () -> String
+  if path.is_empty():
+    return "/".as_slice().to_string()
+  if path.starts_with("/".as_slice()):
+    path.to_string()
+  else:
+    "/".as_slice().to_string().concat(path)
+
+fn join_route_paths(prefix: StringSlice, path: StringSlice): () -> String
+  let left = canonical_prefix(prefix)
+  let right = canonical_route_path(path)
+  if left.equals("/"):
+    return right
+  if right.equals("/"):
+    return left
+  if left.as_slice().ends_with("/".as_slice()):
+    left.concat(right.slice(bytes: 1, len: right.byte_len() - 1))
+  else:
+    left.concat(right)
+
+fn canonical_prefix(prefix: StringSlice): () -> String
+  if prefix.is_empty():
+    return "/".as_slice().to_string()
+  canonical_route_path(prefix)

--- a/packages/web/src/routes.voyd
+++ b/packages/web/src/routes.voyd
@@ -1,0 +1,3759 @@
+//! Builder helper functions for apps assembled with `build_app`.
+
+use std::bytes::Bytes
+use std::http::{ Method, Response, Status }
+use std::json::JsonValue
+use std::optional::types::all
+use std::result::types::all
+use std::string::type::{ String, StringSlice }
+use super::extract::{
+  FromAuth,
+  FromBody,
+  JsonBody,
+  OptionalSession,
+  Rejection,
+  RequiredSession,
+  TextBody,
+  decode_json_value,
+  decode_params,
+  decode_query,
+  default_optional_session,
+  default_optional_session_as,
+  default_required_session,
+  default_required_session_as,
+  extract_headers,
+  extract_params,
+  extract_query,
+  json_body_value,
+  query_from,
+}
+use super::response::{ IntoResponse, json_value, to_response }
+use super::router::{ AppBuild, Context, ErrorHandler, Handler, Middleware }
+
+pub fn get_context(
+  app: AppBuild,
+  path: StringSlice,
+  handler: Handler
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: handler)
+
+pub fn get_context(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(Context) : (open) -> String
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    to_response(handler(ctx))
+  )
+
+pub fn get_context(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(Context) : (open) -> StringSlice
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    to_response(handler(ctx))
+  )
+
+pub fn get_context(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(Context) : (open) -> Bytes
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    to_response(handler(ctx))
+  )
+
+pub fn get_context(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(Context) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    json_value(handler(ctx))
+  )
+
+pub fn get_context(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(Context) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    to_response(handler(ctx))
+  )
+
+pub fn get_context(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(Context) : (open) -> (Status, StringSlice)
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    to_response(handler(ctx))
+  )
+
+pub fn get_context(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(Context) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    to_response(handler(ctx))
+  )
+
+pub fn get_context(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(Context) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    to_response(handler(ctx))
+  )
+
+pub fn get_context<T: IntoResponse<T>, E: IntoResponse<E>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(Context) : (open) -> Result<T, E>
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    to_response<T, E>(handler(ctx))
+  )
+
+pub fn get_context<T: IntoResponse<T>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(Context) : (open) -> Option<T>
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(handler(ctx))
+      Some<T> { value }:
+        to_response<T>(value)
+      None:
+        Response::not_found().empty()
+  )
+
+pub fn get_unit(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn() : (open) -> Response
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (_ctx: Context) -> Response =>
+    handler()
+  )
+
+pub fn get_unit<R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn() : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (_ctx: Context) -> Response =>
+    to_response<R>(handler())
+  )
+
+pub fn get<P>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P) : (open) -> Response
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        handler(value)
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn get<P>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        json_value(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn get<P>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P) : (open) -> String
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn get<P>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P) : (open) -> StringSlice
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn get<P>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P) : (open) -> Bytes
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn get<P>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn get<P>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn get<P>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn get<P, T: IntoResponse<T>, E: IntoResponse<E>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P) : (open) -> Result<T, E>
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response<T, E>(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn get<P, T: IntoResponse<T>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P) : (open) -> Option<T>
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        match(handler(value))
+          Some<T> { value }:
+            to_response<T>(value)
+          None:
+            Response::not_found().empty()
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn get_params_query<P, Q>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P, Q) : (open) -> Response
+) -> AppBuild
+  app.get_params_query<P, Q>(path, handler: handler)
+
+pub fn get<S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { auth: A },
+  handler: fn(S) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(auth.extract_auth(ctx.request))
+      Ok<S> { value }:
+        to_response<R>(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn get<S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { auth: A },
+  handler: fn(S, Context) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(auth.extract_auth(ctx.request))
+      Ok<S> { value }:
+        to_response<R>(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn get<S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { auth: RequiredSession },
+  handler: fn(S) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(default_required_session_as<S>(ctx.request))
+      Ok<S> { value }:
+        to_response<R>(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn get<S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { auth: RequiredSession },
+  handler: fn(S, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(default_required_session_as<S>(ctx.request))
+      Ok<S> { value }:
+        to_response<R>(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn get<S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { auth: OptionalSession },
+  handler: fn(Option<S>) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(default_optional_session_as<S>(ctx.request))
+      Ok<Option<S>> { value }:
+        to_response<R>(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn get<S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { auth: OptionalSession },
+  handler: fn(Option<S>, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Get {}, handler: (ctx: Context) -> Response =>
+    match(default_optional_session_as<S>(ctx.request))
+      Ok<Option<S>> { value }:
+        to_response<R>(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn post_unit<R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn() : (open) -> R
+) -> AppBuild
+  route_unit(app, path, method: Method::Post {}, handler)
+
+pub fn put_context<R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(Context) : (open) -> R
+) -> AppBuild
+  route_context(app, path, method: Method::Put {}, handler)
+
+pub fn put_unit<R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn() : (open) -> R
+) -> AppBuild
+  route_unit(app, path, method: Method::Put {}, handler)
+
+pub fn put<P, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P) : (open) -> R
+) -> AppBuild
+  route_params(app, path, method: Method::Put {}, handler)
+
+pub fn put_params_query<P, Q>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P, Q) : (open) -> Response
+) -> AppBuild
+  app.put_params_query<P, Q>(path, handler: handler)
+
+pub fn put<I>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody },
+  handler: fn(I) : (open) -> Response
+) -> AppBuild
+  app.route_context(path, method: Method::Put {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Ok<JsonValue> { value }:
+        handler(decode_json_value<I>(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn put<I>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, handler: fn(I) : (open) -> Response }
+) -> AppBuild
+  put(app, path, body: body, handler)
+
+pub fn put<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P },
+  handler: fn(I) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, handler)
+
+pub fn put<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P },
+  handler: fn(I, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, handler)
+
+pub fn put<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody },
+  handler: fn(I) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, handler)
+
+pub fn put<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody },
+  handler: fn(I, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, handler)
+
+pub fn put<I, P: FromBody<I>, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: A },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, auth: auth, handler)
+
+pub fn put<I, P: FromBody<I>, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: A },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, auth: auth, handler)
+
+pub fn put<I, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: A },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, auth: auth, handler)
+
+pub fn put<I, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: A },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, auth: auth, handler)
+
+pub fn put<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: RequiredSession },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, auth: auth, handler)
+
+pub fn put<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: RequiredSession },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, auth: auth, handler)
+
+pub fn put<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: RequiredSession },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, auth: auth, handler)
+
+pub fn put<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: RequiredSession },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, auth: auth, handler)
+
+pub fn put<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: OptionalSession },
+  handler: fn(I, Option<S>) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, auth: auth, handler)
+
+pub fn put<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: OptionalSession },
+  handler: fn(I, Option<S>, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, auth: auth, handler)
+
+pub fn put<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: OptionalSession },
+  handler: fn(I, Option<S>) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, auth: auth, handler)
+
+pub fn put<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: OptionalSession },
+  handler: fn(I, Option<S>, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Put {}, body: body, auth: auth, handler)
+
+pub fn patch_context<R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(Context) : (open) -> R
+) -> AppBuild
+  route_context(app, path, method: Method::Patch {}, handler)
+
+pub fn patch_unit<R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn() : (open) -> R
+) -> AppBuild
+  route_unit(app, path, method: Method::Patch {}, handler)
+
+pub fn patch<P, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P) : (open) -> R
+) -> AppBuild
+  route_params(app, path, method: Method::Patch {}, handler)
+
+pub fn patch_params_query<P, Q>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P, Q) : (open) -> Response
+) -> AppBuild
+  app.patch_params_query<P, Q>(path, handler: handler)
+
+pub fn patch(
+  app: AppBuild,
+  path: StringSlice,
+  { body: TextBody, auth: RequiredSession },
+  handler: fn(String, String) : (open) -> Response
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Patch {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<String> { value: input }:
+        match(default_required_session(ctx.request))
+          Ok<String> { value: session }:
+            handler(input, session)
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn patch(
+  app: AppBuild,
+  path: StringSlice,
+  { body: TextBody, auth: RequiredSession, handler: fn(String, String) : (open) -> Response }
+) -> AppBuild
+  patch(app, path, body: body, auth: auth, handler)
+
+pub fn patch<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P },
+  handler: fn(I) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, handler)
+
+pub fn patch<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P },
+  handler: fn(I, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, handler)
+
+pub fn patch<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody },
+  handler: fn(I) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, handler)
+
+pub fn patch<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody },
+  handler: fn(I, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, handler)
+
+pub fn patch<I, P: FromBody<I>, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: A },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, auth: auth, handler)
+
+pub fn patch<I, P: FromBody<I>, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: A },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, auth: auth, handler)
+
+pub fn patch<I, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: A },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, auth: auth, handler)
+
+pub fn patch<I, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: A },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, auth: auth, handler)
+
+pub fn patch<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: RequiredSession },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, auth: auth, handler)
+
+pub fn patch<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: RequiredSession },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, auth: auth, handler)
+
+pub fn patch<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: RequiredSession },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, auth: auth, handler)
+
+pub fn patch<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: RequiredSession },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, auth: auth, handler)
+
+pub fn patch<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: OptionalSession },
+  handler: fn(I, Option<S>) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, auth: auth, handler)
+
+pub fn patch<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: OptionalSession },
+  handler: fn(I, Option<S>, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, auth: auth, handler)
+
+pub fn patch<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: OptionalSession },
+  handler: fn(I, Option<S>) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, auth: auth, handler)
+
+pub fn patch<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: OptionalSession },
+  handler: fn(I, Option<S>, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Patch {}, body: body, auth: auth, handler)
+
+pub fn delete_context<R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(Context) : (open) -> R
+) -> AppBuild
+  route_context(app, path, method: Method::Delete {}, handler)
+
+pub fn delete_unit<R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn() : (open) -> R
+) -> AppBuild
+  route_unit(app, path, method: Method::Delete {}, handler)
+
+pub fn delete<P, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P) : (open) -> R
+) -> AppBuild
+  route_params(app, path, method: Method::Delete {}, handler)
+
+pub fn delete_params_query<P, Q>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P, Q) : (open) -> Response
+) -> AppBuild
+  app.delete_params_query<P, Q>(path, handler: handler)
+
+pub fn delete(
+  app: AppBuild,
+  path: StringSlice,
+  { body: TextBody },
+  handler: fn(String) : (open) -> Response
+) -> AppBuild
+  app.route_context(path, method: Method::Delete {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Ok<String> { value }:
+        handler(value)
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn delete(
+  app: AppBuild,
+  path: StringSlice,
+  { body: TextBody, handler: fn(String) : (open) -> Response }
+) -> AppBuild
+  delete(app, path, body: body, handler)
+
+pub fn delete<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P },
+  handler: fn(I) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, handler)
+
+pub fn delete<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P },
+  handler: fn(I, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, handler)
+
+pub fn delete<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody },
+  handler: fn(I) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, handler)
+
+pub fn delete<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody },
+  handler: fn(I, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, handler)
+
+pub fn delete<I, P: FromBody<I>, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: A },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, auth: auth, handler)
+
+pub fn delete<I, P: FromBody<I>, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: A },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, auth: auth, handler)
+
+pub fn delete<I, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: A },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, auth: auth, handler)
+
+pub fn delete<I, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: A },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, auth: auth, handler)
+
+pub fn delete<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: RequiredSession },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, auth: auth, handler)
+
+pub fn delete<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: RequiredSession },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, auth: auth, handler)
+
+pub fn delete<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: RequiredSession },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, auth: auth, handler)
+
+pub fn delete<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: RequiredSession },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, auth: auth, handler)
+
+pub fn delete<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: OptionalSession },
+  handler: fn(I, Option<S>) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, auth: auth, handler)
+
+pub fn delete<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: OptionalSession },
+  handler: fn(I, Option<S>, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, auth: auth, handler)
+
+pub fn delete<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: OptionalSession },
+  handler: fn(I, Option<S>) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, auth: auth, handler)
+
+pub fn delete<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: OptionalSession },
+  handler: fn(I, Option<S>, Context) : (open) -> R
+) -> AppBuild
+  route(app, path, method: Method::Delete {}, body: body, auth: auth, handler)
+
+pub fn post_context<R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(Context) : (open) -> R
+) -> AppBuild
+  route_context(app, path, method: Method::Post {}, handler)
+
+pub fn post<P, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P) : (open) -> R
+) -> AppBuild
+  route_params(app, path, method: Method::Post {}, handler)
+
+pub fn post_params_query<P, Q>(
+  app: AppBuild,
+  path: StringSlice,
+  handler: fn(P, Q) : (open) -> Response
+) -> AppBuild
+  app.post_params_query<P, Q>(path, handler: handler)
+
+pub fn post<I, P: FromBody<I>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P },
+  handler: fn(I) : (open) -> Response
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Ok<I> { value }:
+        handler(value)
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P },
+  handler: fn(I) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Ok<I> { value }:
+        to_response<R>(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P },
+  handler: fn(I, Context) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Ok<I> { value }:
+        to_response<R>(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, handler: fn(I) : (open) -> Response }
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Ok<I> { value }:
+        handler(value)
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, handler: fn(I) : (open) -> R }
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Ok<I> { value }:
+        to_response<R>(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn post<I>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody },
+  handler: fn(I) : (open) -> Response
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Ok<JsonValue> { value }:
+        handler(decode_json_value<I>(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn post<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody },
+  handler: fn(I) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Ok<JsonValue> { value }:
+        to_response<R>(handler(decode_json_value<I>(value)))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn post<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody },
+  handler: fn(I, Context) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Ok<JsonValue> { value }:
+        to_response<R>(handler(decode_json_value<I>(value), ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn post<I>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, handler: fn(I) : (open) -> Response }
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Ok<JsonValue> { value }:
+        handler(decode_json_value<I>(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn post<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, handler: fn(I) : (open) -> R }
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Ok<JsonValue> { value }:
+        to_response<R>(handler(decode_json_value<I>(value)))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: RequiredSession },
+  handler: fn(I, String) : (open) -> Response
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(default_required_session(ctx.request))
+          Ok<String> { value: session }:
+            handler(input, session)
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: RequiredSession },
+  handler: fn(I, String) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(default_required_session(ctx.request))
+          Ok<String> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: RequiredSession },
+  handler: fn(I, String, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(default_required_session(ctx.request))
+          Ok<String> { value: session }:
+            to_response<R>(handler(input, session, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: RequiredSession },
+  handler: fn(I, String) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<JsonValue> { value }:
+        let input = decode_json_value<I>(value)
+        match(default_required_session(ctx.request))
+          Ok<String> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: RequiredSession },
+  handler: fn(I, String, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<JsonValue> { value }:
+        let input = decode_json_value<I>(value)
+        match(default_required_session(ctx.request))
+          Ok<String> { value: session }:
+            to_response<R>(handler(input, session, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, S>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: RequiredSession },
+  handler: fn(I, S) : (open) -> Response
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(default_required_session_as<S>(ctx.request))
+          Ok<S> { value: session }:
+            handler(input, session)
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: RequiredSession },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(default_required_session_as<S>(ctx.request))
+          Ok<S> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: RequiredSession },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(default_required_session_as<S>(ctx.request))
+          Ok<S> { value: session }:
+            to_response<R>(handler(input, session, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: RequiredSession },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<JsonValue> { value }:
+        let input = decode_json_value<I>(value)
+        match(default_required_session_as<S>(ctx.request))
+          Ok<S> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: RequiredSession },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<JsonValue> { value }:
+        let input = decode_json_value<I>(value)
+        match(default_required_session_as<S>(ctx.request))
+          Ok<S> { value: session }:
+            to_response<R>(handler(input, session, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: OptionalSession },
+  handler: fn(I, Option<String>) : (open) -> Response
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(default_optional_session(ctx.request))
+          Ok<Option<String>> { value: session }:
+            handler(input, session)
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: OptionalSession },
+  handler: fn(I, Option<String>) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(default_optional_session(ctx.request))
+          Ok<Option<String>> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: OptionalSession },
+  handler: fn(I, Option<String>, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(default_optional_session(ctx.request))
+          Ok<Option<String>> { value: session }:
+            to_response<R>(handler(input, session, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: OptionalSession },
+  handler: fn(I, Option<String>) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<JsonValue> { value }:
+        let input = decode_json_value<I>(value)
+        match(default_optional_session(ctx.request))
+          Ok<Option<String>> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: OptionalSession },
+  handler: fn(I, Option<String>, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<JsonValue> { value }:
+        let input = decode_json_value<I>(value)
+        match(default_optional_session(ctx.request))
+          Ok<Option<String>> { value: session }:
+            to_response<R>(handler(input, session, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: OptionalSession },
+  handler: fn(I, Option<S>) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(default_optional_session_as<S>(ctx.request))
+          Ok<Option<S>> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: OptionalSession },
+  handler: fn(I, Option<S>, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(default_optional_session_as<S>(ctx.request))
+          Ok<Option<S>> { value: session }:
+            to_response<R>(handler(input, session, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: OptionalSession },
+  handler: fn(I, Option<S>) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<JsonValue> { value }:
+        let input = decode_json_value<I>(value)
+        match(default_optional_session_as<S>(ctx.request))
+          Ok<Option<S>> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: OptionalSession },
+  handler: fn(I, Option<S>, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<JsonValue> { value }:
+        let input = decode_json_value<I>(value)
+        match(default_optional_session_as<S>(ctx.request))
+          Ok<Option<S>> { value: session }:
+            to_response<R>(handler(input, session, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, S, A: FromAuth<S>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: A },
+  handler: fn(I, S) : (open) -> Response
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(auth.extract_auth(ctx.request))
+          Ok<S> { value: session }:
+            handler(input, session)
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: A },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(auth.extract_auth(ctx.request))
+          Ok<S> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: A },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(auth.extract_auth(ctx.request))
+          Ok<S> { value: session }:
+            to_response<R>(handler(input, session, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: A },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<JsonValue> { value }:
+        let input = decode_json_value<I>(value)
+        match(auth.extract_auth(ctx.request))
+          Ok<S> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: A },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<JsonValue> { value }:
+        let input = decode_json_value<I>(value)
+        match(auth.extract_auth(ctx.request))
+          Ok<S> { value: session }:
+            to_response<R>(handler(input, session, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, S, A: FromAuth<S>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: A, handler: fn(I, S) : (open) -> Response }
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(auth.extract_auth(ctx.request))
+          Ok<S> { value: session }:
+            handler(input, session)
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, P: FromBody<I>, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: P, auth: A, handler: fn(I, S) : (open) -> R }
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(auth.extract_auth(ctx.request))
+          Ok<S> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn post<I, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { body: JsonBody, auth: A, handler: fn(I, S) : (open) -> R }
+) -> AppBuild
+  app.route_context(path, method: Method::Post {}, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<JsonValue> { value }:
+        let input = decode_json_value<I>(value)
+        match(auth.extract_auth(ctx.request))
+          Ok<S> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: TextBody },
+  handler: fn(String) : (open) -> Response
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Ok<String> { value }:
+        handler(value)
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: TextBody, handler: fn(String) : (open) -> Response }
+) -> AppBuild
+  route(app, path, method: method, body: body, handler)
+
+pub fn route<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P },
+  handler: fn(I) : (open) -> R
+) -> AppBuild
+  app.route<I, P, R>(path, method: method, body: body, handler: handler)
+
+pub fn route<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P },
+  handler: fn(I, Context) : (open) -> R
+) -> AppBuild
+  app.route<I, P, R>(path, method: method, body: body, handler: handler)
+
+pub fn route<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P, handler: fn(I) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, handler)
+
+pub fn route<I, P: FromBody<I>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P, handler: fn(I, Context) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, handler)
+
+pub fn route<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody },
+  handler: fn(I) : (open) -> R
+) -> AppBuild
+  app.route<I, R>(path, method: method, body: body, handler: handler)
+
+pub fn route<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody },
+  handler: fn(I, Context) : (open) -> R
+) -> AppBuild
+  app.route<I, R>(path, method: method, body: body, handler: handler)
+
+pub fn route<I>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody },
+  handler: fn(I) : (open) -> Response
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Ok<JsonValue> { value }:
+        handler(decode_json_value<I>(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route<I>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody, handler: fn(I) : (open) -> Response }
+) -> AppBuild
+  route(app, path, method: method, body: body, handler)
+
+pub fn route<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody, handler: fn(I) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, handler)
+
+pub fn route<I, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody, handler: fn(I, Context) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, handler)
+
+pub fn route<I, P: FromBody<I>, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P, auth: A },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  app.route<I, P, S, A, R>(path, method: method, body: body, auth: auth, handler: handler)
+
+pub fn route<I, P: FromBody<I>, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P, auth: A },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  app.route<I, P, S, A, R>(path, method: method, body: body, auth: auth, handler: handler)
+
+pub fn route<I, P: FromBody<I>, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P, auth: A, handler: fn(I, S) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, auth: auth, handler)
+
+pub fn route<I, P: FromBody<I>, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P, auth: A, handler: fn(I, S, Context) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, auth: auth, handler)
+
+pub fn route<I, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody, auth: A },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  app.route<I, S, A, R>(path, method: method, body: body, auth: auth, handler: handler)
+
+pub fn route<I, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody, auth: A },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  app.route<I, S, A, R>(path, method: method, body: body, auth: auth, handler: handler)
+
+pub fn route<I, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody, auth: A, handler: fn(I, S) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, auth: auth, handler)
+
+pub fn route<I, S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody, auth: A, handler: fn(I, S, Context) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, auth: auth, handler)
+
+pub fn route<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P, auth: RequiredSession },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(default_required_session_as<S>(ctx.request))
+          Ok<S> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P, auth: RequiredSession },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(default_required_session_as<S>(ctx.request))
+          Ok<S> { value: session }:
+            to_response<R>(handler(input, session, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P, auth: RequiredSession, handler: fn(I, S) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, auth: auth, handler)
+
+pub fn route<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P, auth: RequiredSession, handler: fn(I, S, Context) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, auth: auth, handler)
+
+pub fn route<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody, auth: RequiredSession },
+  handler: fn(I, S) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<JsonValue> { value }:
+        let input = decode_json_value<I>(value)
+        match(default_required_session_as<S>(ctx.request))
+          Ok<S> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody, auth: RequiredSession },
+  handler: fn(I, S, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<JsonValue> { value }:
+        let input = decode_json_value<I>(value)
+        match(default_required_session_as<S>(ctx.request))
+          Ok<S> { value: session }:
+            to_response<R>(handler(input, session, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody, auth: RequiredSession, handler: fn(I, S) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, auth: auth, handler)
+
+pub fn route<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody, auth: RequiredSession, handler: fn(I, S, Context) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, auth: auth, handler)
+
+pub fn route<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P, auth: OptionalSession },
+  handler: fn(I, Option<S>) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(default_optional_session_as<S>(ctx.request))
+          Ok<Option<S>> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P, auth: OptionalSession },
+  handler: fn(I, Option<S>, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(body.extract_body(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<I> { value: input }:
+        match(default_optional_session_as<S>(ctx.request))
+          Ok<Option<S>> { value: session }:
+            to_response<R>(handler(input, session, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P, auth: OptionalSession, handler: fn(I, Option<S>) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, auth: auth, handler)
+
+pub fn route<I, P: FromBody<I>, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: P, auth: OptionalSession, handler: fn(I, Option<S>, Context) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, auth: auth, handler)
+
+pub fn route<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody, auth: OptionalSession },
+  handler: fn(I, Option<S>) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<JsonValue> { value }:
+        let input = decode_json_value<I>(value)
+        match(default_optional_session_as<S>(ctx.request))
+          Ok<Option<S>> { value: session }:
+            to_response<R>(handler(input, session))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody, auth: OptionalSession },
+  handler: fn(I, Option<S>, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    body
+    match(json_body_value(ctx.request))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<JsonValue> { value }:
+        let input = decode_json_value<I>(value)
+        match(default_optional_session_as<S>(ctx.request))
+          Ok<Option<S>> { value: session }:
+            to_response<R>(handler(input, session, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody, auth: OptionalSession, handler: fn(I, Option<S>) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, auth: auth, handler)
+
+pub fn route<I, S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, body: JsonBody, auth: OptionalSession, handler: fn(I, Option<S>, Context) : (open) -> R }
+) -> AppBuild
+  route(app, path, method: method, body: body, auth: auth, handler)
+
+pub fn route<R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Context) : (open) -> R
+) -> AppBuild
+  route_context(app, path, method: method, handler)
+
+pub fn route_unit<R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn() : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (_ctx: Context) -> Response =>
+    to_response<R>(handler())
+  )
+
+pub fn route_unit(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn() : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: method, handler: (_ctx: Context) -> Response =>
+    json_value(handler())
+  )
+
+pub fn route_unit(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn() : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (_ctx: Context) -> Response =>
+    to_response(handler())
+  )
+
+pub fn route_unit(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn() : (open) -> (Status, StringSlice)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (_ctx: Context) -> Response =>
+    to_response(handler())
+  )
+
+pub fn route_unit(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn() : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (_ctx: Context) -> Response =>
+    to_response(handler())
+  )
+
+pub fn route_unit(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn() : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (_ctx: Context) -> Response =>
+    to_response(handler())
+  )
+
+pub fn route_unit<T: IntoResponse<T>, E: IntoResponse<E>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn() : (open) -> Result<T, E>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (_ctx: Context) -> Response =>
+    to_response<T, E>(handler())
+  )
+
+pub fn route_unit<T: IntoResponse<T>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn() : (open) -> Option<T>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (_ctx: Context) -> Response =>
+    match(handler())
+      Some<T> { value }:
+        to_response<T>(value)
+      None:
+        Response::not_found().empty()
+  )
+
+pub fn route_context<R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Context) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    to_response<R>(handler(ctx))
+  )
+
+pub fn route_context(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Context) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    json_value(handler(ctx))
+  )
+
+pub fn route_context(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Context) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    to_response(handler(ctx))
+  )
+
+pub fn route_context(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Context) : (open) -> (Status, StringSlice)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    to_response(handler(ctx))
+  )
+
+pub fn route_context(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Context) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    to_response(handler(ctx))
+  )
+
+pub fn route_context(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Context) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    to_response(handler(ctx))
+  )
+
+pub fn route_context<T: IntoResponse<T>, E: IntoResponse<E>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Context) : (open) -> Result<T, E>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    to_response<T, E>(handler(ctx))
+  )
+
+pub fn route_context<T: IntoResponse<T>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Context) : (open) -> Option<T>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(handler(ctx))
+      Some<T> { value }:
+        to_response<T>(value)
+      None:
+        Response::not_found().empty()
+  )
+
+pub fn route<S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, auth: A },
+  handler: fn(S) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(auth.extract_auth(ctx.request))
+      Ok<S> { value }:
+        to_response<R>(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route<S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, auth: A },
+  handler: fn(S, Context) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(auth.extract_auth(ctx.request))
+      Ok<S> { value }:
+        to_response<R>(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route<S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, auth: RequiredSession },
+  handler: fn(S) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(default_required_session_as<S>(ctx.request))
+      Ok<S> { value }:
+        to_response<R>(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route<S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, auth: RequiredSession },
+  handler: fn(S, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(default_required_session_as<S>(ctx.request))
+      Ok<S> { value }:
+        to_response<R>(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route<S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, auth: OptionalSession },
+  handler: fn(Option<S>) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(default_optional_session_as<S>(ctx.request))
+      Ok<Option<S>> { value }:
+        to_response<R>(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route<S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, auth: OptionalSession },
+  handler: fn(Option<S>, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(default_optional_session_as<S>(ctx.request))
+      Ok<Option<S>> { value }:
+        to_response<R>(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_auth<S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, auth: A },
+  handler: fn(S) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(auth.extract_auth(ctx.request))
+      Ok<S> { value }:
+        to_response<R>(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_auth<S, A: FromAuth<S>, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, auth: A },
+  handler: fn(S, Context) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(auth.extract_auth(ctx.request))
+      Ok<S> { value }:
+        to_response<R>(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_auth<S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, auth: RequiredSession },
+  handler: fn(S) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(default_required_session_as<S>(ctx.request))
+      Ok<S> { value }:
+        to_response<R>(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_auth<S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, auth: RequiredSession },
+  handler: fn(S, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(default_required_session_as<S>(ctx.request))
+      Ok<S> { value }:
+        to_response<R>(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_auth<S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, auth: OptionalSession },
+  handler: fn(Option<S>) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(default_optional_session_as<S>(ctx.request))
+      Ok<Option<S>> { value }:
+        to_response<R>(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_auth<S, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method, auth: OptionalSession },
+  handler: fn(Option<S>, Context) : (open) -> R
+) -> AppBuild
+  auth
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(default_optional_session_as<S>(ctx.request))
+      Ok<Option<S>> { value }:
+        to_response<R>(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_query_context<Q>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, Context) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(query_from(ctx.request)))
+      Ok<Q> { value }:
+        json_value(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_query_context<Q>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, Context) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(query_from(ctx.request)))
+      Ok<Q> { value }:
+        to_response(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_query_context<Q>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, Context) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(query_from(ctx.request)))
+      Ok<Q> { value }:
+        to_response(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_query_context<Q>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, Context) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(query_from(ctx.request)))
+      Ok<Q> { value }:
+        to_response(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_query_context<Q, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, Context) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(query_from(ctx.request)))
+      Ok<Q> { value }:
+        to_response<R>(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_query_context<Q, T: IntoResponse<T>, E: IntoResponse<E>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, Context) : (open) -> Result<T, E>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(query_from(ctx.request)))
+      Ok<Q> { value }:
+        to_response<T, E>(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_query_context<Q, T: IntoResponse<T>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, Context) : (open) -> Option<T>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(query_from(ctx.request)))
+      Ok<Q> { value }:
+        match(handler(value, ctx))
+          Some<T> { value }:
+            to_response<T>(value)
+          None:
+            Response::not_found().empty()
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_headers<H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(H) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_headers<H>(ctx.request.headers))
+      Ok<H> { value }:
+        json_value(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_headers<H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(H) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_headers<H>(ctx.request.headers))
+      Ok<H> { value }:
+        to_response(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_headers<H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(H) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_headers<H>(ctx.request.headers))
+      Ok<H> { value }:
+        to_response(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_headers<H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(H) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_headers<H>(ctx.request.headers))
+      Ok<H> { value }:
+        to_response(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_headers<H, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(H) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_headers<H>(ctx.request.headers))
+      Ok<H> { value }:
+        to_response<R>(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_headers_context<H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(H, Context) : (open) -> Response
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_headers<H>(ctx.request.headers))
+      Ok<H> { value }:
+        handler(value, ctx)
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_headers_context<H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(H, Context) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_headers<H>(ctx.request.headers))
+      Ok<H> { value }:
+        json_value(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_headers_context<H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(H, Context) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_headers<H>(ctx.request.headers))
+      Ok<H> { value }:
+        to_response(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_headers_context<H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(H, Context) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_headers<H>(ctx.request.headers))
+      Ok<H> { value }:
+        to_response(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_headers_context<H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(H, Context) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_headers<H>(ctx.request.headers))
+      Ok<H> { value }:
+        to_response(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_headers_context<H, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(H, Context) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_headers<H>(ctx.request.headers))
+      Ok<H> { value }:
+        to_response<R>(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_headers_context<H, T: IntoResponse<T>, E: IntoResponse<E>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(H, Context) : (open) -> Result<T, E>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_headers<H>(ctx.request.headers))
+      Ok<H> { value }:
+        to_response<T, E>(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_headers_context<H, T: IntoResponse<T>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(H, Context) : (open) -> Option<T>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_headers<H>(ctx.request.headers))
+      Ok<H> { value }:
+        match(handler(value, ctx))
+          Some<T> { value }:
+            to_response<T>(value)
+          None:
+            Response::not_found().empty()
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_params<P, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response<R>(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_params<P>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        json_value(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_params<P>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_params<P>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_params<P>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_params<P, T: IntoResponse<T>, E: IntoResponse<E>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P) : (open) -> Result<T, E>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response<T, E>(handler(value))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_params<P, T: IntoResponse<T>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P) : (open) -> Option<T>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        match(handler(value))
+          Some<T> { value }:
+            to_response<T>(value)
+          None:
+            Response::not_found().empty()
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_params_context<P>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Context) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        json_value(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_params_context<P>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Context) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_params_context<P>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Context) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_params_context<P>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Context) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_params_context<P, T: IntoResponse<T>, E: IntoResponse<E>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Context) : (open) -> Result<T, E>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response<T, E>(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_params_context<P, T: IntoResponse<T>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Context) : (open) -> Option<T>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        match(handler(value, ctx))
+          Some<T> { value }:
+            to_response<T>(value)
+          None:
+            Response::not_found().empty()
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_params_context<P, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Context) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Ok<P> { value }:
+        to_response(handler(value, ctx))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+  )
+
+pub fn route_params_query<P, Q, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    let params = decode_params<P>(ctx.route.params)
+    let query = decode_query<Q>(ctx.query())
+    to_response<R>(handler(params, query))
+  )
+
+pub fn route_params_query<P, Q>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    let params = decode_params<P>(ctx.route.params)
+    let query = decode_query<Q>(ctx.query())
+    json_value(handler(params, query))
+  )
+
+pub fn route_params_query<P, Q>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    let params = decode_params<P>(ctx.route.params)
+    let query = decode_query<Q>(ctx.query())
+    to_response(handler(params, query))
+  )
+
+pub fn route_params_query<P, Q>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    let params = decode_params<P>(ctx.route.params)
+    let query = decode_query<Q>(ctx.query())
+    to_response(handler(params, query))
+  )
+
+pub fn route_params_query<P, Q>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    let params = decode_params<P>(ctx.route.params)
+    let query = decode_query<Q>(ctx.query())
+    to_response(handler(params, query))
+  )
+
+pub fn route_params_query<P, Q, T: IntoResponse<T>, E: IntoResponse<E>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q) : (open) -> Result<T, E>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    let params = decode_params<P>(ctx.route.params)
+    let query = decode_query<Q>(ctx.query())
+    to_response<T, E>(handler(params, query))
+  )
+
+pub fn route_params_query<P, Q, T: IntoResponse<T>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q) : (open) -> Option<T>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    let params = decode_params<P>(ctx.route.params)
+    let query = decode_query<Q>(ctx.query())
+    match(handler(params, query))
+      Some<T> { value }:
+        to_response<T>(value)
+      None:
+        Response::not_found().empty()
+  )
+
+pub fn route_params_query_context<P, Q>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, Context) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    let params = decode_params<P>(ctx.route.params)
+    let query = decode_query<Q>(ctx.query())
+    json_value(handler(params, query, ctx))
+  )
+
+pub fn route_params_query_context<P, Q>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, Context) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    let params = decode_params<P>(ctx.route.params)
+    let query = decode_query<Q>(ctx.query())
+    to_response(handler(params, query, ctx))
+  )
+
+pub fn route_params_query_context<P, Q>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, Context) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    let params = decode_params<P>(ctx.route.params)
+    let query = decode_query<Q>(ctx.query())
+    to_response(handler(params, query, ctx))
+  )
+
+pub fn route_params_query_context<P, Q>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, Context) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    let params = decode_params<P>(ctx.route.params)
+    let query = decode_query<Q>(ctx.query())
+    to_response(handler(params, query, ctx))
+  )
+
+pub fn route_params_query_context<P, Q, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, Context) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    let params = decode_params<P>(ctx.route.params)
+    let query = decode_query<Q>(ctx.query())
+    to_response<R>(handler(params, query, ctx))
+  )
+
+pub fn route_params_query_context<P, Q, T: IntoResponse<T>, E: IntoResponse<E>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, Context) : (open) -> Result<T, E>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    let params = decode_params<P>(ctx.route.params)
+    let query = decode_query<Q>(ctx.query())
+    to_response<T, E>(handler(params, query, ctx))
+  )
+
+pub fn route_params_query_context<P, Q, T: IntoResponse<T>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, Context) : (open) -> Option<T>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    let params = decode_params<P>(ctx.route.params)
+    let query = decode_query<Q>(ctx.query())
+    match(handler(params, query, ctx))
+      Some<T> { value }:
+        to_response<T>(value)
+      None:
+        Response::not_found().empty()
+  )
+
+pub fn route_params_headers<P, H, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, H) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response<R>(handler(params, headers))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_params_headers<P, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, H) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            json_value(handler(params, headers))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_params_headers<P, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, H) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response(handler(params, headers))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_params_headers<P, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, H) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response(handler(params, headers))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_params_headers<P, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, H) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response(handler(params, headers))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_params_headers_context<P, H, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, H, Context) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response<R>(handler(params, headers, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_params_headers_context<P, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, H, Context) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            json_value(handler(params, headers, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_params_headers_context<P, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, H, Context) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response(handler(params, headers, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_params_headers_context<P, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, H, Context) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response(handler(params, headers, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_params_headers_context<P, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, H, Context) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response(handler(params, headers, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_params_headers_context<P, H, T: IntoResponse<T>, E: IntoResponse<E>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, H, Context) : (open) -> Result<T, E>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response<T, E>(handler(params, headers, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_params_headers_context<P, H, T: IntoResponse<T>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, H, Context) : (open) -> Option<T>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            match(handler(params, headers, ctx))
+              Some<T> { value }:
+                to_response<T>(value)
+              None:
+                Response::not_found().empty()
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_query_headers<Q, H, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, H) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(ctx.query()))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<Q> { value: query }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response<R>(handler(query, headers))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_query_headers<Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, H) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(ctx.query()))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<Q> { value: query }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            json_value(handler(query, headers))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_query_headers<Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, H) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(ctx.query()))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<Q> { value: query }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response(handler(query, headers))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_query_headers<Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, H) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(ctx.query()))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<Q> { value: query }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response(handler(query, headers))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_query_headers<Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, H) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(ctx.query()))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<Q> { value: query }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response(handler(query, headers))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_query_headers_context<Q, H, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, H, Context) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(ctx.query()))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<Q> { value: query }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response<R>(handler(query, headers, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_query_headers_context<Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, H, Context) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(ctx.query()))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<Q> { value: query }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            json_value(handler(query, headers, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_query_headers_context<Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, H, Context) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(ctx.query()))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<Q> { value: query }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response(handler(query, headers, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_query_headers_context<Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, H, Context) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(ctx.query()))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<Q> { value: query }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response(handler(query, headers, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_query_headers_context<Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, H, Context) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(ctx.query()))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<Q> { value: query }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response(handler(query, headers, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_query_headers_context<Q, H, T: IntoResponse<T>, E: IntoResponse<E>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, H, Context) : (open) -> Result<T, E>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(ctx.query()))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<Q> { value: query }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            to_response<T, E>(handler(query, headers, ctx))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_query_headers_context<Q, H, T: IntoResponse<T>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(Q, H, Context) : (open) -> Option<T>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_query<Q>(ctx.query()))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<Q> { value: query }:
+        match(extract_headers<H>(ctx.request.headers))
+          Ok<H> { value: headers }:
+            match(handler(query, headers, ctx))
+              Some<T> { value }:
+                to_response<T>(value)
+              None:
+                Response::not_found().empty()
+          Err<Rejection> { error }:
+            ctx.reject(error)
+  )
+
+pub fn route_params_query_headers<P, Q, H, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, H) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_query<Q>(ctx.query()))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+          Ok<Q> { value: query }:
+            match(extract_headers<H>(ctx.request.headers))
+              Ok<H> { value: headers }:
+                to_response<R>(handler(params, query, headers))
+              Err<Rejection> { error }:
+                ctx.reject(error)
+  )
+
+pub fn route_params_query_headers<P, Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, H) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_query<Q>(ctx.query()))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+          Ok<Q> { value: query }:
+            match(extract_headers<H>(ctx.request.headers))
+              Ok<H> { value: headers }:
+                json_value(handler(params, query, headers))
+              Err<Rejection> { error }:
+                ctx.reject(error)
+  )
+
+pub fn route_params_query_headers<P, Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, H) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_query<Q>(ctx.query()))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+          Ok<Q> { value: query }:
+            match(extract_headers<H>(ctx.request.headers))
+              Ok<H> { value: headers }:
+                to_response(handler(params, query, headers))
+              Err<Rejection> { error }:
+                ctx.reject(error)
+  )
+
+pub fn route_params_query_headers<P, Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, H) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_query<Q>(ctx.query()))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+          Ok<Q> { value: query }:
+            match(extract_headers<H>(ctx.request.headers))
+              Ok<H> { value: headers }:
+                to_response(handler(params, query, headers))
+              Err<Rejection> { error }:
+                ctx.reject(error)
+  )
+
+pub fn route_params_query_headers<P, Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, H) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_query<Q>(ctx.query()))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+          Ok<Q> { value: query }:
+            match(extract_headers<H>(ctx.request.headers))
+              Ok<H> { value: headers }:
+                to_response(handler(params, query, headers))
+              Err<Rejection> { error }:
+                ctx.reject(error)
+  )
+
+pub fn route_params_query_headers_context<P, Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, H, Context) : (open) -> Response
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_query<Q>(ctx.query()))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+          Ok<Q> { value: query }:
+            match(extract_headers<H>(ctx.request.headers))
+              Ok<H> { value: headers }:
+                handler(params, query, headers, ctx)
+              Err<Rejection> { error }:
+                ctx.reject(error)
+  )
+
+pub fn route_params_query_headers_context<P, Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, H, Context) : (open) -> JsonValue
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_query<Q>(ctx.query()))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+          Ok<Q> { value: query }:
+            match(extract_headers<H>(ctx.request.headers))
+              Ok<H> { value: headers }:
+                json_value(handler(params, query, headers, ctx))
+              Err<Rejection> { error }:
+                ctx.reject(error)
+  )
+
+pub fn route_params_query_headers_context<P, Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, H, Context) : (open) -> (Status, String)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_query<Q>(ctx.query()))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+          Ok<Q> { value: query }:
+            match(extract_headers<H>(ctx.request.headers))
+              Ok<H> { value: headers }:
+                to_response(handler(params, query, headers, ctx))
+              Err<Rejection> { error }:
+                ctx.reject(error)
+  )
+
+pub fn route_params_query_headers_context<P, Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, H, Context) : (open) -> (Status, Bytes)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_query<Q>(ctx.query()))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+          Ok<Q> { value: query }:
+            match(extract_headers<H>(ctx.request.headers))
+              Ok<H> { value: headers }:
+                to_response(handler(params, query, headers, ctx))
+              Err<Rejection> { error }:
+                ctx.reject(error)
+  )
+
+pub fn route_params_query_headers_context<P, Q, H>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, H, Context) : (open) -> (Status, JsonValue)
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_query<Q>(ctx.query()))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+          Ok<Q> { value: query }:
+            match(extract_headers<H>(ctx.request.headers))
+              Ok<H> { value: headers }:
+                to_response(handler(params, query, headers, ctx))
+              Err<Rejection> { error }:
+                ctx.reject(error)
+  )
+
+pub fn route_params_query_headers_context<P, Q, H, R: IntoResponse<R>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, H, Context) : (open) -> R
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_query<Q>(ctx.query()))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+          Ok<Q> { value: query }:
+            match(extract_headers<H>(ctx.request.headers))
+              Ok<H> { value: headers }:
+                to_response<R>(handler(params, query, headers, ctx))
+              Err<Rejection> { error }:
+                ctx.reject(error)
+  )
+
+pub fn route_params_query_headers_context<P, Q, H, T: IntoResponse<T>, E: IntoResponse<E>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, H, Context) : (open) -> Result<T, E>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_query<Q>(ctx.query()))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+          Ok<Q> { value: query }:
+            match(extract_headers<H>(ctx.request.headers))
+              Ok<H> { value: headers }:
+                to_response<T, E>(handler(params, query, headers, ctx))
+              Err<Rejection> { error }:
+                ctx.reject(error)
+  )
+
+pub fn route_params_query_headers_context<P, Q, H, T: IntoResponse<T>>(
+  app: AppBuild,
+  path: StringSlice,
+  { method: Method },
+  handler: fn(P, Q, H, Context) : (open) -> Option<T>
+) -> AppBuild
+  app.route_context(path, method: method, handler: (ctx: Context) -> Response =>
+    match(extract_params<P>(ctx.route.params))
+      Err<Rejection> { error }:
+        ctx.reject(error)
+      Ok<P> { value: params }:
+        match(extract_query<Q>(ctx.query()))
+          Err<Rejection> { error }:
+            ctx.reject(error)
+          Ok<Q> { value: query }:
+            match(extract_headers<H>(ctx.request.headers))
+              Ok<H> { value: headers }:
+                match(handler(params, query, headers, ctx))
+                  Some<T> { value }:
+                    to_response<T>(value)
+                  None:
+                    Response::not_found().empty()
+              Err<Rejection> { error }:
+                ctx.reject(error)
+  )
+
+pub fn adopt(app: AppBuild, middleware: Middleware) -> AppBuild
+  app.adopt(middleware)
+
+pub fn group(app: AppBuild, prefix: StringSlice, { routes build: fn(AppBuild) : (open) -> AppBuild }) -> AppBuild
+  app.group(prefix, routes: build)
+
+pub fn not_found(app: AppBuild, handler: Handler) -> AppBuild
+  app.not_found(handler)
+
+pub fn method_not_allowed(app: AppBuild, handler: Handler) -> AppBuild
+  app.method_not_allowed(handler)
+
+pub fn on_error(app: AppBuild, handler: ErrorHandler) -> AppBuild
+  app.on_error(handler)
+
+pub fn on_rejection(app: AppBuild, handler: ErrorHandler) -> AppBuild
+  app.on_rejection(handler)
+
+fn rejection_response(error: Rejection): () -> Response
+  Response::new(status: error.status).text(error.message)

--- a/packages/web/src/static_files.voyd
+++ b/packages/web/src/static_files.voyd
@@ -1,0 +1,72 @@
+//! Static file middleware.
+
+use std::error::IoError
+use std::fs::{ exists as path_exists, read_bytes as read_file_bytes }
+use std::bytes::Bytes
+use std::http::{ Method, Response, method_as_string }
+use std::optional::types::all
+use std::path::Path
+use std::result::types::all
+use std::string::type::{ String, StringSlice }
+use super::router::{ Context, Middleware, Next }
+
+pub fn serve_dir(root: StringSlice) -> Middleware
+  serve_dir(Path::new(root))
+
+pub fn serve_dir(root: String) -> Middleware
+  serve_dir(root.as_slice())
+
+pub fn serve_dir(root: Path) -> Middleware
+  (ctx: Context, next: Next) -> Response =>
+    if not is_get_or_head(ctx.method()):
+      return next(ctx)
+
+    let request_path = clean_request_path(ctx.path())
+    if request_path.contains("..".as_slice()):
+      return Response::forbidden().text("forbidden".as_slice())
+
+    let path = root.join(request_path.as_slice())
+    if not path_exists(path):
+      return next(ctx)
+
+    match(read_file_bytes(path))
+      Ok<Bytes> { value }:
+        let response = Response::ok()
+          .with(header: "content-type".as_slice(), value: content_type(request_path).as_slice())
+        if is_head(ctx.method()) then: response.empty() else: response.bytes(value)
+      Err<IoError>:
+        next(ctx)
+
+fn is_get_or_head(method: Method): () -> bool
+  let name = method_as_string(method)
+  name.equals("GET") or name.equals("HEAD")
+
+fn is_head(method: Method): () -> bool
+  method_as_string(method).equals("HEAD")
+
+fn clean_request_path(path: String): () -> String
+  var start = 0
+  while start < path.byte_len() and path.slice(bytes: start, len: 1).starts_with("/".as_slice()):
+    start = start + 1
+  let len = path.byte_len() - start
+  if len <= 0:
+    return "index.html".as_slice().to_string()
+  let trimmed = path.slice(bytes: start, len: len).to_string()
+  if trimmed.is_empty() then: "index.html".as_slice().to_string() else: trimmed
+
+fn content_type(path: String): () -> String
+  if path.as_slice().ends_with(".html".as_slice()):
+    return "text/html; charset=utf-8".as_slice().to_string()
+  if path.as_slice().ends_with(".css".as_slice()):
+    return "text/css; charset=utf-8".as_slice().to_string()
+  if path.as_slice().ends_with(".js".as_slice()):
+    return "text/javascript; charset=utf-8".as_slice().to_string()
+  if path.as_slice().ends_with(".json".as_slice()):
+    return "application/json".as_slice().to_string()
+  if path.as_slice().ends_with(".png".as_slice()):
+    return "image/png".as_slice().to_string()
+  if path.as_slice().ends_with(".jpg".as_slice()) or path.as_slice().ends_with(".jpeg".as_slice()):
+    return "image/jpeg".as_slice().to_string()
+  if path.as_slice().ends_with(".svg".as_slice()):
+    return "image/svg+xml".as_slice().to_string()
+  "application/octet-stream".as_slice().to_string()

--- a/packages/web/src/web.test.voyd
+++ b/packages/web/src/web.test.voyd
@@ -1,0 +1,1013 @@
+use src::router::{
+  AppBuild,
+  Context,
+  Next,
+  app,
+  build_app,
+  ignore_trailing_slash,
+  Router
+}
+use src::routes::{
+  get,
+  get_context,
+  get_params_query,
+  method_not_allowed,
+  on_rejection,
+  post,
+  route_auth,
+  route_params,
+  route_params_context,
+  route_headers_context,
+  route_params_query_headers_context,
+  route_query_context
+}
+use src::extract::{
+  extract_query,
+  parse_query,
+  QueryParams,
+  Rejection,
+  json as json_body_policy,
+  optional_session,
+  RouteParams,
+  required_session,
+  text as text_body_policy
+}
+use src::html::{ html, render }
+use src::response::{ json as json_response, response_json, to_response }
+use src::static_files::serve_dir
+use std::error::IoError
+use std::fs::write_string
+use std::http::{ Body, Headers, IncomingRequest, Method, QueryString, Response, Status }
+use std::json::{ JsonBool, JsonValue }
+use std::msgpack::MsgPack
+use std::optional::types::all
+use std::path::Path
+use std::result::types::all
+use std::string::type::String
+use std::test::assertions::all
+use std::vx::all
+
+@effect(id: "voyd.web.test.log")
+eff WebTestLog
+  info(resume, value: i32) -> void
+
+fn request(method: Method, path: String) -> IncomingRequest
+  IncomingRequest {
+    method: method,
+    path: path,
+    query: None {},
+    headers: Headers::empty(),
+    body: Body::empty()
+  }
+
+fn request_with_query(method: Method, path: String, query: String) -> IncomingRequest
+  IncomingRequest {
+    method: method,
+    path: path,
+    query: Some<QueryString> { value: QueryString { raw: query } },
+    headers: Headers::empty(),
+    body: Body::empty()
+  }
+
+fn request_with_body(method: Method, path: String, body: Body) -> IncomingRequest
+  IncomingRequest {
+    method: method,
+    path: path,
+    query: None {},
+    headers: Headers::empty(),
+    body: body
+  }
+
+fn request_with_headers_and_body(method: Method, path: String, headers: Headers, body: Body) -> IncomingRequest
+  IncomingRequest {
+    method: method,
+    path: path,
+    query: None {},
+    headers: headers,
+    body: body
+  }
+
+fn request_with_query_and_headers(method: Method, path: String, query: String, headers: Headers) -> IncomingRequest
+  IncomingRequest {
+    method: method,
+    path: path,
+    query: Some<QueryString> { value: QueryString { raw: query } },
+    headers: headers,
+    body: Body::empty()
+  }
+
+fn response_text(response: Response) -> String
+  match(response.text())
+    Ok<String> { value }:
+      value
+    Err:
+      "error".as_slice().to_string()
+
+fn append_header(ctx: Context, next: Next) -> Response
+  next(ctx).with(header: "x-web-test".as_slice(), value: "seen".as_slice())
+
+fn append_child_header(ctx: Context, next: Next) -> Response
+  next(ctx).with(header: "x-child-test".as_slice(), value: "seen".as_slice())
+
+fn custom_rejection(error: Rejection, ctx: Context) -> Response
+  ctx
+  Response::new(status: error.status)
+    .with(header: "x-error".as_slice(), value: "custom".as_slice())
+    .text(error.message)
+
+obj TestSession {
+  api user: String
+}
+
+type TestUserParams = {
+  id: String
+}
+
+type TestUserQuery = {
+  verbose: bool
+}
+
+type TestStringQuery = {
+  q: String
+}
+
+type TestCreateUser = {
+  name: String,
+  active: bool
+}
+
+type TestCreateCount = {
+  count: i32
+}
+
+type TestHeaders = {
+  authorization: String
+}
+
+fn extract_test_session(request: IncomingRequest) -> Result<TestSession, Rejection>
+  match(request.header("authorization".as_slice()))
+    Some<String> { value }:
+      Ok<TestSession> { value: TestSession { user: value } }
+    None:
+      Err<Rejection> { error: Rejection::unauthorized("missing auth".as_slice()) }
+
+fn auth_label(session: Option<String>) -> String
+  match(session)
+    Some<String> { value }:
+      value
+    None:
+      "anonymous".as_slice().to_string()
+
+fn params_query_bool_app() -> AppBuild
+  build_app do(base):
+    get_params_query(base, "/users/:id".as_slice()) do(params: TestUserParams, query: TestUserQuery):
+      let verbose = if query.verbose then: "true".as_slice().to_string() else: "false".as_slice().to_string()
+      Response::ok().text(params.id.concat(":".as_slice()).concat(verbose))
+
+fn structural_dto_app() -> AppBuild
+  build_app do(base):
+    let with_search = route_query_context(base, "/search".as_slice(), method: Method::Get {}) do(query: TestUserQuery, _ctx: Context):
+      let verbose = if query.verbose then: "true".as_slice().to_string() else: "false".as_slice().to_string()
+      Response::ok().text(verbose)
+
+    let with_string_query = get_params_query(with_search, "/query-string/:id".as_slice()) do(_params: TestUserParams, query: TestStringQuery):
+      Response::ok().text(query.q)
+
+    let with_user = get_params_query(with_string_query, "/users/:id".as_slice()) do(params: TestUserParams, query: TestUserQuery):
+      let verbose = if query.verbose then: "true".as_slice().to_string() else: "false".as_slice().to_string()
+      Response::ok().text(params.id.concat(":".as_slice()).concat(verbose))
+
+    let with_created = post(with_user, "/users".as_slice(), body: json_body_policy()) do(input: TestCreateUser):
+      let active = if input.active then: "active".as_slice().to_string() else: "inactive".as_slice().to_string()
+      Response::ok().text(input.name.concat(":".as_slice()).concat(active))
+
+    let with_context = post(with_created, "/users/context".as_slice(), body: json_body_policy()) do(input: TestCreateUser, ctx: Context):
+      Response::ok().text(input.name.concat(":".as_slice()).concat(ctx.path()))
+
+    post(with_context, "/counts".as_slice(), body: json_body_policy()) do(input: TestCreateCount):
+      if input.count == 3:
+        Response::ok().text("count:3".as_slice())
+      else:
+        Response::ok().text("bad-count".as_slice())
+
+test "query extraction decodes bool fields":
+  match(extract_query<TestUserQuery>(parse_query("verbose=true".as_slice())))
+    Ok<TestUserQuery> { value }:
+      assert(value.verbose, eq: true)
+    Err:
+      assert(false, eq: true)
+
+test "query context route extracts bool query DTOs":
+  let built = build_app do(base):
+    route_query_context(base, "/search".as_slice(), method: Method::Get {}) do(query: TestUserQuery, _ctx: Context):
+      if query.verbose then: Response::ok().text("true".as_slice()) else: Response::ok().text("false".as_slice())
+
+  let response = built.handle(
+    request_with_query(
+      Method::Get {},
+      "/search".as_slice().to_string(),
+      "verbose=true".as_slice().to_string()
+    )
+  )
+  assert(response_text(response).equals("true"), eq: true)
+
+test "params query route extracts bool query DTOs":
+  let built = params_query_bool_app()
+  let response = built.handle(
+    request_with_query(
+      Method::Get {},
+      "/users/ada".as_slice().to_string(),
+      "verbose=true".as_slice().to_string()
+    )
+  )
+  assert(response_text(response).equals("ada:true"), eq: true)
+
+test "builder routes match methods static segments params and query":
+  let web_app = app()
+    .get_unit("/ping".as_slice().to_string(), handler: () -> Response =>
+      Response::ok().text("pong".as_slice())
+    )
+    .get("/users/:id".as_slice(), handler: (ctx: Context) -> Response =>
+      let id = ctx.param("id".as_slice()) ?? "missing".as_slice().to_string()
+      let verbose = ctx.query_value("verbose".as_slice()) ?? "false".as_slice().to_string()
+      Response::ok().text(id.concat(":".as_slice()).concat(verbose))
+    )
+    .get("/users/new".as_slice(), handler: (_ctx: Context) -> Response =>
+      Response::ok().text("new".as_slice())
+    )
+
+  let static_response = web_app.handle(request(Method::Get {}, "/users/new".as_slice().to_string()))
+  assert(response_text(static_response).equals("new"), eq: true)
+
+  let unit_response = web_app.handle(request(Method::Get {}, "/ping".as_slice().to_string()))
+  assert(response_text(unit_response).equals("pong"), eq: true)
+
+  let param_response = web_app.handle(
+    request_with_query(
+      Method::Get {},
+      "/users/42".as_slice().to_string(),
+      "verbose=true".as_slice().to_string()
+    )
+  )
+  assert(response_text(param_response).equals("42:true"), eq: true)
+
+  let wrong_method = web_app.handle(request(Method::Post {}, "/users/42".as_slice().to_string()))
+  assert(wrong_method.status.code(), eq: 405)
+
+test "strict trailing slash policy distinguishes path variants":
+  let strict_app = app()
+    .get("/users".as_slice(), handler: (_ctx: Context) -> Response =>
+      Response::ok().text("users".as_slice())
+    )
+
+  let strict_response = strict_app.handle(request(Method::Get {}, "/users/".as_slice().to_string()))
+  assert(strict_response.status.code(), eq: 404)
+
+  let ignore_response = strict_app
+    .with(trailing_slash: ignore_trailing_slash())
+    .handle(request(Method::Get {}, "/users/".as_slice().to_string()))
+  assert(ignore_response.status.code(), eq: 200)
+  assert(response_text(ignore_response).equals("users"), eq: true)
+
+  let slash_route_app = app()
+    .with(trailing_slash: ignore_trailing_slash())
+    .get("/projects/".as_slice(), handler: (_ctx: Context) -> Response =>
+      Response::ok().text("projects".as_slice())
+    )
+
+  let slashless_response = slash_route_app.handle(request(Method::Get {}, "/projects".as_slice().to_string()))
+  assert(slashless_response.status.code(), eq: 200)
+  assert(response_text(slashless_response).equals("projects"), eq: true)
+
+  let slash_response = slash_route_app.handle(request(Method::Get {}, "/projects/".as_slice().to_string()))
+  assert(slash_response.status.code(), eq: 200)
+  assert(response_text(slash_response).equals("projects"), eq: true)
+
+  let param_app = app()
+    .get("/users/:id".as_slice(), handler: (ctx: Context) -> Response =>
+      let id = ctx.param("id".as_slice()) ?? "missing".as_slice().to_string()
+      Response::ok().text(id)
+    )
+  let empty_param_response = param_app.handle(request(Method::Get {}, "/users/".as_slice().to_string()))
+  assert(empty_param_response.status.code(), eq: 404)
+
+test "middleware wraps matched routes in declaration order":
+  let web_app = app()
+    .adopt(append_header)
+    .get("/health".as_slice(), handler: (_ctx: Context) -> Response =>
+      Response::ok().text("ok".as_slice())
+    )
+
+  let response = web_app.handle(request(Method::Get {}, "/health".as_slice().to_string()))
+  assert(response_text(response).equals("ok"), eq: true)
+  match(response.header("x-web-test".as_slice()))
+    Some<String> { value }:
+      assert(value.equals("seen"), eq: true)
+    None:
+      assert(false, eq: true)
+
+test "handlers can return ordinary IntoResponse values":
+  let web_app = app()
+    .get("/health".as_slice(), handler: (_ctx: Context) -> Response =>
+      Response::ok().text("ok".as_slice())
+    )
+
+  let response = web_app.handle(request(Method::Get {}, "/health".as_slice().to_string()))
+  assert(response.status.code(), eq: 200)
+  assert(response_text(response).equals("ok"), eq: true)
+
+test "typed handlers may require application effects":
+  let web_app = app()
+    .get("/log".as_slice(), handler: (_ctx: Context) -> Response =>
+      WebTestLog::info(1)
+      Response::ok().text("ok".as_slice())
+    )
+  web_app
+  assert(true, eq: true)
+
+test "on_error customizes extractor rejections":
+  let web_app = build_app do(base):
+    let with_errors = base.on_error(custom_rejection)
+    get_context(with_errors, "/typed".as_slice()) do(ctx: Context):
+      ctx.reject(Rejection::bad_request("missing typed param".as_slice()))
+
+  let response = web_app.handle(request(Method::Get {}, "/typed".as_slice().to_string()))
+  assert(response.status.code(), eq: 400)
+  assert(response_text(response).equals("missing typed param"), eq: true)
+  match(response.header("x-error".as_slice()))
+    Some<String> { value }:
+      assert(value.equals("custom"), eq: true)
+    None:
+      assert(false, eq: true)
+
+test "error hooks customize rejections and method not allowed":
+  let web_app = build_app do(base):
+    let with_rejections = on_rejection(base, custom_rejection)
+    let with_method = method_not_allowed(with_rejections, (_ctx: Context) -> Response =>
+      Response::new(status: Status::method_not_allowed()).text("custom method".as_slice())
+    )
+    get_context(with_method, "/typed".as_slice()) do(ctx: Context):
+      ctx.reject(Rejection::bad_request("missing typed param".as_slice()))
+
+  let rejection = web_app.handle(request(Method::Get {}, "/typed".as_slice().to_string()))
+  assert(rejection.status.code(), eq: 400)
+  match(rejection.header("x-error".as_slice()))
+    Some<String> { value }:
+      assert(value.equals("custom"), eq: true)
+    None:
+      assert(false, eq: true)
+
+  let wrong_method = web_app.handle(request(Method::Post {}, "/typed".as_slice().to_string()))
+  assert(wrong_method.status.code(), eq: 405)
+  assert(response_text(wrong_method).equals("custom method"), eq: true)
+
+test "mount prefixes routes and preserves parent and child middleware":
+  let child = app()
+    .adopt(append_child_header)
+    .get("/health".as_slice(), handler: (_ctx: Context) -> Response =>
+      Response::ok().text("mounted".as_slice())
+    )
+  let web_app = app()
+    .adopt(append_header)
+    .mount("/api".as_slice(), child)
+
+  let response = web_app.handle(request(Method::Get {}, "/api/health".as_slice().to_string()))
+  assert(response_text(response).equals("mounted"), eq: true)
+  match(response.header("x-web-test".as_slice()))
+    Some<String> { value }:
+      assert(value.equals("seen"), eq: true)
+    None:
+      assert(false, eq: true)
+  match(response.header("x-child-test".as_slice()))
+    Some<String> { value }:
+      assert(value.equals("seen"), eq: true)
+    None:
+      assert(false, eq: true)
+
+test "router builder mirrors app composition":
+  let built = Router::init()
+    .adopt(append_header)
+    .get("/health".as_slice(), handler: (_ctx: Context) -> Response =>
+      Response::ok().text("router".as_slice())
+    )
+    .group("/api".as_slice(), routes: (child: Router) -> Router =>
+      child.get("/nested".as_slice(), handler: (_ctx: Context) -> Response =>
+        Response::ok().text("nested".as_slice())
+      )
+    )
+
+  let health = built.handle(request(Method::Get {}, "/health".as_slice().to_string()))
+  assert(response_text(health).equals("router"), eq: true)
+  match(health.header("x-web-test".as_slice()))
+    Some<String> { value }:
+      assert(value.equals("seen"), eq: true)
+    None:
+      assert(false, eq: true)
+
+  let nested = built.handle(request(Method::Get {}, "/api/nested".as_slice().to_string()))
+  assert(response_text(nested).equals("nested"), eq: true)
+
+test "builder exposes typed params query and json body":
+  let built = app()
+    .get_params_query("/users/:id".as_slice(), handler: (params: TestUserParams, query: TestUserQuery) -> Response =>
+      let verbose = if query.verbose then: "true".as_slice().to_string() else: "false".as_slice().to_string()
+      Response::ok().text(params.id.concat(":".as_slice()).concat(verbose))
+    )
+    .get("/builder-session".as_slice(), auth: required_session(), handler: (session: String, ctx: Context) -> Response =>
+      Response::ok().text(session.concat(":".as_slice()).concat(ctx.path()))
+    )
+    .post("/users".as_slice(), body: json_body_policy(), handler: (input: TestCreateUser) -> Response =>
+      Response::ok().text(input.name)
+    )
+
+  let user = built.handle(
+    request_with_query(
+      Method::Get {},
+      "/users/lin".as_slice().to_string(),
+      "verbose=true".as_slice().to_string()
+    )
+  )
+  assert(response_text(user).equals("lin:true"), eq: true)
+
+  let created = built.handle(
+    request_with_body(
+      Method::Post {},
+      "/users".as_slice().to_string(),
+      Body::text("{\"name\":\"Builder\",\"active\":true}".as_slice())
+    )
+  )
+  assert(response_text(created).equals("Builder"), eq: true)
+
+  let builder_session = built.handle(
+    IncomingRequest {
+      method: Method::Get {},
+      path: "/builder-session".as_slice().to_string(),
+      query: None {},
+      headers: Headers::empty().append(header: "authorization".as_slice(), value: "lin".as_slice()),
+      body: Body::empty()
+    }
+  )
+  assert(response_text(builder_session).equals("lin:/builder-session"), eq: true)
+
+test "build_app helper builds routes and supports typed params":
+  let built = build_app do(base):
+    let with_health = get_context(base, "/health".as_slice()) do(_ctx: Context):
+      Response::ok().text("ok".as_slice())
+
+    get(with_health, "/users/:id".as_slice()) do(params: TestUserParams):
+      Response::ok().text(params.id)
+
+  let health = built.handle(request(Method::Get {}, "/health".as_slice().to_string()))
+  assert(response_text(health).equals("ok"), eq: true)
+
+  let user = built.handle(request(Method::Get {}, "/users/alice".as_slice().to_string()))
+  assert(response_text(user).equals("alice"), eq: true)
+
+test "structural DTO app handles params and bool query":
+  let built = structural_dto_app()
+  let user = built.handle(
+    request_with_query(
+      Method::Get {},
+      "/users/ada".as_slice().to_string(),
+      "verbose=true".as_slice().to_string()
+    )
+  )
+  assert(response_text(user).equals("ada:true"), eq: true)
+
+test "structural DTO app handles query-only and string query":
+  let built = structural_dto_app()
+  let search = built.handle(
+    request_with_query(
+      Method::Get {},
+      "/search".as_slice().to_string(),
+      "verbose=true".as_slice().to_string()
+    )
+  )
+  assert(response_text(search).equals("true"), eq: true)
+
+  let string_query = built.handle(
+    request_with_query(
+      Method::Get {},
+      "/query-string/ignored".as_slice().to_string(),
+      "q=true".as_slice().to_string()
+    )
+  )
+  assert(response_text(string_query).equals("true"), eq: true)
+
+  let leading_zero_query = built.handle(
+    request_with_query(
+      Method::Get {},
+      "/query-string/ignored".as_slice().to_string(),
+      "q=00123".as_slice().to_string()
+    )
+  )
+  assert(response_text(leading_zero_query).equals("00123"), eq: true)
+
+  let decimal_query = built.handle(
+    request_with_query(
+      Method::Get {},
+      "/query-string/ignored".as_slice().to_string(),
+      "q=1.0".as_slice().to_string()
+    )
+  )
+  assert(response_text(decimal_query).equals("1.0"), eq: true)
+
+test "structural DTO app handles json body DTO":
+  let built = structural_dto_app()
+  let created = built.handle(
+    request_with_body(
+      Method::Post {},
+      "/users".as_slice().to_string(),
+      Body::text("{\"name\":\"Grace\",\"active\":true}".as_slice())
+    )
+  )
+  assert(response_text(created).equals("Grace:active"), eq: true)
+
+test "json body policy rejects unsupported content type":
+  let built = structural_dto_app()
+  let rejected = built.handle(
+    request_with_headers_and_body(
+      Method::Post {},
+      "/users".as_slice().to_string(),
+      Headers::empty().append(header: "content-type".as_slice(), value: "text/plain".as_slice()),
+      Body::text("{\"name\":\"Grace\",\"active\":true}".as_slice())
+    )
+  )
+  assert(rejected.status.code(), eq: 415)
+  assert(response_text(rejected).equals("expected application/json request body"), eq: true)
+
+test "structural DTO app handles json body DTO with context":
+  let built = structural_dto_app()
+  let created_with_context = built.handle(
+    request_with_body(
+      Method::Post {},
+      "/users/context".as_slice().to_string(),
+      Body::text("{\"name\":\"Ada\",\"active\":true}".as_slice())
+    )
+  )
+  assert(response_text(created_with_context).equals("Ada:/users/context"), eq: true)
+
+test "structural DTO app handles json integer body DTO":
+  let built = structural_dto_app()
+  let created_count = built.handle(
+    request_with_body(
+      Method::Post {},
+      "/counts".as_slice().to_string(),
+      Body::text("{\"count\":3}".as_slice())
+    )
+  )
+  assert(response_text(created_count).equals("count:3"), eq: true)
+
+test "route helpers support query headers and final context extraction":
+  let built = build_app do(base):
+    let with_query = route_query_context(base, "/search".as_slice(), method: Method::Get {}) do(query: TestUserQuery, _ctx: Context):
+      let verbose = if query.verbose then: "true".as_slice().to_string() else: "false".as_slice().to_string()
+      Response::ok().text(verbose)
+
+    let with_headers = route_headers_context(with_query, "/headers".as_slice(), method: Method::Get {}) do(headers: TestHeaders, ctx: Context):
+      Response::ok().text(headers.authorization.concat(":".as_slice()).concat(ctx.path()))
+
+    let with_json = route_query_context(with_headers, "/json".as_slice(), method: Method::Get {}) do(query: TestUserQuery, _ctx: Context):
+      let value: JsonValue = JsonBool { value: query.verbose }
+      value
+
+    route_params_query_headers_context(with_json, "/users/:id/full".as_slice(), method: Method::Get {}) do(params: TestUserParams, query: TestUserQuery, headers: TestHeaders, ctx: Context):
+      let verbose = if query.verbose then: "true".as_slice().to_string() else: "false".as_slice().to_string()
+      let label = params.id.concat(":".as_slice()).concat(verbose)
+      let with_header = label.concat(":".as_slice()).concat(headers.authorization)
+      Response::ok().text(with_header.concat(":".as_slice()).concat(ctx.path()))
+
+  let headers = Headers::empty().append(header: "Authorization".as_slice(), value: "token".as_slice())
+  let query_only = built.handle(
+    request_with_query_and_headers(
+      Method::Get {},
+      "/search".as_slice().to_string(),
+      "verbose=true".as_slice().to_string(),
+      headers
+    )
+  )
+  assert(response_text(query_only).equals("true"), eq: true)
+
+  let headers_ctx = built.handle(
+    request_with_query_and_headers(
+      Method::Get {},
+      "/headers".as_slice().to_string(),
+      "verbose=false".as_slice().to_string(),
+      headers
+    )
+  )
+  assert(response_text(headers_ctx).equals("token:/headers"), eq: true)
+
+  let json_response = built.handle(
+    request_with_query_and_headers(
+      Method::Get {},
+      "/json".as_slice().to_string(),
+      "verbose=true".as_slice().to_string(),
+      headers
+    )
+  )
+  assert(json_response.status.code(), eq: 200)
+  match(json_response.header("content-type".as_slice()))
+    Some<String> { value }:
+      assert(value.equals("application/json"), eq: true)
+    None:
+      assert(false, eq: true)
+
+  let all_extractors = built.handle(
+    request_with_query_and_headers(
+      Method::Get {},
+      "/users/ada/full".as_slice().to_string(),
+      "verbose=true".as_slice().to_string(),
+      headers
+    )
+  )
+  assert(response_text(all_extractors).equals("ada:true:token:/users/ada/full"), eq: true)
+
+test "extracted route helpers convert status tuple responses":
+  let built = build_app do(base):
+    let with_params = route_params(base, "/tuple/:id".as_slice(), method: Method::Get {}) do(params: TestUserParams):
+      (Status::created(), params.id)
+
+    route_query_context(with_params, "/tuple-query".as_slice(), method: Method::Get {}) do(query: TestStringQuery, _ctx: Context):
+      (Status::created(), query.q)
+
+  let params_response = built.handle(request(Method::Get {}, "/tuple/ada".as_slice().to_string()))
+  assert(params_response.status.code(), eq: 201)
+  assert(response_text(params_response).equals("ada"), eq: true)
+
+  let query_response = built.handle(
+    request_with_query(
+      Method::Get {},
+      "/tuple-query".as_slice().to_string(),
+      "q=grace".as_slice().to_string()
+    )
+  )
+  assert(query_response.status.code(), eq: 201)
+  assert(response_text(query_response).equals("grace"), eq: true)
+
+test "query context route helper converts result responses":
+  let built = build_app do(base):
+    route_query_context(base, "/tuple-result".as_slice(), method: Method::Get {}) do(query: TestStringQuery, _ctx: Context):
+      let value: Result<String, Rejection> = Ok<String> { value: query.q }
+      value
+
+  let result_response = built.handle(
+    request_with_query(
+      Method::Get {},
+      "/tuple-result".as_slice().to_string(),
+      "q=result".as_slice().to_string()
+    )
+  )
+  assert(result_response.status.code(), eq: 200)
+  assert(response_text(result_response).equals("result"), eq: true)
+
+test "query context route helper converts status json tuple responses":
+  let built = build_app do(base):
+    route_query_context(base, "/tuple-json".as_slice(), method: Method::Get {}) do(query: TestUserQuery, _ctx: Context):
+      let value: JsonValue = JsonBool { value: query.verbose }
+      (Status::created(), value)
+
+  let json_tuple_response = built.handle(
+    request_with_query(
+      Method::Get {},
+      "/tuple-json".as_slice().to_string(),
+      "verbose=true".as_slice().to_string()
+    )
+  )
+  assert(json_tuple_response.status.code(), eq: 201)
+  match(json_tuple_response.header("content-type".as_slice()))
+    Some<String> { value }:
+      assert(value.equals("application/json"), eq: true)
+    None:
+      assert(false, eq: true)
+
+test "body policies extract text bodies":
+  let web_app = app()
+    .post("/echo".as_slice(), body: text_body_policy(), handler: (input: String) -> Response =>
+      Response::ok().text(input)
+    )
+
+  let response = web_app.handle(
+    request_with_body(
+      Method::Post {},
+      "/echo".as_slice().to_string(),
+      Body::text("hello".as_slice())
+    )
+  )
+  assert(response_text(response).equals("hello"), eq: true)
+
+test "body auth policies extract session values":
+  let web_app = build_app do(base):
+    let with_session = post(
+      base,
+      "/session".as_slice(),
+      body: text_body_policy(),
+      auth: required_session<TestSession>(extract: extract_test_session),
+      handler: (input: String, session: TestSession) -> Response =>
+        Response::ok().text(session.user.concat(":".as_slice()).concat(input))
+    )
+
+    post(with_session, "/session/context".as_slice(), body: text_body_policy(), auth: required_session<TestSession>(extract: extract_test_session)) do(input: String, session: TestSession, ctx: Context):
+      Response::ok().text(session.user.concat(":".as_slice()).concat(input).concat(":".as_slice()).concat(ctx.path()))
+
+  let authed = web_app.handle(
+    IncomingRequest {
+      method: Method::Post {},
+      path: "/session".as_slice().to_string(),
+      query: None {},
+      headers: Headers::empty().append(header: "authorization".as_slice(), value: "ada".as_slice()),
+      body: Body::text("hello".as_slice())
+    }
+  )
+  assert(response_text(authed).equals("ada:hello"), eq: true)
+
+  let authed_context = web_app.handle(
+    IncomingRequest {
+      method: Method::Post {},
+      path: "/session/context".as_slice().to_string(),
+      query: None {},
+      headers: Headers::empty().append(header: "authorization".as_slice(), value: "grace".as_slice()),
+      body: Body::text("hello".as_slice())
+    }
+  )
+  assert(response_text(authed_context).equals("grace:hello:/session/context"), eq: true)
+
+  let missing = web_app.handle(
+    request_with_body(
+      Method::Post {},
+      "/session".as_slice().to_string(),
+      Body::text("hello".as_slice())
+    )
+  )
+  assert(missing.status.code(), eq: 401)
+
+test "builder body auth handlers can request context":
+  let web_app = app()
+    .post(
+      "/session/context".as_slice(),
+      body: text_body_policy(),
+      auth: required_session<TestSession>(extract: extract_test_session),
+      handler: (input: String, session: TestSession, ctx: Context) -> Response =>
+        Response::ok().text(session.user.concat(":".as_slice()).concat(input).concat(":".as_slice()).concat(ctx.path()))
+    )
+
+  let authed = web_app.handle(
+    IncomingRequest {
+      method: Method::Post {},
+      path: "/session/context".as_slice().to_string(),
+      query: None {},
+      headers: Headers::empty().append(header: "authorization".as_slice(), value: "ada".as_slice()),
+      body: Body::text("hello".as_slice())
+    }
+  )
+  assert(response_text(authed).equals("ada:hello:/session/context"), eq: true)
+
+test "auth-only routes extract required optional and typed sessions":
+  let web_app = build_app do(base):
+    let with_typed = get(
+      base,
+      "/me".as_slice(),
+      auth: required_session<TestSession>(extract: extract_test_session)
+    ) do(session: TestSession):
+      Response::ok().text(session.user)
+
+    let with_required = get(with_typed, "/required".as_slice(), auth: required_session()) do(session: String, ctx: Context):
+      Response::ok().text(session.concat(":".as_slice()).concat(ctx.path()))
+
+    let with_route_auth = route_auth(
+      with_required,
+      "/route-auth".as_slice(),
+      method: Method::Patch {},
+      auth: required_session<TestSession>(extract: extract_test_session)
+    ) do(session: TestSession):
+      Response::ok().text(session.user)
+
+    get(with_route_auth, "/optional".as_slice(), auth: optional_session()) do(session: Option<String>):
+      Response::ok().text(auth_label(session))
+
+  let typed = web_app.handle(
+    IncomingRequest {
+      method: Method::Get {},
+      path: "/me".as_slice().to_string(),
+      query: None {},
+      headers: Headers::empty().append(header: "authorization".as_slice(), value: "ada".as_slice()),
+      body: Body::empty()
+    }
+  )
+  assert(response_text(typed).equals("ada"), eq: true)
+
+  let required = web_app.handle(
+    IncomingRequest {
+      method: Method::Get {},
+      path: "/required".as_slice().to_string(),
+      query: None {},
+      headers: Headers::empty().append(header: "authorization".as_slice(), value: "grace".as_slice()),
+      body: Body::empty()
+    }
+  )
+  assert(response_text(required).equals("grace:/required"), eq: true)
+
+  let missing_required = web_app.handle(request(Method::Get {}, "/required".as_slice().to_string()))
+  assert(missing_required.status.code(), eq: 401)
+
+  let route_auth_response = web_app.handle(
+    IncomingRequest {
+      method: Method::Patch {},
+      path: "/route-auth".as_slice().to_string(),
+      query: None {},
+      headers: Headers::empty().append(header: "authorization".as_slice(), value: "ada".as_slice()),
+      body: Body::empty()
+    }
+  )
+  assert(response_text(route_auth_response).equals("ada"), eq: true)
+
+  let optional = web_app.handle(request(Method::Get {}, "/optional".as_slice().to_string()))
+  assert(response_text(optional).equals("anonymous"), eq: true)
+
+test "no arg auth policies use authorization header strings":
+  let web_app = build_app do(base):
+    let with_required = post(
+      base,
+      "/required".as_slice(),
+      body: text_body_policy(),
+      auth: required_session()
+    ) do(input: String, session: String):
+      Response::ok().text(session.concat(":".as_slice()).concat(input))
+
+    let with_typed = post(
+      with_required,
+      "/typed".as_slice(),
+      body: text_body_policy(),
+      auth: required_session()
+    ) do(input: String, session: TestSession):
+      Response::ok().text(session.user.concat(":".as_slice()).concat(input))
+
+    post(
+      with_typed,
+      "/optional".as_slice(),
+      body: text_body_policy(),
+      auth: optional_session()
+    ) do(input: String, session: Option<String>):
+      Response::ok().text(auth_label(session).concat(":".as_slice()).concat(input))
+
+  let authed = web_app.handle(
+    IncomingRequest {
+      method: Method::Post {},
+      path: "/required".as_slice().to_string(),
+      query: None {},
+      headers: Headers::empty().append(header: "authorization".as_slice(), value: "grace".as_slice()),
+      body: Body::text("hello".as_slice())
+    }
+  )
+  assert(response_text(authed).equals("grace:hello"), eq: true)
+
+  let typed = web_app.handle(
+    IncomingRequest {
+      method: Method::Post {},
+      path: "/typed".as_slice().to_string(),
+      query: None {},
+      headers: Headers::empty().append(header: "authorization".as_slice(), value: "{\"user\":\"ada\"}".as_slice()),
+      body: Body::text("hello".as_slice())
+    }
+  )
+  assert(response_text(typed).equals("ada:hello"), eq: true)
+
+  let missing = web_app.handle(
+    request_with_body(
+      Method::Post {},
+      "/required".as_slice().to_string(),
+      Body::text("hello".as_slice())
+    )
+  )
+  assert(missing.status.code(), eq: 401)
+
+  let anonymous = web_app.handle(
+    request_with_body(
+      Method::Post {},
+      "/optional".as_slice().to_string(),
+      Body::text("hello".as_slice())
+    )
+  )
+  assert(response_text(anonymous).equals("anonymous:hello"), eq: true)
+
+test "response helpers write json content type":
+  let value: JsonValue = JsonBool { value: true }
+  let json_result = json_response(value)
+  assert(json_result.status.code(), eq: 200)
+  match(json_result.header("content-type".as_slice()))
+    Some<String> { value }:
+      assert(value.equals("application/json"), eq: true)
+    None:
+      assert(false, eq: true)
+
+  let replaced = response_json(
+    Response::ok().with(header: "content-type".as_slice(), value: "text/plain".as_slice()),
+    value
+  )
+  match(replaced.header("content-type".as_slice()))
+    Some<String> { value }:
+      assert(value.equals("application/json"), eq: true)
+    None:
+      assert(false, eq: true)
+
+test "response helpers convert result values":
+  let ok_result: Result<String, Rejection> = Ok<String> { value: "ok".as_slice().to_string() }
+  assert(response_text(to_response(ok_result)).equals("ok"), eq: true)
+
+  let err_result: Result<String, Rejection> =
+    Err<Rejection> { error: Rejection::bad_request("bad".as_slice()) }
+  let err_response = to_response(err_result)
+  assert(err_response.status.code(), eq: 400)
+  assert(response_text(err_response).equals("bad"), eq: true)
+
+test "response helpers convert none values":
+  let none_value: Option<String> = None {}
+  assert(to_response<String>(none_value).status.code(), eq: 404)
+
+test "response helpers convert status text tuples":
+  let status_text = to_response((Status::created(), "created".as_slice().to_string()))
+  assert(status_text.status.code(), eq: 201)
+  assert(response_text(status_text).equals("created"), eq: true)
+
+test "static files middleware composes with app builder":
+  let web_app = app().adopt(serve_dir(Path::new("/tmp".as_slice())))
+  web_app
+  assert(true, eq: true)
+
+test "static files middleware accepts string roots":
+  let from_slice = serve_dir("/tmp".as_slice())
+  let from_string = serve_dir("/tmp".as_slice().to_string())
+  from_slice
+  from_string
+  assert(true, eq: true)
+
+test "static files middleware returns empty head responses":
+  match(write_string(Path::new("/tmp/voyd-web-static-asset.json".as_slice()), "ok".as_slice()))
+    Ok<Unit>:
+      void
+    Err<IoError>:
+      assert(false, eq: true)
+
+  let web_app = app().adopt(serve_dir(Path::new("/tmp".as_slice())))
+
+  let get_response = web_app.handle(request(Method::Get {}, "/voyd-web-static-asset.json".as_slice().to_string()))
+  assert(get_response.status.code(), eq: 200)
+  assert(response_text(get_response).equals("ok"), eq: true)
+  match(get_response.header("content-type".as_slice()))
+    Some<String> { value }:
+      assert(value.equals("application/json"), eq: true)
+    None:
+      assert(false, eq: true)
+
+  let head_response = web_app.handle(request(Method::Head {}, "/voyd-web-static-asset.json".as_slice().to_string()))
+  assert(head_response.status.code(), eq: 200)
+  assert(response_text(head_response).equals(""), eq: true)
+  match(head_response.header("content-type".as_slice()))
+    Some<String> { value }:
+      assert(value.equals("application/json"), eq: true)
+    None:
+      assert(false, eq: true)
+
+  let directory_head = app()
+    .adopt(serve_dir(Path::new("/".as_slice())))
+    .handle(request(Method::Head {}, "/tmp".as_slice().to_string()))
+  assert(directory_head.status.code(), eq: 404)
+
+  match(write_string(Path::new("/tmp/voyd-web-static-escape.txt".as_slice()), "escape".as_slice()))
+    Ok<Unit>:
+      void
+    Err<IoError>:
+      assert(false, eq: true)
+  let escaped = app()
+    .adopt(serve_dir(Path::new("/tmp/voyd-web-static-root".as_slice())))
+    .handle(request(Method::Get {}, "//tmp/voyd-web-static-escape.txt".as_slice().to_string()))
+  assert(escaped.status.code(), eq: 404)
+
+test "html rendering turns vx nodes into a text html response":
+  let page: MsgPack =
+    <main class="home">
+      <h1>Hello &amp; welcome</h1>
+      <p data-count="1">Voyd</p>
+    </main>
+
+  let rendered = render<MsgPack>(page)
+  assert(rendered.contains("<main".as_slice()), eq: true)
+  assert(rendered.contains("class=\"home\"".as_slice()), eq: true)
+  assert(rendered.contains("Hello &amp;amp; welcome".as_slice()), eq: true)
+
+  let response = Response::ok().html<MsgPack>(page)
+  assert(response.status.code(), eq: 200)
+  match(response.header("content-type".as_slice()))
+    Some<String> { value }:
+      assert(value.equals("text/html; charset=utf-8"), eq: true)
+    None:
+      assert(false, eq: true)
+
+  let replaced = Response::ok()
+    .with(header: "content-type".as_slice(), value: "text/plain".as_slice())
+    .html<MsgPack>(page)
+  match(replaced.header("content-type".as_slice()))
+    Some<String> { value }:
+      assert(value.equals("text/html; charset=utf-8"), eq: true)
+    None:
+      assert(false, eq: true)


### PR DESCRIPTION
## Summary

Implements the Phase 1 Voyd web framework proposal in `packages/web` and wires it into the monorepo as a source package.

Key pieces:
- Added `@voyd-lang/web` with router/app builders, route helpers, middleware, extractor policies, response conversion, static files, and VX-backed HTML responses.
- Added structural DTO extraction for params/query/headers/JSON body through boundary MessagePack decoding without adding trait support for structural or non-nominal objects.
- Added public smoke coverage through `pkg::web` and package-level web tests for routing, middleware, extraction, response helpers, static files, and HTML rendering.
- Updated compiler/std/sdk support needed by the framework: higher-order overload resolution for inline and named callbacks, boundary MessagePack decode intrinsic/codegen paths, scoped package resolution, and effect/export handling.
- Updated the proposal doc to reflect the implemented Phase 1 surface and explicit limitations.

## Correctness notes

The agentic review loop found and fixed several tangible issues before this PR was opened:
- strict trailing slash matching now distinguishes `/x` from `/x/`, including param routes rejecting empty trailing captures;
- `ignore_trailing_slash()` now works when routes are registered with or without the trailing slash;
- app-level middleware now runs for fallback paths so `adopt(serve_dir(...))` can serve static files without a matched route;
- static `HEAD` responses verify readability, preserve GET/HEAD status parity, and return an empty body;
- static path cleaning strips all leading slashes before `Path::join` to avoid root bypasses;
- query `String` extraction preserves exact numeric-looking text like `00123` and `1.0`;
- JSON/HTML helpers replace an existing `content-type` rather than appending behind it.

## Review loop

- Implementation-gap reviewer: clean after fixes.
- Correctness reviewers: repeated fresh passes until the latest reviewer reported no tangible correctness issues.

## Validation

- `npm --workspace @voyd-lang/web test` pass: 37 tests.
- `VOYD_USE_SRC=1 npx vitest apps/smoke/src/web-framework.test.ts --run` pass: 6 tests.
- Focused vitest batch pass: compiler overload, typecheck budget, pipeline, effects export, SDK node, web smoke: 114 tests.
- `npm run typecheck` pass.
- `npm test` pass under escalation. The sandboxed run failed only on `listen EPERM: operation not permitted 127.0.0.1`; rerunning with localhost binding permission passed.

## Bugs encountered but not addressed

- Imported effect handlers in a package test can reach codegen without effect metadata. While testing `serve_dir`, handling imported `std::fs::Fs` operations from `packages/web/src/web.test.voyd` failed with `CG0001: codegen missing effect metadata for op ...` after typing succeeded. The test was rewritten to use the real host filesystem; the underlying imported-effect metadata/codegen issue remains to investigate.
