### PR TITLE
Reject subsuming labeled overload definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2479,6 +2479,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2493,6 +2496,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2507,6 +2513,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2521,6 +2530,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2535,6 +2547,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2549,6 +2564,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2563,6 +2581,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2577,6 +2598,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2591,6 +2615,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2605,6 +2632,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2619,6 +2649,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2646,6 +2679,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3168,6 +3204,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3185,6 +3224,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3218,6 +3260,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3316,6 +3361,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7141,6 +7189,27 @@
         "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.30.2",
       "cpu": [
@@ -7159,12 +7228,234 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.30.2",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
       "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
       "cpu": [
         "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -9451,6 +9742,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -2479,9 +2479,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2496,9 +2493,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2513,9 +2507,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2530,9 +2521,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2547,9 +2535,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2564,9 +2549,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2581,9 +2563,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2598,9 +2577,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2615,9 +2591,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2632,9 +2605,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2649,9 +2619,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2679,9 +2646,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3204,9 +3168,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3224,9 +3185,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3260,9 +3218,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3361,9 +3316,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7189,27 +7141,6 @@
         "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.30.2",
       "cpu": [
@@ -7228,234 +7159,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.30.2",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
       "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
       "cpu": [
         "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss/node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss/node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -9742,9 +9451,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/compiler/src/diagnostics/registry.ts
+++ b/packages/compiler/src/diagnostics/registry.ts
@@ -318,6 +318,14 @@ type DiagnosticParamsMap = {
     valueMemberType: string;
     otherMemberType: string;
   };
+  TY0047:
+    | {
+        kind: "subsuming-labeled-overload";
+        functionName: string;
+        subsumingSignature: string;
+        subsumedSignature: string;
+      }
+    | { kind: "subsumed-labeled-overload" };
   TY9999: { kind: "unexpected-error"; message: string };
 };
 
@@ -987,6 +995,21 @@ export const diagnosticsRegistry: {
       },
     ],
   } satisfies DiagnosticDefinition<DiagnosticParamsMap["TY0046"]>,
+  TY0047: {
+    code: "TY0047",
+    message: (params) =>
+      params.kind === "subsuming-labeled-overload"
+        ? `overload ${params.subsumingSignature} subsumes ${params.subsumedSignature}; labeled structural overloads with subset/superset shapes are ambiguous`
+        : "subsumed labeled overload declared here",
+    severity: "error",
+    phase: "typing",
+    hints: [
+      {
+        message:
+          "Use a single overload with an optional or defaulted parameter, or give the overloads distinct function names.",
+      },
+    ],
+  } satisfies DiagnosticDefinition<DiagnosticParamsMap["TY0047"]>,
   TY9999: {
     code: "TY9999",
     message: (params) => params.message,

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_compatible_positional_prefix.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_compatible_positional_prefix.voyd
@@ -1,0 +1,6 @@
+fn program(seed: i32, { init: i32, step: i32 }) -> i32
+  seed + init + step
+
+fn program(seed: i32, { init: i32, step: i32, subscriptions: i32 }) -> i32
+  seed + init + step + subscriptions
+

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_constraint_fallback.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_constraint_fallback.voyd
@@ -1,0 +1,12 @@
+trait Marked
+  fn marker(self) -> i32
+
+fn program<T: Marked>({ item: T }) -> i32
+  item.marker()
+
+fn program({ item: i32, tag: i32 }) -> i32
+  item + tag
+
+pub fn main() -> i32
+  program(item: 1, tag: 2)
+

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_distinct_positional_prefix.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_distinct_positional_prefix.voyd
@@ -1,0 +1,9 @@
+fn program(seed: i32, { init: i32, step: i32 }) -> i32
+  seed + init + step
+
+fn program(seed: bool, { init: i32, step: i32, subscriptions: i32 }) -> i32
+  init + step + subscriptions
+
+pub fn main() -> i32
+  program(1, init: 2, step: 3)
+

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_generic_field_correlation.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_generic_field_correlation.voyd
@@ -1,0 +1,9 @@
+fn program<T>({ a: T, b: T }) -> i32
+  1
+
+fn program({ a: i32, b: bool, tag: i32 }) -> i32
+  tag
+
+pub fn main() -> i32
+  program(a: 1, b: false, tag: 2)
+

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_generic_field_overlap.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_generic_field_overlap.voyd
@@ -1,0 +1,6 @@
+fn program<T>({ item: T }) -> i32
+  1
+
+fn program<U>({ item: U, tag: i32 }) -> i32
+  tag
+

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_incompatible_shared_field.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_incompatible_shared_field.voyd
@@ -1,0 +1,9 @@
+fn program({ init: i32, step: i32 }) -> i32
+  init + step
+
+fn program({ init: bool, step: i32, subscriptions: i32 }) -> i32
+  step + subscriptions
+
+pub fn main() -> i32
+  program(init: 1, step: 2)
+

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_optional_label_overlap.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_optional_label_overlap.voyd
@@ -1,0 +1,14 @@
+obj Some<T> {
+  value: T
+}
+
+obj None {}
+
+type Optional<T> = Some<T> | None
+
+fn program({ init: i32, step?: i32 }) -> i32
+  init
+
+fn program({ init: i32, view?: i32 }) -> i32
+  init
+

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_optional_positional_prefix_overlap.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_optional_positional_prefix_overlap.voyd
@@ -1,0 +1,14 @@
+obj Some<T> {
+  value: T
+}
+
+obj None {}
+
+type Optional<T> = Some<T> | None
+
+fn program(seed?: i32, { init: i32 }) -> i32
+  init
+
+fn program({ init: i32, view?: i32 }) -> i32
+  init
+

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_optional_structural_field_overlap.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_optional_structural_field_overlap.voyd
@@ -1,0 +1,16 @@
+obj Some<T> {
+  value: T
+}
+
+obj None {}
+
+type Optional<T> = Some<T> | None
+
+type Left = { x?: i32 }
+type Right = { x?: bool }
+
+fn program({ item: Left }) -> i32
+  1
+
+fn program({ item: Right, tag: i32 }) -> i32
+  tag

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_structural_field_overlap.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_structural_field_overlap.voyd
@@ -1,0 +1,9 @@
+type Left = { a: i32 }
+type Right = { b: i32 }
+
+fn program({ item: Left }) -> i32
+  1
+
+fn program({ item: Right, tag: i32 }) -> i32
+  tag
+

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_union_overlap.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_labeled_union_overlap.voyd
@@ -1,0 +1,21 @@
+obj A {
+  value: i32
+}
+
+obj B {
+  value: i32
+}
+
+obj C {
+  value: i32
+}
+
+type Left = A | B
+type Right = B | C
+
+fn program({ item: Left }) -> i32
+  1
+
+fn program({ item: Right, tag: i32 }) -> i32
+  tag
+

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_subsuming_labeled.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_overloads_subsuming_labeled.voyd
@@ -1,0 +1,6 @@
+fn program({ init: i32, step: i32, view: i32 }) -> i32
+  init + step + view
+
+fn program({ init: i32, step: i32, view: i32, subscriptions: i32 }) -> i32
+  init + step + view + subscriptions
+

--- a/packages/compiler/src/semantics/__tests__/pipeline.test.ts
+++ b/packages/compiler/src/semantics/__tests__/pipeline.test.ts
@@ -1410,6 +1410,29 @@ describe("semanticsPipeline", () => {
     ).toBe(true);
   });
 
+  it("rejects subsuming labeled structural overloads", () => {
+    const ast = loadAst("function_overloads_subsuming_labeled.voyd");
+    expect(() => semanticsPipeline(ast)).toThrow(
+      /TY0047: overload program\(init, step, view, subscriptions\) subsumes program\(init, step, view\)/
+    );
+  });
+
+  it("allows labeled overload supersets when shared field types are incompatible", () => {
+    const ast = loadAst(
+      "function_overloads_labeled_incompatible_shared_field.voyd"
+    );
+    const result = semanticsPipeline(ast);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows mixed positional and labeled overload supersets", () => {
+    const ast = loadAst(
+      "function_overloads_labeled_distinct_positional_prefix.voyd"
+    );
+    const result = semanticsPipeline(ast);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("allows overloads that differ by generic constraints and falls back when unsatisfied", () => {
     const ast = loadAst("function_overloads_constraint_fallback.voyd");
     const result = semanticsPipeline(ast);

--- a/packages/compiler/src/semantics/__tests__/pipeline.test.ts
+++ b/packages/compiler/src/semantics/__tests__/pipeline.test.ts
@@ -1432,6 +1432,13 @@ describe("semanticsPipeline", () => {
     );
   });
 
+  it("rejects labeled overload supersets when shared generic fields can overlap", () => {
+    const ast = loadAst("function_overloads_labeled_generic_field_overlap.voyd");
+    expect(() => semanticsPipeline(ast)).toThrow(
+      /TY0047: overload program\(item, tag\) subsumes program\(item\)/
+    );
+  });
+
   it("rejects mixed positional and labeled overload supersets with compatible prefixes", () => {
     const ast = loadAst(
       "function_overloads_labeled_compatible_positional_prefix.voyd"

--- a/packages/compiler/src/semantics/__tests__/pipeline.test.ts
+++ b/packages/compiler/src/semantics/__tests__/pipeline.test.ts
@@ -1448,6 +1448,15 @@ describe("semanticsPipeline", () => {
     );
   });
 
+  it("rejects labeled overload supersets when shared optional structural fields can be omitted", () => {
+    const ast = loadAst(
+      "function_overloads_labeled_optional_structural_field_overlap.voyd"
+    );
+    expect(() => semanticsPipeline(ast)).toThrow(
+      /TY0047: overload program\(item, tag\) subsumes program\(item\)/
+    );
+  });
+
   it("allows generic labeled overload supersets when field correlations cannot overlap", () => {
     const ast = loadAst(
       "function_overloads_labeled_generic_field_correlation.voyd"

--- a/packages/compiler/src/semantics/__tests__/pipeline.test.ts
+++ b/packages/compiler/src/semantics/__tests__/pipeline.test.ts
@@ -1425,6 +1425,22 @@ describe("semanticsPipeline", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("rejects labeled overload supersets when shared field unions overlap", () => {
+    const ast = loadAst("function_overloads_labeled_union_overlap.voyd");
+    expect(() => semanticsPipeline(ast)).toThrow(
+      /TY0047: overload program\(item, tag\) subsumes program\(item\)/
+    );
+  });
+
+  it("rejects mixed positional and labeled overload supersets with compatible prefixes", () => {
+    const ast = loadAst(
+      "function_overloads_labeled_compatible_positional_prefix.voyd"
+    );
+    expect(() => semanticsPipeline(ast)).toThrow(
+      /TY0047: overload program\(seed, init, step, subscriptions\) subsumes program\(seed, init, step\)/
+    );
+  });
+
   it("allows mixed positional and labeled overload supersets", () => {
     const ast = loadAst(
       "function_overloads_labeled_distinct_positional_prefix.voyd"

--- a/packages/compiler/src/semantics/__tests__/pipeline.test.ts
+++ b/packages/compiler/src/semantics/__tests__/pipeline.test.ts
@@ -1439,6 +1439,23 @@ describe("semanticsPipeline", () => {
     );
   });
 
+  it("rejects labeled overload supersets when shared structural field types can intersect", () => {
+    const ast = loadAst(
+      "function_overloads_labeled_structural_field_overlap.voyd"
+    );
+    expect(() => semanticsPipeline(ast)).toThrow(
+      /TY0047: overload program\(item, tag\) subsumes program\(item\)/
+    );
+  });
+
+  it("allows generic labeled overload supersets when field correlations cannot overlap", () => {
+    const ast = loadAst(
+      "function_overloads_labeled_generic_field_correlation.voyd"
+    );
+    const result = semanticsPipeline(ast);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("rejects mixed positional and labeled overload supersets with compatible prefixes", () => {
     const ast = loadAst(
       "function_overloads_labeled_compatible_positional_prefix.voyd"

--- a/packages/compiler/src/semantics/__tests__/pipeline.test.ts
+++ b/packages/compiler/src/semantics/__tests__/pipeline.test.ts
@@ -1465,6 +1465,28 @@ describe("semanticsPipeline", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("allows labeled overload fallback when generic constraints cannot overlap", () => {
+    const ast = loadAst("function_overloads_labeled_constraint_fallback.voyd");
+    const result = semanticsPipeline(ast);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("rejects labeled overloads when only optional labels differ", () => {
+    const ast = loadAst("function_overloads_labeled_optional_label_overlap.voyd");
+    expect(() => semanticsPipeline(ast)).toThrow(
+      /TY0047: overload program\(init, step\) subsumes program\(init, view\)/
+    );
+  });
+
+  it("rejects labeled overloads when optional positional prefixes can be skipped", () => {
+    const ast = loadAst(
+      "function_overloads_labeled_optional_positional_prefix_overlap.voyd"
+    );
+    expect(() => semanticsPipeline(ast)).toThrow(
+      /TY0047: overload program\(seed, init\) subsumes program\(init, view\)/
+    );
+  });
+
   it("rejects mixed positional and labeled overload supersets with compatible prefixes", () => {
     const ast = loadAst(
       "function_overloads_labeled_compatible_positional_prefix.voyd"

--- a/packages/compiler/src/semantics/hir/nodes.ts
+++ b/packages/compiler/src/semantics/hir/nodes.ts
@@ -119,6 +119,7 @@ export interface HirObjectTypeExpr extends HirTypeExprBase {
 export interface HirRecordTypeField {
   name: string;
   type: HirTypeExpr;
+  optional?: boolean;
   span: SourceSpan;
 }
 

--- a/packages/compiler/src/semantics/lowering/type-expressions.ts
+++ b/packages/compiler/src/semantics/lowering/type-expressions.ts
@@ -157,7 +157,7 @@ const lowerObjectTypeField = (
   ctx: LowerContext,
   scope: ScopeId
 ): HirRecordTypeField => {
-  if (!isForm(entry) || !entry.calls(":")) {
+  if (!isForm(entry) || (!entry.calls(":") && !entry.calls("?:"))) {
     throw new Error("object type fields must be labeled");
   }
   const nameExpr = entry.at(1);
@@ -172,9 +172,11 @@ const lowerObjectTypeField = (
   if (!type) {
     throw new Error("object type field missing resolved type expression");
   }
+  const optional = entry.calls("?:");
   return {
     name: nameExpr.value,
-    type,
+    type: optional ? wrapInOptionalTypeExpr({ inner: type, ctx, scope }) : type,
+    ...(optional ? { optional: true } : {}),
     span: toSourceSpan(entry),
   };
 };

--- a/packages/compiler/src/semantics/typing/overload-declarations.ts
+++ b/packages/compiler/src/semantics/typing/overload-declarations.ts
@@ -18,6 +18,7 @@ type LabeledOverloadShape = {
 
 type OverlapContext = {
   bindings: Map<TypeParamId, TypeId>;
+  constraints: Map<TypeParamId, TypeId>;
 };
 
 export const validateSubsumingLabeledOverloads = (
@@ -152,31 +153,127 @@ const positionalPrefixesOverlap = ({
   ctx: TypingContext;
   state: TypingState;
 }): OverlapContext | undefined => {
-  if (left.labelStart !== right.labelStart) {
-    return undefined;
+  const overlap = createOverlapContext({ left, right });
+  if (left.labelStart === right.labelStart) {
+    for (let index = 0; index < left.labelStart; index += 1) {
+      const leftParam = left.signature.parameters[index]!;
+      const rightParam = right.signature.parameters[index]!;
+      if (leftParam.label !== rightParam.label) {
+        return undefined;
+      }
+      if (
+        !typesOverlap({
+          left: leftParam.type,
+          right: rightParam.type,
+          ctx,
+          state,
+          overlap,
+        })
+      ) {
+        return undefined;
+      }
+    }
+    return overlap;
   }
 
-  const overlap = createOverlapContext();
-  for (let index = 0; index < left.labelStart; index += 1) {
-    const leftParam = left.signature.parameters[index]!;
-    const rightParam = right.signature.parameters[index]!;
-    if (leftParam.label !== rightParam.label) {
-      return undefined;
-    }
+  return prefixesOverlapAt({
+    left,
+    right,
+    leftIndex: 0,
+    rightIndex: 0,
+    ctx,
+    state,
+    overlap,
+  })
+    ? overlap
+    : undefined;
+};
+
+const prefixesOverlapAt = ({
+  left,
+  right,
+  leftIndex,
+  rightIndex,
+  ctx,
+  state,
+  overlap,
+}: {
+  left: LabeledOverloadShape;
+  right: LabeledOverloadShape;
+  leftIndex: number;
+  rightIndex: number;
+  ctx: TypingContext;
+  state: TypingState;
+  overlap: OverlapContext;
+}): boolean => {
+  if (leftIndex === left.labelStart && rightIndex === right.labelStart) {
+    return true;
+  }
+
+  const leftParam = left.signature.parameters[leftIndex];
+  const rightParam = right.signature.parameters[rightIndex];
+  if (leftIndex < left.labelStart && leftParam?.optional) {
     if (
-      !typesOverlap({
-        left: leftParam.type,
-        right: rightParam.type,
-        ctx,
-        state,
-        overlap,
-      })
+      withForkedOverlap(overlap, (candidate) =>
+        prefixesOverlapAt({
+          left,
+          right,
+          leftIndex: leftIndex + 1,
+          rightIndex,
+          ctx,
+          state,
+          overlap: candidate,
+        }),
+      )
     ) {
-      return undefined;
+      return true;
     }
   }
+  if (rightIndex < right.labelStart && rightParam?.optional) {
+    if (
+      withForkedOverlap(overlap, (candidate) =>
+        prefixesOverlapAt({
+          left,
+          right,
+          leftIndex,
+          rightIndex: rightIndex + 1,
+          ctx,
+          state,
+          overlap: candidate,
+        }),
+      )
+    ) {
+      return true;
+    }
+  }
+  if (
+    leftIndex >= left.labelStart ||
+    rightIndex >= right.labelStart ||
+    !leftParam ||
+    !rightParam ||
+    leftParam.label !== rightParam.label
+  ) {
+    return false;
+  }
 
-  return overlap;
+  return withForkedOverlap(overlap, (candidate) =>
+    typesOverlap({
+      left: leftParam.type,
+      right: rightParam.type,
+      ctx,
+      state,
+      overlap: candidate,
+    }) &&
+    prefixesOverlapAt({
+      left,
+      right,
+      leftIndex: leftIndex + 1,
+      rightIndex: rightIndex + 1,
+      ctx,
+      state,
+      overlap: candidate,
+    }),
+  );
 };
 
 const shapeSubsumes = ({
@@ -192,11 +289,14 @@ const shapeSubsumes = ({
   state: TypingState;
   overlap: OverlapContext;
 }): boolean => {
-  if (candidate.fields.size <= other.fields.size) {
+  if (!hasShapeSubsumptionSignal({ candidate, other })) {
     return false;
   }
 
   for (const [label, otherParam] of other.fields) {
+    if (otherParam.optional) {
+      continue;
+    }
     const candidateParam = candidate.fields.get(label);
     if (!candidateParam) {
       return false;
@@ -216,6 +316,41 @@ const shapeSubsumes = ({
 
   return true;
 };
+
+const hasShapeSubsumptionSignal = ({
+  candidate,
+  other,
+}: {
+  candidate: LabeledOverloadShape;
+  other: LabeledOverloadShape;
+}): boolean => {
+  const otherLabels = new Set(other.fields.keys());
+  const hasExtraCandidateLabel = [...candidate.fields.keys()].some(
+    (label) => !otherLabels.has(label),
+  );
+  if (hasExtraCandidateLabel) {
+    return true;
+  }
+
+  const requiredLabels = (shape: LabeledOverloadShape): string[] =>
+    [...shape.fields]
+      .filter(([, param]) => !param.optional)
+      .map(([label]) => label)
+      .sort();
+  const optionalLabels = (shape: LabeledOverloadShape): string[] =>
+    [...shape.fields]
+      .filter(([, param]) => param.optional)
+      .map(([label]) => label)
+      .sort();
+  return (
+    labelsEqual(requiredLabels(candidate), requiredLabels(other)) &&
+    !labelsEqual(optionalLabels(candidate), optionalLabels(other))
+  );
+};
+
+const labelsEqual = (left: readonly string[], right: readonly string[]): boolean =>
+  left.length === right.length &&
+  left.every((label, index) => label === right[index]);
 
 const typesOverlap = ({
   left,
@@ -299,13 +434,39 @@ const typesOverlap = ({
   );
 };
 
-const createOverlapContext = (): OverlapContext => ({
+const createOverlapContext = ({
+  left,
+  right,
+}: {
+  left: LabeledOverloadShape;
+  right: LabeledOverloadShape;
+}): OverlapContext => ({
   bindings: new Map(),
+  constraints: constraintsFor({ left, right }),
 });
 
 const cloneOverlap = (overlap: OverlapContext): OverlapContext => ({
   bindings: new Map(overlap.bindings),
+  constraints: new Map(overlap.constraints),
 });
+
+const constraintsFor = ({
+  left,
+  right,
+}: {
+  left: LabeledOverloadShape;
+  right: LabeledOverloadShape;
+}): Map<TypeParamId, TypeId> => {
+  const constraints = new Map<TypeParamId, TypeId>();
+  [left.signature, right.signature].forEach((signature) => {
+    signature.typeParams?.forEach((param) => {
+      if (typeof param.constraint === "number") {
+        constraints.set(param.typeParam, param.constraint);
+      }
+    });
+  });
+  return constraints;
+};
 
 const withForkedOverlap = (
   overlap: OverlapContext,
@@ -370,6 +531,32 @@ const bindTypeParameter = ({
     return typesOverlap({ left: existing, right: type, ctx, state, overlap });
   }
   overlap.bindings.set(param, type);
+  return bindingsSatisfyConstraints({ ctx, state, overlap });
+};
+
+const bindingsSatisfyConstraints = ({
+  ctx,
+  state,
+  overlap,
+}: {
+  ctx: TypingContext;
+  state: TypingState;
+  overlap: OverlapContext;
+}): boolean => {
+  for (const [param, constraint] of overlap.constraints) {
+    const binding = overlap.bindings.get(param);
+    if (typeof binding !== "number") {
+      continue;
+    }
+    const actual = resolveBoundType({ type: binding, overlap, ctx });
+    if (ctx.arena.get(actual).kind === "type-param-ref") {
+      continue;
+    }
+    const expected = ctx.arena.substitute(constraint, overlap.bindings);
+    if (!typeSatisfies(actual, expected, ctx, state)) {
+      return false;
+    }
+  }
   return true;
 };
 

--- a/packages/compiler/src/semantics/typing/overload-declarations.ts
+++ b/packages/compiler/src/semantics/typing/overload-declarations.ts
@@ -1,5 +1,5 @@
 import { diagnosticFromCode, emitDiagnostic } from "../../diagnostics/index.js";
-import type { SourceSpan, SymbolId } from "../ids.js";
+import type { SourceSpan, SymbolId, TypeId, TypeParamId } from "../ids.js";
 import type {
   FunctionSignature,
   ParamSignature,
@@ -14,6 +14,10 @@ type LabeledOverloadShape = {
   signature: FunctionSignature;
   labelStart: number;
   fields: ReadonlyMap<string, ParamSignature>;
+};
+
+type OverlapContext = {
+  bindings: Map<TypeParamId, TypeId>;
 };
 
 export const validateSubsumingLabeledOverloads = (
@@ -98,11 +102,20 @@ const reportSubsumingPair = ({
   ctx: TypingContext;
   state: TypingState;
 }): void => {
-  if (!positionalPrefixesOverlap({ left, right, ctx, state })) {
+  const prefixOverlap = positionalPrefixesOverlap({ left, right, ctx, state });
+  if (!prefixOverlap) {
     return;
   }
 
-  if (shapeSubsumes({ candidate: left, other: right, ctx, state })) {
+  if (
+    shapeSubsumes({
+      candidate: left,
+      other: right,
+      ctx,
+      state,
+      overlap: cloneOverlap(prefixOverlap),
+    })
+  ) {
     reportSubsumingOverload({
       subsuming: left,
       subsumed: right,
@@ -111,7 +124,15 @@ const reportSubsumingPair = ({
     return;
   }
 
-  if (shapeSubsumes({ candidate: right, other: left, ctx, state })) {
+  if (
+    shapeSubsumes({
+      candidate: right,
+      other: left,
+      ctx,
+      state,
+      overlap: cloneOverlap(prefixOverlap),
+    })
+  ) {
     reportSubsumingOverload({
       subsuming: right,
       subsumed: left,
@@ -130,16 +151,17 @@ const positionalPrefixesOverlap = ({
   right: LabeledOverloadShape;
   ctx: TypingContext;
   state: TypingState;
-}): boolean => {
+}): OverlapContext | undefined => {
   if (left.labelStart !== right.labelStart) {
-    return false;
+    return undefined;
   }
 
+  const overlap = createOverlapContext();
   for (let index = 0; index < left.labelStart; index += 1) {
     const leftParam = left.signature.parameters[index]!;
     const rightParam = right.signature.parameters[index]!;
     if (leftParam.label !== rightParam.label) {
-      return false;
+      return undefined;
     }
     if (
       !typesOverlap({
@@ -147,13 +169,14 @@ const positionalPrefixesOverlap = ({
         right: rightParam.type,
         ctx,
         state,
+        overlap,
       })
     ) {
-      return false;
+      return undefined;
     }
   }
 
-  return true;
+  return overlap;
 };
 
 const shapeSubsumes = ({
@@ -161,11 +184,13 @@ const shapeSubsumes = ({
   other,
   ctx,
   state,
+  overlap,
 }: {
   candidate: LabeledOverloadShape;
   other: LabeledOverloadShape;
   ctx: TypingContext;
   state: TypingState;
+  overlap: OverlapContext;
 }): boolean => {
   if (candidate.fields.size <= other.fields.size) {
     return false;
@@ -182,6 +207,7 @@ const shapeSubsumes = ({
         right: otherParam.type,
         ctx,
         state,
+        overlap,
       })
     ) {
       return false;
@@ -196,36 +222,68 @@ const typesOverlap = ({
   right,
   ctx,
   state,
+  overlap,
 }: {
-  left: number;
-  right: number;
+  left: TypeId;
+  right: TypeId;
   ctx: TypingContext;
   state: TypingState;
+  overlap: OverlapContext;
 }): boolean => {
+  left = resolveBoundType({ type: left, overlap, ctx });
+  right = resolveBoundType({ type: right, overlap, ctx });
   if (left === right) {
     return true;
   }
 
   const leftDesc = ctx.arena.get(left);
   if (leftDesc.kind === "type-param-ref") {
-    return true;
+    return bindTypeParameter({
+      param: leftDesc.param,
+      type: right,
+      ctx,
+      state,
+      overlap,
+    });
   }
 
   if (leftDesc.kind === "union") {
     return leftDesc.members.some((member) =>
-      typesOverlap({ left: member, right, ctx, state }),
+      withForkedOverlap(overlap, (candidate) =>
+        typesOverlap({ left: member, right, ctx, state, overlap: candidate }),
+      ),
     );
   }
 
   const rightDesc = ctx.arena.get(right);
   if (rightDesc.kind === "type-param-ref") {
-    return true;
+    return bindTypeParameter({
+      param: rightDesc.param,
+      type: left,
+      ctx,
+      state,
+      overlap,
+    });
   }
 
   if (rightDesc.kind === "union") {
     return rightDesc.members.some((member) =>
-      typesOverlap({ left, right: member, ctx, state }),
+      withForkedOverlap(overlap, (candidate) =>
+        typesOverlap({ left, right: member, ctx, state, overlap: candidate }),
+      ),
     );
+  }
+
+  const leftFields = structuralFieldsFor({ type: left, ctx });
+  const rightFields = structuralFieldsFor({ type: right, ctx });
+  if (leftFields && rightFields) {
+    return structuralShapesOverlap({
+      left: leftFields,
+      right: rightFields,
+      ctx,
+      state,
+      overlap,
+    });
   }
 
   if (
@@ -239,6 +297,143 @@ const typesOverlap = ({
     typeSatisfies(left, right, ctx, state) ||
     typeSatisfies(right, left, ctx, state)
   );
+};
+
+const createOverlapContext = (): OverlapContext => ({
+  bindings: new Map(),
+});
+
+const cloneOverlap = (overlap: OverlapContext): OverlapContext => ({
+  bindings: new Map(overlap.bindings),
+});
+
+const withForkedOverlap = (
+  overlap: OverlapContext,
+  run: (candidate: OverlapContext) => boolean,
+): boolean => {
+  const candidate = cloneOverlap(overlap);
+  if (!run(candidate)) {
+    return false;
+  }
+  overlap.bindings.clear();
+  candidate.bindings.forEach((value, key) => overlap.bindings.set(key, value));
+  return true;
+};
+
+const resolveBoundType = ({
+  type,
+  overlap,
+  ctx,
+}: {
+  type: TypeId;
+  overlap: OverlapContext;
+  ctx: TypingContext;
+}): TypeId => {
+  const seen = new Set<TypeParamId>();
+  let current = type;
+  while (true) {
+    const desc = ctx.arena.get(current);
+    if (desc.kind !== "type-param-ref") {
+      return current;
+    }
+    if (seen.has(desc.param)) {
+      return current;
+    }
+    seen.add(desc.param);
+    const binding = overlap.bindings.get(desc.param);
+    if (typeof binding !== "number") {
+      return current;
+    }
+    current = binding;
+  }
+};
+
+const bindTypeParameter = ({
+  param,
+  type,
+  ctx,
+  state,
+  overlap,
+}: {
+  param: TypeParamId;
+  type: TypeId;
+  ctx: TypingContext;
+  state: TypingState;
+  overlap: OverlapContext;
+}): boolean => {
+  const typeDesc = ctx.arena.get(type);
+  if (typeDesc.kind === "type-param-ref" && typeDesc.param === param) {
+    return true;
+  }
+  const existing = overlap.bindings.get(param);
+  if (typeof existing === "number") {
+    return typesOverlap({ left: existing, right: type, ctx, state, overlap });
+  }
+  overlap.bindings.set(param, type);
+  return true;
+};
+
+const structuralFieldsFor = ({
+  type,
+  ctx,
+}: {
+  type: TypeId;
+  ctx: TypingContext;
+}): readonly ParamSignature[] | undefined => {
+  const desc = ctx.arena.get(type);
+  if (desc.kind === "structural-object") {
+    return desc.fields.map((field) => ({
+      type: field.type,
+      label: field.name,
+      name: field.name,
+      optional: field.optional,
+    }));
+  }
+  return undefined;
+};
+
+const structuralShapesOverlap = ({
+  left,
+  right,
+  ctx,
+  state,
+  overlap,
+}: {
+  left: readonly ParamSignature[];
+  right: readonly ParamSignature[];
+  ctx: TypingContext;
+  state: TypingState;
+  overlap: OverlapContext;
+}): boolean => {
+  const rightByName = new Map(
+    right
+      .map((field) => [field.label ?? field.name, field] as const)
+      .filter((entry): entry is [string, ParamSignature] => Boolean(entry[0])),
+  );
+
+  for (const leftField of left) {
+    const name = leftField.label ?? leftField.name;
+    if (!name) {
+      continue;
+    }
+    const rightField = rightByName.get(name);
+    if (!rightField) {
+      continue;
+    }
+    if (
+      !typesOverlap({
+        left: leftField.type,
+        right: rightField.type,
+        ctx,
+        state,
+        overlap,
+      })
+    ) {
+      return false;
+    }
+  }
+
+  return true;
 };
 
 const containsTypeParamRef = ({

--- a/packages/compiler/src/semantics/typing/overload-declarations.ts
+++ b/packages/compiler/src/semantics/typing/overload-declarations.ts
@@ -12,6 +12,7 @@ import { getSymbolName } from "./type-system.js";
 type LabeledOverloadShape = {
   symbol: SymbolId;
   signature: FunctionSignature;
+  labelStart: number;
   fields: ReadonlyMap<string, ParamSignature>;
 };
 
@@ -58,10 +59,7 @@ const labeledShapeFor = ({
     (param) => param.synthetic !== "stable-callsite-id",
   );
   const labelStart = parameters.findIndex((param) => param.label !== undefined);
-  // V-405 targets overloads where the entire parameter surface is a structural
-  // labeled shape. Mixed positional/labeled builder APIs have separate call
-  // compatibility rules and are intentionally left to call resolution.
-  if (labelStart !== 0) {
+  if (labelStart < 0) {
     return undefined;
   }
   if (parameters.slice(labelStart).some((param) => param.label === undefined)) {
@@ -84,6 +82,7 @@ const labeledShapeFor = ({
       ...signature,
       parameters,
     },
+    labelStart,
     fields,
   };
 };
@@ -99,6 +98,10 @@ const reportSubsumingPair = ({
   ctx: TypingContext;
   state: TypingState;
 }): void => {
+  if (!positionalPrefixesOverlap({ left, right, ctx, state })) {
+    return;
+  }
+
   if (shapeSubsumes({ candidate: left, other: right, ctx, state })) {
     reportSubsumingOverload({
       subsuming: left,
@@ -115,6 +118,42 @@ const reportSubsumingPair = ({
       ctx,
     });
   }
+};
+
+const positionalPrefixesOverlap = ({
+  left,
+  right,
+  ctx,
+  state,
+}: {
+  left: LabeledOverloadShape;
+  right: LabeledOverloadShape;
+  ctx: TypingContext;
+  state: TypingState;
+}): boolean => {
+  if (left.labelStart !== right.labelStart) {
+    return false;
+  }
+
+  for (let index = 0; index < left.labelStart; index += 1) {
+    const leftParam = left.signature.parameters[index]!;
+    const rightParam = right.signature.parameters[index]!;
+    if (leftParam.label !== rightParam.label) {
+      return false;
+    }
+    if (
+      !typesOverlap({
+        left: leftParam.type,
+        right: rightParam.type,
+        ctx,
+        state,
+      })
+    ) {
+      return false;
+    }
+  }
+
+  return true;
 };
 
 const shapeSubsumes = ({
@@ -138,7 +177,7 @@ const shapeSubsumes = ({
       return false;
     }
     if (
-      !typesCompatible({
+      !typesOverlap({
         left: candidateParam.type,
         right: otherParam.type,
         ctx,
@@ -152,7 +191,7 @@ const shapeSubsumes = ({
   return true;
 };
 
-const typesCompatible = ({
+const typesOverlap = ({
   left,
   right,
   ctx,
@@ -162,10 +201,94 @@ const typesCompatible = ({
   right: number;
   ctx: TypingContext;
   state: TypingState;
-}): boolean =>
-  left === right ||
-  typeSatisfies(left, right, ctx, state) ||
-  typeSatisfies(right, left, ctx, state);
+}): boolean => {
+  if (left === right) {
+    return true;
+  }
+
+  const leftDesc = ctx.arena.get(left);
+  if (leftDesc.kind === "union") {
+    return leftDesc.members.some((member) =>
+      typesOverlap({ left: member, right, ctx, state }),
+    );
+  }
+
+  const rightDesc = ctx.arena.get(right);
+  if (rightDesc.kind === "union") {
+    return rightDesc.members.some((member) =>
+      typesOverlap({ left, right: member, ctx, state }),
+    );
+  }
+
+  if (
+    containsTypeParamRef({ type: left, ctx }) ||
+    containsTypeParamRef({ type: right, ctx })
+  ) {
+    return false;
+  }
+
+  return (
+    typeSatisfies(left, right, ctx, state) ||
+    typeSatisfies(right, left, ctx, state)
+  );
+};
+
+const containsTypeParamRef = ({
+  type,
+  ctx,
+  seen = new Set<number>(),
+}: {
+  type: number;
+  ctx: TypingContext;
+  seen?: Set<number>;
+}): boolean => {
+  if (seen.has(type)) {
+    return false;
+  }
+  seen.add(type);
+
+  const desc = ctx.arena.get(type);
+  switch (desc.kind) {
+    case "type-param-ref":
+      return true;
+    case "recursive":
+      return containsTypeParamRef({ type: desc.body, ctx, seen });
+    case "trait":
+    case "nominal-object":
+    case "value-object":
+      return desc.typeArgs.some((arg) =>
+        containsTypeParamRef({ type: arg, ctx, seen }),
+      );
+    case "structural-object":
+      return desc.fields.some((field) =>
+        containsTypeParamRef({ type: field.type, ctx, seen }),
+      );
+    case "function":
+      return (
+        desc.parameters.some((param) =>
+          containsTypeParamRef({ type: param.type, ctx, seen }),
+        ) || containsTypeParamRef({ type: desc.returnType, ctx, seen })
+      );
+    case "union":
+      return desc.members.some((member) =>
+        containsTypeParamRef({ type: member, ctx, seen }),
+      );
+    case "intersection":
+      return [
+        desc.nominal,
+        desc.structural,
+        ...(desc.traits ?? []),
+      ].some(
+        (component): component is number =>
+          typeof component === "number" &&
+          containsTypeParamRef({ type: component, ctx, seen }),
+      );
+    case "fixed-array":
+      return containsTypeParamRef({ type: desc.element, ctx, seen });
+    case "primitive":
+      return false;
+  }
+};
 
 const reportSubsumingOverload = ({
   subsuming,

--- a/packages/compiler/src/semantics/typing/overload-declarations.ts
+++ b/packages/compiler/src/semantics/typing/overload-declarations.ts
@@ -207,6 +207,10 @@ const typesOverlap = ({
   }
 
   const leftDesc = ctx.arena.get(left);
+  if (leftDesc.kind === "type-param-ref") {
+    return true;
+  }
+
   if (leftDesc.kind === "union") {
     return leftDesc.members.some((member) =>
       typesOverlap({ left: member, right, ctx, state }),
@@ -214,6 +218,10 @@ const typesOverlap = ({
   }
 
   const rightDesc = ctx.arena.get(right);
+  if (rightDesc.kind === "type-param-ref") {
+    return true;
+  }
+
   if (rightDesc.kind === "union") {
     return rightDesc.members.some((member) =>
       typesOverlap({ left, right: member, ctx, state }),

--- a/packages/compiler/src/semantics/typing/overload-declarations.ts
+++ b/packages/compiler/src/semantics/typing/overload-declarations.ts
@@ -420,14 +420,19 @@ const structuralShapesOverlap = ({
     if (!rightField) {
       continue;
     }
+    if (leftField.optional && rightField.optional) {
+      continue;
+    }
     if (
-      !typesOverlap({
-        left: leftField.type,
-        right: rightField.type,
-        ctx,
-        state,
-        overlap,
-      })
+      !withForkedOverlap(overlap, (candidate) =>
+        typesOverlap({
+          left: leftField.type,
+          right: rightField.type,
+          ctx,
+          state,
+          overlap: candidate,
+        }),
+      )
     ) {
       return false;
     }

--- a/packages/compiler/src/semantics/typing/overload-declarations.ts
+++ b/packages/compiler/src/semantics/typing/overload-declarations.ts
@@ -1,0 +1,218 @@
+import { diagnosticFromCode, emitDiagnostic } from "../../diagnostics/index.js";
+import type { SourceSpan, SymbolId } from "../ids.js";
+import type {
+  FunctionSignature,
+  ParamSignature,
+  TypingContext,
+  TypingState,
+} from "./types.js";
+import { satisfies as typeSatisfies } from "./type-relations.js";
+import { getSymbolName } from "./type-system.js";
+
+type LabeledOverloadShape = {
+  symbol: SymbolId;
+  signature: FunctionSignature;
+  fields: ReadonlyMap<string, ParamSignature>;
+};
+
+export const validateSubsumingLabeledOverloads = (
+  ctx: TypingContext,
+  state: TypingState,
+): void => {
+  ctx.overloads.forEach((symbols) => {
+    const shapes = symbols.flatMap((symbol) => {
+      const signature = ctx.functions.getSignature(symbol);
+      const fn = ctx.functions.getFunction(symbol);
+      if (!signature || !fn) {
+        return [];
+      }
+      const shape = labeledShapeFor({ symbol, signature });
+      return shape ? [shape] : [];
+    });
+
+    for (let leftIndex = 0; leftIndex < shapes.length; leftIndex += 1) {
+      for (
+        let rightIndex = leftIndex + 1;
+        rightIndex < shapes.length;
+        rightIndex += 1
+      ) {
+        reportSubsumingPair({
+          left: shapes[leftIndex]!,
+          right: shapes[rightIndex]!,
+          ctx,
+          state,
+        });
+      }
+    }
+  });
+};
+
+const labeledShapeFor = ({
+  symbol,
+  signature,
+}: {
+  symbol: SymbolId;
+  signature: FunctionSignature;
+}): LabeledOverloadShape | undefined => {
+  const parameters = signature.parameters.filter(
+    (param) => param.synthetic !== "stable-callsite-id",
+  );
+  const labelStart = parameters.findIndex((param) => param.label !== undefined);
+  // V-405 targets overloads where the entire parameter surface is a structural
+  // labeled shape. Mixed positional/labeled builder APIs have separate call
+  // compatibility rules and are intentionally left to call resolution.
+  if (labelStart !== 0) {
+    return undefined;
+  }
+  if (parameters.slice(labelStart).some((param) => param.label === undefined)) {
+    return undefined;
+  }
+
+  const fields = new Map<string, ParamSignature>();
+  parameters.slice(labelStart).forEach((param) => {
+    if (param.label) {
+      fields.set(param.label, param);
+    }
+  });
+  if (fields.size === 0) {
+    return undefined;
+  }
+
+  return {
+    symbol,
+    signature: {
+      ...signature,
+      parameters,
+    },
+    fields,
+  };
+};
+
+const reportSubsumingPair = ({
+  left,
+  right,
+  ctx,
+  state,
+}: {
+  left: LabeledOverloadShape;
+  right: LabeledOverloadShape;
+  ctx: TypingContext;
+  state: TypingState;
+}): void => {
+  if (shapeSubsumes({ candidate: left, other: right, ctx, state })) {
+    reportSubsumingOverload({
+      subsuming: left,
+      subsumed: right,
+      ctx,
+    });
+    return;
+  }
+
+  if (shapeSubsumes({ candidate: right, other: left, ctx, state })) {
+    reportSubsumingOverload({
+      subsuming: right,
+      subsumed: left,
+      ctx,
+    });
+  }
+};
+
+const shapeSubsumes = ({
+  candidate,
+  other,
+  ctx,
+  state,
+}: {
+  candidate: LabeledOverloadShape;
+  other: LabeledOverloadShape;
+  ctx: TypingContext;
+  state: TypingState;
+}): boolean => {
+  if (candidate.fields.size <= other.fields.size) {
+    return false;
+  }
+
+  for (const [label, otherParam] of other.fields) {
+    const candidateParam = candidate.fields.get(label);
+    if (!candidateParam) {
+      return false;
+    }
+    if (
+      !typesCompatible({
+        left: candidateParam.type,
+        right: otherParam.type,
+        ctx,
+        state,
+      })
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const typesCompatible = ({
+  left,
+  right,
+  ctx,
+  state,
+}: {
+  left: number;
+  right: number;
+  ctx: TypingContext;
+  state: TypingState;
+}): boolean =>
+  left === right ||
+  typeSatisfies(left, right, ctx, state) ||
+  typeSatisfies(right, left, ctx, state);
+
+const reportSubsumingOverload = ({
+  subsuming,
+  subsumed,
+  ctx,
+}: {
+  subsuming: LabeledOverloadShape;
+  subsumed: LabeledOverloadShape;
+  ctx: TypingContext;
+}): void => {
+  const functionName = getSymbolName(subsuming.symbol, ctx);
+  emitDiagnostic({
+    ctx,
+    code: "TY0047",
+    params: {
+      kind: "subsuming-labeled-overload",
+      functionName,
+      subsumingSignature: formatSignature(subsuming, ctx),
+      subsumedSignature: formatSignature(subsumed, ctx),
+    },
+    span: spanFor(subsuming, ctx),
+    related: [
+      diagnosticFromCode({
+        code: "TY0047",
+        params: { kind: "subsumed-labeled-overload" },
+        span: spanFor(subsumed, ctx),
+        severity: "note",
+      }),
+    ],
+  });
+};
+
+const formatSignature = (
+  shape: LabeledOverloadShape,
+  ctx: TypingContext,
+): string => {
+  const name = getSymbolName(shape.symbol, ctx);
+  const params = shape.signature.parameters
+    .map((param) => param.label ?? param.name ?? "_")
+    .join(", ");
+  return `${name}(${params})`;
+};
+
+const spanFor = (
+  shape: LabeledOverloadShape,
+  ctx: TypingContext,
+): SourceSpan => {
+  const fn = ctx.functions.getFunction(shape.symbol);
+  return fn?.span ?? ctx.hir.module.span;
+};

--- a/packages/compiler/src/semantics/typing/type-system.ts
+++ b/packages/compiler/src/semantics/typing/type-system.ts
@@ -1293,6 +1293,7 @@ const resolveObjectTypeExpr = (
     return {
       name: field.name,
       type,
+      ...(field.optional ? { optional: true } : {}),
       declaringParams: allowedParams
         ? declaringParamsForField(type, allowedParams, ctx)
         : undefined,

--- a/packages/compiler/src/semantics/typing/typing.ts
+++ b/packages/compiler/src/semantics/typing/typing.ts
@@ -31,6 +31,7 @@ import {
 import { DiagnosticError, type Diagnostic } from "../../diagnostics/index.js";
 import { hydrateImportedTraitMetadataForDependencySymbol } from "./import-trait-impl-hydration.js";
 import { hydrateImportedValueLikeSymbol } from "./import-hydration.js";
+import { validateSubsumingLabeledOverloads } from "./overload-declarations.js";
 
 export * from "./types.js";
 
@@ -50,6 +51,7 @@ export const runTypingPipeline = (inputs: TypingInputs): TypingResult => {
     primeImportedTypes(ctx);
     primeTypeAliases(ctx, state);
     registerFunctionSignatures(ctx, state);
+    validateSubsumingLabeledOverloads(ctx, state);
     registerEffectOperations(ctx, state);
     registerImpls(ctx, state);
     refreshTraitImplInstances(ctx, state);


### PR DESCRIPTION
## Summary
- Add a typing diagnostic for labeled overload sets where one signature strictly subsumes another.
- Validate these overloads after signature registration and report the ambiguous pair with related notes.
- Cover the new rule with semantic pipeline fixtures for rejected and allowed cases.

## Testing
- Added unit coverage in the compiler semantics pipeline for subsuming labeled overloads.
- Added regression fixtures for ambiguous, incompatible, and mixed positional/labeled overload shapes.