### PR TITLE
[codex] Refactor overload resolution scoring

### DIFF
--- a/packages/compiler/src/semantics/__tests__/__fixtures__/overload_lambda_method_return_disambiguation.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/overload_lambda_method_return_disambiguation.voyd
@@ -1,0 +1,16 @@
+obj App {}
+
+impl App
+  api fn get(self, path: i32, { handler: fn() -> i32 }) -> i32
+    self
+    path
+    handler()
+
+  api fn get(self, path: i32, { handler: fn() -> bool }) -> i32
+    self
+    path
+    if handler() then: 1 else: 0
+
+pub fn main() -> i32
+  let app = App {}
+  app.get(1, handler: () -> bool => true)

--- a/packages/compiler/src/semantics/typing/__tests__/overload-lambda-return-hint.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/overload-lambda-return-hint.test.ts
@@ -97,6 +97,35 @@ describe("overload lambda return hint", () => {
     ).not.toThrow();
   });
 
+  it("uses callback return types to disambiguate method overloads", () => {
+    const semantics = semanticsPipeline(
+      loadAst("overload_lambda_method_return_disambiguation.voyd"),
+    );
+    const { hir, typing } = semantics;
+    const bool = typing.arena.internPrimitive("bool");
+
+    const call = Array.from(hir.expressions.values()).find(
+      (expr): expr is HirMethodCallExpr =>
+        expr.exprKind === "method-call" && expr.method === "get",
+    );
+    expect(call).toBeDefined();
+    if (!call) return;
+
+    const targets = typing.callTargets.get(call.id);
+    const target = targets?.values().next().value;
+    expect(target).toBeDefined();
+    if (!target) return;
+    const signature = typing.functions.getSignature(target.symbol);
+    expect(signature).toBeDefined();
+    const handlerParam = signature?.parameters[2];
+    expect(handlerParam).toBeDefined();
+    if (!handlerParam) return;
+    const handlerType = typing.arena.get(handlerParam.type);
+    expect(handlerType.kind).toBe("function");
+    if (handlerType.kind !== "function") return;
+    expect(handlerType.returnType).toBe(bool);
+  });
+
   it("applies target type arguments to expected return overload hints", () => {
     const semantics = semanticsPipeline(
       loadAst("static_overload_expected_return_target_args.voyd"),

--- a/packages/compiler/src/semantics/typing/__tests__/overload-resolution.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/overload-resolution.test.ts
@@ -1,10 +1,27 @@
 import { describe, expect, it } from "vitest";
+import { SymbolTable } from "../../binder/index.js";
+import { DeclTable } from "../../decls.js";
 import { runTypingPipeline } from "../typing.js";
-import type { HirNamedTypeExpr, HirObjectTypeExpr } from "../../hir/nodes.js";
-import type { OverloadSetId, ScopeId } from "../../ids.js";
+import type { HirGraph, HirNamedTypeExpr, HirObjectTypeExpr } from "../../hir/index.js";
+import type { OverloadSetId, ScopeId, SourceSpan, SymbolId, TypeId } from "../../ids.js";
 import { createModuleContext } from "./helpers.js";
 import { Expr } from "../../../parser/index.js";
 import { moduleVisibility, packageVisibility } from "../../hir/index.js";
+import { createTypingContext, createTypingState } from "../context.js";
+import {
+  findOverloadMatches,
+  narrowOverloadMatches,
+  type OverloadResolutionCandidate,
+} from "../expressions/overload-resolution.js";
+import { seedBaseObjectType, seedPrimitiveTypes } from "../registry.js";
+import type {
+  FunctionSignature,
+  FunctionTypeParam,
+  ParamSignature,
+  TypingContext,
+} from "../types.js";
+
+const DUMMY_SPAN: SourceSpan = { file: "<test>", start: 0, end: 0 };
 
 const createNamedType = (
   name: string,
@@ -17,7 +34,413 @@ const createNamedType = (
   span,
 });
 
+const createScoringContext = () => {
+  const symbolTable = new SymbolTable({ rootOwner: 0 });
+  const hir: HirGraph = {
+    module: {
+      kind: "module",
+      id: 0,
+      path: "<test>",
+      scope: symbolTable.rootScope,
+      ast: 0,
+      span: DUMMY_SPAN,
+      items: [],
+      exports: [],
+    },
+    items: new Map(),
+    statements: new Map(),
+    expressions: new Map(),
+  };
+  const ctx = createTypingContext({
+    symbolTable,
+    hir,
+    overloads: new Map(),
+    decls: new DeclTable(),
+    moduleId: "test",
+  });
+  seedPrimitiveTypes(ctx);
+  seedBaseObjectType(ctx);
+  return { ctx, state: createTypingState() };
+};
+
+const createSignature = ({
+  ctx,
+  parameters,
+  returnType = ctx.primitives.void,
+  typeParams,
+}: {
+  ctx: TypingContext;
+  parameters: readonly ParamSignature[];
+  returnType?: TypeId;
+  typeParams?: readonly FunctionTypeParam[];
+}): FunctionSignature => {
+  const typeId = ctx.arena.internFunction({
+    parameters,
+    returnType,
+    effectRow: ctx.effects.emptyRow,
+  });
+  return {
+    typeId,
+    parameters,
+    returnType,
+    hasExplicitReturn: true,
+    annotatedReturn: true,
+    effectRow: ctx.effects.emptyRow,
+    annotatedEffects: false,
+    typeParams,
+    scheme: ctx.arena.newScheme(
+      typeParams?.map((param) => param.typeParam) ?? [],
+      typeId,
+    ),
+  };
+};
+
+const createTypeParam = (
+  ctx: TypingContext,
+  constraint?: TypeId,
+): FunctionTypeParam => {
+  const typeParam = ctx.arena.freshTypeParam();
+  return {
+    symbol: -typeParam - 1,
+    typeParam,
+    constraint,
+    typeRef: ctx.arena.internTypeParamRef(typeParam),
+  };
+};
+
+const createCandidate = (
+  symbol: SymbolId,
+  signature: FunctionSignature,
+): OverloadResolutionCandidate => ({ symbol, signature });
+
 describe("overload resolution", () => {
+  it("records call-shape compatibility before argument matching", () => {
+    const { ctx, state } = createScoringContext();
+    const oneArg = createCandidate(
+      1,
+      createSignature({
+        ctx,
+        parameters: [{ type: ctx.primitives.i32 }],
+      }),
+    );
+    const twoArgs = createCandidate(
+      2,
+      createSignature({
+        ctx,
+        parameters: [{ type: ctx.primitives.i32 }, { type: ctx.primitives.i32 }],
+      }),
+    );
+
+    const matches = findOverloadMatches({
+      name: "shape",
+      candidates: [oneArg, twoArgs],
+      args: [{ type: ctx.primitives.i32 }],
+      typeArguments: undefined,
+      span: DUMMY_SPAN,
+      ctx,
+      state,
+      matchesCandidate: () => true,
+    });
+
+    expect(matches).toEqual([oneArg]);
+  });
+
+  it("records argument compatibility separately from call shape", () => {
+    const { ctx, state } = createScoringContext();
+    const rejected = createCandidate(
+      1,
+      createSignature({
+        ctx,
+        parameters: [{ type: ctx.primitives.i32 }],
+      }),
+    );
+    const accepted = createCandidate(
+      2,
+      createSignature({
+        ctx,
+        parameters: [{ type: ctx.primitives.i32 }],
+      }),
+    );
+
+    const matches = findOverloadMatches({
+      name: "argument",
+      candidates: [rejected, accepted],
+      args: [{ type: ctx.primitives.i32 }],
+      typeArguments: undefined,
+      span: DUMMY_SPAN,
+      ctx,
+      state,
+      matchesCandidate: (candidate) => candidate === accepted,
+    });
+
+    expect(matches).toEqual([accepted]);
+  });
+
+  it("keeps lambda compatibility as a score dimension", () => {
+    const { ctx, state } = createScoringContext();
+    const first = createCandidate(
+      1,
+      createSignature({
+        ctx,
+        parameters: [{ type: ctx.primitives.i32 }],
+      }),
+    );
+    const refined = createCandidate(
+      2,
+      createSignature({
+        ctx,
+        parameters: [{ type: ctx.primitives.i32 }],
+      }),
+    );
+
+    const matches = findOverloadMatches({
+      name: "refined",
+      candidates: [first, refined],
+      args: [{ type: ctx.primitives.i32 }],
+      typeArguments: undefined,
+      span: DUMMY_SPAN,
+      ctx,
+      state,
+      matchesCandidate: () => true,
+      scoreMatches: () =>
+        new Map([
+          [first, { lambdaCompatibility: 0 }],
+          [refined, { lambdaCompatibility: 1 }],
+        ]),
+    });
+
+    expect(matches).toEqual([refined]);
+  });
+
+  it("prefers expected-return-compatible matches as a score dimension", () => {
+    const { ctx, state } = createScoringContext();
+    const first = createCandidate(
+      1,
+      createSignature({
+        ctx,
+        parameters: [{ type: ctx.primitives.i32 }],
+      }),
+    );
+    const expected = createCandidate(
+      2,
+      createSignature({
+        ctx,
+        parameters: [{ type: ctx.primitives.i32 }],
+      }),
+    );
+
+    const matches = findOverloadMatches({
+      name: "expected",
+      candidates: [first, expected],
+      args: [{ type: ctx.primitives.i32 }],
+      typeArguments: undefined,
+      span: DUMMY_SPAN,
+      ctx,
+      state,
+      matchesCandidate: () => true,
+      expectedReturnCompatible: (candidate) => candidate === expected,
+    });
+
+    expect(matches).toEqual([expected]);
+  });
+
+  it("falls back when no expected-return-compatible candidate matches", () => {
+    const { ctx, state } = createScoringContext();
+    const expected = createCandidate(
+      1,
+      createSignature({
+        ctx,
+        parameters: [{ type: ctx.primitives.i32 }],
+      }),
+    );
+    const fallback = createCandidate(
+      2,
+      createSignature({
+        ctx,
+        parameters: [{ type: ctx.primitives.i32 }],
+      }),
+    );
+
+    const matches = findOverloadMatches({
+      name: "expectedFallback",
+      candidates: [expected, fallback],
+      args: [{ type: ctx.primitives.i32 }],
+      typeArguments: undefined,
+      span: DUMMY_SPAN,
+      ctx,
+      state,
+      matchesCandidate: (candidate) => candidate === fallback,
+      expectedReturnCompatible: (candidate) => candidate === expected,
+    });
+
+    expect(matches).toEqual([fallback]);
+  });
+
+  it("uses dominance before later scoring dimensions", () => {
+    const { ctx, state } = createScoringContext();
+    const typeParam = createTypeParam(ctx);
+    const concrete = createCandidate(
+      1,
+      createSignature({
+        ctx,
+        parameters: [{ type: ctx.primitives.i32 }],
+      }),
+    );
+    const generic = createCandidate(
+      2,
+      createSignature({
+        ctx,
+        parameters: [{ type: typeParam.typeRef }],
+        typeParams: [typeParam],
+      }),
+    );
+
+    const matches = narrowOverloadMatches({
+      matches: [generic, concrete],
+      typeArguments: undefined,
+      ctx,
+      state,
+    });
+
+    expect(matches).toEqual([concrete]);
+  });
+
+  it("uses genericity penalty after dominance", () => {
+    const { ctx, state } = createScoringContext();
+    const fieldParam = createTypeParam(ctx);
+    const callbackParam = createTypeParam(ctx);
+    const structuralGeneric = createCandidate(
+      1,
+      createSignature({
+        ctx,
+        parameters: [
+          {
+            type: ctx.arena.internStructuralObject({
+              fields: [{ name: "value", type: fieldParam.typeRef }],
+            }),
+          },
+        ],
+        typeParams: [fieldParam],
+      }),
+    );
+    const callbackReturnGeneric = createCandidate(
+      2,
+      createSignature({
+        ctx,
+        parameters: [
+          {
+            type: ctx.arena.internFunction({
+              parameters: [{ type: ctx.primitives.i32 }],
+              returnType: callbackParam.typeRef,
+              effectRow: ctx.effects.emptyRow,
+            }),
+          },
+        ],
+        typeParams: [callbackParam],
+      }),
+    );
+
+    const matches = narrowOverloadMatches({
+      matches: [callbackReturnGeneric, structuralGeneric],
+      typeArguments: undefined,
+      ctx,
+      state,
+    });
+
+    expect(matches).toEqual([structuralGeneric]);
+  });
+
+  it("does not reintroduce candidates eliminated by earlier score dimensions", () => {
+    const { ctx, state } = createScoringContext();
+    const leftParam = createTypeParam(ctx);
+    const rightParam = createTypeParam(ctx);
+    const callbackParam = createTypeParam(ctx);
+    const leftStructural = createCandidate(
+      1,
+      createSignature({
+        ctx,
+        parameters: [
+          {
+            type: ctx.arena.internStructuralObject({
+              fields: [{ name: "left", type: leftParam.typeRef }],
+            }),
+          },
+        ],
+        typeParams: [leftParam],
+      }),
+    );
+    const rightStructural = createCandidate(
+      2,
+      createSignature({
+        ctx,
+        parameters: [
+          {
+            type: ctx.arena.internStructuralObject({
+              fields: [{ name: "right", type: rightParam.typeRef }],
+            }),
+          },
+        ],
+        typeParams: [rightParam],
+      }),
+    );
+    const callbackReturnGeneric = createCandidate(
+      3,
+      createSignature({
+        ctx,
+        parameters: [
+          {
+            type: ctx.arena.internFunction({
+              parameters: [{ type: ctx.primitives.i32 }],
+              returnType: callbackParam.typeRef,
+              effectRow: ctx.effects.emptyRow,
+            }),
+          },
+        ],
+        typeParams: [callbackParam],
+      }),
+    );
+
+    const matches = narrowOverloadMatches({
+      matches: [callbackReturnGeneric, leftStructural, rightStructural],
+      typeArguments: undefined,
+      ctx,
+      state,
+    });
+
+    expect(matches).toEqual([leftStructural, rightStructural]);
+  });
+
+  it("uses constraint specificity after genericity", () => {
+    const { ctx, state } = createScoringContext();
+    const unconstrainedParam = createTypeParam(ctx);
+    const constrainedParam = createTypeParam(ctx, ctx.primitives.i32);
+    const unconstrained = createCandidate(
+      1,
+      createSignature({
+        ctx,
+        parameters: [{ type: unconstrainedParam.typeRef }],
+        typeParams: [unconstrainedParam],
+      }),
+    );
+    const constrained = createCandidate(
+      2,
+      createSignature({
+        ctx,
+        parameters: [{ type: constrainedParam.typeRef }],
+        typeParams: [constrainedParam],
+      }),
+    );
+
+    const matches = narrowOverloadMatches({
+      matches: [unconstrained, constrained],
+      typeArguments: undefined,
+      ctx,
+      state,
+    });
+
+    expect(matches).toEqual([constrained]);
+  });
+
   it("matches structural arguments against overload parameters", () => {
     const ctx = createModuleContext();
     const overloadSetId: OverloadSetId = 0;

--- a/packages/compiler/src/semantics/typing/__tests__/typecheck-budget.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/typecheck-budget.test.ts
@@ -287,7 +287,10 @@ const createLabeledShapeNarrowingCase = (overloadCount: number) => {
   };
 };
 
-const createReturnTypeNarrowingCase = (overloadCount: number) => {
+const createReturnTypeNarrowingCase = (
+  overloadCount: number,
+  options?: { expectedReturnParamType?: "i32" | "bool" },
+) => {
   const ctx = createModuleContext();
   const overloadSetId: OverloadSetId = 0;
   const functionScope = ctx.symbolTable.rootScope as ScopeId;
@@ -332,7 +335,10 @@ const createReturnTypeNarrowingCase = (overloadCount: number) => {
           pattern: { kind: "identifier", symbol: valueParam },
           mutable: false,
           span: ctx.span,
-          type: i32(),
+          type:
+            returnsI32 && options?.expectedReturnParamType === "bool"
+              ? bool()
+              : i32(),
         },
       ],
       returnType: returnsI32 ? i32() : bool(),
@@ -1405,6 +1411,21 @@ describe("type-check budgets", () => {
       moduleId: "local",
       symbol: fanout.selectedSymbol,
     });
+  });
+
+  it("applies fallback overload budget checks when expected return matches fail arguments", () => {
+    const fanout = createReturnTypeNarrowingCase(18, {
+      expectedReturnParamType: "bool",
+    });
+    const error = expectDiagnosticError(() =>
+      runTypingPipeline({
+        ...fanout.inputs,
+        typeCheckBudget: { maxOverloadCandidates: 5 },
+      }),
+    );
+
+    expect(error.diagnostic.code).toBe("TY0041");
+    expect(error.diagnostic.message).toContain("pick_by_return");
   });
 
   it("applies explicit type argument narrowing before overload candidate budget checks", () => {

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -68,7 +68,7 @@ import {
   applyExplicitTypeArguments,
   enforceOverloadCandidateBudget,
   findOverloadMatches,
-  narrowOverloadMatches,
+  type OverloadMatchScoreOverrides,
   selectHintedOverloadCandidates,
   signatureCallShapeCouldMatch,
 } from "./overload-resolution.js";
@@ -1178,42 +1178,51 @@ const specializeOverloadParametersWithTargetTypeArguments = ({
 const findMatchingOverloadCandidates = <
   T extends { symbol: SymbolId; signature: FunctionSignature },
 >({
+  name,
   candidates,
   args,
+  span,
   ctx,
   state,
   typeArguments,
   targetTypeArguments,
   argsForCandidate,
-  refineMatches,
+  scoreMatches,
 }: {
+  name: string;
   candidates: readonly T[];
   args: readonly Arg[];
+  span: SourceSpan;
   ctx: TypingContext;
   state: TypingState;
   typeArguments?: readonly TypeId[];
   targetTypeArguments?: readonly TypeId[];
   argsForCandidate?: (candidate: T) => readonly Arg[];
-  refineMatches?: (matches: readonly T[]) => readonly T[];
+  scoreMatches?: (
+    matches: readonly T[],
+  ) => ReadonlyMap<T, OverloadMatchScoreOverrides>;
 }): readonly T[] => {
-  const matches = candidates.filter((candidate) =>
-    matchesOverloadSignature(
-      candidate.symbol,
-      candidate.signature,
-      argsForCandidate ? argsForCandidate(candidate) : args,
-      ctx,
-      state,
-      typeArguments,
-      targetTypeArguments,
-    ),
-  );
-  const refined = refineMatches ? refineMatches(matches) : matches;
-  return narrowOverloadMatches({
-    matches: refined,
+  return findOverloadMatches({
+    name,
+    candidates,
+    args,
     typeArguments,
     targetTypeArguments,
+    span,
     ctx,
     state,
+    matchesCandidate: (candidate, argsForMatch) =>
+      matchesOverloadSignature(
+        candidate.symbol,
+        candidate.signature,
+        argsForMatch,
+        ctx,
+        state,
+        typeArguments,
+        targetTypeArguments,
+    ),
+    argsForCandidate,
+    scoreMatches,
   });
 };
 
@@ -3479,16 +3488,19 @@ const selectMethodCallCandidate = ({
     span: expr.span,
   });
   let matches = findMatchingOverloadCandidates({
+    name: expr.method,
     candidates,
     args: probeArgs,
+    span: expr.span,
     ctx,
     state,
     typeArguments,
     argsForCandidate,
-    refineMatches: (rawMatches) =>
-      narrowOverloadMatchesByLambdaCompatibility({
+    scoreMatches: (rawMatches) =>
+      scoreOverloadMatchesByLambdaCompatibility({
         matches: rawMatches,
         args: probeArgs,
+        callArgs: [{ expr: expr.target }, ...expr.args],
         argsForCandidate,
         typeArguments,
         ctx,
@@ -3540,16 +3552,19 @@ const selectMethodCallCandidate = ({
         span: expr.span,
       });
       matches = findMatchingOverloadCandidates({
+        name: expr.method,
         candidates,
         args: probeArgs,
+        span: expr.span,
         ctx,
         state,
         typeArguments,
         argsForCandidate,
-        refineMatches: (rawMatches) =>
-          narrowOverloadMatchesByLambdaCompatibility({
+        scoreMatches: (rawMatches) =>
+          scoreOverloadMatchesByLambdaCompatibility({
             matches: rawMatches,
             args: probeArgs,
+            callArgs: [{ expr: expr.target }, ...expr.args],
             argsForCandidate,
             typeArguments,
             ctx,
@@ -3874,11 +3889,22 @@ const typeOperatorOverloadCall = ({
   });
 
   const matches = findMatchingOverloadCandidates({
+    name: operatorName,
     candidates,
     args,
+    span: call.span,
     ctx,
     state,
     typeArguments,
+    scoreMatches: (rawMatches) =>
+      scoreOverloadMatchesByLambdaCompatibility({
+        matches: rawMatches,
+        args,
+        callArgs: call.args,
+        typeArguments,
+        ctx,
+        state,
+      }),
   });
   const traitDispatch =
     matches.length === 0
@@ -5588,7 +5614,7 @@ const typeOverloadedCall = (
     }
     return { symbol, signature };
   });
-  const { hintedCandidates, fallbackCandidates } =
+  const { candidates: candidatesForResolution, expectedReturnCompatibleSymbols } =
     selectHintedOverloadCandidates({
       candidates,
       typeArguments,
@@ -5599,8 +5625,7 @@ const typeOverloadedCall = (
       state,
     });
 
-  let candidatesForResolution = hintedCandidates;
-  let matches = findOverloadMatches({
+  const matches = findOverloadMatches({
     name: callee.name,
     candidates: candidatesForResolution,
     args: probeArgs,
@@ -5619,68 +5644,20 @@ const typeOverloadedCall = (
         typeArguments,
         targetTypeArguments,
       ),
-    refineMatches: (rawMatches) => {
-      const lambdaCompatible = narrowOverloadMatchesByLambdaCompatibility({
+    expectedReturnCompatible: expectedReturnCompatibleSymbols
+      ? (candidate) => expectedReturnCompatibleSymbols.has(candidate.symbol)
+      : undefined,
+    scoreMatches: (rawMatches) =>
+      scoreOverloadMatchesByLambdaCompatibility({
         matches: rawMatches,
         args: probeArgs,
-        typeArguments,
-        targetTypeArguments,
-        ctx,
-        state,
-      });
-      return narrowOverloadMatchesByLambdaReturn({
-        matches: lambdaCompatible,
         callArgs: call.args,
         typeArguments,
         targetTypeArguments,
         ctx,
         state,
-      });
-    },
+      }),
   });
-  if (matches.length === 0 && fallbackCandidates) {
-    // Expected-return narrowing is a hint. If it removes all valid matches,
-    // retry with the full overload set before failing.
-    candidatesForResolution = fallbackCandidates;
-    matches = findOverloadMatches({
-      name: callee.name,
-      candidates: candidatesForResolution,
-      args: probeArgs,
-      typeArguments,
-      targetTypeArguments,
-      span: call.span,
-      ctx,
-      state,
-      matchesCandidate: (candidate, argsForMatch) =>
-        matchesOverloadSignature(
-          candidate.symbol,
-          candidate.signature,
-          argsForMatch,
-          ctx,
-          state,
-          typeArguments,
-          targetTypeArguments,
-        ),
-      refineMatches: (rawMatches) => {
-        const lambdaCompatible = narrowOverloadMatchesByLambdaCompatibility({
-          matches: rawMatches,
-          args: probeArgs,
-          typeArguments,
-          targetTypeArguments,
-          ctx,
-          state,
-        });
-        return narrowOverloadMatchesByLambdaReturn({
-          matches: lambdaCompatible,
-          callArgs: call.args,
-          typeArguments,
-          targetTypeArguments,
-          ctx,
-          state,
-        });
-      },
-    });
-  }
 
   const traitDispatch =
     matches.length === 0 && (!typeArguments || typeArguments.length === 0)
@@ -5904,6 +5881,68 @@ const narrowOverloadMatchesByLambdaReturn = <
     return checkedMatches.map(({ candidate }) => candidate);
   }
   return matches;
+};
+
+const scoreOverloadMatchesByLambdaCompatibility = <
+  T extends { symbol: SymbolId; signature: FunctionSignature },
+>({
+  matches,
+  args,
+  callArgs,
+  argsForCandidate,
+  typeArguments,
+  targetTypeArguments,
+  ctx,
+  state,
+}: {
+  matches: readonly T[];
+  args: readonly Arg[];
+  callArgs: readonly { expr: HirExprId; label?: string }[];
+  argsForCandidate?: (candidate: T) => readonly Arg[];
+  typeArguments: readonly TypeId[] | undefined;
+  targetTypeArguments?: readonly TypeId[] | undefined;
+  ctx: TypingContext;
+  state: TypingState;
+}): ReadonlyMap<T, OverloadMatchScoreOverrides> => {
+  if (matches.length <= 1) {
+    return new Map(matches.map((candidate) => [candidate, { lambdaCompatibility: 0 }]));
+  }
+
+  const lambdaCompatible = narrowOverloadMatchesByLambdaCompatibility({
+    matches,
+    args,
+    argsForCandidate,
+    typeArguments,
+    targetTypeArguments,
+    ctx,
+    state,
+  });
+  const lambdaReturnCompatible = narrowOverloadMatchesByLambdaReturn({
+    matches: lambdaCompatible,
+    callArgs,
+    typeArguments,
+    targetTypeArguments,
+    ctx,
+    state,
+  });
+  const compatibilityNarrowed = lambdaCompatible.length < matches.length;
+  const returnNarrowed =
+    lambdaReturnCompatible.length < lambdaCompatible.length;
+  const compatibleSet = new Set(lambdaCompatible);
+  const returnCompatibleSet = new Set(lambdaReturnCompatible);
+
+  return new Map(
+    matches.map((candidate) => {
+      const compatibilityScore =
+        !compatibilityNarrowed || compatibleSet.has(candidate) ? 1 : 0;
+      const returnScore =
+        returnNarrowed && returnCompatibleSet.has(candidate) ? 1 : 0;
+      return [
+        candidate,
+        { lambdaCompatibility: compatibilityScore + returnScore },
+      ];
+    }),
+  );
 };
 
 const inferLambdaReturnSubstitutionForCandidate = <

--- a/packages/compiler/src/semantics/typing/expressions/overload-resolution.ts
+++ b/packages/compiler/src/semantics/typing/expressions/overload-resolution.ts
@@ -19,6 +19,26 @@ export type OverloadResolutionCandidate = {
   signature: FunctionSignature;
 };
 
+export type OverloadCandidateScore<T extends OverloadResolutionCandidate> = {
+  candidate: T;
+  shapeMatch: boolean;
+  argumentMatch: boolean;
+  dominance: number;
+  genericityPenalty: number;
+  constraintSpecificity: number;
+  lambdaCompatibility: number;
+  expectedReturnCompatibility: boolean;
+};
+
+type OverloadScoreInput<T extends OverloadResolutionCandidate> = Omit<
+  OverloadCandidateScore<T>,
+  "dominance" | "genericityPenalty" | "constraintSpecificity"
+>;
+
+export type OverloadMatchScoreOverrides = {
+  lambdaCompatibility?: number;
+};
+
 export const enforceOverloadCandidateBudget = ({
   name,
   candidateCount,
@@ -63,8 +83,8 @@ export const selectHintedOverloadCandidates = <T extends OverloadResolutionCandi
   ctx: TypingContext;
   state: TypingState;
 }): {
-  hintedCandidates: readonly T[];
-  fallbackCandidates?: readonly T[];
+  candidates: readonly T[];
+  expectedReturnCompatibleSymbols?: ReadonlySet<SymbolId>;
 } => {
   const candidatesForBudget = filterCandidatesByExplicitTypeArguments({
     candidates,
@@ -90,12 +110,14 @@ export const selectHintedOverloadCandidates = <T extends OverloadResolutionCandi
     returnHintCandidates.length === 0 ||
     returnHintCandidates.length === candidatesForBudget.length
   ) {
-    return { hintedCandidates: candidatesForBudget };
+    return { candidates: candidatesForBudget };
   }
 
   return {
-    hintedCandidates: returnHintCandidates,
-    fallbackCandidates: candidatesForBudget,
+    candidates: candidatesForBudget,
+    expectedReturnCompatibleSymbols: new Set(
+      returnHintCandidates.map((candidate) => candidate.symbol),
+    ),
   };
 };
 
@@ -110,7 +132,8 @@ export const findOverloadMatches = <T extends OverloadResolutionCandidate>({
   state,
   matchesCandidate,
   argsForCandidate,
-  refineMatches,
+  scoreMatches,
+  expectedReturnCompatible,
 }: {
   name: string;
   candidates: readonly T[];
@@ -122,28 +145,75 @@ export const findOverloadMatches = <T extends OverloadResolutionCandidate>({
   state: TypingState;
   matchesCandidate: (candidate: T, args: readonly Arg[]) => boolean;
   argsForCandidate?: (candidate: T) => readonly Arg[];
-  refineMatches?: (matches: readonly T[]) => readonly T[];
+  scoreMatches?: (
+    matches: readonly T[],
+  ) => ReadonlyMap<T, OverloadMatchScoreOverrides>;
+  expectedReturnCompatible?: (candidate: T) => boolean;
 }): readonly T[] => {
-  const shapeCompatibleCandidates = candidates.filter((candidate) =>
-    signatureCallShapeCouldMatch({
+  const shapedScores = candidates.map((candidate) => ({
+    candidate,
+    shapeMatch: signatureCallShapeCouldMatch({
       args,
       signature: candidate.signature,
       ctx,
       state,
     }),
-  );
+    argumentMatch: false,
+    lambdaCompatibility: 0,
+    expectedReturnCompatibility: expectedReturnCompatible
+      ? expectedReturnCompatible(candidate)
+      : true,
+  }));
+  const shapeCompatibleCandidates = shapedScores
+    .filter((score) => score.shapeMatch)
+    .map(({ candidate }) => candidate);
+  const expectedReturnShapeCompatibleCandidates = shapedScores
+    .filter((score) => score.shapeMatch && score.expectedReturnCompatibility)
+    .map(({ candidate }) => candidate);
+  const candidatesForBudget =
+    expectedReturnShapeCompatibleCandidates.length > 0
+      ? expectedReturnShapeCompatibleCandidates
+      : shapeCompatibleCandidates;
   enforceOverloadCandidateBudget({
     name,
-    candidateCount: shapeCompatibleCandidates.length,
+    candidateCount: candidatesForBudget.length,
     ctx,
     span,
   });
-  const matches = shapeCompatibleCandidates.filter((candidate) =>
+
+  const candidatesForInitialMatch = candidatesForBudget;
+  const initialMatches = candidatesForInitialMatch.filter((candidate) =>
     matchesCandidate(candidate, argsForCandidate ? argsForCandidate(candidate) : args),
   );
-  const refined = refineMatches ? refineMatches(matches) : matches;
-  return narrowOverloadMatches({
-    matches: refined,
+  const shouldCheckFallback =
+    expectedReturnShapeCompatibleCandidates.length > 0 &&
+    initialMatches.length === 0;
+  if (shouldCheckFallback) {
+    enforceOverloadCandidateBudget({
+      name,
+      candidateCount: shapeCompatibleCandidates.length,
+      ctx,
+      span,
+    });
+  }
+  const matches = shouldCheckFallback
+    ? shapeCompatibleCandidates.filter((candidate) =>
+        matchesCandidate(
+          candidate,
+          argsForCandidate ? argsForCandidate(candidate) : args,
+        ),
+      )
+    : initialMatches;
+  const scoreOverrides = scoreMatches?.(matches) ?? new Map();
+  const matchesSet = new Set(matches);
+  const scoreInputs = shapedScores.map((score) => ({
+    ...score,
+    argumentMatch: matchesSet.has(score.candidate),
+    lambdaCompatibility:
+      scoreOverrides.get(score.candidate)?.lambdaCompatibility ?? 0,
+  }));
+  return selectOverloadMatchesFromScores({
+    scores: scoreInputs,
     typeArguments,
     targetTypeArguments,
     ctx,
@@ -642,6 +712,181 @@ const overloadConstraintSpecificity = (
     0
   );
 
+const scoreOverloadMatches = <T extends OverloadResolutionCandidate>({
+  matches,
+  typeArguments,
+  targetTypeArguments,
+  ctx,
+  state,
+}: {
+  matches: readonly T[];
+  typeArguments: readonly TypeId[] | undefined;
+  targetTypeArguments: readonly TypeId[] | undefined;
+  ctx: TypingContext;
+  state: TypingState;
+}): readonly OverloadCandidateScore<T>[] =>
+  matches.map((candidate) => {
+    const isDominated = matches.some(
+      (other) =>
+        candidate !== other &&
+        overloadDominates({
+          candidate: other,
+          other: candidate,
+          typeArguments,
+          targetTypeArguments,
+          ctx,
+          state,
+        }),
+    );
+    return {
+      candidate,
+      shapeMatch: true,
+      argumentMatch: true,
+      dominance: isDominated ? 0 : 1,
+      genericityPenalty: overloadGenericityPenalty({
+        candidate,
+        typeArguments,
+        targetTypeArguments,
+        ctx,
+      }),
+      constraintSpecificity: overloadConstraintSpecificity(candidate),
+      lambdaCompatibility: 0,
+      expectedReturnCompatibility: true,
+    };
+  });
+
+const completeOverloadScores = <T extends OverloadResolutionCandidate>({
+  scores,
+  typeArguments,
+  targetTypeArguments,
+  ctx,
+  state,
+}: {
+  scores: readonly OverloadScoreInput<T>[];
+  typeArguments: readonly TypeId[] | undefined;
+  targetTypeArguments: readonly TypeId[] | undefined;
+  ctx: TypingContext;
+  state: TypingState;
+}): readonly OverloadCandidateScore<T>[] => {
+  const candidates = scores
+    .filter(
+      (score) =>
+        score.shapeMatch &&
+        score.argumentMatch &&
+        Number.isFinite(score.lambdaCompatibility),
+    )
+    .map(({ candidate }) => candidate);
+  const scoredMatches = scoreOverloadMatches({
+    matches: candidates,
+    typeArguments,
+    targetTypeArguments,
+    ctx,
+    state,
+  });
+  const scoredByCandidate = new Map(
+    scoredMatches.map((score) => [score.candidate, score]),
+  );
+
+  return scores.map((score) => {
+    const scored = scoredByCandidate.get(score.candidate);
+    return {
+      ...score,
+      dominance: scored?.dominance ?? 0,
+      genericityPenalty: scored?.genericityPenalty ?? Number.POSITIVE_INFINITY,
+      constraintSpecificity: scored?.constraintSpecificity ?? 0,
+    };
+  });
+};
+
+const selectOverloadMatchesFromScores = <T extends OverloadResolutionCandidate>({
+  scores,
+  typeArguments,
+  targetTypeArguments,
+  ctx,
+  state,
+}: {
+  scores: readonly OverloadScoreInput<T>[];
+  typeArguments: readonly TypeId[] | undefined;
+  targetTypeArguments?: readonly TypeId[] | undefined;
+  ctx: TypingContext;
+  state: TypingState;
+}): readonly T[] => {
+  const completedScores = completeOverloadScores({
+    scores,
+    typeArguments,
+    targetTypeArguments,
+    ctx,
+    state,
+  });
+  const compatibleScores = completedScores.filter(
+    (score) =>
+      score.shapeMatch &&
+      score.argumentMatch,
+  );
+  if (compatibleScores.length <= 1) {
+    return compatibleScores.map(({ candidate }) => candidate);
+  }
+
+  const expectedReturnScores = selectExpectedReturnCompatibleScores(compatibleScores);
+  if (expectedReturnScores.length === 1) {
+    return expectedReturnScores.map(({ candidate }) => candidate);
+  }
+
+  const lambdaCompatibleScores = selectScoresByMax(
+    expectedReturnScores,
+    "lambdaCompatibility",
+  );
+  if (lambdaCompatibleScores.length === 1) {
+    return lambdaCompatibleScores.map(({ candidate }) => candidate);
+  }
+
+  const maximalScores = selectScoresByMax(lambdaCompatibleScores, "dominance");
+  if (maximalScores.length === 1) {
+    return maximalScores.map(({ candidate }) => candidate);
+  }
+
+  // Labeled parameter groups are structural: a value with extra fields can
+  // satisfy a smaller labeled shape. Do not rank matches by "most fields
+  // consumed" here; subset/superset structural overloads should remain
+  // ambiguous until declaration-time validation rejects them.
+  const leastGenericScores = selectScoresByMin(
+    maximalScores,
+    "genericityPenalty",
+  );
+  if (leastGenericScores.length === 1) {
+    return leastGenericScores.map(({ candidate }) => candidate);
+  }
+
+  const mostConstrainedScores = selectScoresByMax(
+    leastGenericScores,
+    "constraintSpecificity",
+  );
+  return mostConstrainedScores.map(({ candidate }) => candidate);
+};
+
+const selectExpectedReturnCompatibleScores = <T extends OverloadResolutionCandidate>(
+  scores: readonly OverloadCandidateScore<T>[],
+): readonly OverloadCandidateScore<T>[] => {
+  const compatible = scores.filter((score) => score.expectedReturnCompatibility);
+  return compatible.length > 0 ? compatible : scores;
+};
+
+const selectScoresByMax = <T extends OverloadResolutionCandidate>(
+  scores: readonly OverloadCandidateScore<T>[],
+  dimension: "lambdaCompatibility" | "dominance" | "constraintSpecificity",
+): readonly OverloadCandidateScore<T>[] => {
+  const max = Math.max(...scores.map((score) => score[dimension]));
+  return scores.filter((score) => score[dimension] === max);
+};
+
+const selectScoresByMin = <T extends OverloadResolutionCandidate>(
+  scores: readonly OverloadCandidateScore<T>[],
+  dimension: "genericityPenalty",
+): readonly OverloadCandidateScore<T>[] => {
+  const min = Math.min(...scores.map((score) => score[dimension]));
+  return scores.filter((score) => score[dimension] === min);
+};
+
 export const narrowOverloadMatches = <T extends OverloadResolutionCandidate>({
   matches,
   typeArguments,
@@ -659,59 +904,17 @@ export const narrowOverloadMatches = <T extends OverloadResolutionCandidate>({
     return matches;
   }
 
-  const maximalMatches = matches.filter((candidate) =>
-    matches.every(
-      (other) =>
-        candidate === other ||
-        !overloadDominates({
-          candidate: other,
-          other: candidate,
-          typeArguments,
-          targetTypeArguments,
-          ctx,
-          state,
-        }),
-    ),
-  );
-
-  if (maximalMatches.length === 1) {
-    return maximalMatches;
-  }
-
-  // Labeled parameter groups are structural: a value with extra fields can
-  // satisfy a smaller labeled shape. Do not rank matches by "most fields
-  // consumed" here; subset/superset structural overloads should remain
-  // ambiguous until declaration-time validation rejects them.
-  const minPenalty = Math.min(
-    ...maximalMatches.map((candidate) =>
-      overloadGenericityPenalty({
-        candidate,
-        typeArguments,
-        targetTypeArguments,
-        ctx,
-      }),
-    ),
-  );
-  const leastGenericMatches = maximalMatches.filter(
-    (candidate) =>
-      overloadGenericityPenalty({
-        candidate,
-        typeArguments,
-        targetTypeArguments,
-        ctx,
-      }) === minPenalty,
-  );
-
-  if (leastGenericMatches.length === 1) {
-    return leastGenericMatches;
-  }
-
-  const maxConstraintSpecificity = Math.max(
-    ...leastGenericMatches.map(overloadConstraintSpecificity)
-  );
-  const mostConstrainedMatches = leastGenericMatches.filter(
-    (candidate) => overloadConstraintSpecificity(candidate) === maxConstraintSpecificity
-  );
-
-  return mostConstrainedMatches.length === 1 ? mostConstrainedMatches : matches;
+  return selectOverloadMatchesFromScores({
+    scores: matches.map((candidate) => ({
+      candidate,
+      shapeMatch: true,
+      argumentMatch: true,
+      lambdaCompatibility: 0,
+      expectedReturnCompatibility: true,
+    })),
+    typeArguments,
+    targetTypeArguments,
+    ctx,
+    state,
+  });
 };


### PR DESCRIPTION
## Summary

Refactors overload resolution around explicit scored candidate records with named dimensions for shape, argument match, expected return compatibility, lambda compatibility, dominance, genericity penalty, and constraint specificity.

The shared scored pipeline is now used by direct overload calls plus method/operator overload helper paths. Expected-return hints and lambda-return compatibility feed the score pipeline rather than living as separate prefilter/refinement selection paths.

## Details

- Adds `OverloadCandidateScore` and centralized score completion/selection in `overload-resolution.ts`.
- Preserves expected-return budget narrowing while enforcing fallback fanout budgets when hinted candidates fail argument matching.
- Converts method/operator lambda compatibility and lambda-return refinement into numeric score overrides.
- Adds targeted tests for each score dimension and regressions for budget fallback and method callback-return disambiguation.

## Validation

- `npx vitest packages/compiler/src/semantics/typing/__tests__/typecheck-budget.test.ts packages/compiler/src/semantics/typing/__tests__/overload-resolution.test.ts packages/compiler/src/semantics/typing/__tests__/overload-lambda-return-hint.test.ts packages/compiler/src/semantics/typing/__tests__/operator-overloads-external.test.ts packages/compiler/src/__tests__/static-access.test.ts`
- `npm run typecheck`
- `npm test`

## Review loop

Agentic review loop completed:

- Implementation gap reviewer: latest reviewer reported no tangible implementation gaps.
- Correctness reviewer: latest reviewer reported no tangible correctness findings remain.

Linear: V-406