### PR TITLE
Rewrite VX reference docs

### DIFF
--- a/apps/smoke/fixtures/vx.voyd
+++ b/apps/smoke/fixtures/vx.voyd
@@ -39,7 +39,7 @@ fn Card({ children: Array<MsgPack> })
 
 fn List({ value: Array<String> })
   <ul style="margin: 0; padding-left: 16px;">
-    {value.map(f => <li style="line-height: 1.6;">{f}</li>)}
+    {value.map(f => <li key={f} style="line-height: 1.6;">{f}</li>)}
   </ul>
 
 fn feature_list() -> Array<String>

--- a/packages/compiler/src/parser/__tests__/html-inline-lambda.test.ts
+++ b/packages/compiler/src/parser/__tests__/html-inline-lambda.test.ts
@@ -72,6 +72,44 @@ pub fn main()
   t.expect(findFirstCall(ast, "html_event_handler")).toBeUndefined();
 });
 
+test("lowers HTML key attributes to keyed nodes", (t) => {
+  const code = `
+use std::all
+use std::vx::all
+
+pub fn main()
+  let items = ["first"]
+  <ul>
+    {items.map(item => <li key={item} class="row">{item}</li>)}
+  </ul>
+`;
+
+  const ast = toPlain(code);
+  t.expect(findFirstCall(ast, "keyed")).toBeDefined();
+  t.expect(findFirstCall(ast, "class")).toBeDefined();
+});
+
+test("lowers component key attributes to keyed component nodes", (t) => {
+  const code = `
+use std::all
+use std::vx::all
+
+enum Msg
+  Noop
+
+fn Row({ title: String }) -> Html<Msg>
+  <li>{title}</li>
+
+pub fn main()
+  let title = "first"
+  <Row key={title} title={title} />
+`;
+
+  const ast = toPlain(code);
+  t.expect(findFirstCall(ast, "keyed")).toBeDefined();
+  t.expect(findFirstCall(ast, "Row")).toBeDefined();
+});
+
 test("lowers closure-valued HTML events to retained HTML event helpers", (t) => {
   const code = `
 use std::msgpack

--- a/packages/compiler/src/parser/reader-macros/html/html-parser.ts
+++ b/packages/compiler/src/parser/reader-macros/html/html-parser.ts
@@ -19,6 +19,8 @@ type ParseOptions = {
   onUnescapedCurlyBrace: (stream: CharStream) => Expr | undefined;
 };
 
+type HtmlAttribute = { name: string; value: Expr };
+
 export class HTMLParser {
   private stream: CharStream;
   private options: ParseOptions;
@@ -58,7 +60,9 @@ export class HTMLParser {
     const lastSegment = tagName.split("::").pop() ?? "";
     const isComponent = /^[A-Z]/.test(lastSegment);
     // Parse attributes/props before closing the tag
-    const propsOrAttrs = this.parseAttributes();
+    const { key, attributes: propsOrAttrs } = splitKeyAttribute(
+      this.parseAttributes(),
+    );
 
     const selfClosing = this.stream.next === "/";
     if (selfClosing) this.stream.consumeChar();
@@ -85,13 +89,19 @@ export class HTMLParser {
         const inner = call(identifier(last), propsObj).setLocation(
           this.stream.currentSourceLocation(),
         );
-        return surfaceCall("::", left, inner).setLocation(
-          this.stream.currentSourceLocation(),
+        return this.applyKeyAttribute(
+          surfaceCall("::", left, inner).setLocation(
+            this.stream.currentSourceLocation(),
+          ),
+          key,
         );
       }
 
-      return surfaceCall(tagName, propsObj).setLocation(
-        this.stream.currentSourceLocation(),
+      return this.applyKeyAttribute(
+        surfaceCall(tagName, propsObj).setLocation(
+          this.stream.currentSourceLocation(),
+        ),
+        key,
       );
     }
 
@@ -108,8 +118,11 @@ export class HTMLParser {
 
     args.push(label("children", children));
 
-    return surfaceCall("html_element", ...args).setLocation(
-      this.stream.currentSourceLocation(),
+    return this.applyKeyAttribute(
+      surfaceCall("html_element", ...args).setLocation(
+        this.stream.currentSourceLocation(),
+      ),
+      key,
     );
   }
 
@@ -227,6 +240,15 @@ export class HTMLParser {
     ).setLocation(this.stream.currentSourceLocation());
   }
 
+  private applyKeyAttribute(node: Expr, key: Expr | undefined): Expr {
+    if (!key) return node;
+    return surfaceCall(
+      "keyed",
+      label("key", key),
+      label("child", node),
+    ).setLocation(this.stream.currentSourceLocation());
+  }
+
   private parseChildren(tagName: string) {
     const lower = tagName.toLowerCase();
     const preserve = lower === "pre" || lower === "textarea";
@@ -334,7 +356,7 @@ export class HTMLParser {
   }
 
   private withChildrenProp(
-    props: { name: string; value: Expr }[],
+    props: HtmlAttribute[],
     tagName: string,
   ) {
     const children = this.parseChildren(tagName);
@@ -359,6 +381,17 @@ export class HTMLParser {
     throw new ParserSyntaxError(message, location);
   }
 }
+
+const splitKeyAttribute = (
+  attributes: HtmlAttribute[],
+): { key?: Expr; attributes: HtmlAttribute[] } => {
+  const key = attributes.find((attribute) => attribute.name === "key")?.value;
+  if (!key) return { attributes };
+  return {
+    key,
+    attributes: attributes.filter((attribute) => attribute.name !== "key"),
+  };
+};
 
 const unwrapInlineExpr = (expr: Expr): Expr => {
   const lambda = unwrapInlineLambdaExpr(expr);

--- a/packages/reference/docs/vx.md
+++ b/packages/reference/docs/vx.md
@@ -4,219 +4,1473 @@ order: 8
 
 # VX
 
-VX is Voyd's UI layer for typed browser apps. A VX app is a small state
-machine: `Model` is durable app state, `Msg` describes transitions, `step`
-advances the model, `view` renders HTML, commands describe one-off work, and
-subscriptions describe ongoing outside events.
+VX is Voyd's web application framework. Inspired by Elm, it gives a Voyd program
+a typed way to describe browser UI, respond to user input, run async work,
+subscribe to outside events, and render the same virtual tree in the browser or
+on the server.
 
-The canonical app entrypoint is:
+The shape is deliberately small:
 
 ```voyd
 pub fn app() -> Program<Model, Msg>
   program({ init, step, view, subscriptions })
 ```
 
-`step`, not `update`, handles messages:
+`Model` is the durable state of the feature. `Msg` is the closed set of events
+that can change that state. `step` receives the current model and one message,
+then returns the next model plus any one-off commands. `view` turns a model into
+HTML. `subscriptions` describes ongoing outside events that should be active for
+the latest model.
+
+That is the core loop:
+
+```text
+init() -> model and optional startup commands
+view(model) -> virtual HTML
+user event, command result, or subscription event -> Msg
+step(model, Msg) -> next model and optional commands
+view(next model)
+subscriptions(next model) are reconciled
+commands are run
+```
+
+VX code should read as a small state machine. The browser runtime owns DOM
+patching, event listener lifetimes, command execution, subscription disposal,
+and callback retention.
+
+## Importing VX
+
+Most applications import the full VX surface:
 
 ```voyd
-fn step(model: Model, message: Msg) -> Program<Model, Msg>
-  match(message)
-    Msg::Edit { value }:
-      next<Model, Msg>(Model { title: value, saved: false })
-    Msg::Save:
-      next<Model, Msg>(
-        model: Model { title: model.title, saved: false },
-        cmd: save_title(model.title)
+use std::vx::all
+```
+
+The main public types are:
+
+- `Program<Model, Msg>`: either an app descriptor or one transition result.
+- `Html<Msg>`: typed virtual HTML that can dispatch `Msg`.
+- `Attr<Msg>`: an attribute, property, style, or event descriptor for `Html`.
+- `Cmd<Msg>`: one-off work that may dispatch a later `Msg`.
+- `Sub<Msg>`: ongoing outside input that may dispatch many `Msg` values.
+- `EventOptions`: browser event listener options.
+- `Ref<T>` and `DomElement`: typed DOM targets for focus and scrolling commands.
+- `StateHandle<T>`: a handle for restricted component-local state.
+
+`Html<Msg>`, `Attr<Msg>`, `Cmd<Msg>`, `Sub<Msg>`, and `Program<Model, Msg>` are
+typed values that cross the Wasm boundary. Application code should construct
+them through the VX helpers.
+
+Messages, models, command values, and subscription values must be
+boundary-compatible data: primitives, `String`, arrays, records or objects with
+public DTO fields, value objects, and enum variants made from those values. Keep
+functions, trait objects, arbitrary dictionaries, DOM nodes, and recursive
+object graphs out of lifecycle data.
+
+## The App Contract
+
+A full app usually has these pieces:
+
+```voyd
+obj Model {
+  count: i32
+}
+
+enum Msg
+  Increment
+  Decrement
+
+pub fn app() -> Program<Model, Msg>
+  program({ init, step, view })
+
+fn init() -> Model
+  Model { count: 0 }
+
+fn step(model: Model, msg: Msg) -> Program<Model, Msg>
+  match(msg)
+    Msg::Increment:
+      next<Model, Msg>(Model { count: model.count + 1 })
+    Msg::Decrement:
+      next<Model, Msg>(Model { count: model.count - 1 })
+
+fn view(model: Model) -> Html<Msg>
+  <main>
+    <button on_click={Msg::Decrement {}}>-</button>
+    <span>{count_label(model.count)}</span>
+    <button on_click={Msg::Increment {}}>+</button>
+  </main>
+```
+
+The canonical typed VX app entrypoint is `app`. The transition function used by
+the standard helpers and generated runtime descriptor is `step`.
+
+When the local function names match the labels, prefer the struct shorthand call:
+
+```voyd
+program({ init, step, view, subscriptions })
+```
+
+The return type on `app` and the signatures of `init`, `step`, `view`, and
+`subscriptions` give the compiler enough context to infer `Model` and `Msg`.
+Use explicit labels when local function names differ from the program labels:
+
+```voyd
+program(
+  init: initialize,
+  step: handle_message,
+  view: render,
+  subscriptions: active_subscriptions
+)
+```
+
+There are two useful `program` forms for app descriptors:
+
+```voyd
+program(
+  init: fn() -> Model,
+  step: fn(Model, Msg) -> Program<Model, Msg>,
+  view: fn(Model) -> Html<Msg>,
+  subscriptions: fn(Model) -> Sub<Msg> = ...
+)
+```
+
+Use this when startup is pure and only returns the initial model.
+
+```voyd
+program(
+  init: fn() -> Program<Model, Msg>,
+  step: fn(Model, Msg) -> Program<Model, Msg>,
+  view: fn(Model) -> Html<Msg>,
+  subscriptions: fn(Model) -> Sub<Msg> = ...
+)
+```
+
+Use this when startup also needs commands, for example loading data. In that
+case `init` returns `next(model: initial_model, cmd: load())`.
+
+Inside `step`, return `next`:
+
+```voyd
+next<Model, Msg>(next_model)
+next(model: next_model, cmd: save_title(next_model.title))
+```
+
+`next` is a pure constructor. It only describes the transition result; command
+execution, DOM patching, and subscription management happen in the runtime.
+
+## Models And Messages
+
+Put durable state in `Model`: server data, form data that other code needs,
+URLs, selected ids, loading flags, validation errors, pending request status,
+feature state, and anything you want to test as application behavior.
+
+Use `Msg` for every event that can change that model. Prefer messages that
+describe the event that occurred and leave implementation choices in `step`:
+
+```voyd
+enum Msg
+  DraftChanged { value: String }
+  Submit
+  SaveFinished { result: Result<Todo, String> }
+  CancelEdit
+```
+
+This keeps `step` readable. Each branch answers two questions:
+
+- What is the next model?
+- Is there one-off work to start?
+
+```voyd
+fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
+  match(msg)
+    Msg::DraftChanged { value }:
+      next<Model, Msg>(Model { draft: value, saving: model.saving })
+    Msg::Submit:
+      next(
+        model: Model { draft: model.draft, saving: true },
+        cmd: save_draft(model.draft)
       )
 ```
 
-`next` is a pure constructor for the `Program<Model, Msg>` returned by `step`.
-It always requires the next model. Commands are returned as data; `next` does
-not run work and does not manage subscriptions.
+For expected failures, make the task return a `Result` and map the `Result` into
+a message. If a task itself fails, the browser runtime reports the error through
+its runtime error handler; application messages remain focused on domain
+outcomes.
 
-Typed lifecycle values must be boundary-compatible DTOs: primitives, `String`,
-arrays, records/objects with public DTO fields, value objects, and named message
-variants built from those values. Functions, trait objects, arbitrary
-dictionaries, and recursive object graphs are not app-boundary DTOs.
+## The Step Function
 
-`Cmd<Msg>` and `Sub<Msg>` are typed payload objects. `Html<Msg>`,
-`Attr<Msg>`, and `Program<Model, Msg>` remain payload-compatible VX values for
-the current compiler/runtime boundary; app code should construct them through
-the typed helpers instead of raw `MsgPack`. The intended direction is stronger
-nominal app-facing wrappers once the compiler can support them without
-excessive type-checking cost.
+`step` is the transition table for an app or feature.
+
+```voyd
+fn step(model: Model, msg: Msg) -> Program<Model, Msg>
+```
+
+It receives the current model and one message. It returns a `Program` transition
+containing the next model and any command work that should begin after the model
+has been accepted.
+
+Most branches have this shape:
+
+```voyd
+Msg::DraftChanged { value }:
+  next<Model, Msg>(with_draft(model, value))
+Msg::Submit:
+  next(model: saving_now(model), cmd: save_draft(model.draft))
+```
+
+Use `next<Model, Msg>(next_model)` for a pure state transition. Use
+`next(model:, cmd:)` when the transition also starts one-off work.
+
+Commands returned from `step` are descriptions. The runtime runs them after it
+stores the next model, renders, and reconciles subscriptions. That ordering lets
+`step` stay easy to test: given a model and message, it produces a transition
+value.
+
+When a branch becomes large, extract the model update into a named helper:
+
+```voyd
+Msg::Saved { result }:
+  match(result)
+    Ok { value }:
+      next<Model, Msg>(saved(model, value))
+    Err { error }:
+      next<Model, Msg>(with_error(model, error))
+
+fn saved(model: Model, todo: Todo) -> Model
+  Model {
+    todos: replace_todo(model.todos, todo),
+    draft: model.draft,
+    loading: false,
+    saving: false,
+    error: String::init()
+  }
+```
+
+The helper name should describe the state transition. Keep command constructors
+similarly named:
+
+```voyd
+Msg::Refresh:
+  next(model: loading(model), cmd: load_todos())
+```
+
+This keeps the branch readable without hiding the architecture: message in,
+model out, commands described.
+
+Use effects on `step` only when constructing the returned transition needs that
+effect. For example, a `step` branch that calls a helper using `Cmd.task` needs
+`TaskRuntime`:
+
+```voyd
+fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
+  match(msg)
+    Msg::Submit:
+      next(model: saving_now(model), cmd: save_draft(model.draft))
+```
+
+The task itself completes later and returns to the app as another `Msg`.
 
 ## Views
 
-Use HTML syntax for normal UI:
+Views are plain functions from model to `Html<Msg>`.
+
+```voyd
+fn view(model: Model) -> Html<Msg>
+  <main class="editor">
+    <label for="title">Title</label>
+    <input
+      id="title"
+      value={model.title}
+      on_input={(event: InputEvent) -> Msg =>
+        Msg::TitleChanged { value: event.value }
+      }
+    />
+    <button type="button" on_click={Msg::Save {}}>Save</button>
+  </main>
+```
+
+VX HTML is virtual DOM. A render builds a tree of text, fragment, and element
+nodes. The browser runtime compares the new tree with the previous tree and
+patches real DOM nodes.
+
+### Components
+
+Components are ordinary functions that return `Html<Msg>`.
+
+```voyd
+fn Toolbar({ saving: bool }) -> Html<Msg>
+  <div class="toolbar">
+    <button type="button" disabled={saving} on_click={Msg::Save {}}>
+      Save
+    </button>
+    <button type="button" on_click={Msg::Cancel {}}>Cancel</button>
+  </div>
+```
+
+Call components with element syntax:
 
 ```voyd
 fn view(model: Model) -> Html<Msg>
   <main>
-    <input
-      value={model.title}
-      on_input={(event: InputEvent) -> Msg => Msg::Edit { value: event.value }}
-    />
-    <button on_click={Msg::Save {}}>Save</button>
+    <Toolbar saving={model.saving} />
   </main>
 ```
 
-Components are regular functions that return `Html<Msg>`:
+Component parameters are just function parameters. Keep components mostly
+presentational when possible. If a component needs to change durable app state,
+pass it enough model data and let it emit parent messages.
+
+### Children
+
+Text children can be string literals or interpolated values:
 
 ```voyd
-fn Toolbar({ on_save: fn() -> Msg }) -> Html<Msg>
-  <button on_click={on_save}>Save</button>
+<p>Hello, {model.name}</p>
 ```
 
-Use `keyed(key:, child:)` when list items should keep DOM identity while
-reordering. If keyed children create component-local state, use
-`keyed(key:, body:)` so the local state scope follows the key.
-
-## Events
-
-Events can send fixed messages, call closures, or pass normalized browser event
-payloads:
+Use arrays of `Html<Msg>` for lists:
 
 ```voyd
-<button on_click={Msg::Save {}}>Save</button>
-<button on_click={() -> Msg => Msg::Cancel {}}>Cancel</button>
-<input on_input={(event: InputEvent) -> Msg => Msg::Edit { value: event.value }} />
+<ul>
+  {model.todos.map((todo) => <li key={todo.id}>{todo.title}</li>)}
+</ul>
 ```
 
-Use `EventOptions` for browser behavior such as form submission:
+Use `key` on list children with stable identity. A key tells the renderer that
+an item is the same logical item after insertion, deletion, or reordering.
+
+### Attributes, Properties, And Styles
+
+Most HTML syntax maps directly to attributes:
 
 ```voyd
-on_submit_with(
-  options: EventOptions { prevent_default: true },
-  message: Msg::Submit {}
-)
+<button id="save" class="primary" type="button">Save</button>
 ```
 
-## State
-
-Durable, shared, server, URL, command, subscription, and testable business state
-belongs in `Model`. Component-local state remains a restricted UI-local escape
-valve for small component-owned `String`, `i32`, or serialized values:
+Attribute helpers return `Attr<Msg>` values. They are useful when a helper
+function returns an attribute list, or when an element is built with the
+lower-level constructors:
 
 ```voyd
-let (panel, set_panel) = state(initial: "closed")
-<button on_click={() => set_panel("open")}>Open</button>
-```
-
-Do not use component-local state for data that other features need to read, save,
-load, subscribe from, or test as application behavior.
-
-## Commands
-
-Commands are one-off work that eventually dispatches messages:
-
-```voyd
-Cmd<Msg>::message(Msg::Saved {})
-Cmd<Msg>::delay(millis: 250i64, value: Msg::Saved {})
-Cmd<Msg>::batch([first, second])
-Cmd<Msg>::focus<DomElement>(editor_ref)
-Cmd<Msg>::scroll_into_view<DomElement>(editor_ref)
-```
-
-Use named command constructors so `step` stays focused on state transitions.
-Use `Cmd.task` for one-off async work that should dispatch a typed result.
-
-```voyd
-fn save_title(title: String): TaskRuntime -> Cmd<Msg>
-  Cmd<Msg>::task(
-    work: () -> SaveResult => api_save_title(title),
-    handler: (result: SaveResult) -> Msg => Msg::Saved { result: result }
+fn SaveButton() -> Html<Msg>
+  html_element(
+    tag: "button",
+    attrs: [
+      id("save"),
+      class("primary"),
+      input_type("button"),
+      attr(name: "aria-label", value: "Save")
+    ],
+    children: [text("Save")]
   )
 ```
 
-Use `Cmd.map` when a child feature command should return parent messages.
+The individual attribute helpers are:
+
+```voyd
+id("save")
+class("primary")
+classes(["primary", "wide"])
+role("button")
+name("title")
+placeholder("Untitled")
+input_type("text")
+tab_index(0)
+attr(name: "aria-label", value: "Save")
+```
+
+Use properties for live DOM state such as `value`, `checked`, and `disabled`:
+
+```voyd
+<input value={model.draft} />
+<input type="checkbox" checked={model.enabled} />
+<button disabled={model.saving}>Save</button>
+```
+
+The lower-level helpers are:
+
+```voyd
+value(model.draft)
+checked(model.enabled)
+disabled(model.saving)
+prop(name: "value", value: model.draft)
+```
+
+Styles are explicit property/value pairs:
+
+```voyd
+style(name: "display", value: "grid")
+style(name: "grid-template-columns", value: "1fr auto")
+styles([("display", "grid"), ("gap", "0.5rem")])
+```
+
+The runtime validates tag names, attribute names, and CSS property names. Invalid
+frames fail before malformed DOM can be produced.
+
+### Refs
+
+`Ref<T>` is a typed way to identify a DOM element for a later command.
+
+```voyd
+let editor = Ref<DomElement> { id: "editor" }
+
+fn view(model: Model) -> Html<Msg>
+  <input data-vx-ref="editor" value={model.draft} />
+```
+
+The helper form is clearer when building attributes manually:
+
+```voyd
+ref<DomElement>(editor)
+```
+
+Refs are looked up by `data-vx-ref`. They are useful with `Cmd.focus` and
+`Cmd.scroll_into_view`.
+
+### Lower-Level Render Constructors
+
+HTML syntax is the normal surface. These functions are available for generated
+code, interop, and advanced helpers:
+
+```voyd
+text("hello")
+fragment(children)
+element(tag: "section", attrs: attrs, children: children)
+html_element(tag: "section", attrs: attrs, children: children)
+frame(root)
+```
+
+`frame(root)` wraps a root node in the versioned VX render-frame format used by
+the browser and server renderers.
+
+## Events
+
+Events turn browser input into messages.
+
+Use a fixed message when the event payload can be ignored:
+
+```voyd
+<button type="button" on_click={Msg::Save {}}>Save</button>
+```
+
+Use a zero-argument closure when you need to compute the message:
+
+```voyd
+<button
+  type="button"
+  on_click={() -> Msg => Msg::Select { id: todo.id }}
+>
+  Select
+</button>
+```
+
+Use a typed payload closure when the browser event contains the data:
+
+```voyd
+<input
+  value={model.search}
+  on_input={(event: InputEvent) -> Msg =>
+    Msg::SearchChanged { value: event.value }
+  }
+/>
+```
+
+The standard event payload types are:
+
+```voyd
+MouseEvent {
+  kind: String,
+  x: f64,
+  y: f64,
+  client_x: f64,
+  client_y: f64,
+  button: i32,
+  alt_key: bool,
+  ctrl_key: bool,
+  meta_key: bool,
+  shift_key: bool,
+  delta_x: f64,
+  delta_y: f64
+}
+
+KeyboardEvent {
+  kind: String,
+  key: String,
+  code: String,
+  alt_key: bool,
+  ctrl_key: bool,
+  meta_key: bool,
+  shift_key: bool
+}
+
+InputEvent {
+  kind: String,
+  value: String,
+  checked: bool,
+  input_type: String
+}
+
+SubmitEvent {
+  kind: String,
+  form_keys: Array<String>,
+  form_values: Array<String>
+}
+
+GenericEvent {
+  kind: String,
+  event: String
+}
+```
+
+Use `EventOptions` for browser listener behavior:
+
+```voyd
+<form
+  on_submit={on_submit_with(
+    options: EventOptions { prevent_default: true },
+    message: Msg::Submit {}
+  )}
+>
+  ...
+</form>
+```
+
+The options are `prevent_default`, `stop_propagation`, `capture`, and `passive`.
+
+The event helper pattern is consistent:
+
+```voyd
+on_click_message(Msg::Save {})
+on_click_with(options: EventOptions { prevent_default: true }, message: Msg::Save {})
+event_message<InputEvent, Msg>(
+  name: "input",
+  message: (event: InputEvent) -> Msg => Msg::Edit { value: event.value }
+)
+```
+
+The named event families are:
+
+- Mouse: `on_click`, `on_double_click`, `on_mouse_down`, `on_mouse_up`,
+  `on_mouse_move`, `on_mouse_enter`, `on_mouse_leave`.
+- Pointer: `on_pointer_down`, `on_pointer_up`, `on_pointer_move`.
+- Keyboard: `on_key_down`, `on_key_up`.
+- Form/input: `on_input`, `on_change`, `on_submit`.
+- Focus/scroll/wheel: `on_focus`, `on_blur`, `on_scroll`, `on_wheel`.
+- Drag/drop/context: `on_drag_start`, `on_drag`, `on_drag_end`, `on_drop`,
+  `on_context_menu`.
+
+Each family has forms for retained handler ids, typed messages, typed event
+closures, and `EventOptions`. Application code usually needs the HTML attribute
+syntax, fixed typed messages, typed event closures, and the `_with` helpers for
+options.
+
+## Component-Local State
+
+Most state belongs in `Model`. Reach for component-local state for small local
+UI details outside app behavior: a small open/closed flag, an uncontrolled input
+draft inside a reusable widget, or a temporary visual value.
+
+Component-local state is intentionally restricted to small boundary-safe values,
+with direct helpers for `String` and `i32`.
+
+```voyd
+fn Disclosure(): Component -> Html<Msg>
+  let (panel, set_panel) = state(initial: "closed")
+  <section>
+    <button
+      type="button"
+      on_click={() => set_panel("open")}
+    >
+      Open
+    </button>
+    <p>{panel}</p>
+  </section>
+```
+
+For more control, use a handle:
+
+```voyd
+fn CounterButton(): Component -> Html<Msg>
+  let handle = state_handle(initial: 0)
+  <button on_click={() => handle.set(handle.value + 1)}>
+    Increment
+  </button>
+```
+
+`StateHandle<T>` methods:
+
+- `set(value)` replaces state and schedules the component runtime.
+- `update(value)` replaces state and returns a new handle with the updated
+  value.
+
+Keep server data, shared feature data, command inputs, URL state, and testable
+application behavior in `Model`.
+
+## Commands
+
+`Cmd<Msg>` describes one-off work. A command value is returned from `init` or
+`step`, and the browser runtime handles the command after it has stored the new
+model, rendered the new view, and reconciled subscriptions.
+
+Most command constructors only build data. `Cmd.task` is the important exception:
+it detaches a Voyd task while constructing the command, stores the task id in the
+command, and the browser runtime later observes that task and dispatches the
+mapped result. That is why any function that calls `Cmd.task` needs the
+`TaskRuntime` effect.
+
+Commands exist so state transitions stay explicit. `step` decides what should
+happen next; command constructors isolate outside work from the model update.
+
+### Command Constructors
+
+`Cmd.none()` does nothing.
+
+```voyd
+Cmd<Msg>::none()
+```
+
+Use it when a helper has to return a command for an empty branch.
+
+`Cmd.message(value)` queues a typed message.
+
+```voyd
+Cmd::message(Msg::Saved {})
+```
+
+Use it to split a state-machine transition into a follow-up message. Message
+loops can occur if every handling of a message immediately commands the same
+message again.
+
+`Cmd.delay(millis:, value:)` dispatches a typed message after a timer.
+
+```voyd
+Cmd::delay(millis: 250i64, value: Msg::Autosave {})
+```
+
+The browser runtime clears pending delays when the app is disposed.
+
+`Cmd.batch(values)` runs several commands.
+
+```voyd
+Cmd::batch([focus_editor(), announce_saved()])
+```
+
+The browser runtime walks command batches in order. A batch is useful when one
+transition needs independent side effects, such as starting a request and moving
+focus.
+
+`Cmd.task(work:, handler:)` starts one detached Voyd task and dispatches the
+handler result when the task completes.
+
+```voyd
+fn save_title(title: String): TaskRuntime -> Cmd<Msg>
+  Cmd::task(
+    work: () -> Result<Todo, String> => api_save_title(title),
+    handler: (result: Result<Todo, String>) -> Msg =>
+      Msg::SaveFinished { result: result }
+  )
+```
+
+Use `Cmd.task` for API requests, database writes, and other async work. The
+function that creates the task needs the `TaskRuntime` effect because the task is
+detached as part of constructing the command.
+
+`Cmd.perform` is the lower-level task command. Use it when you already have a
+`Task<T>` or a task id and want to attach a retained result mapper yourself.
+
+```voyd
+Cmd::perform(
+  task: task_value,
+  handler: (value: Todo) -> Msg =>
+    Msg::Saved { result: Ok { value: value } }
+)
+Cmd<Msg>::perform(task_id: task_id, handler_id: mapper_id)
+```
+
+Most application code should prefer `Cmd.task`.
+
+`Cmd.runtime(kind:)` creates a host command envelope.
+
+```voyd
+Cmd<Msg>::runtime(kind: "copy_to_clipboard")
+```
+
+The browser host must register a command executor for the `kind`. Use runtime
+commands for browser capabilities beyond VX's built-in set.
+
+`Cmd.focus(target)` focuses a DOM element found by `data-vx-ref`.
+
+```voyd
+let editor = Ref<DomElement> { id: "editor" }
+Cmd<Msg>::focus(editor)
+```
+
+`Cmd.scroll_into_view(target)` scrolls a DOM element found by `data-vx-ref`.
+
+```voyd
+Cmd<Msg>::scroll_into_view(editor)
+```
+
+`Cmd.map(handler)` lifts child commands into parent message space.
+
+```voyd
+child_cmd.map(
+  (msg: ChildMsg) -> AppMsg => AppMsg::Child { value: msg }
+)
+```
+
+Use `Cmd.map` when composing features. It keeps child features independent of
+the parent's message type.
+
+### Command Design
+
+Name command constructors after the work they describe:
+
+```voyd
+fn load_todos(): TaskRuntime -> Cmd<Msg>
+  Cmd::task(
+    work: () -> Result<Array<Todo>, String> => api_load_todos(),
+    handler: (result: Result<Array<Todo>, String>) -> Msg =>
+      Msg::Loaded { result: result }
+  )
+```
+
+Then `step` stays focused on transitions:
+
+```voyd
+Msg::Refresh:
+  next(model: loading(model), cmd: load_todos())
+```
+
+This is the main VX habit: isolate outside work in command constructors and keep
+model changes visible in `step`.
 
 ## Subscriptions
 
-Subscriptions are declarative ongoing listeners derived from the latest model:
+`Sub<Msg>` describes ongoing outside input. A subscription can dispatch many
+messages over time: timer ticks, global keyboard shortcuts, browser connection
+state, WebSocket messages, host events, or any other listener managed by the
+runtime.
+
+The `subscriptions` function is part of the app contract:
+
+```voyd
+fn subscriptions(model: Model) -> Sub<Msg>
+  ...
+```
+
+VX calls it after `init` and after every `step`. The returned value is the full
+set of listeners that should be active for the current model. When the model
+changes, VX compares the latest subscription set with the previous one and
+updates the running listeners.
+
+```text
+init or step produces a model
+view renders that model
+subscriptions(model) returns the active subscription set
+VX starts new listeners
+VX disposes listeners that disappeared
+VX replaces listeners whose descriptor changed
+```
+
+This makes subscriptions model-driven. Editing mode can enable an Escape key
+listener. Leaving editing mode removes it:
 
 ```voyd
 fn subscriptions(model: Model) -> Sub<Msg>
   if
-    model.editing:
-      keyboard_on_key_down<Msg>(key: "Escape", value: Msg::Cancel {})
+    model.editing_id.len() > 0:
+      keyboard_on_key_down(key: "Escape", value: Msg::CancelEdit {})
     else:
       Sub<Msg>::none()
 ```
 
-The runtime syncs subscriptions after each message:
+The subscription value is data. Creating the value only describes the listener.
+The browser runtime attaches, updates, and disposes the listener after it has
+accepted the latest model.
 
-```text
-message -> step(model, msg) -> Program(next_model, commands)
-runtime stores next_model
-runtime evaluates subscriptions(next_model)
-runtime disposes disappeared or changed subscriptions
-runtime starts new subscriptions
-runtime runs commands
-```
+### Keys And Identity
 
-Unsubscribe by omission: leave a subscription out of the latest
-`subscriptions(model)` result and the runtime disposes it. Stable keys identify
-subscriptions; if a subscription with the same key changes descriptor fields, it
-is replaced.
+Every active subscription needs a stable key. The runtime uses the subscription
+kind plus key, and any message mapping chain, as its identity. Use ids that
+represent the logical listener, such as `"clock"`, `"escape"`, or
+`"todo:" + todo.id`.
 
-## Feature Composition
-
-Feature modules should own their own `Model`, `Msg`, `step`, `view`, command
-constructors, and subscriptions. Parent features can delegate child work and
-lift the complete child `Program` result back into the parent model/message
-space:
+A stable key lets VX keep the same listener alive across renders. If the key
+changes, VX treats the next descriptor as a different listener.
 
 ```voyd
-AppMsg::Todos { value }:
-  let child = todos::step(model.todos, value)
-  let with_parent_model = map_model(
-    child,
-    (todos_model: todos::Model) -> AppModel =>
-      AppModel { todos: todos_model, session: model.session }
+Sub::every(key: "clock", millis: 1000i64, value: Msg::Tick {})
+```
+
+The string `"clock"` means "the app's clock listener." It should stay the same
+even though the model changes after each tick.
+
+Use model data in a key when the listener really belongs to one model entity:
+
+```voyd
+Sub::runtime(
+  kind: "todo_status",
+  key: "todo:" + model.selected_id
+)
+```
+
+When `selected_id` changes, the old selected-todo listener is disposed and a new
+selected-todo listener starts.
+
+### Empty And Batch
+
+`Sub.none()` creates an empty subscription set.
+
+```voyd
+Sub<Msg>::none()
+```
+
+Use it when a model state has no outside input to listen to.
+
+`Sub.batch(values)` combines several subscriptions into one value. This is the
+normal shape once a screen has more than one active listener:
+
+```voyd
+fn subscriptions(model: Model) -> Sub<Msg>
+  if
+    model.editing_id.len() > 0:
+      Sub::batch([
+        Sub::every(key: "clock", millis: 1000i64, value: Msg::Tick {}),
+        keyboard_on_key_down(key: "Escape", value: Msg::CancelEdit {})
+      ])
+    else:
+      Sub::every(key: "clock", millis: 1000i64, value: Msg::Tick {})
+```
+
+`Sub.batch` can contain `Sub.none()` values. Empty children are ignored by the
+runtime.
+
+### Intervals
+
+`Sub.every(key:, millis:, value:)` dispatches a typed message at an interval.
+
+```voyd
+Sub::every(key: "autosave", millis: 5000i64, value: Msg::Autosave {})
+```
+
+Use intervals for polling, clocks, debounced reminders, and periodic autosave
+checks. The `value` is the message dispatched on every tick.
+
+```voyd
+enum Msg
+  Tick
+  Autosave
+
+fn subscriptions(model: Model) -> Sub<Msg>
+  Sub::batch([
+    Sub::every(key: "clock", millis: 1000i64, value: Msg::Tick {}),
+    Sub::every(key: "autosave", millis: 5000i64, value: Msg::Autosave {})
+  ])
+```
+
+A message produced by an interval goes through the same `step` function as a
+button click or command result:
+
+```voyd
+fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
+  match(msg)
+    Msg::Tick:
+      next<Model, Msg>(Model { ticks: model.ticks + 1 })
+    Msg::Autosave:
+      next(model: model, cmd: save_draft(model.draft))
+```
+
+### Keyboard
+
+Keyboard helpers subscribe to global browser keyboard events:
+
+```voyd
+keyboard_on_key_down(key: "Escape", value: Msg::CancelEdit {})
+keyboard_on_key_up(key: "Enter", value: Msg::Submit {})
+```
+
+The `key` parameter is both the browser key filter and the stable key for the
+subscription. The dispatched `value` is a typed message.
+
+Keyboard subscriptions are especially useful for mode-dependent shortcuts:
+
+```voyd
+fn subscriptions(model: Model) -> Sub<Msg>
+  if
+    model.modal_open:
+      keyboard_on_key_down(key: "Escape", value: Msg::CloseModal {})
+    else:
+      Sub<Msg>::none()
+```
+
+### Runtime Subscriptions
+
+`Sub.runtime(kind:, key:)` creates a host subscription envelope for browser or
+application capabilities supplied by JavaScript.
+
+```voyd
+enum Msg
+  OnlineChanged { online: bool }
+
+fn subscriptions(model: Model) -> Sub<Msg>
+  Sub<bool>::runtime(kind: "online_status", key: "network").map(
+    (online: bool) -> Msg => Msg::OnlineChanged { online: online }
   )
-  map_message(
-    with_parent_model,
+```
+
+The browser host must register a subscription runner for the `kind` through
+`runtimeHost.subscriptions`. The runner receives the subscription descriptor and
+a `context` with `dispatch`, `signal`, and `reportError`.
+
+```ts
+await mountVxApp({
+  container,
+  app,
+  runtimeHost: {
+    subscriptions: {
+      online_status: (subscription, context) => {
+        const dispatch = () => {
+          void context.dispatch({
+            kind: "subscription",
+            subscriptionKind: "online_status",
+            key: String(subscription.key),
+            payload: navigator.onLine,
+          });
+        };
+
+        window.addEventListener("online", dispatch);
+        window.addEventListener("offline", dispatch);
+        dispatch();
+
+        return () => {
+          window.removeEventListener("online", dispatch);
+          window.removeEventListener("offline", dispatch);
+        };
+      },
+    },
+  },
+});
+```
+
+The runner returns an optional disposer that VX calls when the subscription
+disappears or is replaced. In this example, the host dispatches a `bool` payload
+and the Voyd `map` closure turns that payload into `Msg::OnlineChanged`.
+
+Use `value` when the host runner needs configuration:
+
+```voyd
+Sub<String>::runtime(
+  kind: "websocket",
+  key: "project:" + model.project_id,
+  value: websocket_config(model.project_id)
+).map(
+  (message: String) -> Msg => Msg::SocketMessage { value: message }
+)
+```
+
+The `value` field is sent to the host in the subscription descriptor. It is
+configuration for starting the listener, such as a channel name, URL, or topic.
+Data from the listener reaches Voyd when the host runner calls
+`context.dispatch`.
+
+### Mapping Child Subscriptions
+
+`Sub.map(handler)` lifts child subscriptions into parent message space. Use it
+when a feature module owns its own `Msg` type:
+
+```voyd
+fn subscriptions(model: AppModel) -> Sub<AppMsg>
+  todos::subscriptions(model.todos).map(
     (msg: todos::Msg) -> AppMsg => AppMsg::Todos { value: msg }
   )
 ```
 
-Compose views with `map_html`, commands with `Cmd.map`, subscriptions with
-`Sub.map`, and complete child program results with `map_model` and
-`map_message`.
+Mapping becomes part of subscription identity. The runtime keeps mapped child
+subscriptions separate from unmapped subscriptions with the same kind and key.
+
+### Choosing The Shape
+
+Start with `Sub.none()`. Add a subscription when the app needs ongoing input
+from outside the current message. Keep the subscription constructor close to the
+feature that handles its messages:
+
+```voyd
+obj Model {
+  editing_id: String
+}
+
+enum Msg
+  StartEdit { id: String }
+  CancelEdit
+
+fn subscriptions(model: Model) -> Sub<Msg>
+  if
+    model.editing_id.len() > 0:
+      keyboard_on_key_down(key: "Escape", value: Msg::CancelEdit {})
+    else:
+      Sub<Msg>::none()
+
+fn step(model: Model, msg: Msg) -> Program<Model, Msg>
+  match(msg)
+    Msg::StartEdit { id }:
+      next<Model, Msg>(Model { editing_id: id })
+    Msg::CancelEdit:
+      next<Model, Msg>(Model { editing_id: String::init() })
+```
+
+When `StartEdit` sets `editing_id`, the next subscription pass starts the Escape
+listener. When `CancelEdit` clears `editing_id`, the next subscription pass
+disposes it.
+
+## Feature Composition
+
+Large VX apps should be built from features. A feature can own its own `Model`,
+`Msg`, `step`, `view`, command constructors, and subscriptions. The parent app
+stores the child model and wraps child messages in a parent message variant.
+
+In a `todos` module, the feature can define a small state machine:
+
+```voyd
+obj Model {
+  items: Array<Todo>,
+  draft: String,
+  saving: bool,
+  error: String
+}
+
+enum Msg
+  DraftChanged { value: String }
+  Submit
+  Created { result: Result<Todo, String> }
+
+pub fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
+  match(msg)
+    Msg::DraftChanged { value }:
+      next<Model, Msg>(with_draft(model, value))
+    Msg::Submit:
+      next(model: saving_now(model), cmd: create_todo(model.draft))
+    Msg::Created { result }:
+      match(result)
+        Ok { value }:
+          next<Model, Msg>(adding(model, value))
+        Err { error }:
+          next<Model, Msg>(with_error(model, error))
+```
+
+The parent model keeps the feature model as a field:
+
+```voyd
+obj AppModel {
+  todos: todos::Model,
+  session: Session
+}
+
+enum AppMsg
+  Todos { value: todos::Msg }
+  SignedOut
+```
+
+When a child message arrives, delegate to the child `step`, then lift the child
+transition into the parent app:
+
+```voyd
+AppMsg::Todos { value }:
+  let child = todos::step(model.todos, value)
+  let with_model = map_model(
+    child,
+    (next_todos: todos::Model) -> AppModel =>
+      AppModel { todos: next_todos, session: model.session }
+  )
+  map_message(
+    with_model,
+    (child_msg: todos::Msg) -> AppMsg =>
+      AppMsg::Todos { value: child_msg }
+  )
+```
+
+`map_model` replaces the child transition model with a parent model. The mapper
+receives the next `todos::Model`, then rebuilds `AppModel` with the existing
+parent state around it.
+
+`map_message` lifts every child message inside the child transition into the
+parent message type. That includes messages produced later by child commands and
+subscriptions.
+
+Views, commands, and subscriptions have matching mappers:
+
+```voyd
+fn view(model: AppModel) -> Html<AppMsg>
+  let handler_id = retain_typed_message_mapper(
+    (msg: todos::Msg) -> AppMsg => AppMsg::Todos { value: msg }
+  )
+  <main>
+    {map_html(
+      html: todos::view(model.todos),
+      handler_id: handler_id
+    )}
+  </main>
+
+fn app_subscriptions(model: AppModel) -> Sub<AppMsg>
+  todos::subscriptions(model.todos).map(
+    (msg: todos::Msg) -> AppMsg => AppMsg::Todos { value: msg }
+  )
+
+fn load_todos_for_app(): TaskRuntime -> Cmd<AppMsg>
+  todos::load_todos().map(
+    (msg: todos::Msg) -> AppMsg => AppMsg::Todos { value: msg }
+  )
+```
+
+Use the mapper that matches the value being composed:
+
+- `map_html(html:, handler_id:)` lifts child HTML after you retain a message
+  mapper with `retain_typed_message_mapper`.
+- `Cmd.map` lifts child commands.
+- `Sub.map` lifts child subscriptions.
+- `map_model` lifts the model inside a child `Program`.
+- `map_message` lifts messages inside a child `Program`.
+
+This is the main tool for keeping feature state local. A todos feature can grow
+its own loading flags, edit form, persistence commands, and keyboard
+subscriptions while the parent app only knows that todos has a model field and a
+message wrapper.
 
 ## Runtime And Interop
 
-Typed apps should export `app() -> Program<Model, Msg>`. The JavaScript host
-uses `createVoydVxAppRuntime({ host })` and `mountVxApp({ container, app })`.
+The default browser path is:
 
-Raw frame rendering remains available for lower-level renderer interop through
-`renderVxToString`, `renderNodeToString`, `renderMsgPackNode`, and explicit
-custom lifecycle export names. Those APIs are not the default app architecture.
+```ts
+import { createVoydHost } from "@voyd-lang/sdk/js-host";
+import { createVoydVxAppRuntime, mountVxApp } from "@voyd-lang/vx-dom/browser";
 
-Versioned VX frames are strict. Malformed typed frames, invalid HTML tag names,
-invalid attribute names, invalid CSS property names, malformed command or
-subscription envelopes, and missing runtime handlers are reported as errors.
+const host = await createVoydHost({
+  wasm,
+  bufferSize: 256 * 1024,
+});
 
-Server rendering does not start commands or browser subscriptions. App-level SSR
-renders from an initialized model snapshot and serializes the frame for
-hydration. Client hydration adopts the hydrated frame, then normal runtime
-message handling evaluates `subscriptions(model)` and syncs listeners from the
-current model. Commands returned by server initialization should be treated as
-client/runtime work, not server-side browser effects.
+const app = createVoydVxAppRuntime({ host });
+const mounted = await mountVxApp({
+  container: document.getElementById("root")!,
+  app,
+});
+```
 
-## Database-Backed Todos
+`createVoydVxAppRuntime` looks for an exported `app` by default. If you are
+using custom exports, pass them explicitly:
 
-This example shows the recommended shape for a todos app. The database/API calls
-are intentionally isolated in named command constructors; `step` only chooses
-the next model and command data.
+```ts
+const app = createVoydVxAppRuntime({
+  host,
+  exports: {
+    init: "init",
+    step: "step",
+    view: "view",
+    subscriptions: "subscriptions",
+  },
+});
+```
+
+Use `runtimeHost` to add custom commands and subscriptions:
+
+```ts
+await mountVxApp({
+  container,
+  app,
+  runtimeHost: {
+    commands: {
+      copy_to_clipboard: async (command) => {
+        if (typeof command.value === "string") {
+          await navigator.clipboard.writeText(command.value);
+        }
+      },
+    },
+    subscriptions: {
+      online_status: (subscription, context) => {
+        const dispatch = () =>
+          context.dispatch({
+            kind: "subscription",
+            subscriptionKind: "online_status",
+            key: String(subscription.key),
+            payload: navigator.onLine,
+          });
+        window.addEventListener("online", dispatch);
+        window.addEventListener("offline", dispatch);
+        dispatch();
+        return () => {
+          window.removeEventListener("online", dispatch);
+          window.removeEventListener("offline", dispatch);
+        };
+      },
+    },
+  },
+});
+```
+
+The built-in browser runtime host already handles:
+
+- Commands: `delay`, `task`, `focus`, `scroll_into_view`.
+- Subscriptions: `interval`, `keyboard`.
+
+Lower-level renderer APIs are available for integration work:
+
+- `createVxDomRenderer(container)` returns a renderer that can render, hydrate,
+  dispose, and expose a snapshot.
+- `renderVxToString(...)` renders a VX frame or Wasm component to HTML on the
+  server.
+- `renderNodeToString(vnode)` renders an already-normalized node.
+
+Server rendering produces a frame and hydration data. Browser commands and
+browser subscriptions begin on the client after hydration, through normal message
+handling and `subscriptions(model)`.
+
+Runtime errors are reported by phase: `init`, `dispatch`, `render`,
+`subscriptions`, `commands`, or `dispose`. Malformed frames, invalid tag names,
+invalid attributes, invalid CSS names, unknown command kinds, unknown
+subscription kinds, and malformed envelopes are errors.
+
+## Testing VX Code
+
+The easiest tests target pure pieces:
+
+- `step` with a model and message.
+- model helper functions such as `with_error` or `adding`.
+- command constructors by checking the command structure when the boundary matters.
+- subscriptions by checking they appear and disappear for the right model states.
+
+Prefer one integration test at the public boundary for browser behavior: mount
+the app, dispatch events, and assert the DOM or runtime messages. Keep
+state-machine assertions at one layer.
+
+## Guide: Database-Backed Todos
+
+The rest of this page builds a todos app in pieces, then shows the complete file.
+The example is a vehicle for the VX shape: model data is durable, messages
+describe events, `step` chooses the next model, commands isolate outside work,
+subscriptions describe ambient input, and the view renders the current model.
+
+### 1. Data And State
+
+Start with the data the app owns.
+
+```voyd
+obj Todo {
+  id: String,
+  title: String,
+  done: bool
+}
+
+obj Model {
+  todos: Array<Todo>,
+  draft: String,
+  editing_id: String,
+  editing_title: String,
+  loading: bool,
+  saving: bool,
+  error: String
+}
+```
+
+This model is intentionally explicit. It tracks the list, the new-todo draft,
+the edit form, and UI state for loading, saving, and errors. A richer app might
+use `Option<String>` for `editing_id`; this example keeps strings to stay focused
+on VX.
+
+### 2. Messages
+
+Every way the model can change becomes a message.
+
+```voyd
+enum Msg
+  Load
+  Loaded { result: Result<Array<Todo>, String> }
+  DraftChanged { value: String }
+  Submit
+  Created { result: Result<Todo, String> }
+  StartEdit { id: String, title: String }
+  EditChanged { value: String }
+  SaveEdit
+  Saved { result: Result<Todo, String> }
+  Delete { id: String }
+  Deleted { result: Result<String, String> }
+  CancelEdit
+```
+
+The async result messages carry `Result`. That makes expected persistence
+failures part of the state machine and keeps runtime exceptions for unexpected
+runtime failures.
+
+### 3. Entrypoint And Startup
+
+The app should load todos immediately, so `init` returns a `Program` with an
+initial model and a command.
+
+```voyd
+pub fn app() -> Program<Model, Msg>
+  program({ init, step, view, subscriptions })
+
+fn init(): TaskRuntime -> Program<Model, Msg>
+  next(
+    model: Model {
+      todos: Array<Todo>::init(),
+      draft: String::init(),
+      editing_id: String::init(),
+      editing_title: String::init(),
+      loading: true,
+      saving: false,
+      error: String::init()
+    },
+    cmd: load_todos()
+  )
+```
+
+`init` has a `TaskRuntime` effect because `load_todos` uses `Cmd.task`.
+
+### 4. Transitions
+
+`step` is the center of the app. Database work is represented as command data.
+
+```voyd
+fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
+  match(msg)
+    Msg::Load:
+      next(model: loading(model), cmd: load_todos())
+    Msg::Loaded { result }:
+      match(result)
+        Ok { value }:
+          next<Model, Msg>(with_todos(model, value))
+        Err { error }:
+          next<Model, Msg>(with_error(model, error))
+    Msg::DraftChanged { value }:
+      next<Model, Msg>(with_draft(model, value))
+    Msg::Submit:
+      next(model: saving_now(model), cmd: create_todo(model.draft))
+    Msg::Created { result }:
+      match(result)
+        Ok { value }:
+          next<Model, Msg>(adding(model, value))
+        Err { error }:
+          next<Model, Msg>(with_error(model, error))
+    Msg::StartEdit { id, title }:
+      next<Model, Msg>(start_edit(model, id, title))
+    Msg::EditChanged { value }:
+      next<Model, Msg>(with_edit(model, value))
+    Msg::SaveEdit:
+      next(
+        model: saving_now(model),
+        cmd: save_todo(model.editing_id, model.editing_title)
+      )
+    Msg::Saved { result }:
+      match(result)
+        Ok { value }:
+          next<Model, Msg>(replacing(model, value))
+        Err { error }:
+          next<Model, Msg>(with_error(model, error))
+    Msg::Delete { id }:
+      next(model: saving_now(model), cmd: delete_todo(id))
+    Msg::Deleted { result }:
+      match(result)
+        Ok { value }:
+          next<Model, Msg>(removing(model, value))
+        Err { error }:
+          next<Model, Msg>(with_error(model, error))
+    Msg::CancelEdit:
+      next<Model, Msg>(cancel_edit(model))
+```
+
+This example is pessimistic: it waits for persistence to succeed before changing
+the todo list. An optimistic version would update the list before returning the
+command and roll back if a result message reports failure.
+
+### 5. Command Constructors
+
+Each persistence operation gets a named command constructor.
+
+```voyd
+fn load_todos(): TaskRuntime -> Cmd<Msg>
+  Cmd::task(
+    work: () -> Result<Array<Todo>, String> => Ok { value: db_load_todos() },
+    handler: (result: Result<Array<Todo>, String>) -> Msg =>
+      Msg::Loaded { result: result }
+  )
+
+fn create_todo(title: String): TaskRuntime -> Cmd<Msg>
+  Cmd::task(
+    work: () -> Result<Todo, String> => Ok { value: db_create_todo(title) },
+    handler: (result: Result<Todo, String>) -> Msg =>
+      Msg::Created { result: result }
+  )
+```
+
+Keep command constructors small. If an operation needs retries, authentication,
+or richer error mapping, keep that detail inside the command constructor or the
+API layer it calls. `step` should still read as a transition table.
+
+### 6. Subscriptions
+
+While editing, Escape should cancel the edit. Outside edit mode, the app returns
+an empty subscription set.
+
+```voyd
+fn subscriptions(model: Model) -> Sub<Msg>
+  if
+    model.editing_id.len() > 0:
+      keyboard_on_key_down(key: "Escape", value: Msg::CancelEdit {})
+    else:
+      Sub<Msg>::none()
+```
+
+The runtime starts the keyboard subscription when editing begins and disposes it
+when editing ends.
+
+### 7. View
+
+The view is split into a form, a list, and one row component.
+
+```voyd
+fn view(model: Model) -> Html<Msg>
+  <main>
+    <form on_submit={on_submit_with(options: EventOptions { prevent_default: true }, message: Msg::Submit {})}>
+      <input value={model.draft} on_input={(event: InputEvent) -> Msg => Msg::DraftChanged { value: event.value }} />
+      <button type="submit" disabled={model.saving}>Add</button>
+    </form>
+    <ul>
+      {model.todos.map((todo) =>
+        <TodoRow key={todo.id} todo={todo} model={model} />
+      )}
+    </ul>
+  </main>
+```
+
+`TodoRow` renders either a read-only row or the edit controls:
+
+```voyd
+fn TodoRow({ todo: Todo, model: Model }) -> Html<Msg>
+  if editing_todo(model, todo):
+    <li>
+      <input
+        value={model.editing_title}
+        on_input={(event: InputEvent) -> Msg => Msg::EditChanged { value: event.value }}
+      />
+      <button type="button" on_click={Msg::SaveEdit {}}>Save</button>
+      <button type="button" on_click={Msg::CancelEdit {}}>Cancel</button>
+    </li>
+  else:
+    <li>
+      <span>{todo.title}</span>
+      <button type="button" on_click={Msg::StartEdit { id: todo.id, title: todo.title }}>Edit</button>
+      <button type="button" on_click={Msg::Delete { id: todo.id }}>Delete</button>
+    </li>
+```
+
+### Complete Example
 
 ```voyd
 use std::array::Array
 use std::enums::{ enum }
 use std::result::types::all
 use std::string::type::String
-use std::task::{ TaskRuntime, detach }
+use std::task::TaskRuntime
 use std::vx::all
 
 obj Todo {
@@ -250,15 +1504,10 @@ enum Msg
   CancelEdit
 
 pub fn app() -> Program<Model, Msg>
-  program<Model, Msg>(
-    init: init,
-    step: step,
-    view: view,
-    subscriptions: subscriptions
-  )
+  program({ init, step, view, subscriptions })
 
 fn init(): TaskRuntime -> Program<Model, Msg>
-  next<Model, Msg>(
+  next(
     model: Model {
       todos: Array<Todo>::init(),
       draft: String::init(),
@@ -274,77 +1523,85 @@ fn init(): TaskRuntime -> Program<Model, Msg>
 fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
   match(msg)
     Msg::Load:
-      next<Model, Msg>(model: loading(model), cmd: load_todos())
+      next(model: loading(model), cmd: load_todos())
     Msg::Loaded { result }:
       match(result)
-        Ok<Array<Todo>> { value }:
+        Ok { value }:
           next<Model, Msg>(with_todos(model, value))
-        Err<String> { error }:
+        Err { error }:
           next<Model, Msg>(with_error(model, error))
     Msg::DraftChanged { value }:
       next<Model, Msg>(with_draft(model, value))
     Msg::Submit:
-      next<Model, Msg>(model: saving_now(model), cmd: create_todo(model.draft))
+      next(model: saving_now(model), cmd: create_todo(model.draft))
     Msg::Created { result }:
       match(result)
-        Ok<Todo> { value }:
+        Ok { value }:
           next<Model, Msg>(adding(model, value))
-        Err<String> { error }:
+        Err { error }:
           next<Model, Msg>(with_error(model, error))
     Msg::StartEdit { id, title }:
       next<Model, Msg>(start_edit(model, id, title))
     Msg::EditChanged { value }:
       next<Model, Msg>(with_edit(model, value))
     Msg::SaveEdit:
-      next<Model, Msg>(
+      next(
         model: saving_now(model),
         cmd: save_todo(model.editing_id, model.editing_title)
       )
     Msg::Saved { result }:
       match(result)
-        Ok<Todo> { value }:
+        Ok { value }:
           next<Model, Msg>(replacing(model, value))
-        Err<String> { error }:
+        Err { error }:
           next<Model, Msg>(with_error(model, error))
     Msg::Delete { id }:
-      next<Model, Msg>(model: saving_now(model), cmd: delete_todo(id))
+      next(model: saving_now(model), cmd: delete_todo(id))
     Msg::Deleted { result }:
       match(result)
-        Ok<String> { value }:
+        Ok { value }:
           next<Model, Msg>(removing(model, value))
-        Err<String> { error }:
+        Err { error }:
           next<Model, Msg>(with_error(model, error))
     Msg::CancelEdit:
       next<Model, Msg>(cancel_edit(model))
 
 fn load_todos(): TaskRuntime -> Cmd<Msg>
-  Cmd<Msg>::task(
-    work: () -> Array<Todo> => db_load_todos(),
-    handler: (todos: Array<Todo>) -> Msg => Msg::Loaded { result: Ok<Array<Todo>> { value: todos } }
+  Cmd::task(
+    work: () -> Result<Array<Todo>, String> =>
+      Ok { value: db_load_todos() },
+    handler: (result: Result<Array<Todo>, String>) -> Msg =>
+      Msg::Loaded { result: result }
   )
 
 fn create_todo(title: String): TaskRuntime -> Cmd<Msg>
-  Cmd<Msg>::task(
-    work: () -> Todo => db_create_todo(title),
-    handler: (todo: Todo) -> Msg => Msg::Created { result: Ok<Todo> { value: todo } }
+  Cmd::task(
+    work: () -> Result<Todo, String> =>
+      Ok { value: db_create_todo(title) },
+    handler: (result: Result<Todo, String>) -> Msg =>
+      Msg::Created { result: result }
   )
 
 fn save_todo(id: String, title: String): TaskRuntime -> Cmd<Msg>
-  Cmd<Msg>::task(
-    work: () -> Todo => db_save_todo(id, title),
-    handler: (todo: Todo) -> Msg => Msg::Saved { result: Ok<Todo> { value: todo } }
+  Cmd::task(
+    work: () -> Result<Todo, String> =>
+      Ok { value: db_save_todo(id, title) },
+    handler: (result: Result<Todo, String>) -> Msg =>
+      Msg::Saved { result: result }
   )
 
 fn delete_todo(id: String): TaskRuntime -> Cmd<Msg>
-  Cmd<Msg>::task(
-    work: () -> String => db_delete_todo(id),
-    handler: (deleted_id: String) -> Msg => Msg::Deleted { result: Ok<String> { value: deleted_id } }
+  Cmd::task(
+    work: () -> Result<String, String> =>
+      Ok { value: db_delete_todo(id) },
+    handler: (result: Result<String, String>) -> Msg =>
+      Msg::Deleted { result: result }
   )
 
 fn subscriptions(model: Model) -> Sub<Msg>
   if
     model.editing_id.len() > 0:
-      keyboard_on_key_down<Msg>(key: "Escape", value: Msg::CancelEdit {})
+      keyboard_on_key_down(key: "Escape", value: Msg::CancelEdit {})
     else:
       Sub<Msg>::none()
 
@@ -352,14 +1609,30 @@ fn view(model: Model) -> Html<Msg>
   <main>
     <form on_submit={on_submit_with(options: EventOptions { prevent_default: true }, message: Msg::Submit {})}>
       <input value={model.draft} on_input={(event: InputEvent) -> Msg => Msg::DraftChanged { value: event.value }} />
-      <button type="submit">Add</button>
+      <button type="submit" disabled={model.saving}>Add</button>
     </form>
+
     <ul>
-      {model.todos.map<Html<Msg>>((todo: Todo) -> Html<Msg> =>
-        keyed(key: todo.id, child: <TodoRow todo={todo} model={model} />)
+      {model.todos.map((todo) =>
+        <TodoRow key={todo.id} todo={todo} model={model} />
       )}
     </ul>
+
+    {loading_status(model)}
+    {error_status(model)}
   </main>
+
+fn loading_status(model: Model) -> Html<Msg>
+  if model.loading:
+    <p>Loading...</p>
+  else:
+    <span></span>
+
+fn error_status(model: Model) -> Html<Msg>
+  if model.error.len() > 0:
+    <p role="alert">{model.error}</p>
+  else:
+    <span></span>
 
 fn TodoRow({ todo: Todo, model: Model }) -> Html<Msg>
   if editing_todo(model, todo):
@@ -368,14 +1641,14 @@ fn TodoRow({ todo: Todo, model: Model }) -> Html<Msg>
         value={model.editing_title}
         on_input={(event: InputEvent) -> Msg => Msg::EditChanged { value: event.value }}
       />
-      <button on_click={Msg::SaveEdit {}}>Save</button>
-      <button on_click={Msg::CancelEdit {}}>Cancel</button>
+      <button type="button" on_click={Msg::SaveEdit {}}>Save</button>
+      <button type="button" on_click={Msg::CancelEdit {}}>Cancel</button>
     </li>
   else:
     <li>
       <span>{todo.title}</span>
-      <button on_click={Msg::StartEdit { id: todo.id, title: todo.title }}>Edit</button>
-      <button on_click={Msg::Delete { id: todo.id }}>Delete</button>
+      <button type="button" on_click={Msg::StartEdit { id: todo.id, title: todo.title }}>Edit</button>
+      <button type="button" on_click={Msg::Delete { id: todo.id }}>Delete</button>
     </li>
 
 fn loading(model: Model) -> Model
@@ -401,24 +1674,72 @@ fn with_todos(model: Model, todos: Array<Todo>) -> Model
   }
 
 fn with_draft(model: Model, draft: String) -> Model
-  Model { todos: model.todos, draft: draft, editing_id: model.editing_id, editing_title: model.editing_title, loading: model.loading, saving: model.saving, error: model.error }
+  Model {
+    todos: model.todos,
+    draft: draft,
+    editing_id: model.editing_id,
+    editing_title: model.editing_title,
+    loading: model.loading,
+    saving: model.saving,
+    error: model.error
+  }
 
 fn saving_now(model: Model) -> Model
-  Model { todos: model.todos, draft: model.draft, editing_id: model.editing_id, editing_title: model.editing_title, loading: false, saving: true, error: String::init() }
+  Model {
+    todos: model.todos,
+    draft: model.draft,
+    editing_id: model.editing_id,
+    editing_title: model.editing_title,
+    loading: false,
+    saving: true,
+    error: String::init()
+  }
 
 fn with_error(model: Model, error: String) -> Model
-  Model { todos: model.todos, draft: model.draft, editing_id: model.editing_id, editing_title: model.editing_title, loading: false, saving: false, error: error }
+  Model {
+    todos: model.todos,
+    draft: model.draft,
+    editing_id: model.editing_id,
+    editing_title: model.editing_title,
+    loading: false,
+    saving: false,
+    error: error
+  }
 
 fn adding(model: Model, todo: Todo) -> Model
   let ~todos = model.todos
   todos.push(todo)
-  Model { todos: todos, draft: String::init(), editing_id: model.editing_id, editing_title: model.editing_title, loading: false, saving: false, error: String::init() }
+  Model {
+    todos: todos,
+    draft: String::init(),
+    editing_id: model.editing_id,
+    editing_title: model.editing_title,
+    loading: false,
+    saving: false,
+    error: String::init()
+  }
 
 fn start_edit(model: Model, id: String, title: String) -> Model
-  Model { todos: model.todos, draft: model.draft, editing_id: id, editing_title: title, loading: model.loading, saving: model.saving, error: model.error }
+  Model {
+    todos: model.todos,
+    draft: model.draft,
+    editing_id: id,
+    editing_title: title,
+    loading: model.loading,
+    saving: model.saving,
+    error: model.error
+  }
 
 fn with_edit(model: Model, title: String) -> Model
-  Model { todos: model.todos, draft: model.draft, editing_id: model.editing_id, editing_title: title, loading: model.loading, saving: model.saving, error: model.error }
+  Model {
+    todos: model.todos,
+    draft: model.draft,
+    editing_id: model.editing_id,
+    editing_title: title,
+    loading: model.loading,
+    saving: model.saving,
+    error: model.error
+  }
 
 fn replacing(model: Model, todo: Todo) -> Model
   let ~todos = Array<Todo>::init()
@@ -430,7 +1751,15 @@ fn replacing(model: Model, todo: Todo) -> Model
     else:
       todos.push(current)
     index = index + 1
-  Model { todos: todos, draft: model.draft, editing_id: String::init(), editing_title: String::init(), loading: false, saving: false, error: String::init() }
+  Model {
+    todos: todos,
+    draft: model.draft,
+    editing_id: String::init(),
+    editing_title: String::init(),
+    loading: false,
+    saving: false,
+    error: String::init()
+  }
 
 fn removing(model: Model, id: String) -> Model
   let ~todos = Array<Todo>::init()
@@ -440,10 +1769,26 @@ fn removing(model: Model, id: String) -> Model
     if current.id != id:
       todos.push(current)
     index = index + 1
-  Model { todos: todos, draft: model.draft, editing_id: model.editing_id, editing_title: model.editing_title, loading: false, saving: false, error: String::init() }
+  Model {
+    todos: todos,
+    draft: model.draft,
+    editing_id: model.editing_id,
+    editing_title: model.editing_title,
+    loading: false,
+    saving: false,
+    error: String::init()
+  }
 
 fn cancel_edit(model: Model) -> Model
-  Model { todos: model.todos, draft: model.draft, editing_id: String::init(), editing_title: String::init(), loading: model.loading, saving: false, error: String::init() }
+  Model {
+    todos: model.todos,
+    draft: model.draft,
+    editing_id: String::init(),
+    editing_title: String::init(),
+    loading: model.loading,
+    saving: false,
+    error: String::init()
+  }
 
 fn editing_todo(model: Model, todo: Todo) -> bool
   model.editing_id == todo.id
@@ -463,7 +1808,7 @@ fn db_delete_todo(id: String) -> String
   id
 ```
 
-The example uses a pessimistic persistence strategy: UI enters loading/saving
-states immediately, then updates the durable todo list only after the command
-returns a result message. Optimistic updates use the same architecture, but
-`step` changes the model before returning the command and rolls back on failure.
+The same structure scales beyond todos. Add features by giving each feature its
+own model, messages, view, commands, and subscriptions. Let parents compose those
+pieces with the VX mapping helpers. Keep outside work behind commands and
+subscriptions, and keep durable behavior visible in `step`.


### PR DESCRIPTION
## Summary

- Rewrite the VX reference docs into a full guide covering app structure, `Model`/`Msg`, `step`, views, events, commands, subscriptions, runtime interop, composition, SSR/hydration, and a database-backed todos walkthrough.
- Update VX list examples to prefer `<li key={...}>` syntax and teach stable keys directly in HTML syntax.
- Teach the HTML parser to lower a `key={...}` attribute into VX `keyed(key:, child:)` wrapping, with parser coverage and the VX smoke fixture updated.
- Reduce unnecessary type annotations in examples where inference is clear, while keeping the current `next<Model, Msg>(...)` workaround until V-409 is fixed.

## Notes

- V-408 now tracks the broader runtime command/subscription API and host documentation follow-up.
- V-409 now tracks the compiler inference fix plus the docs cleanup needed to remove remaining pure `next<Model, Msg>(...)` annotations.

## Validation

- `npx vitest packages/compiler/src/parser/__tests__/html-inline-lambda.test.ts`
- `npm --workspace @voyd-lang/reference run build`
- `npm run typecheck`
- `npm test` initially failed under sandbox because smoke HTTP tests could not bind `127.0.0.1` (`listen EPERM`); reran with local listener permissions and it passed.