### PR TITLE
Expand VX runtime commands and subscriptions

### DIFF
--- a/apps/smoke/fixtures/vx-runtime-browser.voyd
+++ b/apps/smoke/fixtures/vx-runtime-browser.voyd
@@ -11,6 +11,14 @@ obj Model {
 
 enum Msg
   KeyDown { key: String, code: String, ctrl: bool }
+  ClipboardRead { value: String }
+  LocationChanged { href: String }
+  WindowEvent { event: String }
+  Frame { timestamp: f64 }
+  Media { matches: bool }
+  Storage { key: String }
+  Broadcast { value: String }
+  Changed
 
 pub fn app() -> Program<Model, Msg>
   program({ init, step, view, subscriptions })
@@ -25,6 +33,8 @@ fn step(model: Model, msg: Msg) -> Program<Model, Msg>
   match(msg)
     Msg::KeyDown { key, code, ctrl }:
       next<Model, Msg>(Model { status: "key", key: key, code: code, ctrl: ctrl })
+    else:
+      next<Model, Msg>(model)
 
 fn view(model: Model) -> Html<Msg>
   <div>
@@ -40,6 +50,80 @@ fn subscriptions(model: Model) -> Sub<Msg>
     handler: (event: KeyboardEvent) -> Msg =>
       Msg::KeyDown { key: event.key, code: event.code, ctrl: event.ctrl_key }
   )
+
+pub fn standard_commands() -> Cmd<Msg>
+  let editor = Ref<DomElement> { id: "editor" }
+  Cmd::batch([
+    Cmd<Msg>::copy_to_clipboard("Copied from Voyd"),
+    Cmd<Msg>::read_clipboard((value: String) -> Msg => Msg::ClipboardRead { value: value }),
+    Cmd<Msg>::set_document_title("VX"),
+    Cmd<Msg>::push_url("/next"),
+    Cmd<Msg>::replace_url("/next?replace=1"),
+    Cmd<Msg>::set_hash("section"),
+    Cmd<Msg>::navigate_back(),
+    Cmd<Msg>::navigate_forward(),
+    Cmd<Msg>::open_url("/external"),
+    Cmd<Msg>::open_url(url: "/external", target: "_self"),
+    Cmd<Msg>::scroll_window_to(x: 0.0, y: 10.0),
+    Cmd<Msg>::scroll_window_by(x: 1.0, y: 2.0),
+    Cmd<Msg>::local_storage_set(key: "draft", value: "yes"),
+    Cmd<Msg>::local_storage_remove("draft"),
+    Cmd<Msg>::local_storage_clear(),
+    Cmd<Msg>::session_storage_set(key: "draft", value: "yes"),
+    Cmd<Msg>::session_storage_remove("draft"),
+    Cmd<Msg>::session_storage_clear(),
+    Cmd<Msg>::focus(editor),
+    Cmd<Msg>::scroll_into_view(editor),
+    Cmd<Msg>::select_text(editor)
+  ])
+
+pub fn standard_subscriptions() -> Sub<Msg>
+  Sub::batch([
+    keyboard_on_key_down(key: "s", value: Msg::Changed {}),
+    keyboard_on_key_up(
+      key: "s",
+      handler: (event: KeyboardEvent) -> Msg =>
+        Msg::KeyDown { key: event.key, code: event.code, ctrl: event.ctrl_key }
+    ),
+    online_status(key: "network", value: Msg::Changed {}),
+    online_status(
+      key: "network-payload",
+      handler: (_online: bool) -> Msg => Msg::Changed {}
+    ),
+    window_on_resize(
+      key: "viewport",
+      handler: (_size: WindowSize) -> Msg => Msg::Changed {}
+    ),
+    document_on_visibility_change(
+      key: "visibility",
+      handler: (_visibility: DocumentVisibility) -> Msg => Msg::Changed {}
+    ),
+    location_on_change(
+      key: "location",
+      handler: (location: Location) -> Msg => Msg::LocationChanged { href: location.href }
+    ),
+    window_on_focus(
+      key: "focus",
+      handler: (event: GenericEvent) -> Msg => Msg::WindowEvent { event: event.event }
+    ),
+    window_on_blur(key: "blur", value: Msg::Changed {}),
+    animation_frame(
+      key: "frame",
+      handler: (frame: AnimationFrame) -> Msg => Msg::Frame { timestamp: frame.timestamp }
+    ),
+    media_query(
+      query: "(prefers-reduced-motion: reduce)",
+      handler: (query: MediaQuery) -> Msg => Msg::Media { matches: query.matches }
+    ),
+    storage_on_change(
+      key: "storage",
+      handler: (_change: StorageChange) -> Msg => Msg::Changed {}
+    ),
+    broadcast_channel<String, Msg>(
+      name: "updates",
+      handler: (value: String) -> Msg => Msg::Broadcast { value: value }
+    )
+  ])
 
 fn ctrl_label(value: bool) -> String
   if

--- a/apps/smoke/fixtures/vx-runtime-browser.voyd
+++ b/apps/smoke/fixtures/vx-runtime-browser.voyd
@@ -1,4 +1,5 @@
 use std::enums::{ enum }
+use std::msgpack::self as msgpack
 use std::string::type::String
 use std::vx::all
 
@@ -118,6 +119,12 @@ pub fn standard_subscriptions() -> Sub<Msg>
     storage_on_change(
       key: "storage",
       handler: (_change: StorageChange) -> Msg => Msg::Changed {}
+    ),
+    Sub<Msg>::runtime_configured<String>(
+      kind: "websocket",
+      key: "socket",
+      value: msgpack::make_string("updates"),
+      handler: (value: String) -> Msg => Msg::Broadcast { value: value }
     ),
     broadcast_channel<String, Msg>(
       name: "updates",

--- a/apps/smoke/fixtures/vx-runtime-browser.voyd
+++ b/apps/smoke/fixtures/vx-runtime-browser.voyd
@@ -1,0 +1,47 @@
+use std::enums::{ enum }
+use std::string::type::String
+use std::vx::all
+
+obj Model {
+  api status: String,
+  api key: String,
+  api code: String,
+  api ctrl: bool
+}
+
+enum Msg
+  KeyDown { key: String, code: String, ctrl: bool }
+
+pub fn app() -> Program<Model, Msg>
+  program({ init, step, view, subscriptions })
+
+fn init() -> Program<Model, Msg>
+  next<Model, Msg>(
+    model: Model { status: "ready", key: "none", code: "none", ctrl: false },
+    cmd: Cmd<Msg>::copy_to_clipboard("Copied from Voyd")
+  )
+
+fn step(model: Model, msg: Msg) -> Program<Model, Msg>
+  match(msg)
+    Msg::KeyDown { key, code, ctrl }:
+      next<Model, Msg>(Model { status: "key", key: key, code: code, ctrl: ctrl })
+
+fn view(model: Model) -> Html<Msg>
+  <div>
+    <p class="status">{model.status}</p>
+    <p class="key">{model.key}</p>
+    <p class="code">{model.code}</p>
+    <p class="ctrl">{ctrl_label(model.ctrl)}</p>
+  </div>
+
+fn subscriptions(model: Model) -> Sub<Msg>
+  keyboard_on_key_down(
+    key: "s",
+    handler: (event: KeyboardEvent) -> Msg =>
+      Msg::KeyDown { key: event.key, code: event.code, ctrl: event.ctrl_key }
+  )
+
+fn ctrl_label(value: bool) -> String
+  if
+    value: "ctrl"
+    else: "no-ctrl"

--- a/apps/smoke/src/vx-dom.test.ts
+++ b/apps/smoke/src/vx-dom.test.ts
@@ -455,7 +455,7 @@ describe("smoke: compiled VX DOM rendering", () => {
     const subscriptions = await host.run<{ children?: unknown[] }>("standard_subscriptions");
 
     expect(commands.children).toHaveLength(21);
-    expect(subscriptions.children).toHaveLength(13);
+    expect(subscriptions.children).toHaveLength(14);
 
     const app = createVoydVxAppRuntime({ host });
 

--- a/apps/smoke/src/vx-dom.test.ts
+++ b/apps/smoke/src/vx-dom.test.ts
@@ -451,6 +451,12 @@ describe("smoke: compiled VX DOM rendering", () => {
       wasm: result.wasm,
       bufferSize: 256 * 1024,
     });
+    const commands = await host.run<{ children?: unknown[] }>("standard_commands");
+    const subscriptions = await host.run<{ children?: unknown[] }>("standard_subscriptions");
+
+    expect(commands.children).toHaveLength(21);
+    expect(subscriptions.children).toHaveLength(13);
+
     const app = createVoydVxAppRuntime({ host });
 
     const container = document.createElement("div");

--- a/apps/smoke/src/vx-dom.test.ts
+++ b/apps/smoke/src/vx-dom.test.ts
@@ -36,6 +36,7 @@ const valueArrayModelEntryPath = path.join(
 );
 const typedMouseEventEntryPath = path.join(fixtureRoot, "vx-typed-mouse-event.voyd");
 const userProgramNameEntryPath = path.join(fixtureRoot, "vx-user-program-name.voyd");
+const runtimeBrowserEntryPath = path.join(fixtureRoot, "vx-runtime-browser.voyd");
 const wideValueModelEntryPath = path.join(fixtureRoot, "vx-wide-value-model.voyd");
 
 const expectCompileSuccess = (
@@ -433,6 +434,42 @@ describe("smoke: compiled VX DOM rendering", () => {
     await nextTurn();
 
     expect(container.querySelector("button")?.textContent).toContain("X: 10");
+
+    mounted.dispose();
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("runs compiled browser runtime commands and payload subscriptions", async () => {
+    const writeText = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const sdk = createSdk();
+    const result = expectCompileSuccess(await sdk.compile({ entryPath: runtimeBrowserEntryPath }));
+    const host = await createVoydHost({
+      wasm: result.wasm,
+      bufferSize: 256 * 1024,
+    });
+    const app = createVoydVxAppRuntime({ host });
+
+    const container = document.createElement("div");
+    const mounted = await mountVxApp({ container, app });
+
+    expect(writeText).toHaveBeenCalledWith("Copied from Voyd");
+    expect(container.querySelector(".status")?.textContent).toBe("ready");
+
+    window.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "s",
+      code: "KeyS",
+      ctrlKey: true,
+    }));
+    await nextTurn();
+
+    expect(container.querySelector(".status")?.textContent).toBe("key");
+    expect(container.querySelector(".key")?.textContent).toBe("s");
+    expect(container.querySelector(".code")?.textContent).toBe("KeyS");
+    expect(container.querySelector(".ctrl")?.textContent).toBe("ctrl");
 
     mounted.dispose();
     expect(container.innerHTML).toBe("");

--- a/packages/reference/docs/vx.md
+++ b/packages/reference/docs/vx.md
@@ -689,14 +689,11 @@ Cmd<Msg>::perform(task_id: task_id, handler_id: mapper_id)
 
 Most application code should prefer `Cmd.task`.
 
-`Cmd.runtime(kind:)` creates a host command envelope.
+`Cmd.copy_to_clipboard(value:)` copies text to the browser clipboard.
 
 ```voyd
-Cmd<Msg>::runtime(kind: "copy_to_clipboard")
+Cmd<Msg>::copy_to_clipboard("Saved URL")
 ```
-
-The browser host must register a command executor for the `kind`. Use runtime
-commands for browser capabilities beyond VX's built-in set.
 
 `Cmd.focus(target)` focuses a DOM element found by `data-vx-ref`.
 
@@ -710,6 +707,28 @@ Cmd<Msg>::focus(editor)
 ```voyd
 Cmd<Msg>::scroll_into_view(editor)
 ```
+
+`Cmd.set_document_title(value:)`, `Cmd.push_url(value:)`,
+`Cmd.replace_url(value:)`, `Cmd.navigate_back()`, and
+`Cmd.navigate_forward()` cover common document and history effects.
+
+```voyd
+Cmd::batch([
+  Cmd<Msg>::set_document_title("Editing"),
+  Cmd<Msg>::push_url("/todos/active")
+])
+```
+
+`Cmd.runtime(kind:)` creates a host command envelope for custom browser or
+application capabilities.
+
+```voyd
+Cmd<Msg>::runtime(kind: "analytics_track", value: analytics_payload(event))
+```
+
+The browser host must register a command executor for the `kind`. Use runtime
+commands when the effect is app-specific or not part of VX's built-in browser
+host.
 
 `Cmd.map(handler)` lifts child commands into parent message space.
 
@@ -893,6 +912,19 @@ keyboard_on_key_up(key: "Enter", value: Msg::Submit {})
 The `key` parameter is both the browser key filter and the stable key for the
 subscription. The dispatched `value` is a typed message.
 
+Use the `handler` form when the app needs the normalized keyboard payload:
+
+```voyd
+keyboard_on_key_down(
+  key: "Escape",
+  handler: (event: KeyboardEvent) -> Msg =>
+    Msg::KeyPressed { key: event.key, code: event.code }
+)
+```
+
+The handler receives the same `KeyboardEvent` payload shape used by typed DOM
+keyboard event handlers.
+
 Keyboard subscriptions are especially useful for mode-dependent shortcuts:
 
 ```voyd
@@ -904,18 +936,49 @@ fn subscriptions(model: Model) -> Sub<Msg>
       Sub<Msg>::none()
 ```
 
+### Browser State Subscriptions
+
+The default browser runtime host also exposes subscriptions for common window
+and document state:
+
+```voyd
+online_status(
+  key: "network",
+  handler: (online: bool) -> Msg =>
+    Msg::OnlineChanged { online: online }
+)
+
+window_on_resize(
+  key: "viewport",
+  handler: (size: WindowSize) -> Msg =>
+    Msg::ViewportChanged { width: size.width, height: size.height }
+)
+
+document_on_visibility_change(
+  key: "visibility",
+  handler: (visibility: DocumentVisibility) -> Msg =>
+    Msg::VisibilityChanged { hidden: visibility.hidden }
+)
+```
+
+Each helper also has a fixed-message form with `value:` when the app only needs
+to know that the event happened.
+
 ### Runtime Subscriptions
 
-`Sub.runtime(kind:, key:)` creates a host subscription envelope for browser or
-application capabilities supplied by JavaScript.
+`Sub.runtime_payload(kind:, key:, handler:)` creates a host subscription
+envelope and maps incoming host payloads through a typed handler.
 
 ```voyd
 enum Msg
   OnlineChanged { online: bool }
 
 fn subscriptions(model: Model) -> Sub<Msg>
-  Sub<bool>::runtime(kind: "online_status", key: "network").map(
-    (online: bool) -> Msg => Msg::OnlineChanged { online: online }
+  Sub::runtime_payload(
+    kind: "online_status",
+    key: "network",
+    handler: (online: bool) -> Msg =>
+      Msg::OnlineChanged { online: online }
   )
 ```
 
@@ -955,17 +1018,18 @@ await mountVxApp({
 
 The runner returns an optional disposer that VX calls when the subscription
 disappears or is replaced. In this example, the host dispatches a `bool` payload
-and the Voyd `map` closure turns that payload into `Msg::OnlineChanged`.
+and the Voyd `handler` closure turns that payload into `Msg::OnlineChanged`.
 
-Use `value` when the host runner needs configuration:
+Use `Sub.runtime_configured(kind:, key:, value:, handler:)` when the host runner
+needs configuration:
 
 ```voyd
-Sub<String>::runtime(
+Sub::runtime_configured(
   kind: "websocket",
   key: "project:" + model.project_id,
-  value: websocket_config(model.project_id)
-).map(
-  (message: String) -> Msg => Msg::SocketMessage { value: message }
+  value: websocket_config(model.project_id),
+  handler: (message: String) -> Msg =>
+    Msg::SocketMessage { value: message }
 )
 ```
 
@@ -973,6 +1037,13 @@ The `value` field is sent to the host in the subscription descriptor. It is
 configuration for starting the listener, such as a channel name, URL, or topic.
 Data from the listener reaches Voyd when the host runner calls
 `context.dispatch`.
+
+The lower-level composition form is still available:
+
+```voyd
+Sub<String>::runtime(kind: "websocket", key: "project:" + model.project_id)
+  .map((message: String) -> Msg => Msg::SocketMessage { value: message })
+```
 
 ### Mapping Child Subscriptions
 
@@ -1207,10 +1278,44 @@ await mountVxApp({
 });
 ```
 
+Command handlers receive the command descriptor that Voyd produced. The
+descriptor always has `type: "cmd"` and `kind`; constructors that take input put
+that input in `value` after boundary encoding. A handler may be synchronous or
+async. Unknown command kinds, thrown errors, and rejected promises are reported
+through the runtime error handler with `phase: "commands"`. Runtime commands are
+best for fire-and-forget host effects. Use `Cmd.task` when the work should
+produce a typed result message through Voyd's task runtime.
+
+Subscription runners receive the subscription descriptor that Voyd produced. The
+descriptor always has `type: "sub"`, `kind`, and a stable `key`; optional
+configuration is in `value`. A runner starts the listener and returns an
+optional disposer. VX calls the disposer when the descriptor disappears, when the
+same kind/key is replaced by a changed descriptor, and when the app is disposed.
+
+Send data back by calling `context.dispatch`:
+
+```ts
+context.dispatch({
+  kind: "subscription",
+  subscriptionKind: String(subscription.kind),
+  key: String(subscription.key),
+  payload: nextValue,
+});
+```
+
+The `payload` becomes the input to the Voyd `handler:` or `Sub.map` closure. If
+the dispatched message includes `value`, VX treats it as a fixed message and the
+payload is still available to custom runtime code but is not passed to the Voyd
+mapper. `context.signal` is aborted during teardown, and `context.reportError`
+reports asynchronous listener failures with `phase: "subscriptions"`.
+
 The built-in browser runtime host already handles:
 
-- Commands: `delay`, `task`, `focus`, `scroll_into_view`.
-- Subscriptions: `interval`, `keyboard`.
+- Commands: `delay`, `task`, `copy_to_clipboard`, `focus`,
+  `scroll_into_view`, `set_document_title`, `push_url`, `replace_url`,
+  `navigate_back`, `navigate_forward`.
+- Subscriptions: `interval`, `keyboard`, `online_status`, `window_resize`,
+  `visibility_change`.
 
 Lower-level renderer APIs are available for integration work:
 

--- a/packages/reference/docs/vx.md
+++ b/packages/reference/docs/vx.md
@@ -695,6 +695,20 @@ Most application code should prefer `Cmd.task`.
 Cmd<Msg>::copy_to_clipboard("Saved URL")
 ```
 
+`Cmd.read_clipboard(handler:)` reads text from the browser clipboard and
+dispatches the handler result.
+
+```voyd
+Cmd<Msg>::read_clipboard(
+  (value: String) -> Msg => Msg::ClipboardRead { value: value }
+)
+```
+
+Clipboard reads can fail because of browser permissions or unavailable APIs.
+Those failures are reported through the runtime command error path. Use
+`Cmd.task` when the response-producing work should be owned by Voyd task code
+instead of the browser runtime host.
+
 `Cmd.focus(target)` focuses a DOM element found by `data-vx-ref`.
 
 ```voyd
@@ -708,8 +722,15 @@ Cmd<Msg>::focus(editor)
 Cmd<Msg>::scroll_into_view(editor)
 ```
 
+`Cmd.select_text(target)` selects text in an input-like DOM element found by
+`data-vx-ref`.
+
+```voyd
+Cmd<Msg>::select_text(editor)
+```
+
 `Cmd.set_document_title(value:)`, `Cmd.push_url(value:)`,
-`Cmd.replace_url(value:)`, `Cmd.navigate_back()`, and
+`Cmd.replace_url(value:)`, `Cmd.set_hash(value:)`, `Cmd.navigate_back()`, and
 `Cmd.navigate_forward()` cover common document and history effects.
 
 ```voyd
@@ -717,6 +738,32 @@ Cmd::batch([
   Cmd<Msg>::set_document_title("Editing"),
   Cmd<Msg>::push_url("/todos/active")
 ])
+```
+
+`Cmd.scroll_window_to(x:, y:)` and `Cmd.scroll_window_by(x:, y:)` control the
+browser window scroll position.
+
+```voyd
+Cmd<Msg>::scroll_window_to(x: 0.0, y: 240.0)
+Cmd<Msg>::scroll_window_by(x: 0.0, y: 80.0)
+```
+
+`Cmd.local_storage_set(key:, value:)`, `Cmd.local_storage_remove(key:)`,
+`Cmd.local_storage_clear()`, `Cmd.session_storage_set(key:, value:)`,
+`Cmd.session_storage_remove(key:)`, and `Cmd.session_storage_clear()` cover
+string storage writes and removals.
+
+```voyd
+Cmd<Msg>::local_storage_set(key: "draft", value: model.draft)
+Cmd<Msg>::session_storage_remove("wizard-step")
+```
+
+`Cmd.open_url(value:)` opens a URL in a new browser context. Use the labeled
+form to choose the browser target.
+
+```voyd
+Cmd<Msg>::open_url("https://voyd.dev")
+Cmd<Msg>::open_url(url: "/help", target: "_self")
 ```
 
 `Cmd.runtime(kind:)` creates a host command envelope for custom browser or
@@ -959,10 +1006,56 @@ document_on_visibility_change(
   handler: (visibility: DocumentVisibility) -> Msg =>
     Msg::VisibilityChanged { hidden: visibility.hidden }
 )
+
+location_on_change(
+  key: "location",
+  handler: (location: Location) -> Msg =>
+    Msg::LocationChanged { href: location.href }
+)
+
+window_on_focus(key: "focus", value: Msg::WindowFocused {})
+window_on_blur(key: "blur", value: Msg::WindowBlurred {})
 ```
 
 Each helper also has a fixed-message form with `value:` when the app only needs
 to know that the event happened.
+
+For rendering loops and browser preferences, use animation frame and media query
+subscriptions:
+
+```voyd
+animation_frame(
+  key: "render-loop",
+  handler: (frame: AnimationFrame) -> Msg =>
+    Msg::Frame { timestamp: frame.timestamp }
+)
+
+media_query(
+  query: "(prefers-reduced-motion: reduce)",
+  handler: (query: MediaQuery) -> Msg =>
+    Msg::ReducedMotionChanged { enabled: query.matches }
+)
+```
+
+For cross-tab and cross-context coordination, use storage and broadcast channel
+subscriptions:
+
+```voyd
+storage_on_change(
+  key: "storage",
+  handler: (change: StorageChange) -> Msg =>
+    Msg::StorageChanged { key: change.key }
+)
+
+broadcast_channel<String, Msg>(
+  name: "updates",
+  handler: (value: String) -> Msg =>
+    Msg::Broadcast { value: value }
+)
+```
+
+`StorageChange.key`, `old_value`, and `new_value` are optional because browser
+storage events use `null` for clears, missing old values, and removals.
 
 ### Runtime Subscriptions
 
@@ -1312,10 +1405,14 @@ reports asynchronous listener failures with `phase: "subscriptions"`.
 The built-in browser runtime host already handles:
 
 - Commands: `delay`, `task`, `copy_to_clipboard`, `focus`,
-  `scroll_into_view`, `set_document_title`, `push_url`, `replace_url`,
-  `navigate_back`, `navigate_forward`.
+  `read_clipboard`, `scroll_into_view`, `select_text`, `set_document_title`,
+  `push_url`, `replace_url`, `set_hash`, `navigate_back`,
+  `navigate_forward`, `open_url`, `scroll_window_to`, `scroll_window_by`,
+  `local_storage_set`, `local_storage_remove`, `local_storage_clear`,
+  `session_storage_set`, `session_storage_remove`, `session_storage_clear`.
 - Subscriptions: `interval`, `keyboard`, `online_status`, `window_resize`,
-  `visibility_change`.
+  `visibility_change`, `location_change`, `window_focus`, `window_blur`,
+  `animation_frame`, `media_query`, `storage`, `broadcast_channel`.
 
 Lower-level renderer APIs are available for integration work:
 

--- a/packages/std/src/vx.test.voyd
+++ b/packages/std/src/vx.test.voyd
@@ -490,6 +490,13 @@ test "vx typed subscription constructors encode messages through the boundary":
   assert_string_payload_field(batch.payload, "kind", "batch")
   assert_array_payload_len(batch.payload, "children", 1)
 
+  let mapped = every.map<MsgPack>((_msg: TypedVxTestMsg) -> MsgPack => msgpack::make_string("mapped"))
+  assert_string_payload_field(mapped.payload, "type", "sub")
+  assert_string_payload_field(mapped.payload, "kind", "map")
+  assert_payload_has_field(mapped.payload, "handlerId")
+  assert_payload_has_field(mapped.payload, "child")
+  assert_array_payload_len(mapped.payload, "__vxOwnedMapHandlerIds", 1)
+
 test "vx component state and task APIs use component effect":
   let ~seen = Array<String>::init()
 

--- a/packages/std/src/vx.test.voyd
+++ b/packages/std/src/vx.test.voyd
@@ -389,6 +389,13 @@ test "vx typed command constructors encode messages through the boundary":
   assert_string_payload_field(batch.payload, "kind", "batch")
   assert_array_payload_len(batch.payload, "children", 2)
 
+  let mapped = message.map<MsgPack>((_msg: TypedVxTestMsg) -> MsgPack => msgpack::make_string("mapped"))
+  assert_string_payload_field(mapped.payload, "type", "cmd")
+  assert_string_payload_field(mapped.payload, "kind", "map")
+  assert_payload_has_field(mapped.payload, "handlerId")
+  assert_payload_has_field(mapped.payload, "child")
+  assert_array_payload_len(mapped.payload, "__vxOwnedMapHandlerIds", 1)
+
   let task = Task<String> { id: 23 }
   let performed = Cmd<TypedVxTestMsg>::perform<String>(
     task: task,
@@ -398,6 +405,7 @@ test "vx typed command constructors encode messages through the boundary":
   assert_string_payload_field(performed.payload, "kind", "task")
   assert_i32_payload_field(performed.payload, "taskId", 23)
   assert_payload_has_field(performed.payload, "handlerId")
+  assert_array_payload_len(performed.payload, "__vxOwnedMapHandlerIds", 1)
 
   try open
     let spawned = Cmd<TypedVxTestMsg>::task(
@@ -408,6 +416,7 @@ test "vx typed command constructors encode messages through the boundary":
     assert_string_payload_field(spawned.payload, "kind", "task")
     assert_payload_has_field(spawned.payload, "taskId")
     assert_payload_has_field(spawned.payload, "handlerId")
+    assert_array_payload_len(spawned.payload, "__vxOwnedMapHandlerIds", 1)
 
 test "vx subscription constructors encode runtime payloads":
   let none = Sub<MsgPack>::none()

--- a/packages/std/src/vx.test.voyd
+++ b/packages/std/src/vx.test.voyd
@@ -396,6 +396,14 @@ test "vx typed command constructors encode messages through the boundary":
   assert_payload_has_field(mapped.payload, "child")
   assert_array_payload_len(mapped.payload, "__vxOwnedMapHandlerIds", 1)
 
+  let read_clipboard = Cmd<TypedVxTestMsg>::read_clipboard(
+    (value: String) -> TypedVxTestMsg => TypedVxTestMsg::Rename { value: value }
+  )
+  assert_string_payload_field(read_clipboard.payload, "type", "cmd")
+  assert_string_payload_field(read_clipboard.payload, "kind", "read_clipboard")
+  assert_payload_has_field(read_clipboard.payload, "handlerId")
+  assert_array_payload_len(read_clipboard.payload, "__vxOwnedMapHandlerIds", 1)
+
   let task = Task<String> { id: 23 }
   let performed = Cmd<TypedVxTestMsg>::perform<String>(
     task: task,

--- a/packages/std/src/vx.voyd
+++ b/packages/std/src/vx.voyd
@@ -87,6 +87,34 @@ pub type DocumentVisibility = {
   hidden: bool
 }
 
+pub type Location = {
+  kind: String,
+  href: String,
+  pathname: String,
+  search: String,
+  hash: String
+}
+
+pub type AnimationFrame = {
+  kind: String,
+  timestamp: f64
+}
+
+pub type MediaQuery = {
+  kind: String,
+  query: String,
+  matches: bool
+}
+
+pub type StorageChange = {
+  kind: String,
+  storage: String,
+  key?: String,
+  old_value?: String,
+  new_value?: String,
+  url: String
+}
+
 pub type InputEvent = {
   kind: String,
   value: String,
@@ -251,6 +279,15 @@ impl<Msg> Cmd<Msg>
   api fn copy_to_clipboard(value: StringSlice) -> Cmd<Msg>
     Cmd<Msg>::copy_to_clipboard(value.to_string())
 
+  /// Reads text from the browser clipboard and dispatches the handler result.
+  api fn read_clipboard({ handler_id: i32 }) -> Cmd<Msg>
+    let ~out = command_map("read_clipboard")
+    out.set("handlerId", msgpack::make_i32(handler_id))
+    Cmd<Msg> { payload: msgpack::make_map(out) }
+
+  api fn read_clipboard(handler: fn(String) -> Msg) -> Cmd<Msg>
+    Cmd<Msg>::read_clipboard(handler_id: retain_typed_message_mapper(handler))
+
   /// Sets the browser document title through the VX runtime host.
   api fn set_document_title(value: String) -> Cmd<Msg>
     Cmd<Msg>::runtime(kind: "set_document_title", value: msgpack::make_string(value))
@@ -272,6 +309,13 @@ impl<Msg> Cmd<Msg>
   api fn replace_url(value: StringSlice) -> Cmd<Msg>
     Cmd<Msg>::replace_url(value.to_string())
 
+  /// Replaces the browser location hash through the VX runtime host.
+  api fn set_hash(value: String) -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "set_hash", value: msgpack::make_string(value))
+
+  api fn set_hash(value: StringSlice) -> Cmd<Msg>
+    Cmd<Msg>::set_hash(value.to_string())
+
   /// Navigates one entry back in browser history.
   api fn navigate_back() -> Cmd<Msg>
     Cmd<Msg>::runtime(kind: "navigate_back")
@@ -279,6 +323,63 @@ impl<Msg> Cmd<Msg>
   /// Navigates one entry forward in browser history.
   api fn navigate_forward() -> Cmd<Msg>
     Cmd<Msg>::runtime(kind: "navigate_forward")
+
+  /// Opens a URL in a browser window or tab.
+  api fn open_url(value: String) -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "open_url", value: msgpack::make_string(value))
+
+  api fn open_url(value: StringSlice) -> Cmd<Msg>
+    Cmd<Msg>::open_url(value.to_string())
+
+  api fn open_url({ url: String, target: String }) -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "open_url", value: open_url_value(url: url, target: target))
+
+  api fn open_url({ url: StringSlice, target: StringSlice }) -> Cmd<Msg>
+    Cmd<Msg>::open_url(url: url.to_string(), target: target.to_string())
+
+  /// Scrolls the browser window to an absolute coordinate.
+  api fn scroll_window_to({ x: f64, y: f64 }) -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "scroll_window_to", value: window_scroll_value(x: x, y: y))
+
+  /// Scrolls the browser window by a relative coordinate.
+  api fn scroll_window_by({ x: f64, y: f64 }) -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "scroll_window_by", value: window_scroll_value(x: x, y: y))
+
+  /// Writes a string value into localStorage.
+  api fn local_storage_set({ key: String, value: String }) -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "local_storage_set", value: storage_entry_value(key: key, value: value))
+
+  api fn local_storage_set({ key: StringSlice, value: StringSlice }) -> Cmd<Msg>
+    Cmd<Msg>::local_storage_set(key: key.to_string(), value: value.to_string())
+
+  /// Removes a localStorage key.
+  api fn local_storage_remove(key: String) -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "local_storage_remove", value: msgpack::make_string(key))
+
+  api fn local_storage_remove(key: StringSlice) -> Cmd<Msg>
+    Cmd<Msg>::local_storage_remove(key.to_string())
+
+  /// Clears localStorage.
+  api fn local_storage_clear() -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "local_storage_clear")
+
+  /// Writes a string value into sessionStorage.
+  api fn session_storage_set({ key: String, value: String }) -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "session_storage_set", value: storage_entry_value(key: key, value: value))
+
+  api fn session_storage_set({ key: StringSlice, value: StringSlice }) -> Cmd<Msg>
+    Cmd<Msg>::session_storage_set(key: key.to_string(), value: value.to_string())
+
+  /// Removes a sessionStorage key.
+  api fn session_storage_remove(key: String) -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "session_storage_remove", value: msgpack::make_string(key))
+
+  api fn session_storage_remove(key: StringSlice) -> Cmd<Msg>
+    Cmd<Msg>::session_storage_remove(key.to_string())
+
+  /// Clears sessionStorage.
+  api fn session_storage_clear() -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "session_storage_clear")
 
   /// Creates a task command envelope for a retained result mapper.
   api fn perform({ task_id: i32, handler_id: i32 }) -> Cmd<Msg>
@@ -341,6 +442,10 @@ impl<Msg> Cmd<Msg>
   /// Creates a scroll-into-view command for a constrained VX ref.
   api fn scroll_into_view<T>(target: Ref<T>) -> Cmd<Msg>
     Cmd<Msg>::runtime(kind: "scroll_into_view", value: msgpack::make_string(target.id))
+
+  /// Selects text in an input-like DOM element found by `data-vx-ref`.
+  api fn select_text<T>(target: Ref<T>) -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "select_text", value: msgpack::make_string(target.id))
 
 impl<Msg> Sub<Msg>
   /// Creates an empty subscription set.
@@ -559,6 +664,140 @@ pub fn document_on_visibility_change<Msg>({
   handler: fn(DocumentVisibility) -> Msg
 }) -> Sub<Msg>
   document_on_visibility_change<Msg>(key: key.to_string(), handler: handler)
+
+/// Subscribes to browser URL changes from history traversal or hash changes.
+pub fn location_on_change<Msg>({ key: String, value: Msg }) -> Sub<Msg>
+  Sub<Msg>::runtime(
+    kind: "location_change",
+    key: key,
+    value: boundary_value_to_msgpack(value)
+  )
+
+pub fn location_on_change<Msg>({ key: String, handler: fn(Location) -> Msg }) -> Sub<Msg>
+  Sub<Msg>::runtime_payload<Location>(kind: "location_change", key: key, handler: handler)
+
+pub fn location_on_change<Msg>({ key: StringSlice, value: Msg }) -> Sub<Msg>
+  location_on_change<Msg>(key: key.to_string(), value: value)
+
+pub fn location_on_change<Msg>({ key: StringSlice, handler: fn(Location) -> Msg }) -> Sub<Msg>
+  location_on_change<Msg>(key: key.to_string(), handler: handler)
+
+/// Subscribes to browser window focus events.
+pub fn window_on_focus<Msg>({ key: String, value: Msg }) -> Sub<Msg>
+  window_event_subscription<Msg>(
+    kind: "window_focus",
+    event: "focus",
+    key: key,
+    value: boundary_value_to_msgpack(value)
+  )
+
+pub fn window_on_focus<Msg>({ key: String, handler: fn(GenericEvent) -> Msg }) -> Sub<Msg>
+  window_event_payload_subscription(kind: "window_focus", event: "focus", key: key).map<Msg>(handler)
+
+pub fn window_on_focus<Msg>({ key: StringSlice, value: Msg }) -> Sub<Msg>
+  window_on_focus<Msg>(key: key.to_string(), value: value)
+
+pub fn window_on_focus<Msg>({
+  key: StringSlice,
+  handler: fn(GenericEvent) -> Msg
+}) -> Sub<Msg>
+  window_on_focus<Msg>(key: key.to_string(), handler: handler)
+
+/// Subscribes to browser window blur events.
+pub fn window_on_blur<Msg>({ key: String, value: Msg }) -> Sub<Msg>
+  window_event_subscription<Msg>(
+    kind: "window_blur",
+    event: "blur",
+    key: key,
+    value: boundary_value_to_msgpack(value)
+  )
+
+pub fn window_on_blur<Msg>({ key: String, handler: fn(GenericEvent) -> Msg }) -> Sub<Msg>
+  window_event_payload_subscription(kind: "window_blur", event: "blur", key: key).map<Msg>(handler)
+
+pub fn window_on_blur<Msg>({ key: StringSlice, value: Msg }) -> Sub<Msg>
+  window_on_blur<Msg>(key: key.to_string(), value: value)
+
+pub fn window_on_blur<Msg>({
+  key: StringSlice,
+  handler: fn(GenericEvent) -> Msg
+}) -> Sub<Msg>
+  window_on_blur<Msg>(key: key.to_string(), handler: handler)
+
+/// Subscribes to browser animation frames.
+pub fn animation_frame<Msg>({ key: String, value: Msg }) -> Sub<Msg>
+  Sub<Msg>::runtime(
+    kind: "animation_frame",
+    key: key,
+    value: boundary_value_to_msgpack(value)
+  )
+
+pub fn animation_frame<Msg>({
+  key: String,
+  handler: fn(AnimationFrame) -> Msg
+}) -> Sub<Msg>
+  Sub<Msg>::runtime_payload<AnimationFrame>(kind: "animation_frame", key: key, handler: handler)
+
+pub fn animation_frame<Msg>({ key: StringSlice, value: Msg }) -> Sub<Msg>
+  animation_frame<Msg>(key: key.to_string(), value: value)
+
+pub fn animation_frame<Msg>({
+  key: StringSlice,
+  handler: fn(AnimationFrame) -> Msg
+}) -> Sub<Msg>
+  animation_frame<Msg>(key: key.to_string(), handler: handler)
+
+/// Subscribes to a browser media query.
+pub fn media_query<Msg>({ query: String, value: Msg }) -> Sub<Msg>
+  media_query_subscription<Msg>(query: query, value: boundary_value_to_msgpack(value))
+
+pub fn media_query<Msg>({ query: String, handler: fn(MediaQuery) -> Msg }) -> Sub<Msg>
+  media_query_payload_subscription(query).map<Msg>(handler)
+
+pub fn media_query<Msg>({ query: StringSlice, value: Msg }) -> Sub<Msg>
+  media_query<Msg>(query: query.to_string(), value: value)
+
+pub fn media_query<Msg>({ query: StringSlice, handler: fn(MediaQuery) -> Msg }) -> Sub<Msg>
+  media_query<Msg>(query: query.to_string(), handler: handler)
+
+/// Subscribes to browser storage events.
+pub fn storage_on_change<Msg>({ key: String, value: Msg }) -> Sub<Msg>
+  Sub<Msg>::runtime(
+    kind: "storage",
+    key: key,
+    value: boundary_value_to_msgpack(value)
+  )
+
+pub fn storage_on_change<Msg>({ key: String, handler: fn(StorageChange) -> Msg }) -> Sub<Msg>
+  Sub<Msg>::runtime_payload<StorageChange>(kind: "storage", key: key, handler: handler)
+
+pub fn storage_on_change<Msg>({ key: StringSlice, value: Msg }) -> Sub<Msg>
+  storage_on_change<Msg>(key: key.to_string(), value: value)
+
+pub fn storage_on_change<Msg>({
+  key: StringSlice,
+  handler: fn(StorageChange) -> Msg
+}) -> Sub<Msg>
+  storage_on_change<Msg>(key: key.to_string(), handler: handler)
+
+/// Subscribes to messages from a browser BroadcastChannel.
+pub fn broadcast_channel<Msg>({ name: String, value: Msg }) -> Sub<Msg>
+  broadcast_channel_subscription<Msg>(name: name, value: boundary_value_to_msgpack(value))
+
+pub fn broadcast_channel<Payload, Msg>({
+  name: String,
+  handler: fn(Payload) -> Msg
+}) -> Sub<Msg>
+  broadcast_channel_payload_subscription<Payload>(name).map<Msg>(handler)
+
+pub fn broadcast_channel<Msg>({ name: StringSlice, value: Msg }) -> Sub<Msg>
+  broadcast_channel<Msg>(name: name.to_string(), value: value)
+
+pub fn broadcast_channel<Payload, Msg>({
+  name: StringSlice,
+  handler: fn(Payload) -> Msg
+}) -> Sub<Msg>
+  broadcast_channel<Payload, Msg>(name: name.to_string(), handler: handler)
 
 /// Reads a component-local serialized state handle.
 pub fn state_handle({
@@ -1988,6 +2227,24 @@ fn set_bool_option(~out: Dict<String, MsgPack>, name: String, value: Optional<bo
     None:
       void
 
+fn window_scroll_value({ x: f64, y: f64 }) -> MsgPack
+  let ~out = Dict<String, MsgPack>::init()
+  out.set("x", msgpack::make_f64(x))
+  out.set("y", msgpack::make_f64(y))
+  msgpack::make_map(out)
+
+fn storage_entry_value({ key: String, value: String }) -> MsgPack
+  let ~out = Dict<String, MsgPack>::init()
+  out.set("key", key)
+  out.set("value", value)
+  msgpack::make_map(out)
+
+fn open_url_value({ url: String, target: String }) -> MsgPack
+  let ~out = Dict<String, MsgPack>::init()
+  out.set("url", url)
+  out.set("target", target)
+  msgpack::make_map(out)
+
 fn command_payload(kind: String): () -> MsgPack
   msgpack::make_map(command_map(kind))
 
@@ -2012,6 +2269,54 @@ fn keyboard_payload_subscription({ kind: String, key: String }) -> Sub<KeyboardE
   out.set("key", key)
   out.set("event", kind)
   Sub<KeyboardEvent> { payload: msgpack::make_map(out) }
+
+fn window_event_subscription<Msg>({
+  kind: String,
+  event: String,
+  key: String,
+  value: MsgPack
+}) -> Sub<Msg>
+  let ~out = subscription_map(kind)
+  out.set("key", key)
+  out.set("event", event)
+  out.set("value", value)
+  Sub<Msg> { payload: msgpack::make_map(out) }
+
+fn window_event_payload_subscription({
+  kind: String,
+  event: String,
+  key: String
+}) -> Sub<GenericEvent>
+  let ~out = subscription_map(kind)
+  out.set("key", key)
+  out.set("event", event)
+  Sub<GenericEvent> { payload: msgpack::make_map(out) }
+
+fn media_query_subscription<Msg>({ query: String, value: MsgPack }) -> Sub<Msg>
+  let ~out = subscription_map("media_query")
+  out.set("key", query)
+  out.set("query", query)
+  out.set("value", value)
+  Sub<Msg> { payload: msgpack::make_map(out) }
+
+fn media_query_payload_subscription(query: String) -> Sub<MediaQuery>
+  let ~out = subscription_map("media_query")
+  out.set("key", query)
+  out.set("query", query)
+  Sub<MediaQuery> { payload: msgpack::make_map(out) }
+
+fn broadcast_channel_subscription<Msg>({ name: String, value: MsgPack }) -> Sub<Msg>
+  let ~out = subscription_map("broadcast_channel")
+  out.set("key", name)
+  out.set("name", name)
+  out.set("value", value)
+  Sub<Msg> { payload: msgpack::make_map(out) }
+
+fn broadcast_channel_payload_subscription<Payload>(name: String) -> Sub<Payload>
+  let ~out = subscription_map("broadcast_channel")
+  out.set("key", name)
+  out.set("name", name)
+  Sub<Payload> { payload: msgpack::make_map(out) }
 
 fn tagged_vx_runtime_map(type_name: String, kind: String): () -> Dict<String, MsgPack>
   let ~out = Dict<String, MsgPack>::init()

--- a/packages/std/src/vx.voyd
+++ b/packages/std/src/vx.voyd
@@ -75,6 +75,18 @@ pub type KeyboardEvent = {
   shift_key: bool
 }
 
+pub type WindowSize = {
+  kind: String,
+  width: f64,
+  height: f64
+}
+
+pub type DocumentVisibility = {
+  kind: String,
+  state: String,
+  hidden: bool
+}
+
 pub type InputEvent = {
   kind: String,
   value: String,
@@ -232,6 +244,42 @@ impl<Msg> Cmd<Msg>
   api fn runtime({ kind: StringSlice, value?: MsgPack }) -> Cmd<Msg>
     Cmd<Msg>::runtime(kind: kind.to_string(), value: value)
 
+  /// Copies text to the browser clipboard through the VX runtime host.
+  api fn copy_to_clipboard(value: String) -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "copy_to_clipboard", value: msgpack::make_string(value))
+
+  api fn copy_to_clipboard(value: StringSlice) -> Cmd<Msg>
+    Cmd<Msg>::copy_to_clipboard(value.to_string())
+
+  /// Sets the browser document title through the VX runtime host.
+  api fn set_document_title(value: String) -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "set_document_title", value: msgpack::make_string(value))
+
+  api fn set_document_title(value: StringSlice) -> Cmd<Msg>
+    Cmd<Msg>::set_document_title(value.to_string())
+
+  /// Pushes a URL into browser history through the VX runtime host.
+  api fn push_url(value: String) -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "push_url", value: msgpack::make_string(value))
+
+  api fn push_url(value: StringSlice) -> Cmd<Msg>
+    Cmd<Msg>::push_url(value.to_string())
+
+  /// Replaces the current browser history URL through the VX runtime host.
+  api fn replace_url(value: String) -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "replace_url", value: msgpack::make_string(value))
+
+  api fn replace_url(value: StringSlice) -> Cmd<Msg>
+    Cmd<Msg>::replace_url(value.to_string())
+
+  /// Navigates one entry back in browser history.
+  api fn navigate_back() -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "navigate_back")
+
+  /// Navigates one entry forward in browser history.
+  api fn navigate_forward() -> Cmd<Msg>
+    Cmd<Msg>::runtime(kind: "navigate_forward")
+
   /// Creates a task command envelope for a retained result mapper.
   api fn perform({ task_id: i32, handler_id: i32 }) -> Cmd<Msg>
     let ~out = command_map("task")
@@ -338,6 +386,47 @@ impl<Msg> Sub<Msg>
   api fn runtime({ kind: StringSlice, key: StringSlice, value?: MsgPack }) -> Sub<Msg>
     Sub<Msg>::runtime(kind: kind.to_string(), key: key.to_string(), value: value)
 
+  /// Creates a host/runtime subscription and maps incoming payloads through a typed handler.
+  api fn runtime_payload<Payload>({
+    kind: String,
+    key: String,
+    handler: fn(Payload) -> Msg
+  }) -> Sub<Msg>
+    Sub<Payload>::runtime(kind: kind, key: key).map<Msg>(handler)
+
+  api fn runtime_payload<Payload>({
+    kind: StringSlice,
+    key: StringSlice,
+    handler: fn(Payload) -> Msg
+  }) -> Sub<Msg>
+    Sub<Msg>::runtime_payload<Payload>(
+      kind: kind.to_string(),
+      key: key.to_string(),
+      handler: handler
+    )
+
+  /// Creates a configured host/runtime subscription and maps incoming payloads.
+  api fn runtime_configured<Payload>({
+    kind: String,
+    key: String,
+    value: MsgPack,
+    handler: fn(Payload) -> Msg
+  }) -> Sub<Msg>
+    Sub<Payload>::runtime(kind: kind, key: key, value: value).map<Msg>(handler)
+
+  api fn runtime_configured<Payload>({
+    kind: StringSlice,
+    key: StringSlice,
+    value: MsgPack,
+    handler: fn(Payload) -> Msg
+  }) -> Sub<Msg>
+    Sub<Msg>::runtime_configured<Payload>(
+      kind: kind.to_string(),
+      key: key.to_string(),
+      value: value,
+      handler: handler
+    )
+
   /// Creates an interval subscription envelope for a serialized host runtime value.
   api fn every_serialized({ key: String, millis: i64, value: MsgPack }) -> Sub<Msg>
     let ~out = subscription_map("interval")
@@ -367,11 +456,20 @@ pub fn keyboard_on_key_down_serialized<Msg>({ key: String, value: MsgPack }) -> 
 pub fn keyboard_on_key_down<Msg>({ key: String, value: Msg }) -> Sub<Msg>
   keyboard_subscription(kind: "keydown", key: key, value: boundary_value_to_msgpack(value))
 
+pub fn keyboard_on_key_down<Msg>({ key: String, handler: fn(KeyboardEvent) -> Msg }) -> Sub<Msg>
+  keyboard_payload_subscription(kind: "keydown", key: key).map<Msg>(handler)
+
 pub fn keyboard_on_key_down_serialized<Msg>({ key: StringSlice, value: MsgPack }) -> Sub<Msg>
   keyboard_on_key_down_serialized<Msg>(key: key.to_string(), value: value)
 
 pub fn keyboard_on_key_down<Msg>({ key: StringSlice, value: Msg }) -> Sub<Msg>
   keyboard_on_key_down<Msg>(key: key.to_string(), value: value)
+
+pub fn keyboard_on_key_down<Msg>({
+  key: StringSlice,
+  handler: fn(KeyboardEvent) -> Msg
+}) -> Sub<Msg>
+  keyboard_on_key_down<Msg>(key: key.to_string(), handler: handler)
 
 /// Subscribes to global keyup events through the browser VX runtime host.
 pub fn keyboard_on_key_up_serialized<Msg>({ key: String, value: MsgPack }) -> Sub<Msg>
@@ -380,11 +478,87 @@ pub fn keyboard_on_key_up_serialized<Msg>({ key: String, value: MsgPack }) -> Su
 pub fn keyboard_on_key_up<Msg>({ key: String, value: Msg }) -> Sub<Msg>
   keyboard_subscription(kind: "keyup", key: key, value: boundary_value_to_msgpack(value))
 
+pub fn keyboard_on_key_up<Msg>({ key: String, handler: fn(KeyboardEvent) -> Msg }) -> Sub<Msg>
+  keyboard_payload_subscription(kind: "keyup", key: key).map<Msg>(handler)
+
 pub fn keyboard_on_key_up_serialized<Msg>({ key: StringSlice, value: MsgPack }) -> Sub<Msg>
   keyboard_on_key_up_serialized<Msg>(key: key.to_string(), value: value)
 
 pub fn keyboard_on_key_up<Msg>({ key: StringSlice, value: Msg }) -> Sub<Msg>
   keyboard_on_key_up<Msg>(key: key.to_string(), value: value)
+
+pub fn keyboard_on_key_up<Msg>({
+  key: StringSlice,
+  handler: fn(KeyboardEvent) -> Msg
+}) -> Sub<Msg>
+  keyboard_on_key_up<Msg>(key: key.to_string(), handler: handler)
+
+/// Subscribes to browser online/offline changes through the VX runtime host.
+pub fn online_status<Msg>({ key: String, value: Msg }) -> Sub<Msg>
+  Sub<Msg>::runtime(
+    kind: "online_status",
+    key: key,
+    value: boundary_value_to_msgpack(value)
+  )
+
+pub fn online_status<Msg>({ key: String, handler: fn(bool) -> Msg }) -> Sub<Msg>
+  Sub<Msg>::runtime_payload<bool>(kind: "online_status", key: key, handler: handler)
+
+pub fn online_status<Msg>({ key: StringSlice, value: Msg }) -> Sub<Msg>
+  online_status<Msg>(key: key.to_string(), value: value)
+
+pub fn online_status<Msg>({ key: StringSlice, handler: fn(bool) -> Msg }) -> Sub<Msg>
+  online_status<Msg>(key: key.to_string(), handler: handler)
+
+/// Subscribes to browser window resize changes through the VX runtime host.
+pub fn window_on_resize<Msg>({ key: String, value: Msg }) -> Sub<Msg>
+  Sub<Msg>::runtime(
+    kind: "window_resize",
+    key: key,
+    value: boundary_value_to_msgpack(value)
+  )
+
+pub fn window_on_resize<Msg>({
+  key: String,
+  handler: fn(WindowSize) -> Msg
+}) -> Sub<Msg>
+  Sub<Msg>::runtime_payload<WindowSize>(kind: "window_resize", key: key, handler: handler)
+
+pub fn window_on_resize<Msg>({ key: StringSlice, value: Msg }) -> Sub<Msg>
+  window_on_resize<Msg>(key: key.to_string(), value: value)
+
+pub fn window_on_resize<Msg>({
+  key: StringSlice,
+  handler: fn(WindowSize) -> Msg
+}) -> Sub<Msg>
+  window_on_resize<Msg>(key: key.to_string(), handler: handler)
+
+/// Subscribes to document visibility changes through the VX runtime host.
+pub fn document_on_visibility_change<Msg>({ key: String, value: Msg }) -> Sub<Msg>
+  Sub<Msg>::runtime(
+    kind: "visibility_change",
+    key: key,
+    value: boundary_value_to_msgpack(value)
+  )
+
+pub fn document_on_visibility_change<Msg>({
+  key: String,
+  handler: fn(DocumentVisibility) -> Msg
+}) -> Sub<Msg>
+  Sub<Msg>::runtime_payload<DocumentVisibility>(
+    kind: "visibility_change",
+    key: key,
+    handler: handler
+  )
+
+pub fn document_on_visibility_change<Msg>({ key: StringSlice, value: Msg }) -> Sub<Msg>
+  document_on_visibility_change<Msg>(key: key.to_string(), value: value)
+
+pub fn document_on_visibility_change<Msg>({
+  key: StringSlice,
+  handler: fn(DocumentVisibility) -> Msg
+}) -> Sub<Msg>
+  document_on_visibility_change<Msg>(key: key.to_string(), handler: handler)
 
 /// Reads a component-local serialized state handle.
 pub fn state_handle({
@@ -1832,6 +2006,12 @@ fn keyboard_subscription<Msg>({ kind: String, key: String, value: MsgPack }) -> 
   out.set("event", kind)
   out.set("value", value)
   Sub<Msg> { payload: msgpack::make_map(out) }
+
+fn keyboard_payload_subscription({ kind: String, key: String }) -> Sub<KeyboardEvent>
+  let ~out = subscription_map("keyboard")
+  out.set("key", key)
+  out.set("event", kind)
+  Sub<KeyboardEvent> { payload: msgpack::make_map(out) }
 
 fn tagged_vx_runtime_map(type_name: String, kind: String): () -> Dict<String, MsgPack>
   let ~out = Dict<String, MsgPack>::init()

--- a/packages/std/src/vx.voyd
+++ b/packages/std/src/vx.voyd
@@ -288,7 +288,8 @@ impl<Msg> Cmd<Msg>
     Cmd<Msg> { payload: msgpack::make_map(out) }
 
   api fn read_clipboard(handler: fn(String) -> Msg) -> Cmd<Msg>
-    Cmd<Msg>::read_clipboard(handler_id: retain_typed_message_mapper(handler))
+    let handler_id = retain_typed_message_mapper(handler)
+    mark_owned_handler(Cmd<Msg>::read_clipboard(handler_id: handler_id), handler_id)
 
   /// Sets the browser document title through the VX runtime host.
   api fn set_document_title(value: String) -> Cmd<Msg>

--- a/packages/std/src/vx.voyd
+++ b/packages/std/src/vx.voyd
@@ -256,11 +256,13 @@ impl<Msg> Cmd<Msg>
 
   /// Lifts a child command through a retained serialized message mapper.
   api fn map_serialized<NextMsg>(self, handler: fn(MsgPack) -> MsgPack) -> Cmd<NextMsg>
-    self.map<NextMsg>(handler_id: retain_message_mapper(handler))
+    let handler_id = retain_message_mapper(handler)
+    Cmd<NextMsg> { payload: msgpack::make_map(command_map_with_owned_handler(self.payload, handler_id)) }
 
   /// Lifts a child command through a retained typed message mapper.
   api fn map<NextMsg>(self, handler: fn(Msg) -> NextMsg) -> Cmd<NextMsg>
-    self.map<NextMsg>(handler_id: retain_typed_message_mapper(handler))
+    let handler_id = retain_typed_message_mapper(handler)
+    Cmd<NextMsg> { payload: msgpack::make_map(command_map_with_owned_handler(self.payload, handler_id)) }
 
   /// Creates a host/runtime command envelope for a registered VX command executor.
   api fn runtime({ kind: String, value?: MsgPack }) -> Cmd<Msg>
@@ -390,11 +392,13 @@ impl<Msg> Cmd<Msg>
 
   /// Creates a task command envelope for a retained Voyd result mapper.
   api fn perform({ task_id: i32, handler: fn(MsgPack) -> MsgPack }) -> Cmd<Msg>
-    Cmd<Msg>::perform(task_id: task_id, handler_id: retain_message_mapper(handler))
+    let handler_id = retain_message_mapper(handler)
+    mark_owned_handler(Cmd<Msg>::perform(task_id: task_id, handler_id: handler_id), handler_id)
 
   /// Creates a task command envelope for a retained typed result mapper.
   api fn perform<T>({ task_id: i32, handler: fn(T) -> Msg }) -> Cmd<Msg>
-    Cmd<Msg>::perform(task_id: task_id, handler_id: retain_typed_message_mapper(handler))
+    let handler_id = retain_typed_message_mapper(handler)
+    mark_owned_handler(Cmd<Msg>::perform(task_id: task_id, handler_id: handler_id), handler_id)
 
   /// Creates a task command envelope from a Voyd task and retained result mapper.
   api fn perform<T>({ task: Task<T>, handler_id: i32 }) -> Cmd<Msg>
@@ -405,21 +409,24 @@ impl<Msg> Cmd<Msg>
 
   /// Creates a task command envelope from a Voyd task and retained result mapper.
   api fn perform<T>({ task: Task<T>, handler: fn(MsgPack) -> MsgPack }) -> Cmd<Msg>
-    Cmd<Msg>::perform<T>(task: task, handler_id: retain_message_mapper(handler))
+    let handler_id = retain_message_mapper(handler)
+    mark_owned_handler(Cmd<Msg>::perform<T>(task: task, handler_id: handler_id), handler_id)
 
   /// Creates a task command envelope from a Voyd task and retained typed result mapper.
   api fn perform<T>({ task: Task<T>, handler: fn(T) -> Msg }) -> Cmd<Msg>
-    Cmd<Msg>::perform<T>(task: task, handler_id: retain_typed_message_mapper(handler))
+    let handler_id = retain_typed_message_mapper(handler)
+    mark_owned_handler(Cmd<Msg>::perform<T>(task: task, handler_id: handler_id), handler_id)
 
   /// Starts one-off async work and dispatches the mapped result when it completes.
   api fn task<T>({
     work: fn() : (open) -> T,
     handler: fn(T) -> Msg
   }): (TaskRuntime, open) -> Cmd<Msg>
-    Cmd<Msg>::perform<T>(
+    let handler_id = retain_typed_message_mapper(handler)
+    mark_owned_handler(Cmd<Msg>::perform<T>(
       task: tasks::detach(work),
-      handler_id: retain_typed_message_mapper(handler)
-    )
+      handler_id: handler_id
+    ), handler_id)
 
   /// Creates a timer command that dispatches a serialized value after the delay.
   api fn delay_serialized({ millis: i64, value: MsgPack }) -> Cmd<Msg>
@@ -2270,6 +2277,27 @@ fn command_payload(kind: String): () -> MsgPack
 
 fn command_map(kind: String): () -> Dict<String, MsgPack>
   tagged_vx_runtime_map("cmd", kind)
+
+fn command_map_with_owned_handler(child: MsgPack, handler_id: i32): () -> Dict<String, MsgPack>
+  let ~out = command_map("map")
+  out.set("child", child)
+  out.set("handlerId", msgpack::make_i32(handler_id))
+  set_owned_handler(~out, handler_id)
+  out
+
+fn mark_owned_handler<Msg>(cmd: Cmd<Msg>, handler_id: i32) -> Cmd<Msg>
+  match(msgpack::unpack_map(cmd.payload))
+    Ok<Dict<String, MsgPack>> { value }:
+      let ~out = value
+      set_owned_handler(~out, handler_id)
+      Cmd<Msg> { payload: msgpack::make_map(out) }
+    Err:
+      cmd
+
+fn set_owned_handler(~out: Dict<String, MsgPack>, handler_id: i32) -> void
+  let ~owned = Array<MsgPack>::with_capacity(1)
+  owned.push(msgpack::make_i32(handler_id))
+  out.set("__vxOwnedMapHandlerIds", msgpack::make_array(owned))
 
 fn subscription_payload(kind: String): () -> MsgPack
   msgpack::make_map(subscription_map(kind))

--- a/packages/std/src/vx.voyd
+++ b/packages/std/src/vx.voyd
@@ -466,19 +466,35 @@ impl<Msg> Sub<Msg>
     Sub<Msg> { payload: msgpack::make_map(out) }
 
   /// Lifts a child subscription through a retained message mapper.
-  api fn map<NextMsg>(self, { handler_id: i32 }) -> Sub<NextMsg>
+  api fn map<NextMsg>(self, { handler_id: i32, handler_key?: i32 }) -> Sub<NextMsg>
     let ~out = subscription_map("map")
     out.set("child", self.payload)
     out.set("handlerId", msgpack::make_i32(handler_id))
+    if handler_key is Some:
+      out.set("handlerKey", msgpack::make_i32(handler_key.value))
     Sub<NextMsg> { payload: msgpack::make_map(out) }
 
   /// Lifts a child subscription through a retained serialized message mapper.
-  api fn map_serialized<NextMsg>(self, handler: fn(MsgPack) -> MsgPack) -> Sub<NextMsg>
-    self.map<NextMsg>(handler_id: retain_message_mapper(handler))
+  api fn map_serialized<NextMsg>(
+    self,
+    handler: fn(MsgPack) -> MsgPack,
+    { handler_key: i32 = stable_callsite_id() }
+  ) -> Sub<NextMsg>
+    self.map<NextMsg>(
+      handler_id: retain_message_mapper(handler),
+      handler_key: handler_key
+    )
 
   /// Lifts a child subscription through a retained typed message mapper.
-  api fn map<NextMsg>(self, handler: fn(Msg) -> NextMsg) -> Sub<NextMsg>
-    self.map<NextMsg>(handler_id: retain_typed_message_mapper(handler))
+  api fn map<NextMsg>(
+    self,
+    handler: fn(Msg) -> NextMsg,
+    { handler_key: i32 = stable_callsite_id() }
+  ) -> Sub<NextMsg>
+    self.map<NextMsg>(
+      handler_id: retain_typed_message_mapper(handler),
+      handler_key: handler_key
+    )
 
   /// Creates a host/runtime subscription envelope for a registered VX subscription runner.
   api fn runtime({ kind: String, key: String, value?: MsgPack }) -> Sub<Msg>

--- a/packages/std/src/vx.voyd
+++ b/packages/std/src/vx.voyd
@@ -533,7 +533,11 @@ impl<Msg> Sub<Msg>
     value: MsgPack,
     handler: fn(Payload) -> Msg
   }) -> Sub<Msg>
-    Sub<Payload>::runtime(kind: kind, key: key, value: value).map<Msg>(handler)
+    let ~out = subscription_map(kind)
+    out.set("key", key)
+    out.set("value", value)
+    out.set("valueRole", "config")
+    Sub<Payload> { payload: msgpack::make_map(out) }.map<Msg>(handler)
 
   api fn runtime_configured<Payload>({
     kind: StringSlice,

--- a/packages/std/src/vx.voyd
+++ b/packages/std/src/vx.voyd
@@ -488,9 +488,10 @@ impl<Msg> Sub<Msg>
     handler: fn(MsgPack) -> MsgPack,
     { handler_key: i32 = stable_callsite_id() }
   ) -> Sub<NextMsg>
-    self.map<NextMsg>(
-      handler_id: retain_message_mapper(handler),
-      handler_key: handler_key
+    let handler_id = retain_message_mapper(handler)
+    mark_owned_subscription(
+      self.map<NextMsg>(handler_id: handler_id, handler_key: handler_key),
+      handler_id
     )
 
   /// Lifts a child subscription through a retained typed message mapper.
@@ -499,9 +500,10 @@ impl<Msg> Sub<Msg>
     handler: fn(Msg) -> NextMsg,
     { handler_key: i32 = stable_callsite_id() }
   ) -> Sub<NextMsg>
-    self.map<NextMsg>(
-      handler_id: retain_typed_message_mapper(handler),
-      handler_key: handler_key
+    let handler_id = retain_typed_message_mapper(handler)
+    mark_owned_subscription(
+      self.map<NextMsg>(handler_id: handler_id, handler_key: handler_key),
+      handler_id
     )
 
   /// Creates a host/runtime subscription envelope for a registered VX subscription runner.
@@ -2294,6 +2296,15 @@ fn mark_owned_handler<Msg>(cmd: Cmd<Msg>, handler_id: i32) -> Cmd<Msg>
       Cmd<Msg> { payload: msgpack::make_map(out) }
     Err:
       cmd
+
+fn mark_owned_subscription<Msg>(sub: Sub<Msg>, handler_id: i32) -> Sub<Msg>
+  match(msgpack::unpack_map(sub.payload))
+    Ok<Dict<String, MsgPack>> { value }:
+      let ~out = value
+      set_owned_handler(~out, handler_id)
+      Sub<Msg> { payload: msgpack::make_map(out) }
+    Err:
+      sub
 
 fn set_owned_handler(~out: Dict<String, MsgPack>, handler_id: i32) -> void
   let ~owned = Array<MsgPack>::with_capacity(1)

--- a/packages/vx-dom/src/__tests__/app-runtime.test.ts
+++ b/packages/vx-dom/src/__tests__/app-runtime.test.ts
@@ -190,6 +190,39 @@ describe("createVoydVxAppRuntime", () => {
     ]);
   });
 
+  it("resolves mapped subscription payloads through retained callbacks before step", async () => {
+    const seenMessages: unknown[] = [];
+    const retainedDispatch = vi.fn(async (id: number, payload: unknown) => {
+      if (id === 9) return { type: "online", online: payload };
+      throw new Error(`unexpected retained handler ${id}`);
+    });
+    const host = fakeHost({
+      init: async () => "ready",
+      view: async ([current]) => textFrame(String(current)),
+      step: async ([current, message]) => {
+        seenMessages.push(message);
+        return current;
+      },
+    });
+    host.retainedCallbacks = { dispatch: retainedDispatch };
+    const app = createVoydVxAppRuntime({ host });
+
+    await app.init?.();
+    await app.dispatch({
+      kind: "map",
+      handlerId: 9,
+      message: {
+        kind: "subscription",
+        subscriptionKind: "online_status",
+        key: "network",
+        payload: true,
+      },
+    });
+
+    expect(seenMessages).toEqual([{ type: "online", online: true }]);
+    expect(retainedDispatch).toHaveBeenCalledWith(9, true);
+  });
+
   it("rerenders mapped local-only retained callbacks without step or mapper dispatch", async () => {
     const seenMessages: unknown[] = [];
     const retainedDispatch = vi.fn(async (id: number) => {

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -1555,8 +1555,8 @@ describe("vx-dom browser renderer", () => {
         frame: counterNode(0),
         subscriptions: [
           { type: "sub", kind: "location_change", key: "location" },
-          { type: "sub", kind: "window_focus", key: "focus", event: "focus" },
-          { type: "sub", kind: "window_blur", key: "blur", event: "blur", value: { type: "blur" } },
+          { type: "sub", kind: "window_focus", key: "focus" },
+          { type: "sub", kind: "window_blur", key: "blur", value: { type: "blur" } },
           { type: "sub", kind: "animation_frame", key: "frame" },
           {
             type: "sub",

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -1430,6 +1430,44 @@ describe("vx-dom browser renderer", () => {
     expect(releaseMany).toHaveBeenCalledWith([1]);
   });
 
+  it("releases app-owned subscription handlers through the app registry", async () => {
+    let nextHandlerId = 1;
+    const appRelease = vi.fn<(id: number) => void>();
+    const overrideReleaseMany = vi.fn<(ids: Iterable<number>) => void>();
+    const mappedSubscription = () => ({
+      type: "sub",
+      kind: "map",
+      handlerId: nextHandlerId++,
+      handlerKey: 9001,
+      child: { type: "sub", kind: "timer", key: "main" },
+    });
+    const app: VxAppRuntime = {
+      retainedCallbacks: { release: appRelease },
+      init: () => ({
+        frame: counterNode(0),
+        subscriptions: mappedSubscription(),
+      }),
+      render: () => counterNode(0),
+      dispatch: () => ({
+        frame: counterNode(0),
+        subscriptions: mappedSubscription(),
+      }),
+    };
+
+    const mounted = await mountVxApp({
+      container,
+      app,
+      handlers: { dispatch: vi.fn(), releaseMany: overrideReleaseMany },
+      runtimeHost: { subscriptions: { timer: () => undefined } },
+    });
+
+    await mounted.dispatch({ kind: "debug", name: "refresh" });
+    await nextTurn();
+
+    expect(appRelease).toHaveBeenCalledWith(1);
+    expect(overrideReleaseMany).not.toHaveBeenCalled();
+  });
+
   it("does not release outer mapped subscription handlers", async () => {
     const seenMessages: unknown[] = [];
     let nextHandlerId = 1;

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -1032,6 +1032,7 @@ describe("vx-dom browser renderer", () => {
   it("does not await queued clipboard dispatches from step commands", async () => {
     const seenMessages: unknown[] = [];
     const readText = vi.fn(async () => "Clipboard text");
+    const release = vi.fn<(id: number) => void>();
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { readText },
@@ -1053,6 +1054,7 @@ describe("vx-dom browser renderer", () => {
       },
     };
 
+    app.retainedCallbacks = { release };
     const mounted = await mountVxApp({ container, app });
     const dispatch = mounted.dispatch({ kind: "debug", name: "read" });
 
@@ -1069,6 +1071,31 @@ describe("vx-dom browser renderer", () => {
       handlerId: 77,
       message: { kind: "msgpack", value: "Clipboard text" },
     });
+    expect(release).toHaveBeenCalledWith(77);
+  });
+
+  it("releases clipboard read handlers when the clipboard read fails", async () => {
+    const release = vi.fn<(id: number) => void>();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { readText: vi.fn(async () => {
+        throw new Error("clipboard denied");
+      }) },
+    });
+    const app: VxAppRuntime = {
+      retainedCallbacks: { release },
+      init: () => ({
+        frame: counterNode(0),
+        commands: { type: "cmd", kind: "read_clipboard", handlerId: 77 },
+      }),
+      render: () => counterNode(0),
+      dispatch: () => counterNode(0),
+    };
+
+    await expect(mountVxApp({ container, app })).rejects.toThrow("clipboard denied");
+    await nextTurn();
+
+    expect(release).toHaveBeenCalledWith(77);
   });
 
   it("reports diagnostics for malformed ref DOM commands", async () => {

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -833,6 +833,7 @@ describe("vx-dom browser renderer", () => {
 
   it("runs ref DOM commands with the default browser runtime host", async () => {
     const focus = vi.spyOn(HTMLElement.prototype, "focus").mockImplementation(() => undefined);
+    const select = vi.spyOn(HTMLInputElement.prototype, "select").mockImplementation(() => undefined);
     const scrollIntoView = vi.fn();
     const previousScrollIntoView = HTMLElement.prototype.scrollIntoView;
     HTMLElement.prototype.scrollIntoView = scrollIntoView;
@@ -852,6 +853,7 @@ describe("vx-dom browser renderer", () => {
             children: [
               { type: "cmd", kind: "focus", value: "editor" },
               { type: "cmd", kind: "scroll_into_view", value: "editor" },
+              { type: "cmd", kind: "select_text", value: "editor" },
             ],
           },
         }),
@@ -868,49 +870,104 @@ describe("vx-dom browser renderer", () => {
 
       expect(focus).toHaveBeenCalledOnce();
       expect(scrollIntoView).toHaveBeenCalledOnce();
+      expect(select).toHaveBeenCalledOnce();
     } finally {
       HTMLElement.prototype.scrollIntoView = previousScrollIntoView;
     }
   });
 
   it("runs browser runtime commands with the default browser runtime host", async () => {
+    const seenMessages: unknown[] = [];
     const writeText = vi.fn(async () => undefined);
+    const readText = vi.fn(async () => "Clipboard text");
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
-      value: { writeText },
+      value: { readText, writeText },
     });
-    const pushState = vi.spyOn(history, "pushState").mockImplementation(() => undefined);
-    const replaceState = vi.spyOn(history, "replaceState").mockImplementation(() => undefined);
+    Object.defineProperty(window, "open", { configurable: true, value: vi.fn() });
+    Object.defineProperty(window, "scrollBy", { configurable: true, value: vi.fn() });
+    Object.defineProperty(window, "scrollTo", { configurable: true, value: vi.fn() });
+    localStorage.clear();
+    sessionStorage.clear();
+    const originalPushState = history.pushState.bind(history);
+    const originalReplaceState = history.replaceState.bind(history);
+    const pushState = vi.spyOn(history, "pushState")
+      .mockImplementation((data, title, url) => originalPushState(data, title, url));
+    const replaceState = vi.spyOn(history, "replaceState")
+      .mockImplementation((data, title, url) => originalReplaceState(data, title, url));
     const back = vi.spyOn(history, "back").mockImplementation(() => undefined);
     const forward = vi.spyOn(history, "forward").mockImplementation(() => undefined);
     const app: VxAppRuntime = {
       init: () => ({
         frame: counterNode(0),
+        subscriptions: { type: "sub", kind: "location_change", key: "location" },
         commands: {
           type: "cmd",
           kind: "batch",
           children: [
             { type: "cmd", kind: "copy_to_clipboard", value: "Draft" },
+            { type: "cmd", kind: "read_clipboard", handlerId: 77 },
             { type: "cmd", kind: "set_document_title", value: "VX Draft" },
             { type: "cmd", kind: "push_url", value: "/draft" },
             { type: "cmd", kind: "replace_url", value: "/draft?edited=1" },
+            { type: "cmd", kind: "set_hash", value: "section" },
             { type: "cmd", kind: "navigate_back" },
             { type: "cmd", kind: "navigate_forward" },
+            { type: "cmd", kind: "open_url", value: { url: "/external", target: "_self" } },
+            { type: "cmd", kind: "scroll_window_to", value: { x: 10, y: 20 } },
+            { type: "cmd", kind: "scroll_window_by", value: { x: 1, y: 2 } },
+            { type: "cmd", kind: "local_storage_set", value: { key: "draft", value: "yes" } },
+            { type: "cmd", kind: "local_storage_remove", value: "draft" },
+            { type: "cmd", kind: "local_storage_clear" },
+            { type: "cmd", kind: "session_storage_set", value: { key: "draft", value: "yes" } },
+            { type: "cmd", kind: "session_storage_remove", value: "draft" },
+            { type: "cmd", kind: "session_storage_clear" },
           ],
         },
       }),
       render: () => counterNode(0),
-      dispatch: () => counterNode(0),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        return counterNode(seenMessages.length);
+      },
     };
 
     await mountVxApp({ container, app });
+    await nextTurn();
 
     expect(writeText).toHaveBeenCalledWith("Draft");
+    expect(readText).toHaveBeenCalledOnce();
+    expect(seenMessages).toContainEqual({
+      kind: "map",
+      handlerId: 77,
+      message: { kind: "msgpack", value: "Clipboard text" },
+    });
+    expect(seenMessages).toContainEqual(expect.objectContaining({
+      kind: "subscription",
+      subscriptionKind: "location_change",
+      payload: expect.objectContaining({
+        pathname: "/draft",
+      }),
+    }));
+    expect(seenMessages).toContainEqual(expect.objectContaining({
+      kind: "subscription",
+      subscriptionKind: "location_change",
+      payload: expect.objectContaining({
+        pathname: "/draft",
+        search: "?edited=1",
+      }),
+    }));
     expect(document.title).toBe("VX Draft");
     expect(pushState).toHaveBeenCalledWith(null, "", "/draft");
     expect(replaceState).toHaveBeenCalledWith(null, "", "/draft?edited=1");
+    expect(location.hash).toBe("#section");
     expect(back).toHaveBeenCalledOnce();
     expect(forward).toHaveBeenCalledOnce();
+    expect(window.open).toHaveBeenCalledWith("/external", "_self");
+    expect(window.scrollTo).toHaveBeenCalledWith(10, 20);
+    expect(window.scrollBy).toHaveBeenCalledWith(1, 2);
+    expect(localStorage.length).toBe(0);
+    expect(sessionStorage.length).toBe(0);
   });
 
   it("reports diagnostics for malformed ref DOM commands", async () => {
@@ -1358,6 +1415,183 @@ describe("vx-dom browser renderer", () => {
     window.dispatchEvent(new Event("resize"));
     await nextTurn();
     expect(seenMessages).toHaveLength(2);
+  });
+
+  it("runs expanded browser subscriptions with structured payloads", async () => {
+    const seenMessages: unknown[] = [];
+    let mediaMatches = false;
+    let mediaListener: (() => void) | undefined;
+    let animationFrame: ((timestamp: number) => void) | undefined;
+    const broadcastInstances: Array<{
+      close: ReturnType<typeof vi.fn>;
+      emit(data: unknown): void;
+    }> = [];
+    class TestBroadcastChannel {
+      close = vi.fn();
+      private listener: ((event: MessageEvent) => void) | undefined;
+
+      constructor(readonly name: string) {
+        void name;
+        broadcastInstances.push(this);
+      }
+
+      addEventListener(event: string, listener: (event: MessageEvent) => void): void {
+        if (event === "message") this.listener = listener;
+      }
+
+      removeEventListener(event: string): void {
+        if (event === "message") this.listener = undefined;
+      }
+
+      emit(data: unknown): void {
+        this.listener?.({ data } as MessageEvent);
+      }
+    }
+    Object.defineProperty(globalThis, "BroadcastChannel", {
+      configurable: true,
+      value: TestBroadcastChannel,
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn((query: string) => ({
+        media: query,
+        get matches() {
+          return mediaMatches;
+        },
+        addEventListener: (_event: string, listener: () => void) => {
+          mediaListener = listener;
+        },
+        removeEventListener: vi.fn(),
+      })),
+    });
+    Object.defineProperty(window, "requestAnimationFrame", {
+      configurable: true,
+      value: vi.fn((callback: (timestamp: number) => void) => {
+        animationFrame = callback;
+        return 1;
+      }),
+    });
+    Object.defineProperty(window, "cancelAnimationFrame", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    history.replaceState(null, "", "/start");
+    const app: VxAppRuntime = {
+      init: () => ({
+        frame: counterNode(0),
+        subscriptions: [
+          { type: "sub", kind: "location_change", key: "location" },
+          { type: "sub", kind: "window_focus", key: "focus", event: "focus" },
+          { type: "sub", kind: "window_blur", key: "blur", event: "blur", value: { type: "blur" } },
+          { type: "sub", kind: "animation_frame", key: "frame" },
+          {
+            type: "sub",
+            kind: "media_query",
+            key: "(prefers-reduced-motion: reduce)",
+            query: "(prefers-reduced-motion: reduce)",
+          },
+          { type: "sub", kind: "storage", key: "storage" },
+          { type: "sub", kind: "broadcast_channel", key: "updates", name: "updates" },
+        ],
+      }),
+      render: () => counterNode(0),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        return counterNode(seenMessages.length);
+      },
+    };
+
+    const mounted = await mountVxApp({ container, app });
+    await nextTurn();
+
+    history.replaceState(null, "", "/next?x=1#top");
+    window.dispatchEvent(new Event("hashchange"));
+    window.dispatchEvent(new Event("focus"));
+    window.dispatchEvent(new Event("blur"));
+    animationFrame?.(123);
+    mediaMatches = true;
+    mediaListener?.();
+    window.dispatchEvent(new StorageEvent("storage", {
+      key: "draft",
+      oldValue: "no",
+      newValue: "yes",
+      storageArea: localStorage,
+      url: location.href,
+    }));
+    window.dispatchEvent(new StorageEvent("storage", {
+      storageArea: localStorage,
+      url: location.href,
+    }));
+    broadcastInstances[0]?.emit("hello");
+    await nextTurn();
+
+    expect(seenMessages).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: "subscription",
+        subscriptionKind: "location_change",
+        payload: expect.objectContaining({
+          kind: "location",
+          pathname: "/next",
+          search: "?x=1",
+          hash: "#top",
+        }),
+      }),
+      expect.objectContaining({
+        kind: "subscription",
+        subscriptionKind: "window_focus",
+        payload: { kind: "event", event: "focus" },
+      }),
+      expect.objectContaining({
+        kind: "subscription",
+        subscriptionKind: "window_blur",
+        value: { type: "blur" },
+        payload: { kind: "event", event: "blur" },
+      }),
+      expect.objectContaining({
+        kind: "subscription",
+        subscriptionKind: "animation_frame",
+        payload: { kind: "animation_frame", timestamp: 123 },
+      }),
+      expect.objectContaining({
+        kind: "subscription",
+        subscriptionKind: "media_query",
+        payload: {
+          kind: "media_query",
+          query: "(prefers-reduced-motion: reduce)",
+          matches: true,
+        },
+      }),
+      expect.objectContaining({
+        kind: "subscription",
+        subscriptionKind: "storage",
+        payload: expect.objectContaining({
+          kind: "storage",
+          storage: "local",
+          key: "draft",
+          old_value: "no",
+          new_value: "yes",
+        }),
+      }),
+      expect.objectContaining({
+        kind: "subscription",
+        subscriptionKind: "storage",
+        payload: {
+          kind: "storage",
+          storage: "local",
+          url: location.href,
+        },
+      }),
+      expect.objectContaining({
+        kind: "subscription",
+        subscriptionKind: "broadcast_channel",
+        payload: "hello",
+      }),
+    ]));
+
+    mounted.dispose();
+    await nextTurn();
+    expect(broadcastInstances[0]?.close).toHaveBeenCalledOnce();
+    expect(window.cancelAnimationFrame).toHaveBeenCalledWith(1);
   });
 
   it("hydrates a runtime-owned app without replacing matching server nodes", async () => {

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -981,6 +981,48 @@ describe("vx-dom browser renderer", () => {
     expect(sessionStorage.length).toBe(0);
   });
 
+  it("does not await queued clipboard dispatches from step commands", async () => {
+    const seenMessages: unknown[] = [];
+    const readText = vi.fn(async () => "Clipboard text");
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { readText },
+    });
+    const app: VxAppRuntime = {
+      init: () => ({ frame: counterNode(0) }),
+      render: () => counterNode(seenMessages.length),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        const shouldReadClipboard = isRecord(message) &&
+          message.kind === "debug" &&
+          message.name === "read";
+        return {
+          frame: counterNode(seenMessages.length),
+          ...(shouldReadClipboard
+            ? { commands: { type: "cmd", kind: "read_clipboard", handlerId: 77 } }
+            : {}),
+        };
+      },
+    };
+
+    const mounted = await mountVxApp({ container, app });
+    const dispatch = mounted.dispatch({ kind: "debug", name: "read" });
+
+    await expect(Promise.race([
+      dispatch.then(() => "resolved"),
+      new Promise((resolve) => setTimeout(() => resolve("timeout"), 50)),
+    ])).resolves.toBe("resolved");
+    expect(readText).toHaveBeenCalledOnce();
+
+    await nextTurn();
+
+    expect(seenMessages).toContainEqual({
+      kind: "map",
+      handlerId: 77,
+      message: { kind: "msgpack", value: "Clipboard text" },
+    });
+  });
+
   it("reports diagnostics for malformed ref DOM commands", async () => {
     const app: VxAppRuntime = {
       init: () => ({
@@ -1265,6 +1307,72 @@ describe("vx-dom browser renderer", () => {
 
     expect(dispose).toHaveBeenCalledOnce();
     expect(releaseMany).toHaveBeenCalledWith([3]);
+  });
+
+  it("does not release outer mapped subscription handlers", async () => {
+    const seenMessages: unknown[] = [];
+    let nextHandlerId = 1;
+    let dispatchSubscription: ((message: VxRuntimeMessage) => Promise<void>) | undefined;
+    const dispose = vi.fn();
+    const releaseMany = vi.fn<(ids: Iterable<number>) => void>();
+    const mappedSubscription = () => ({
+      type: "sub",
+      kind: "map",
+      handlerId: 99,
+      child: {
+        type: "sub",
+        kind: "map",
+        handlerId: nextHandlerId++,
+        handlerKey: 9001,
+        child: { type: "sub", kind: "timer", key: "main" },
+      },
+    });
+    const runSubscription = vi.fn<VxSubscriptionRunner>((_subscription, context) => {
+      dispatchSubscription = context.dispatch;
+      return dispose;
+    });
+    const app: VxAppRuntime = {
+      retainedCallbacks: { releaseMany },
+      init: () => ({
+        frame: counterNode(0),
+        subscriptions: mappedSubscription(),
+      }),
+      render: () => counterNode(seenMessages.length),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        return {
+          frame: counterNode(seenMessages.length),
+          subscriptions: mappedSubscription(),
+        };
+      },
+    };
+
+    const mounted = await mountVxApp({
+      container,
+      app,
+      runtimeHost: { subscriptions: { timer: runSubscription } },
+    });
+
+    await mounted.dispatch({ kind: "debug", name: "refresh" });
+    await dispatchSubscription?.({ kind: "debug", name: "tick" });
+
+    expect(seenMessages).toContainEqual({
+      kind: "map",
+      handlerId: 99,
+      message: {
+        kind: "map",
+        handlerId: 2,
+        message: { kind: "debug", name: "tick" },
+      },
+    });
+    expect(releaseMany).toHaveBeenCalledWith([1]);
+
+    mounted.dispose();
+    await nextTurn();
+
+    const releasedIds = releaseMany.mock.calls.flatMap(([ids]) => Array.from(ids));
+    expect(releasedIds).not.toContain(99);
+    expect(releasedIds).toEqual([1, 2, 3]);
   });
 
   it("runs interval subscriptions with the default browser runtime host", async () => {

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -368,6 +368,54 @@ describe("vx-dom browser renderer", () => {
     ]);
   });
 
+  it("preserves nested DOM event mapper order", async () => {
+    const seenMessages: unknown[] = [];
+    const app: VxAppRuntime = {
+      init: () => ({
+        version: 1,
+        root: {
+          kind: "map",
+          handlerId: 20,
+          child: {
+            kind: "map",
+            handlerId: 10,
+            child: {
+              kind: "element",
+              tag: "button",
+              events: [{
+                kind: "event",
+                event: "click",
+                message: { type: "child" },
+              }],
+              children: [{ kind: "text", value: "Child" }],
+            },
+          },
+        },
+      }),
+      render: () => counterNode(seenMessages.length),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        return counterNode(seenMessages.length);
+      },
+    };
+
+    await mountVxApp({ container, app });
+    container.querySelector("button")!.click();
+    await nextTurn();
+
+    expect(seenMessages).toEqual([
+      {
+        kind: "map",
+        handlerId: 20,
+        message: {
+          kind: "map",
+          handlerId: 10,
+          message: { kind: "msgpack", value: { type: "child" } },
+        },
+      },
+    ]);
+  });
+
   it("allows explicit handler registries to override runtime event dispatch", async () => {
     const runtimeDispatch = vi.fn<VxAppRuntime["dispatch"]>();
     const handlerDispatch = vi.fn<RetainedDispatch>();
@@ -1548,6 +1596,56 @@ describe("vx-dom browser renderer", () => {
       }),
     }));
     expect(Object.hasOwn(seenMessages[0] as object, "value")).toBe(false);
+  });
+
+  it("passes configured subscription payloads through mapped handlers", async () => {
+    const seenMessages: unknown[] = [];
+    const app: VxAppRuntime = {
+      init: () => ({
+        frame: counterNode(0),
+        subscriptions: {
+          type: "sub",
+          kind: "map",
+          handlerId: 42,
+          child: {
+            type: "sub",
+            kind: "keyboard",
+            key: "s",
+            value: { topic: "config" },
+            valueRole: "config",
+          },
+        },
+      }),
+      render: () => counterNode(0),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        return counterNode(seenMessages.length);
+      },
+    };
+
+    await mountVxApp({ container, app });
+    window.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "s",
+      code: "KeyS",
+    }));
+    await nextTurn();
+
+    expect(seenMessages[0]).toEqual({
+      kind: "map",
+      handlerId: 42,
+      message: expect.objectContaining({
+        kind: "subscription",
+        subscriptionKind: "keyboard",
+        key: "s",
+        payload: expect.objectContaining({
+          kind: "keyboard",
+          key: "s",
+          code: "KeyS",
+        }),
+      }),
+    });
+    const childMessage = (seenMessages[0] as { message: object }).message;
+    expect(Object.hasOwn(childMessage, "value")).toBe(false);
   });
 
   it("runs window resize subscriptions with structured payloads", async () => {

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -1338,6 +1338,7 @@ describe("vx-dom browser renderer", () => {
     await mounted.dispatch({ kind: "debug", name: "refresh" });
 
     expect(runSubscription).toHaveBeenCalledOnce();
+    await nextTurn();
     expect(releaseMany).toHaveBeenCalledWith([1]);
 
     await dispatchSubscription?.({ kind: "debug", name: "tick" });
@@ -1348,6 +1349,7 @@ describe("vx-dom browser renderer", () => {
       message: { kind: "debug", name: "tick" },
     });
     expect(runSubscription).toHaveBeenCalledOnce();
+    await nextTurn();
     expect(releaseMany).toHaveBeenCalledWith([2]);
 
     mounted.dispose();
@@ -1355,6 +1357,77 @@ describe("vx-dom browser renderer", () => {
 
     expect(dispose).toHaveBeenCalledOnce();
     expect(releaseMany).toHaveBeenCalledWith([3]);
+  });
+
+  it("delays releasing refreshed subscription handlers until queued messages drain", async () => {
+    const seenMessages: unknown[] = [];
+    let nextHandlerId = 1;
+    let dispatchSubscription: ((message: VxRuntimeMessage) => Promise<void>) | undefined;
+    let resolveQueuedTick: (() => void) | undefined;
+    const releaseMany = vi.fn<(ids: Iterable<number>) => void>();
+    const mappedSubscription = () => ({
+      type: "sub",
+      kind: "map",
+      handlerId: nextHandlerId++,
+      handlerKey: 9001,
+      child: { type: "sub", kind: "timer", key: "main" },
+    });
+    const runSubscription = vi.fn<VxSubscriptionRunner>((_subscription, context) => {
+      dispatchSubscription = context.dispatch;
+    });
+    const app: VxAppRuntime = {
+      retainedCallbacks: { releaseMany },
+      init: () => ({
+        frame: counterNode(0),
+        subscriptions: mappedSubscription(),
+      }),
+      render: () => counterNode(seenMessages.length),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        if (message.kind === "debug" && message.name === "refresh") {
+          void dispatchSubscription?.({ kind: "debug", name: "queued-tick" });
+        }
+        if (
+          message.kind === "map" &&
+          message.handlerId === 1 &&
+          message.message.kind === "debug" &&
+          message.message.name === "queued-tick"
+        ) {
+          return new Promise((resolve) => {
+            resolveQueuedTick = () =>
+              resolve({
+                frame: counterNode(seenMessages.length),
+                subscriptions: mappedSubscription(),
+              });
+          });
+        }
+        return {
+          frame: counterNode(seenMessages.length),
+          subscriptions: mappedSubscription(),
+        };
+      },
+    };
+
+    const mounted = await mountVxApp({
+      container,
+      app,
+      runtimeHost: { subscriptions: { timer: runSubscription } },
+    });
+
+    await mounted.dispatch({ kind: "debug", name: "refresh" });
+    await nextTurn();
+
+    expect(seenMessages).toContainEqual({
+      kind: "map",
+      handlerId: 1,
+      message: { kind: "debug", name: "queued-tick" },
+    });
+    expect(releaseMany).not.toHaveBeenCalled();
+
+    resolveQueuedTick?.();
+    await nextTurn();
+
+    expect(releaseMany).toHaveBeenCalledWith([1]);
   });
 
   it("does not release outer mapped subscription handlers", async () => {

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -8,6 +8,7 @@ import type {
   VxAppRuntime,
   VxElementNode,
   VxRenderFrame,
+  VxRuntimeMessage,
   VxSubscriptionSyncContext,
   VxSubscriptionRunner,
 } from "../types.js";
@@ -942,6 +943,16 @@ describe("vx-dom browser renderer", () => {
       handlerId: 77,
       message: { kind: "msgpack", value: "Clipboard text" },
     });
+    const locationMessages = seenMessages.filter((message) =>
+      isRecord(message) &&
+      message.kind === "subscription" &&
+      message.subscriptionKind === "location_change"
+    );
+    expect(locationMessages[0]).toEqual(expect.objectContaining({
+      payload: expect.objectContaining({
+        pathname: "/draft",
+      }),
+    }));
     expect(seenMessages).toContainEqual(expect.objectContaining({
       kind: "subscription",
       subscriptionKind: "location_change",
@@ -1191,6 +1202,69 @@ describe("vx-dom browser renderer", () => {
 
     await mounted.dispatch({ kind: "debug", name: "stop" });
     expect(dispose).toHaveBeenCalledTimes(2);
+  });
+
+  it("updates stable mapped subscription handlers without reinstalling listeners", async () => {
+    const seenMessages: unknown[] = [];
+    let nextHandlerId = 1;
+    let dispatchSubscription: ((message: VxRuntimeMessage) => Promise<void>) | undefined;
+    const dispose = vi.fn();
+    const releaseMany = vi.fn<(ids: Iterable<number>) => void>();
+    const mappedSubscription = () => ({
+      type: "sub",
+      kind: "map",
+      handlerId: nextHandlerId++,
+      handlerKey: 9001,
+      child: { type: "sub", kind: "timer", key: "main" },
+    });
+    const runSubscription = vi.fn<VxSubscriptionRunner>((_subscription, context) => {
+      dispatchSubscription = context.dispatch;
+      return dispose;
+    });
+    const app: VxAppRuntime = {
+      retainedCallbacks: { releaseMany },
+      init: () => ({
+        frame: counterNode(0),
+        subscriptions: mappedSubscription(),
+      }),
+      render: () => counterNode(seenMessages.length),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        return {
+          frame: counterNode(seenMessages.length),
+          subscriptions: mappedSubscription(),
+        };
+      },
+    };
+
+    const mounted = await mountVxApp({
+      container,
+      app,
+      runtimeHost: { subscriptions: { timer: runSubscription } },
+    });
+
+    expect(runSubscription).toHaveBeenCalledOnce();
+
+    await mounted.dispatch({ kind: "debug", name: "refresh" });
+
+    expect(runSubscription).toHaveBeenCalledOnce();
+    expect(releaseMany).toHaveBeenCalledWith([1]);
+
+    await dispatchSubscription?.({ kind: "debug", name: "tick" });
+
+    expect(seenMessages).toContainEqual({
+      kind: "map",
+      handlerId: 2,
+      message: { kind: "debug", name: "tick" },
+    });
+    expect(runSubscription).toHaveBeenCalledOnce();
+    expect(releaseMany).toHaveBeenCalledWith([2]);
+
+    mounted.dispose();
+    await nextTurn();
+
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(releaseMany).toHaveBeenCalledWith([3]);
   });
 
   it("runs interval subscriptions with the default browser runtime host", async () => {
@@ -1661,6 +1735,10 @@ type RetainedDispatch = (
   id: number,
   payload: NormalizedEventPayload,
 ) => Promise<unknown> | unknown;
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === "object" && input !== null;
+}
 
 function frame(root: VNode): VxRenderFrame {
   return { version: 1, root };

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -136,7 +136,7 @@ describe("vx-dom browser renderer", () => {
     expect(dispatch).toHaveBeenLastCalledWith(2, expect.objectContaining({ kind: "mouse" }));
   });
 
-  it("releases mapped event handler ids when mapped views are removed", () => {
+  it("does not release outer mapped event handler ids when mapped views are removed", () => {
     const dispatch = vi.fn<RetainedDispatch>();
     const releaseMany = vi.fn<(ids: Iterable<number>) => void>();
     const renderer = createVxDomRenderer(container, {
@@ -153,7 +153,7 @@ describe("vx-dom browser renderer", () => {
     });
     renderer.render(frame(buttonNode(2)));
 
-    expect(releaseMany).toHaveBeenCalledWith([1, 9]);
+    expect(releaseMany).toHaveBeenCalledWith([1]);
 
     renderer.dispose();
     expect(releaseMany).toHaveBeenLastCalledWith(new Set([2]));
@@ -1216,7 +1216,14 @@ describe("vx-dom browser renderer", () => {
         return {
           frame: counterNode(seenMessages.length),
           ...(shouldReadClipboard
-            ? { commands: { type: "cmd", kind: "read_clipboard", handlerId: 77 } }
+            ? {
+                commands: {
+                  type: "cmd",
+                  kind: "read_clipboard",
+                  handlerId: 77,
+                  __vxOwnedMapHandlerIds: [77],
+                },
+              }
             : {}),
         };
       },
@@ -1259,7 +1266,12 @@ describe("vx-dom browser renderer", () => {
           kind: "map",
           handlerId: 44,
           __vxOwnedMapHandlerIds: [44],
-          child: { type: "cmd", kind: "read_clipboard", handlerId: 77 },
+          child: {
+            type: "cmd",
+            kind: "read_clipboard",
+            handlerId: 77,
+            __vxOwnedMapHandlerIds: [77],
+          },
         },
       }),
       render: () => counterNode(seenMessages.length),
@@ -1284,6 +1296,38 @@ describe("vx-dom browser renderer", () => {
     });
     expect(release).toHaveBeenCalledWith(77);
     expect(release).toHaveBeenCalledWith(44);
+  });
+
+  it("does not release caller-owned clipboard read handlers", async () => {
+    const seenMessages: unknown[] = [];
+    const readText = vi.fn(async () => "Clipboard text");
+    const release = vi.fn<(id: number) => void>();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { readText },
+    });
+    const app: VxAppRuntime = {
+      retainedCallbacks: { release },
+      init: () => ({
+        frame: counterNode(0),
+        commands: { type: "cmd", kind: "read_clipboard", handlerId: 77 },
+      }),
+      render: () => counterNode(seenMessages.length),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        return counterNode(seenMessages.length);
+      },
+    };
+
+    await mountVxApp({ container, app });
+    await nextTurn();
+
+    expect(seenMessages).toContainEqual({
+      kind: "map",
+      handlerId: 77,
+      message: { kind: "msgpack", value: "Clipboard text" },
+    });
+    expect(release).not.toHaveBeenCalled();
   });
 
   it("keeps owned mapped command handlers until async commands dispatch", async () => {
@@ -1342,7 +1386,12 @@ describe("vx-dom browser renderer", () => {
       retainedCallbacks: { release },
       init: () => ({
         frame: counterNode(0),
-        commands: { type: "cmd", kind: "read_clipboard", handlerId: 77 },
+        commands: {
+          type: "cmd",
+          kind: "read_clipboard",
+          handlerId: 77,
+          __vxOwnedMapHandlerIds: [77],
+        },
       }),
       render: () => counterNode(0),
       dispatch: () => counterNode(0),
@@ -1948,6 +1997,50 @@ describe("vx-dom browser renderer", () => {
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "s" }));
     await nextTurn();
     expect(seenMessages).toHaveLength(1);
+  });
+
+  it("keeps keyboard down and up subscriptions distinct for the same key", async () => {
+    const seenMessages: unknown[] = [];
+    const app: VxAppRuntime = {
+      init: () => ({
+        frame: counterNode(0),
+        subscriptions: {
+          type: "sub",
+          kind: "batch",
+          children: [
+            {
+              type: "sub",
+              kind: "keyboard",
+              key: "Escape",
+              event: "keydown",
+              value: { type: "down" },
+            },
+            {
+              type: "sub",
+              kind: "keyboard",
+              key: "Escape",
+              event: "keyup",
+              value: { type: "up" },
+            },
+          ],
+        },
+      }),
+      render: () => counterNode(seenMessages.length),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        return counterNode(seenMessages.length);
+      },
+    };
+
+    await mountVxApp({ container, app });
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    window.dispatchEvent(new KeyboardEvent("keyup", { key: "Escape" }));
+    await nextTurn();
+
+    expect(seenMessages).toEqual([
+      expect.objectContaining({ value: { type: "down" } }),
+      expect.objectContaining({ value: { type: "up" } }),
+    ]);
   });
 
   it("runs keyboard payload subscriptions without fixed message values", async () => {

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -704,6 +704,52 @@ describe("vx-dom browser renderer", () => {
     ]);
   });
 
+  it("releases app-retained DOM handlers through the app registry", async () => {
+    const release = vi.fn<(id: number) => void>();
+    const app: VxAppRuntime = {
+      retainedCallbacks: { release },
+      init: () => ({ frame: frame(buttonNode(1)) }),
+      render: () => frame(buttonNode(1)),
+      dispatch: () => ({ frame: frame(buttonNode(2)) }),
+    };
+
+    const mounted = await mountVxApp({ container, app });
+    container.querySelector("button")!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await nextTurn();
+
+    expect(release).toHaveBeenCalledWith(1);
+
+    mounted.dispose();
+    await nextTurn();
+
+    expect(release).toHaveBeenCalledWith(2);
+  });
+
+  it("delays app-retained DOM handler release until queued events drain", async () => {
+    const release = vi.fn<(id: number) => void>();
+    const releaseCountsAtDispatch: number[] = [];
+    const app: VxAppRuntime = {
+      retainedCallbacks: { release },
+      init: () => ({ frame: frame(buttonNode(1)) }),
+      render: () => frame(buttonNode(1)),
+      dispatch: () => {
+        releaseCountsAtDispatch.push(release.mock.calls.length);
+        return { frame: frame({ kind: "fragment", children: [] }) };
+      },
+    };
+
+    await mountVxApp({ container, app });
+    const button = container.querySelector("button")!;
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await nextTurn();
+
+    expect(releaseCountsAtDispatch).toEqual([0, 0]);
+    expect(release).toHaveBeenCalledWith(1);
+  });
+
   it("runs delay commands with the default browser runtime host", async () => {
     vi.useFakeTimers();
     let count = 0;
@@ -770,6 +816,128 @@ describe("vx-dom browser renderer", () => {
     await nextTurn();
 
     expect(container.textContent).toBe("Count: 1");
+  });
+
+  it("releases owned task command handlers after task completion dispatches", async () => {
+    const seenMessages: unknown[] = [];
+    const release = vi.fn<(id: number) => void>();
+    let resolveTask:
+      | ((outcome: { kind: "value"; value: { type: "increment" } }) => void)
+      | undefined;
+    const observeTask = vi.fn(
+      () =>
+        new Promise<{ kind: "value"; value: { type: "increment" } }>((resolve) => {
+          resolveTask = resolve;
+        }),
+    );
+    const commands = {
+      type: "cmd",
+      kind: "task",
+      taskId: 7,
+      handlerId: 88,
+      __vxOwnedMapHandlerIds: [88],
+    };
+    Object.defineProperty(commands, Symbol.for("voyd.taskObserver"), {
+      configurable: true,
+      value: observeTask,
+    });
+    const app: VxAppRuntime = {
+      retainedCallbacks: { release },
+      init: () => ({
+        frame: counterNode(0),
+        commands,
+      }),
+      render: () => counterNode(seenMessages.length),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        expect(release).not.toHaveBeenCalledWith(88);
+        return counterNode(seenMessages.length);
+      },
+    };
+
+    await mountVxApp({ container, app });
+
+    expect(release).not.toHaveBeenCalledWith(88);
+
+    resolveTask?.({ kind: "value", value: { type: "increment" } });
+    await nextTurn();
+
+    expect(seenMessages).toContainEqual({
+      kind: "map",
+      handlerId: 88,
+      message: { kind: "msgpack", value: { type: "increment" } },
+    });
+    expect(release).toHaveBeenCalledWith(88);
+  });
+
+  it("releases owned task command handlers after failed task outcomes", async () => {
+    const error = new Error("task failed");
+    const onError = vi.fn();
+    const release = vi.fn<(id: number) => void>();
+    const observeTask = vi.fn(async () => ({ kind: "failed" as const, error }));
+    const commands = {
+      type: "cmd",
+      kind: "task",
+      taskId: 7,
+      handlerId: 88,
+      __vxOwnedMapHandlerIds: [88],
+    };
+    Object.defineProperty(commands, Symbol.for("voyd.taskObserver"), {
+      configurable: true,
+      value: observeTask,
+    });
+    const app: VxAppRuntime = {
+      retainedCallbacks: { release },
+      init: () => ({
+        frame: counterNode(0),
+        commands,
+      }),
+      render: () => counterNode(0),
+      dispatch: () => counterNode(0),
+    };
+
+    await mountVxApp({ container, app, onError });
+    await nextTurn();
+
+    expect(onError).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({ phase: "commands" }),
+    );
+    expect(release).toHaveBeenCalledWith(88);
+  });
+
+  it("releases owned task command handlers when disposed before task completion", async () => {
+    const release = vi.fn<(id: number) => void>();
+    const observeTask = vi.fn(() => new Promise<{ kind: "value"; value: { type: "increment" } }>(() => undefined));
+    const commands = {
+      type: "cmd",
+      kind: "task",
+      taskId: 7,
+      handlerId: 88,
+      __vxOwnedMapHandlerIds: [88],
+    };
+    Object.defineProperty(commands, Symbol.for("voyd.taskObserver"), {
+      configurable: true,
+      value: observeTask,
+    });
+    const app: VxAppRuntime = {
+      retainedCallbacks: { release },
+      init: () => ({
+        frame: counterNode(0),
+        commands,
+      }),
+      render: () => counterNode(0),
+      dispatch: () => counterNode(0),
+    };
+
+    const mounted = await mountVxApp({ container, app });
+
+    expect(release).not.toHaveBeenCalledWith(88);
+
+    mounted.dispose();
+    await nextTurn();
+
+    expect(release).toHaveBeenCalledWith(88);
   });
 
   it("reports asynchronous task command failures through onError", async () => {
@@ -1072,6 +1240,94 @@ describe("vx-dom browser renderer", () => {
       message: { kind: "msgpack", value: "Clipboard text" },
     });
     expect(release).toHaveBeenCalledWith(77);
+  });
+
+  it("releases mapped clipboard read handlers", async () => {
+    const seenMessages: unknown[] = [];
+    const readText = vi.fn(async () => "Clipboard text");
+    const release = vi.fn<(id: number) => void>();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { readText },
+    });
+    const app: VxAppRuntime = {
+      retainedCallbacks: { release },
+      init: () => ({
+        frame: counterNode(0),
+        commands: {
+          type: "cmd",
+          kind: "map",
+          handlerId: 44,
+          __vxOwnedMapHandlerIds: [44],
+          child: { type: "cmd", kind: "read_clipboard", handlerId: 77 },
+        },
+      }),
+      render: () => counterNode(seenMessages.length),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        return counterNode(seenMessages.length);
+      },
+    };
+
+    await mountVxApp({ container, app });
+    await nextTurn();
+
+    expect(readText).toHaveBeenCalledOnce();
+    expect(seenMessages).toContainEqual({
+      kind: "map",
+      handlerId: 44,
+      message: {
+        kind: "map",
+        handlerId: 77,
+        message: { kind: "msgpack", value: "Clipboard text" },
+      },
+    });
+    expect(release).toHaveBeenCalledWith(77);
+    expect(release).toHaveBeenCalledWith(44);
+  });
+
+  it("keeps owned mapped command handlers until async commands dispatch", async () => {
+    vi.useFakeTimers();
+    const seenMessages: unknown[] = [];
+    const release = vi.fn<(id: number) => void>();
+    const app: VxAppRuntime = {
+      retainedCallbacks: { release },
+      init: () => ({
+        frame: counterNode(0),
+        commands: {
+          type: "cmd",
+          kind: "map",
+          handlerId: 44,
+          __vxOwnedMapHandlerIds: [44],
+          child: {
+            type: "cmd",
+            kind: "delay",
+            ms: 25,
+            value: { type: "increment" },
+          },
+        },
+      }),
+      render: () => counterNode(seenMessages.length),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        expect(release).not.toHaveBeenCalledWith(44);
+        return counterNode(seenMessages.length);
+      },
+    };
+
+    await mountVxApp({ container, app });
+    await vi.advanceTimersByTimeAsync(24);
+
+    expect(release).not.toHaveBeenCalledWith(44);
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(seenMessages).toContainEqual({
+      kind: "map",
+      handlerId: 44,
+      message: { kind: "msgpack", value: { type: "increment" } },
+    });
+    expect(release).toHaveBeenCalledWith(44);
   });
 
   it("releases clipboard read handlers when the clipboard read fails", async () => {

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -1205,6 +1205,32 @@ describe("vx-dom browser renderer", () => {
     expect(sessionStorage.length).toBe(0);
   });
 
+  it("cancels deferred initial location_change emits after subscription removal", async () => {
+    const seenMessages: unknown[] = [];
+    const app: VxAppRuntime = {
+      init: () => ({
+        frame: counterNode(0),
+        subscriptions: { type: "sub", kind: "location_change", key: "location" },
+        commands: { type: "cmd", kind: "message", value: { type: "remove-location" } },
+      }),
+      render: () => counterNode(seenMessages.length),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        return {
+          frame: counterNode(seenMessages.length),
+          subscriptions: { type: "sub", kind: "none" },
+        };
+      },
+    };
+
+    await mountVxApp({ container, app });
+    await nextTurn();
+
+    expect(seenMessages).toEqual([
+      { kind: "msgpack", value: { type: "remove-location" } },
+    ]);
+  });
+
   it("does not await queued clipboard dispatches from step commands", async () => {
     const seenMessages: unknown[] = [];
     const readText = vi.fn(async () => "Clipboard text");

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -873,6 +873,46 @@ describe("vx-dom browser renderer", () => {
     }
   });
 
+  it("runs browser runtime commands with the default browser runtime host", async () => {
+    const writeText = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const pushState = vi.spyOn(history, "pushState").mockImplementation(() => undefined);
+    const replaceState = vi.spyOn(history, "replaceState").mockImplementation(() => undefined);
+    const back = vi.spyOn(history, "back").mockImplementation(() => undefined);
+    const forward = vi.spyOn(history, "forward").mockImplementation(() => undefined);
+    const app: VxAppRuntime = {
+      init: () => ({
+        frame: counterNode(0),
+        commands: {
+          type: "cmd",
+          kind: "batch",
+          children: [
+            { type: "cmd", kind: "copy_to_clipboard", value: "Draft" },
+            { type: "cmd", kind: "set_document_title", value: "VX Draft" },
+            { type: "cmd", kind: "push_url", value: "/draft" },
+            { type: "cmd", kind: "replace_url", value: "/draft?edited=1" },
+            { type: "cmd", kind: "navigate_back" },
+            { type: "cmd", kind: "navigate_forward" },
+          ],
+        },
+      }),
+      render: () => counterNode(0),
+      dispatch: () => counterNode(0),
+    };
+
+    await mountVxApp({ container, app });
+
+    expect(writeText).toHaveBeenCalledWith("Draft");
+    expect(document.title).toBe("VX Draft");
+    expect(pushState).toHaveBeenCalledWith(null, "", "/draft");
+    expect(replaceState).toHaveBeenCalledWith(null, "", "/draft?edited=1");
+    expect(back).toHaveBeenCalledOnce();
+    expect(forward).toHaveBeenCalledOnce();
+  });
+
   it("reports diagnostics for malformed ref DOM commands", async () => {
     const app: VxAppRuntime = {
       init: () => ({
@@ -903,7 +943,12 @@ describe("vx-dom browser renderer", () => {
     let tick: (() => Promise<void>) | undefined;
     const dispose = vi.fn();
     const runSubscription = vi.fn((_subscription, { dispatch }) => {
-      tick = () => dispatch({ kind: "debug", name: "tick" });
+      tick = () => dispatch({
+        kind: "subscription",
+        subscriptionKind: "timer",
+        key: "main",
+        payload: { type: "tick" },
+      });
       return dispose;
     });
     const app: VxAppRuntime = {
@@ -913,7 +958,10 @@ describe("vx-dom browser renderer", () => {
       }),
       render: () => counterNode(count),
       dispatch: (message) => {
-        if (message.kind === "debug" && message.name === "tick") count += 1;
+        if (message.kind === "subscription" && message.subscriptionKind === "timer") {
+          const payload = message.payload as { type?: unknown };
+          if (payload.type === "tick") count += 1;
+        }
         if (message.kind === "debug" && message.name === "stop") subscribed = false;
         return {
           frame: counterNode(count),
@@ -1014,21 +1062,6 @@ describe("vx-dom browser renderer", () => {
 
     await expect(mountVxApp({ container, app, onError })).rejects.toThrow(
       "subscription map missing required child",
-    );
-  });
-
-  it("reports subscription diagnostics for malformed keyboard envelopes", async () => {
-    const app: VxAppRuntime = {
-      init: () => ({
-        frame: counterNode(0),
-        subscriptions: { type: "sub", kind: "keyboard", key: "Escape" },
-      }),
-      render: () => counterNode(0),
-      dispatch: () => counterNode(0),
-    };
-
-    await expect(mountVxApp({ container, app })).rejects.toThrow(
-      "keyboard subscription missing value",
     );
   });
 
@@ -1234,6 +1267,97 @@ describe("vx-dom browser renderer", () => {
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "s" }));
     await nextTurn();
     expect(seenMessages).toHaveLength(1);
+  });
+
+  it("runs keyboard payload subscriptions without fixed message values", async () => {
+    const seenMessages: unknown[] = [];
+    const app: VxAppRuntime = {
+      init: () => ({
+        frame: counterNode(0),
+        subscriptions: {
+          type: "sub",
+          kind: "keyboard",
+          key: "s",
+          event: "keydown",
+        },
+      }),
+      render: () => counterNode(0),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        return counterNode(seenMessages.length);
+      },
+    };
+
+    await mountVxApp({ container, app });
+    window.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "s",
+      code: "KeyS",
+      ctrlKey: true,
+    }));
+    await nextTurn();
+
+    expect(container.textContent).toBe("Count: 1");
+    expect(seenMessages[0]).toEqual(expect.objectContaining({
+      kind: "subscription",
+      subscriptionKind: "keyboard",
+      key: "s",
+      payload: expect.objectContaining({
+        kind: "keyboard",
+        key: "s",
+        code: "KeyS",
+        ctrl_key: true,
+      }),
+    }));
+    expect(Object.hasOwn(seenMessages[0] as object, "value")).toBe(false);
+  });
+
+  it("runs window resize subscriptions with structured payloads", async () => {
+    const seenMessages: unknown[] = [];
+    const app: VxAppRuntime = {
+      init: () => ({
+        frame: counterNode(0),
+        subscriptions: {
+          type: "sub",
+          kind: "window_resize",
+          key: "viewport",
+        },
+      }),
+      render: () => counterNode(0),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        return counterNode(seenMessages.length);
+      },
+    };
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 800 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 600 });
+
+    const mounted = await mountVxApp({ container, app });
+    await nextTurn();
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1024 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 768 });
+    window.dispatchEvent(new Event("resize"));
+    await nextTurn();
+
+    expect(seenMessages).toEqual([
+      expect.objectContaining({
+        kind: "subscription",
+        subscriptionKind: "window_resize",
+        key: "viewport",
+        payload: { kind: "window_size", width: 800, height: 600 },
+      }),
+      expect.objectContaining({
+        kind: "subscription",
+        subscriptionKind: "window_resize",
+        key: "viewport",
+        payload: { kind: "window_size", width: 1024, height: 768 },
+      }),
+    ]);
+
+    mounted.dispose();
+    window.dispatchEvent(new Event("resize"));
+    await nextTurn();
+    expect(seenMessages).toHaveLength(2);
   });
 
   it("hydrates a runtime-owned app without replacing matching server nodes", async () => {

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -1184,6 +1184,14 @@ describe("vx-dom browser renderer", () => {
         search: "?edited=1",
       }),
     }));
+    const finalLocationMessages = locationMessages.filter((message) =>
+      isRecord(message) &&
+      isRecord(message.payload) &&
+      message.payload.pathname === "/draft" &&
+      message.payload.search === "?edited=1" &&
+      message.payload.hash === "#section"
+    );
+    expect(finalLocationMessages).toHaveLength(1);
     expect(document.title).toBe("VX Draft");
     expect(pushState).toHaveBeenCalledWith(null, "", "/draft");
     expect(replaceState).toHaveBeenCalledWith(null, "", "/draft?edited=1");
@@ -1632,13 +1640,17 @@ describe("vx-dom browser renderer", () => {
     let dispatchSubscription: ((message: VxRuntimeMessage) => Promise<void>) | undefined;
     const dispose = vi.fn();
     const releaseMany = vi.fn<(ids: Iterable<number>) => void>();
-    const mappedSubscription = () => ({
-      type: "sub",
-      kind: "map",
-      handlerId: nextHandlerId++,
-      handlerKey: 9001,
-      child: { type: "sub", kind: "timer", key: "main" },
-    });
+    const mappedSubscription = () => {
+      const handlerId = nextHandlerId++;
+      return {
+        type: "sub",
+        kind: "map",
+        handlerId,
+        handlerKey: 9001,
+        __vxOwnedMapHandlerIds: [handlerId],
+        child: { type: "sub", kind: "timer", key: "main" },
+      };
+    };
     const runSubscription = vi.fn<VxSubscriptionRunner>((_subscription, context) => {
       dispatchSubscription = context.dispatch;
       return dispose;
@@ -1697,13 +1709,17 @@ describe("vx-dom browser renderer", () => {
     let dispatchSubscription: ((message: VxRuntimeMessage) => Promise<void>) | undefined;
     let resolveQueuedTick: (() => void) | undefined;
     const releaseMany = vi.fn<(ids: Iterable<number>) => void>();
-    const mappedSubscription = () => ({
-      type: "sub",
-      kind: "map",
-      handlerId: nextHandlerId++,
-      handlerKey: 9001,
-      child: { type: "sub", kind: "timer", key: "main" },
-    });
+    const mappedSubscription = () => {
+      const handlerId = nextHandlerId++;
+      return {
+        type: "sub",
+        kind: "map",
+        handlerId,
+        handlerKey: 9001,
+        __vxOwnedMapHandlerIds: [handlerId],
+        child: { type: "sub", kind: "timer", key: "main" },
+      };
+    };
     const runSubscription = vi.fn<VxSubscriptionRunner>((_subscription, context) => {
       dispatchSubscription = context.dispatch;
     });
@@ -1766,13 +1782,17 @@ describe("vx-dom browser renderer", () => {
     let nextHandlerId = 1;
     const appRelease = vi.fn<(id: number) => void>();
     const overrideReleaseMany = vi.fn<(ids: Iterable<number>) => void>();
-    const mappedSubscription = () => ({
-      type: "sub",
-      kind: "map",
-      handlerId: nextHandlerId++,
-      handlerKey: 9001,
-      child: { type: "sub", kind: "timer", key: "main" },
-    });
+    const mappedSubscription = () => {
+      const handlerId = nextHandlerId++;
+      return {
+        type: "sub",
+        kind: "map",
+        handlerId,
+        handlerKey: 9001,
+        __vxOwnedMapHandlerIds: [handlerId],
+        child: { type: "sub", kind: "timer", key: "main" },
+      };
+    };
     const app: VxAppRuntime = {
       retainedCallbacks: { release: appRelease },
       init: () => ({
@@ -1800,24 +1820,65 @@ describe("vx-dom browser renderer", () => {
     expect(overrideReleaseMany).not.toHaveBeenCalled();
   });
 
+  it("does not release caller-owned stable subscription handlers", async () => {
+    let nextHandlerId = 1;
+    const releaseMany = vi.fn<(ids: Iterable<number>) => void>();
+    const mappedSubscription = () => ({
+      type: "sub",
+      kind: "map",
+      handlerId: nextHandlerId++,
+      handlerKey: 9001,
+      child: { type: "sub", kind: "timer", key: "main" },
+    });
+    const app: VxAppRuntime = {
+      retainedCallbacks: { releaseMany },
+      init: () => ({
+        frame: counterNode(0),
+        subscriptions: mappedSubscription(),
+      }),
+      render: () => counterNode(0),
+      dispatch: () => ({
+        frame: counterNode(0),
+        subscriptions: mappedSubscription(),
+      }),
+    };
+
+    const mounted = await mountVxApp({
+      container,
+      app,
+      runtimeHost: { subscriptions: { timer: () => undefined } },
+    });
+
+    await mounted.dispatch({ kind: "debug", name: "refresh" });
+    mounted.dispose();
+    await nextTurn();
+
+    const releasedIds = releaseMany.mock.calls.flatMap(([ids]) => Array.from(ids));
+    expect(releasedIds).toEqual([]);
+  });
+
   it("does not release outer mapped subscription handlers", async () => {
     const seenMessages: unknown[] = [];
     let nextHandlerId = 1;
     let dispatchSubscription: ((message: VxRuntimeMessage) => Promise<void>) | undefined;
     const dispose = vi.fn();
     const releaseMany = vi.fn<(ids: Iterable<number>) => void>();
-    const mappedSubscription = () => ({
-      type: "sub",
-      kind: "map",
-      handlerId: 99,
-      child: {
+    const mappedSubscription = () => {
+      const handlerId = nextHandlerId++;
+      return {
         type: "sub",
         kind: "map",
-        handlerId: nextHandlerId++,
-        handlerKey: 9001,
-        child: { type: "sub", kind: "timer", key: "main" },
-      },
-    });
+        handlerId: 99,
+        child: {
+          type: "sub",
+          kind: "map",
+          handlerId,
+          handlerKey: 9001,
+          __vxOwnedMapHandlerIds: [handlerId],
+          child: { type: "sub", kind: "timer", key: "main" },
+        },
+      };
+    };
     const runSubscription = vi.fn<VxSubscriptionRunner>((_subscription, context) => {
       dispatchSubscription = context.dispatch;
       return dispose;

--- a/packages/vx-dom/src/app-runtime.ts
+++ b/packages/vx-dom/src/app-runtime.ts
@@ -16,6 +16,8 @@ export type VoydVxAppHost = {
   ) => unknown;
   retainedCallbacks?: {
     dispatch(id: number, payload: unknown): Promise<unknown> | unknown;
+    release?: (id: number) => void;
+    releaseMany?: (ids: Iterable<number>) => void;
   };
 };
 
@@ -198,6 +200,7 @@ export function createVoydVxAppRuntime(
   };
 
   return {
+    retainedCallbacks: options.host.retainedCallbacks,
     init: async () => {
       const descriptor = await readProgramRunner();
       if (initialized && descriptor?.hydrate(model)) {

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -322,6 +322,27 @@ async function mountRuntimeApp(
   };
   const afterCommandCallbacks: Array<Array<() => void>> = [];
   let queue = Promise.resolve();
+  const queuedRetainedHandlerReleaser: RetainedHandlerReleaser = {
+    release: (id) => {
+      void queue.catch(() => undefined).then(() => {
+        if (retainedHandlerReleaser.release) {
+          retainedHandlerReleaser.release(id);
+          return;
+        }
+        retainedHandlerReleaser.releaseMany?.([id]);
+      });
+    },
+    releaseMany: (ids) => {
+      const retainedIds = Array.from(ids);
+      void queue.catch(() => undefined).then(() => {
+        if (retainedHandlerReleaser.releaseMany) {
+          retainedHandlerReleaser.releaseMany(retainedIds);
+          return;
+        }
+        retainedIds.forEach((id) => retainedHandlerReleaser.release?.(id));
+      });
+    },
+  };
 
   const dispatchNow = async (message: VxRuntimeMessage): Promise<void> => {
     if (disposed) return;
@@ -405,7 +426,7 @@ async function mountRuntimeApp(
             activeSubscriptions,
             runtimeHost,
             executionContext,
-            retainedHandlerReleaser,
+            queuedRetainedHandlerReleaser,
           );
         } catch (error) {
           reportError(error, { phase: "subscriptions" });

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -1265,22 +1265,30 @@ function runLocationChangeSubscription(
   context: VxRuntimeExecutionContext,
 ): VxSubscriptionDisposer | void {
   if (typeof window === "undefined") return;
+  let observedChange = false;
   const dispatch = () => {
     if (context.signal.aborted) return;
     settleAsyncDispatch(context.dispatch(subscriptionMessage(subscription, locationPayload())));
   };
-  window.addEventListener("popstate", dispatch);
-  window.addEventListener("hashchange", dispatch);
-  window.addEventListener(locationChangeEvent, dispatch);
+  const dispatchObserved = () => {
+    observedChange = true;
+    dispatch();
+  };
+  const dispatchInitial = () => {
+    if (!observedChange) dispatch();
+  };
+  window.addEventListener("popstate", dispatchObserved);
+  window.addEventListener("hashchange", dispatchObserved);
+  window.addEventListener(locationChangeEvent, dispatchObserved);
   if (context.deferAfterCommands) {
-    context.deferAfterCommands(dispatch);
+    context.deferAfterCommands(dispatchInitial);
   } else {
-    setTimeout(dispatch, 0);
+    setTimeout(dispatchInitial, 0);
   }
   return () => {
-    window.removeEventListener("popstate", dispatch);
-    window.removeEventListener("hashchange", dispatch);
-    window.removeEventListener(locationChangeEvent, dispatch);
+    window.removeEventListener("popstate", dispatchObserved);
+    window.removeEventListener("hashchange", dispatchObserved);
+    window.removeEventListener(locationChangeEvent, dispatchObserved);
   };
 }
 
@@ -1527,11 +1535,12 @@ function flattenSubscriptions(
     const handlerId = readHandlerId(envelope);
     if (handlerId === undefined) throw new Error("vx-dom: subscription map missing numeric handlerId");
     const handlerKey = readHandlerKey(envelope);
+    const ownedHandlerIds = mappedOwnedHandlerIds(envelope);
     return flattenSubscriptions(
       readRequiredMappedChild(envelope, "subscription map"),
       [...mapHandlerIds, handlerId],
       [...mapHandlerKeys, handlerKey ?? `id:${handlerId}`],
-      handlerKey === undefined ? ownedMapHandlerIds : [...ownedMapHandlerIds, handlerId],
+      [...ownedMapHandlerIds, ...ownedHandlerIds],
     );
   }
   if (!optionalSubscriptionKey(envelope)) {

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -382,8 +382,8 @@ async function mountRuntimeApp(
       }
     },
     dispatchMessage: (message) => dispatchQueued(toRuntimeMessage(message)),
-    release: options.handlers?.release,
-    releaseMany: options.handlers?.releaseMany,
+    release: queuedRetainedHandlerReleaser.release,
+    releaseMany: queuedRetainedHandlerReleaser.releaseMany,
   };
   const renderer = createVxDomRenderer(options.container, {
     handlers: runtimeHandlers,
@@ -950,12 +950,21 @@ async function runCommands(
     const handlerId = readHandlerId(commandEnvelope);
     if (handlerId === undefined) throw new Error("vx-dom: command map missing numeric handlerId");
     const child = readRequiredMappedChild(commandEnvelope, "command map");
-    await runCommands(
-      child,
-      host,
-      mapExecutionContext(context, handlerId),
-      nextTaskObserver,
+    const mapped = ownedCommandMapExecutionContext(
+      context,
+      handlerId,
+      mappedOwnedHandlerIds(commandEnvelope),
     );
+    try {
+      await runCommands(
+        child,
+        host,
+        mapped.context,
+        nextTaskObserver,
+      );
+    } finally {
+      mapped.finish();
+    }
     return;
   }
   const command = nextTaskObserver
@@ -973,11 +982,23 @@ function runDelayCommand(
   const ms = readMillis(command);
   if (ms === undefined) throw new Error("vx-dom: delay command missing non-negative millis");
   if (!Object.hasOwn(command, "value")) throw new Error("vx-dom: delay command missing value");
+  let resolveCompletion: () => void = () => undefined;
+  const completion = new Promise<void>((resolve) => {
+    resolveCompletion = resolve;
+  });
   const timeout = setTimeout(() => {
-    if (context.signal.aborted) return;
-    settleAsyncDispatch(context.dispatch(toVxMessage(command.value)));
+    if (context.signal.aborted) {
+      resolveCompletion();
+      return;
+    }
+    Promise.resolve(context.dispatch(toVxMessage(command.value))).then(resolveCompletion, resolveCompletion);
   }, ms);
-  context.signal.addEventListener("abort", () => clearTimeout(timeout), { once: true });
+  context.signal.addEventListener("abort", () => {
+    clearTimeout(timeout);
+    resolveCompletion();
+  }, { once: true });
+  context.trackRetainedHandlerUse?.(completion);
+  settleAsyncDispatch(completion);
 }
 
 function runTaskCommand(
@@ -989,7 +1010,24 @@ function runTaskCommand(
   if (taskId === undefined) throw new Error("vx-dom: task command missing numeric taskId");
   if (!observeTask) throw new Error("vx-dom: task command requires task runtime support");
 
-  void observeTask(taskId).then((outcome) => {
+  const ownedHandlerIds = mappedOwnedHandlerIds(command);
+  let released = false;
+  const releaseOwnedHandlers = () => {
+    if (released) return;
+    released = true;
+    ownedHandlerIds.forEach((id) => context.releaseRetainedHandler?.(id));
+  };
+  let resolveAbort: () => void = () => undefined;
+  const abortCompletion = new Promise<void>((resolve) => {
+    resolveAbort = resolve;
+  });
+  const abortListener = () => {
+    releaseOwnedHandlers();
+    resolveAbort();
+  };
+  context.signal.addEventListener("abort", abortListener, { once: true });
+
+  const completion = observeTask(taskId).then((outcome) => {
     if (context.signal.aborted) return;
     if (outcome.kind === "failed") {
       context.reportError?.(outcome.error, { phase: "commands" });
@@ -1005,7 +1043,13 @@ function runTaskCommand(
     );
   }).catch((error) => {
     context.reportError?.(error, { phase: "commands" });
+  }).finally(() => {
+    context.signal.removeEventListener("abort", abortListener);
+    releaseOwnedHandlers();
+    resolveAbort();
   });
+  context.trackRetainedHandlerUse?.(Promise.race([completion, abortCompletion]));
+  settleAsyncDispatch(completion);
 }
 
 async function runCopyToClipboardCommand(command: VxCommandEnvelope): Promise<void> {
@@ -1704,8 +1748,63 @@ function mapExecutionContext(
 ): VxRuntimeExecutionContext {
   return {
     signal: context.signal,
+    deferAfterCommands: context.deferAfterCommands,
+    releaseRetainedHandler: context.releaseRetainedHandler,
+    trackRetainedHandlerUse: context.trackRetainedHandlerUse,
     reportError: context.reportError,
     dispatch: (message) => context.dispatch({ kind: "map", handlerId, message }),
+  };
+}
+
+function ownedCommandMapExecutionContext(
+  context: VxRuntimeExecutionContext,
+  handlerId: number,
+  ownedHandlerIds: readonly number[],
+): {
+  context: VxRuntimeExecutionContext;
+  finish: () => void;
+} {
+  if (ownedHandlerIds.length === 0) {
+    return {
+      context: mapExecutionContext(context, handlerId),
+      finish: () => undefined,
+    };
+  }
+
+  let commandReturned = false;
+  let pendingUses = 0;
+  let released = false;
+  const releaseIfDone = () => {
+    if (!commandReturned || pendingUses > 0 || released) return;
+    released = true;
+    ownedHandlerIds.forEach((id) => context.releaseRetainedHandler?.(id));
+  };
+  const trackUse = (result: Promise<unknown> | unknown) => {
+    pendingUses += 1;
+    context.trackRetainedHandlerUse?.(result);
+    void Promise.resolve(result).catch(() => undefined).then(() => {
+      pendingUses -= 1;
+      releaseIfDone();
+    });
+  };
+
+  return {
+    context: {
+      signal: context.signal,
+      deferAfterCommands: context.deferAfterCommands,
+      releaseRetainedHandler: context.releaseRetainedHandler,
+      trackRetainedHandlerUse: trackUse,
+      reportError: context.reportError,
+      dispatch: (message) => {
+        const result = context.dispatch({ kind: "map", handlerId, message });
+        trackUse(result);
+        return result;
+      },
+    },
+    finish: () => {
+      commandReturned = true;
+      releaseIfDone();
+    },
   };
 }
 
@@ -1721,6 +1820,8 @@ function mutableMappedSubscriptionContext(
     context: {
       signal: context.signal,
       deferAfterCommands: context.deferAfterCommands,
+      releaseRetainedHandler: context.releaseRetainedHandler,
+      trackRetainedHandlerUse: context.trackRetainedHandlerUse,
       reportError: context.reportError,
       dispatch: (message) => context.dispatch(mapRuntimeMessage(message, mapHandlerIds)),
     },
@@ -1735,8 +1836,8 @@ function mappedHandlerIds(subscription: VxSubscriptionEnvelope): number[] {
   return Array.isArray(raw) ? raw.filter((id): id is number => typeof id === "number") : [];
 }
 
-function mappedOwnedHandlerIds(subscription: VxSubscriptionEnvelope): number[] {
-  const raw = subscription[ownedMapHandlerIdsProperty];
+function mappedOwnedHandlerIds(input: Record<string, unknown>): number[] {
+  const raw = input[ownedMapHandlerIdsProperty];
   return Array.isArray(raw) ? raw.filter((id): id is number => typeof id === "number") : [];
 }
 

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -362,6 +362,7 @@ async function mountRuntimeApp(
       }
       callback();
     },
+    releaseRetainedHandler: (id) => queuedRetainedHandlerReleaser.release?.(id),
     reportError,
     signal: abortController.signal,
   };
@@ -1071,9 +1072,13 @@ async function runReadClipboardCommand(
   if (!clipboard || typeof clipboard.readText !== "function") {
     throw new Error("vx-dom: read_clipboard command requires navigator.clipboard.readText");
   }
-  const value = await clipboard.readText();
-  if (context.signal.aborted) return;
-  settleAsyncDispatch(context.dispatch({ kind: "map", handlerId, message: toVxMessage(value) }));
+  try {
+    const value = await clipboard.readText();
+    if (context.signal.aborted) return;
+    settleAsyncDispatch(context.dispatch({ kind: "map", handlerId, message: toVxMessage(value) }));
+  } finally {
+    context.releaseRetainedHandler?.(handlerId);
+  }
 }
 
 function runReplaceUrlCommand(command: VxCommandEnvelope): void {

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -1266,8 +1266,10 @@ function runLocationChangeSubscription(
 ): VxSubscriptionDisposer | void {
   if (typeof window === "undefined") return;
   let observedChange = false;
+  let cancelled = false;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   const dispatch = () => {
-    if (context.signal.aborted) return;
+    if (cancelled || context.signal.aborted) return;
     settleAsyncDispatch(context.dispatch(subscriptionMessage(subscription, locationPayload())));
   };
   const dispatchObserved = () => {
@@ -1283,9 +1285,11 @@ function runLocationChangeSubscription(
   if (context.deferAfterCommands) {
     context.deferAfterCommands(dispatchInitial);
   } else {
-    setTimeout(dispatchInitial, 0);
+    timeout = setTimeout(dispatchInitial, 0);
   }
   return () => {
+    cancelled = true;
+    if (timeout !== undefined) clearTimeout(timeout);
     window.removeEventListener("popstate", dispatchObserved);
     window.removeEventListener("hashchange", dispatchObserved);
     window.removeEventListener(locationChangeEvent, dispatchObserved);

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -104,6 +104,7 @@ type ActiveSubscription = {
 
 const mapHandlerIdsProperty = "__vxMapHandlerIds";
 const taskObserverProperty = Symbol.for("voyd.taskObserver");
+const locationChangeEvent = "vxlocationchange";
 const listenerState = new WeakMap<Element, Map<string, ListenerRecord>>();
 
 type TaskRunOutcome =
@@ -121,20 +122,39 @@ export function createBrowserVxRuntimeHost(
       copy_to_clipboard: runCopyToClipboardCommand,
       delay: runDelayCommand,
       focus: runFocusCommand,
+      local_storage_clear: runLocalStorageClearCommand,
+      local_storage_remove: runLocalStorageRemoveCommand,
+      local_storage_set: runLocalStorageSetCommand,
       navigate_back: runNavigateBackCommand,
       navigate_forward: runNavigateForwardCommand,
+      open_url: runOpenUrlCommand,
       push_url: runPushUrlCommand,
+      read_clipboard: runReadClipboardCommand,
       replace_url: runReplaceUrlCommand,
       scroll_into_view: runScrollIntoViewCommand,
+      scroll_window_by: runScrollWindowByCommand,
+      scroll_window_to: runScrollWindowToCommand,
+      select_text: runSelectTextCommand,
+      session_storage_clear: runSessionStorageClearCommand,
+      session_storage_remove: runSessionStorageRemoveCommand,
+      session_storage_set: runSessionStorageSetCommand,
+      set_hash: runSetHashCommand,
       set_document_title: runSetDocumentTitleCommand,
       task: runTaskCommand,
       ...overrides.commands,
     },
     subscriptions: {
+      animation_frame: runAnimationFrameSubscription,
+      broadcast_channel: runBroadcastChannelSubscription,
       interval: runIntervalSubscription,
       keyboard: runKeyboardSubscription,
+      location_change: runLocationChangeSubscription,
+      media_query: runMediaQuerySubscription,
       online_status: runOnlineStatusSubscription,
+      storage: runStorageSubscription,
       visibility_change: runVisibilityChangeSubscription,
+      window_blur: runWindowEventSubscription,
+      window_focus: runWindowEventSubscription,
       window_resize: runWindowResizeSubscription,
       ...overrides.subscriptions,
     },
@@ -932,6 +952,21 @@ async function runCopyToClipboardCommand(command: VxCommandEnvelope): Promise<vo
   await clipboard.writeText(value);
 }
 
+function runLocalStorageClearCommand(): void {
+  readBrowserStorage("local_storage_clear", "local").clear();
+}
+
+function runLocalStorageRemoveCommand(command: VxCommandEnvelope): void {
+  readBrowserStorage("local_storage_remove", "local").removeItem(
+    readRequiredStringValue(command, "local_storage_remove"),
+  );
+}
+
+function runLocalStorageSetCommand(command: VxCommandEnvelope): void {
+  const entry = readStorageEntry(command, "local_storage_set");
+  readBrowserStorage("local_storage_set", "local").setItem(entry.key, entry.value);
+}
+
 function runFocusCommand(command: VxCommandEnvelope): void {
   const target = findRefElement(readRequiredStringValue(command, "focus"));
   if (target instanceof HTMLElement) target.focus();
@@ -945,19 +980,90 @@ function runNavigateForwardCommand(): void {
   if (typeof history !== "undefined") history.forward();
 }
 
+function runOpenUrlCommand(command: VxCommandEnvelope): void {
+  const target = readOpenUrlTarget(command);
+  if (typeof window !== "undefined" && typeof window.open === "function") {
+    window.open(target.url, target.target);
+  }
+}
+
 function runPushUrlCommand(command: VxCommandEnvelope): void {
   const value = readRequiredStringValue(command, "push_url");
-  if (typeof history !== "undefined") history.pushState(null, "", value);
+  if (typeof history !== "undefined") {
+    history.pushState(null, "", value);
+    dispatchLocationChange();
+  }
+}
+
+async function runReadClipboardCommand(
+  command: VxCommandEnvelope,
+  context: VxRuntimeExecutionContext,
+): Promise<void> {
+  const handlerId = readHandlerId(command);
+  if (handlerId === undefined) {
+    throw new Error("vx-dom: read_clipboard command missing numeric handlerId");
+  }
+  const clipboard = typeof navigator === "undefined" ? undefined : navigator.clipboard;
+  if (!clipboard || typeof clipboard.readText !== "function") {
+    throw new Error("vx-dom: read_clipboard command requires navigator.clipboard.readText");
+  }
+  const value = await clipboard.readText();
+  if (context.signal.aborted) return;
+  await context.dispatch({ kind: "map", handlerId, message: toVxMessage(value) });
 }
 
 function runReplaceUrlCommand(command: VxCommandEnvelope): void {
   const value = readRequiredStringValue(command, "replace_url");
-  if (typeof history !== "undefined") history.replaceState(null, "", value);
+  if (typeof history !== "undefined") {
+    history.replaceState(null, "", value);
+    dispatchLocationChange();
+  }
 }
 
 function runScrollIntoViewCommand(command: VxCommandEnvelope): void {
   const target = findRefElement(readRequiredStringValue(command, "scroll_into_view"));
   if (typeof target?.scrollIntoView === "function") target.scrollIntoView();
+}
+
+function runScrollWindowByCommand(command: VxCommandEnvelope): void {
+  const point = readPointValue(command, "scroll_window_by");
+  if (typeof window !== "undefined" && typeof window.scrollBy === "function") {
+    window.scrollBy(point.x, point.y);
+  }
+}
+
+function runScrollWindowToCommand(command: VxCommandEnvelope): void {
+  const point = readPointValue(command, "scroll_window_to");
+  if (typeof window !== "undefined" && typeof window.scrollTo === "function") {
+    window.scrollTo(point.x, point.y);
+  }
+}
+
+function runSelectTextCommand(command: VxCommandEnvelope): void {
+  const target = findRefElement(readRequiredStringValue(command, "select_text"));
+  if (target && "select" in target && typeof target.select === "function") {
+    target.select();
+  }
+}
+
+function runSessionStorageClearCommand(): void {
+  readBrowserStorage("session_storage_clear", "session").clear();
+}
+
+function runSessionStorageRemoveCommand(command: VxCommandEnvelope): void {
+  readBrowserStorage("session_storage_remove", "session").removeItem(
+    readRequiredStringValue(command, "session_storage_remove"),
+  );
+}
+
+function runSessionStorageSetCommand(command: VxCommandEnvelope): void {
+  const entry = readStorageEntry(command, "session_storage_set");
+  readBrowserStorage("session_storage_set", "session").setItem(entry.key, entry.value);
+}
+
+function runSetHashCommand(command: VxCommandEnvelope): void {
+  const value = readRequiredStringValue(command, "set_hash");
+  if (typeof location !== "undefined") location.hash = value;
 }
 
 function runSetDocumentTitleCommand(command: VxCommandEnvelope): void {
@@ -1000,6 +1106,94 @@ function runKeyboardSubscription(
   return () => window.removeEventListener(eventName, listener);
 }
 
+function runAnimationFrameSubscription(
+  subscription: VxSubscriptionEnvelope,
+  context: VxRuntimeExecutionContext,
+): VxSubscriptionDisposer | void {
+  if (typeof window === "undefined" || typeof window.requestAnimationFrame !== "function") return;
+  let frameId: number | undefined;
+  const tick = (timestamp: number) => {
+    if (context.signal.aborted) return;
+    settleAsyncDispatch(context.dispatch(subscriptionMessage(subscription, {
+      kind: "animation_frame",
+      timestamp,
+    })));
+    frameId = window.requestAnimationFrame(tick);
+  };
+  frameId = window.requestAnimationFrame(tick);
+  return () => {
+    if (frameId !== undefined && typeof window.cancelAnimationFrame === "function") {
+      window.cancelAnimationFrame(frameId);
+    }
+  };
+}
+
+function runBroadcastChannelSubscription(
+  subscription: VxSubscriptionEnvelope,
+  context: VxRuntimeExecutionContext,
+): VxSubscriptionDisposer | void {
+  const channelName = readRequiredStringField(subscription, "name", "broadcast_channel subscription");
+  if (typeof BroadcastChannel === "undefined") {
+    throw new Error("vx-dom: broadcast_channel subscription requires BroadcastChannel");
+  }
+  const channel = new BroadcastChannel(channelName);
+  const listener = (event: MessageEvent) => {
+    if (context.signal.aborted) return;
+    settleAsyncDispatch(context.dispatch(subscriptionMessage(subscription, event.data)));
+  };
+  channel.addEventListener("message", listener);
+  return () => {
+    channel.removeEventListener("message", listener);
+    channel.close();
+  };
+}
+
+function runLocationChangeSubscription(
+  subscription: VxSubscriptionEnvelope,
+  context: VxRuntimeExecutionContext,
+): VxSubscriptionDisposer | void {
+  if (typeof window === "undefined") return;
+  const dispatch = () => {
+    if (context.signal.aborted) return;
+    settleAsyncDispatch(context.dispatch(subscriptionMessage(subscription, locationPayload())));
+  };
+  window.addEventListener("popstate", dispatch);
+  window.addEventListener("hashchange", dispatch);
+  window.addEventListener(locationChangeEvent, dispatch);
+  dispatch();
+  return () => {
+    window.removeEventListener("popstate", dispatch);
+    window.removeEventListener("hashchange", dispatch);
+    window.removeEventListener(locationChangeEvent, dispatch);
+  };
+}
+
+function runMediaQuerySubscription(
+  subscription: VxSubscriptionEnvelope,
+  context: VxRuntimeExecutionContext,
+): VxSubscriptionDisposer | void {
+  const query = readRequiredStringField(subscription, "query", "media_query subscription");
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    throw new Error("vx-dom: media_query subscription requires window.matchMedia");
+  }
+  const media = window.matchMedia(query);
+  const dispatch = () => {
+    if (context.signal.aborted) return;
+    settleAsyncDispatch(context.dispatch(subscriptionMessage(subscription, {
+      kind: "media_query",
+      query,
+      matches: media.matches,
+    })));
+  };
+  dispatch();
+  if (typeof media.addEventListener === "function") {
+    media.addEventListener("change", dispatch);
+    return () => media.removeEventListener("change", dispatch);
+  }
+  media.addListener(dispatch);
+  return () => media.removeListener(dispatch);
+}
+
 function runOnlineStatusSubscription(
   subscription: VxSubscriptionEnvelope,
   context: VxRuntimeExecutionContext,
@@ -1017,6 +1211,19 @@ function runOnlineStatusSubscription(
     window.removeEventListener("online", dispatch);
     window.removeEventListener("offline", dispatch);
   };
+}
+
+function runStorageSubscription(
+  subscription: VxSubscriptionEnvelope,
+  context: VxRuntimeExecutionContext,
+): VxSubscriptionDisposer | void {
+  if (typeof window === "undefined") return;
+  const listener = (event: StorageEvent) => {
+    if (context.signal.aborted) return;
+    settleAsyncDispatch(context.dispatch(subscriptionMessage(subscription, storagePayload(event))));
+  };
+  window.addEventListener("storage", listener);
+  return () => window.removeEventListener("storage", listener);
 }
 
 function runVisibilityChangeSubscription(
@@ -1053,6 +1260,23 @@ function runWindowResizeSubscription(
   window.addEventListener("resize", dispatch);
   dispatch();
   return () => window.removeEventListener("resize", dispatch);
+}
+
+function runWindowEventSubscription(
+  subscription: VxSubscriptionEnvelope,
+  context: VxRuntimeExecutionContext,
+): VxSubscriptionDisposer | void {
+  if (typeof window === "undefined") return;
+  const eventName = typeof subscription.event === "string" ? subscription.event : subscription.kind;
+  const listener = () => {
+    if (context.signal.aborted) return;
+    settleAsyncDispatch(context.dispatch(subscriptionMessage(subscription, {
+      kind: "event",
+      event: eventName,
+    })));
+  };
+  window.addEventListener(eventName, listener);
+  return () => window.removeEventListener(eventName, listener);
 }
 
 async function syncRuntimeSubscriptions(
@@ -1192,6 +1416,67 @@ function readRequiredStringValue(
   return input.value;
 }
 
+function readBrowserStorage(commandKind: string, storageKind: "local" | "session"): Storage {
+  const storage = storageKind === "local"
+    ? typeof localStorage === "undefined" ? undefined : localStorage
+    : typeof sessionStorage === "undefined" ? undefined : sessionStorage;
+  if (!storage) throw new Error(`vx-dom: ${commandKind} command requires ${storageKind}Storage`);
+  return storage;
+}
+
+function readOpenUrlTarget(command: VxCommandEnvelope): { url: string; target?: string } {
+  if (typeof command.value === "string") return { url: command.value, target: "_blank" };
+  if (!isRecord(command.value) || typeof command.value.url !== "string") {
+    throw new Error("vx-dom: open_url command missing string url");
+  }
+  return {
+    url: command.value.url,
+    target: typeof command.value.target === "string" ? command.value.target : "_blank",
+  };
+}
+
+function readPointValue(
+  command: VxCommandEnvelope,
+  commandKind: string,
+): { x: number; y: number } {
+  if (
+    !isRecord(command.value) ||
+    typeof command.value.x !== "number" ||
+    typeof command.value.y !== "number" ||
+    !Number.isFinite(command.value.x) ||
+    !Number.isFinite(command.value.y)
+  ) {
+    throw new Error(`vx-dom: ${commandKind} command missing numeric x/y value`);
+  }
+  return { x: command.value.x, y: command.value.y };
+}
+
+function readRequiredStringField(
+  input: Record<string, unknown>,
+  field: string,
+  label: string,
+): string {
+  const value = input[field];
+  if (typeof value !== "string") {
+    throw new Error(`vx-dom: ${label} missing string ${field}`);
+  }
+  return value;
+}
+
+function readStorageEntry(
+  command: VxCommandEnvelope,
+  commandKind: string,
+): { key: string; value: string } {
+  if (
+    !isRecord(command.value) ||
+    typeof command.value.key !== "string" ||
+    typeof command.value.value !== "string"
+  ) {
+    throw new Error(`vx-dom: ${commandKind} command missing string key/value`);
+  }
+  return { key: command.value.key, value: command.value.value };
+}
+
 function subscriptionMessage(
   subscription: VxSubscriptionEnvelope,
   payload: unknown,
@@ -1203,6 +1488,46 @@ function subscriptionMessage(
     ...(Object.hasOwn(subscription, "value") ? { value: subscription.value } : {}),
     payload,
   };
+}
+
+function dispatchLocationChange(): void {
+  if (typeof window !== "undefined") window.dispatchEvent(new Event(locationChangeEvent));
+}
+
+function locationPayload(): Record<string, string> {
+  if (typeof location === "undefined") {
+    return {
+      kind: "location",
+      href: "",
+      pathname: "",
+      search: "",
+      hash: "",
+    };
+  }
+  return {
+    kind: "location",
+    href: location.href,
+    pathname: location.pathname,
+    search: location.search,
+    hash: location.hash,
+  };
+}
+
+function storagePayload(event: StorageEvent): Record<string, unknown> {
+  return {
+    kind: "storage",
+    storage: storageKind(event.storageArea),
+    ...(event.key !== null ? { key: event.key } : {}),
+    ...(event.oldValue !== null ? { old_value: event.oldValue } : {}),
+    ...(event.newValue !== null ? { new_value: event.newValue } : {}),
+    url: event.url ?? "",
+  };
+}
+
+function storageKind(storageArea: Storage | null): string {
+  if (typeof sessionStorage !== "undefined" && storageArea === sessionStorage) return "session";
+  if (typeof localStorage !== "undefined" && storageArea === localStorage) return "local";
+  return "unknown";
 }
 
 function mapExecutionContext(

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -21,6 +21,7 @@ import type {
   VxRuntimeExecutionContext,
   VxRuntimeHostOptions,
   VxRuntimeMessage,
+  VxRuntimeSubscriptionMessage,
   VxRuntimeStep,
   VxSubscriptionDisposer,
   VxSubscriptionEnvelope,
@@ -117,15 +118,24 @@ export function createBrowserVxRuntimeHost(
 ): VxRuntimeHostOptions {
   return {
     commands: {
+      copy_to_clipboard: runCopyToClipboardCommand,
       delay: runDelayCommand,
       focus: runFocusCommand,
+      navigate_back: runNavigateBackCommand,
+      navigate_forward: runNavigateForwardCommand,
+      push_url: runPushUrlCommand,
+      replace_url: runReplaceUrlCommand,
       scroll_into_view: runScrollIntoViewCommand,
+      set_document_title: runSetDocumentTitleCommand,
       task: runTaskCommand,
       ...overrides.commands,
     },
     subscriptions: {
       interval: runIntervalSubscription,
       keyboard: runKeyboardSubscription,
+      online_status: runOnlineStatusSubscription,
+      visibility_change: runVisibilityChangeSubscription,
+      window_resize: runWindowResizeSubscription,
       ...overrides.subscriptions,
     },
     onError: overrides.onError,
@@ -913,16 +923,46 @@ function runTaskCommand(
   });
 }
 
+async function runCopyToClipboardCommand(command: VxCommandEnvelope): Promise<void> {
+  const value = readRequiredStringValue(command, "copy_to_clipboard");
+  const clipboard = typeof navigator === "undefined" ? undefined : navigator.clipboard;
+  if (!clipboard || typeof clipboard.writeText !== "function") {
+    throw new Error("vx-dom: copy_to_clipboard command requires navigator.clipboard.writeText");
+  }
+  await clipboard.writeText(value);
+}
+
 function runFocusCommand(command: VxCommandEnvelope): void {
-  if (typeof command.value !== "string") throw new Error("vx-dom: focus command missing string value");
-  const target = findRefElement(command.value);
+  const target = findRefElement(readRequiredStringValue(command, "focus"));
   if (target instanceof HTMLElement) target.focus();
 }
 
+function runNavigateBackCommand(): void {
+  if (typeof history !== "undefined") history.back();
+}
+
+function runNavigateForwardCommand(): void {
+  if (typeof history !== "undefined") history.forward();
+}
+
+function runPushUrlCommand(command: VxCommandEnvelope): void {
+  const value = readRequiredStringValue(command, "push_url");
+  if (typeof history !== "undefined") history.pushState(null, "", value);
+}
+
+function runReplaceUrlCommand(command: VxCommandEnvelope): void {
+  const value = readRequiredStringValue(command, "replace_url");
+  if (typeof history !== "undefined") history.replaceState(null, "", value);
+}
+
 function runScrollIntoViewCommand(command: VxCommandEnvelope): void {
-  if (typeof command.value !== "string") throw new Error("vx-dom: scroll_into_view command missing string value");
-  const target = findRefElement(command.value);
+  const target = findRefElement(readRequiredStringValue(command, "scroll_into_view"));
   if (typeof target?.scrollIntoView === "function") target.scrollIntoView();
+}
+
+function runSetDocumentTitleCommand(command: VxCommandEnvelope): void {
+  const value = readRequiredStringValue(command, "set_document_title");
+  if (typeof document !== "undefined") document.title = value;
 }
 
 function runIntervalSubscription(
@@ -943,7 +983,6 @@ function runKeyboardSubscription(
   subscription: VxSubscriptionEnvelope,
   context: VxRuntimeExecutionContext,
 ): VxSubscriptionDisposer | void {
-  if (!Object.hasOwn(subscription, "value")) throw new Error("vx-dom: keyboard subscription missing value");
   const eventName = typeof subscription.event === "string"
     ? subscription.event
     : "keydown";
@@ -952,16 +991,68 @@ function runKeyboardSubscription(
     if (context.signal.aborted) return;
     const subscribedKey = optionalSubscriptionKey(subscription);
     if (subscribedKey && isKeyboardEvent(event) && event.key !== subscribedKey) return;
-    settleAsyncDispatch(context.dispatch({
-      kind: "subscription",
-      subscriptionKind: "keyboard",
-      key: subscribedKey,
-      value: subscription.value,
-      payload: normalizeBrowserEvent(event),
-    }));
+    settleAsyncDispatch(context.dispatch(subscriptionMessage(
+      subscription,
+      normalizeBrowserEvent(event),
+    )));
   };
   window.addEventListener(eventName, listener);
   return () => window.removeEventListener(eventName, listener);
+}
+
+function runOnlineStatusSubscription(
+  subscription: VxSubscriptionEnvelope,
+  context: VxRuntimeExecutionContext,
+): VxSubscriptionDisposer | void {
+  if (typeof window === "undefined") return;
+  const dispatch = () => {
+    if (context.signal.aborted) return;
+    const online = typeof navigator === "undefined" ? true : navigator.onLine;
+    settleAsyncDispatch(context.dispatch(subscriptionMessage(subscription, online)));
+  };
+  window.addEventListener("online", dispatch);
+  window.addEventListener("offline", dispatch);
+  dispatch();
+  return () => {
+    window.removeEventListener("online", dispatch);
+    window.removeEventListener("offline", dispatch);
+  };
+}
+
+function runVisibilityChangeSubscription(
+  subscription: VxSubscriptionEnvelope,
+  context: VxRuntimeExecutionContext,
+): VxSubscriptionDisposer | void {
+  if (typeof document === "undefined") return;
+  const dispatch = () => {
+    if (context.signal.aborted) return;
+    settleAsyncDispatch(context.dispatch(subscriptionMessage(subscription, {
+      kind: "visibility",
+      state: document.visibilityState,
+      hidden: document.hidden,
+    })));
+  };
+  document.addEventListener("visibilitychange", dispatch);
+  dispatch();
+  return () => document.removeEventListener("visibilitychange", dispatch);
+}
+
+function runWindowResizeSubscription(
+  subscription: VxSubscriptionEnvelope,
+  context: VxRuntimeExecutionContext,
+): VxSubscriptionDisposer | void {
+  if (typeof window === "undefined") return;
+  const dispatch = () => {
+    if (context.signal.aborted) return;
+    settleAsyncDispatch(context.dispatch(subscriptionMessage(subscription, {
+      kind: "window_size",
+      width: window.innerWidth,
+      height: window.innerHeight,
+    })));
+  };
+  window.addEventListener("resize", dispatch);
+  dispatch();
+  return () => window.removeEventListener("resize", dispatch);
 }
 
 async function syncRuntimeSubscriptions(
@@ -1089,6 +1180,29 @@ function readMillis(input: Record<string, unknown>): number | undefined {
   }
   if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 0) return undefined;
   return raw;
+}
+
+function readRequiredStringValue(
+  input: Record<string, unknown>,
+  commandKind: string,
+): string {
+  if (typeof input.value !== "string") {
+    throw new Error(`vx-dom: ${commandKind} command missing string value`);
+  }
+  return input.value;
+}
+
+function subscriptionMessage(
+  subscription: VxSubscriptionEnvelope,
+  payload: unknown,
+): VxRuntimeSubscriptionMessage {
+  return {
+    kind: "subscription",
+    subscriptionKind: subscription.kind,
+    key: optionalSubscriptionKey(subscription),
+    ...(Object.hasOwn(subscription, "value") ? { value: subscription.value } : {}),
+    payload,
+  };
 }
 
 function mapExecutionContext(

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -100,9 +100,15 @@ type ListenerRecord = {
 type ActiveSubscription = {
   signature: string;
   dispose: VxSubscriptionDisposer;
+  mapHandlerIds: number[];
+  setMapHandlerIds: (ids: number[]) => void;
 };
 
+type RetainedHandlerReleaser = Pick<RetainedEventHandlerRegistry, "release" | "releaseMany">;
+
 const mapHandlerIdsProperty = "__vxMapHandlerIds";
+const mapHandlerKeysProperty = "__vxMapHandlerKeys";
+const mapHandlerIdentityProperty = "__vxMapHandlerIdentity";
 const taskObserverProperty = Symbol.for("voyd.taskObserver");
 const locationChangeEvent = "vxlocationchange";
 const listenerState = new WeakMap<Element, Map<string, ListenerRecord>>();
@@ -308,6 +314,11 @@ async function mountRuntimeApp(
   const activeSubscriptions = new Map<string, ActiveSubscription>();
   const runtimeHost = createBrowserVxRuntimeHost(options.runtimeHost);
   const reportError = createRuntimeErrorReporter(options.onError ?? runtimeHost.onError);
+  const retainedHandlerReleaser: RetainedHandlerReleaser = {
+    release: app.retainedCallbacks?.release ?? options.handlers?.release,
+    releaseMany: app.retainedCallbacks?.releaseMany ?? options.handlers?.releaseMany,
+  };
+  const afterCommandCallbacks: Array<Array<() => void>> = [];
   let queue = Promise.resolve();
 
   const dispatchNow = async (message: VxRuntimeMessage): Promise<void> => {
@@ -323,6 +334,14 @@ async function mountRuntimeApp(
   };
   const executionContext: VxRuntimeExecutionContext = {
     dispatch: dispatchQueued,
+    deferAfterCommands: (callback) => {
+      const callbacks = afterCommandCallbacks.at(-1);
+      if (callbacks) {
+        callbacks.push(callback);
+        return;
+      }
+      callback();
+    },
     reportError,
     signal: abortController.signal,
   };
@@ -361,38 +380,46 @@ async function mountRuntimeApp(
       throw error;
     }
 
-    if (step.subscriptions !== undefined && app.syncSubscriptions) {
-      const previous = previousSubscriptions;
-      previousSubscriptions = step.subscriptions;
-      try {
-        await app.syncSubscriptions(step.subscriptions, {
-          previous,
-          dispatch: dispatchQueued,
-        });
-      } catch (error) {
-        reportError(error, { phase: "subscriptions" });
-        throw error;
-      }
-    } else if (step.subscriptions !== undefined) {
-      try {
-        await syncRuntimeSubscriptions(
-          step.subscriptions,
-          activeSubscriptions,
-          runtimeHost,
-          executionContext,
-        );
-      } catch (error) {
-        reportError(error, { phase: "subscriptions" });
-        throw error;
-      }
-    }
-
+    const deferredCallbacks: Array<() => void> = [];
+    afterCommandCallbacks.push(deferredCallbacks);
+    let commandPhaseStarted = false;
     try {
+      if (step.subscriptions !== undefined && app.syncSubscriptions) {
+        const previous = previousSubscriptions;
+        previousSubscriptions = step.subscriptions;
+        try {
+          await app.syncSubscriptions(step.subscriptions, {
+            previous,
+            dispatch: dispatchQueued,
+          });
+        } catch (error) {
+          reportError(error, { phase: "subscriptions" });
+          throw error;
+        }
+      } else if (step.subscriptions !== undefined) {
+        try {
+          await syncRuntimeSubscriptions(
+            step.subscriptions,
+            activeSubscriptions,
+            runtimeHost,
+            executionContext,
+            retainedHandlerReleaser,
+          );
+        } catch (error) {
+          reportError(error, { phase: "subscriptions" });
+          throw error;
+        }
+      }
+
+      commandPhaseStarted = true;
       await runCommands(step.commands, runtimeHost, executionContext);
     } catch (error) {
-      reportError(error, { phase: "commands" });
+      if (commandPhaseStarted) reportError(error, { phase: "commands" });
       throw error;
+    } finally {
+      afterCommandCallbacks.pop();
     }
+    deferredCallbacks.forEach((callback) => callback());
   };
 
   try {
@@ -411,7 +438,8 @@ async function mountRuntimeApp(
     dispose() {
       disposed = true;
       abortController.abort();
-      void disposeSubscriptions(activeSubscriptions).catch((error) => reportError(error, { phase: "dispose" }));
+      void disposeSubscriptions(activeSubscriptions, retainedHandlerReleaser)
+        .catch((error) => reportError(error, { phase: "dispose" }));
       renderer.dispose();
       void Promise.resolve(app.dispose?.()).catch((error) => reportError(error, { phase: "dispose" }));
     },
@@ -1160,7 +1188,11 @@ function runLocationChangeSubscription(
   window.addEventListener("popstate", dispatch);
   window.addEventListener("hashchange", dispatch);
   window.addEventListener(locationChangeEvent, dispatch);
-  dispatch();
+  if (context.deferAfterCommands) {
+    context.deferAfterCommands(dispatch);
+  } else {
+    setTimeout(dispatch, 0);
+  }
   return () => {
     window.removeEventListener("popstate", dispatch);
     window.removeEventListener("hashchange", dispatch);
@@ -1284,47 +1316,106 @@ async function syncRuntimeSubscriptions(
   active: Map<string, ActiveSubscription>,
   host: VxRuntimeHostOptions | undefined,
   context: VxRuntimeExecutionContext,
+  releaser?: RetainedHandlerReleaser,
 ): Promise<void> {
   const next = flattenSubscriptions(input);
   const nextKeys = new Set(next.map(subscriptionIdentityKey));
 
   for (const [key, record] of active) {
     if (nextKeys.has(key)) continue;
-    await record.dispose();
     active.delete(key);
+    await disposeActiveSubscription(record, releaser, active);
   }
 
   for (const subscription of next) {
     const key = subscriptionIdentityKey(subscription);
     const signature = subscriptionSignature(subscription);
+    const mapHandlerIds = mappedHandlerIds(subscription);
     const previous = active.get(key);
-    if (previous?.signature === signature) continue;
+    if (previous?.signature === signature) {
+      updateActiveSubscriptionMapHandlers(previous, mapHandlerIds, releaser, active);
+      continue;
+    }
     if (previous) {
-      await previous.dispose();
       active.delete(key);
+      await disposeActiveSubscription(previous, releaser, active);
     }
     const runner = host?.subscriptions?.[subscription.kind];
     if (!runner) throw new Error(`vx-dom: no runtime subscription handler registered for "${subscription.kind}"`);
-    const dispose = await runner(subscription, mapSubscriptionContext(subscription, context));
-    active.set(key, { signature, dispose: dispose ?? (() => undefined) });
+    const mappedContext = mutableMappedSubscriptionContext(subscription, context);
+    const dispose = await runner(subscription, mappedContext.context);
+    active.set(key, {
+      signature,
+      dispose: dispose ?? (() => undefined),
+      mapHandlerIds,
+      setMapHandlerIds: mappedContext.setMapHandlerIds,
+    });
   }
 }
 
 async function disposeSubscriptions(
   active: Map<string, ActiveSubscription>,
+  releaser?: RetainedHandlerReleaser,
 ): Promise<void> {
-  const disposers = Array.from(active.values()).map((record) => record.dispose);
+  const records = Array.from(active.values());
   active.clear();
-  for (const dispose of disposers) await dispose();
+  for (const record of records) await disposeActiveSubscription(record, releaser, active);
+}
+
+async function disposeActiveSubscription(
+  record: ActiveSubscription,
+  releaser: RetainedHandlerReleaser | undefined,
+  active: Map<string, ActiveSubscription>,
+): Promise<void> {
+  try {
+    await record.dispose();
+  } finally {
+    releaseRetainedHandlers(record.mapHandlerIds, releaser, active);
+  }
+}
+
+function updateActiveSubscriptionMapHandlers(
+  record: ActiveSubscription,
+  nextIds: number[],
+  releaser: RetainedHandlerReleaser | undefined,
+  active: Map<string, ActiveSubscription>,
+): void {
+  const removed = record.mapHandlerIds.filter((id) => !nextIds.includes(id));
+  record.mapHandlerIds = nextIds;
+  record.setMapHandlerIds(nextIds);
+  releaseRetainedHandlers(removed, releaser, active);
+}
+
+function releaseRetainedHandlers(
+  ids: readonly number[],
+  releaser: RetainedHandlerReleaser | undefined,
+  active: Map<string, ActiveSubscription>,
+): void {
+  const inactiveIds = Array.from(new Set(ids))
+    .filter((id) => !activeSubscriptionUsesHandler(active, id));
+  if (inactiveIds.length === 0) return;
+  if (releaser?.releaseMany) {
+    releaser.releaseMany(inactiveIds);
+    return;
+  }
+  inactiveIds.forEach((id) => releaser?.release?.(id));
+}
+
+function activeSubscriptionUsesHandler(
+  active: Map<string, ActiveSubscription>,
+  id: number,
+): boolean {
+  return Array.from(active.values()).some((record) => record.mapHandlerIds.includes(id));
 }
 
 function flattenSubscriptions(
   input: unknown,
   mapHandlerIds: number[] = [],
+  mapHandlerKeys: string[] = [],
 ): VxSubscriptionEnvelope[] {
   if (input === undefined || input === null) return [];
   if (Array.isArray(input)) {
-    return input.flatMap((child) => flattenSubscriptions(child, mapHandlerIds));
+    return input.flatMap((child) => flattenSubscriptions(child, mapHandlerIds, mapHandlerKeys));
   }
   const envelope = readRuntimeEnvelope(input, "sub", "subscriptions");
   if (envelope.kind === "none") return [];
@@ -1332,23 +1423,31 @@ function flattenSubscriptions(
     if (!Object.hasOwn(envelope, "children")) {
       throw new Error("vx-dom: subscription batch missing required children");
     }
-    return flattenSubscriptions(envelope.children, mapHandlerIds);
+    return flattenSubscriptions(envelope.children, mapHandlerIds, mapHandlerKeys);
   }
   if (envelope.kind === "map") {
     const handlerId = readHandlerId(envelope);
     if (handlerId === undefined) throw new Error("vx-dom: subscription map missing numeric handlerId");
-    return flattenSubscriptions(readRequiredMappedChild(envelope, "subscription map"), [...mapHandlerIds, handlerId]);
+    const handlerKey = readHandlerKey(envelope) ?? `id:${handlerId}`;
+    return flattenSubscriptions(
+      readRequiredMappedChild(envelope, "subscription map"),
+      [...mapHandlerIds, handlerId],
+      [...mapHandlerKeys, handlerKey],
+    );
   }
   if (!optionalSubscriptionKey(envelope)) {
     throw new Error(`vx-dom: subscription "${envelope.kind}" requires a stable key`);
   }
   if (mapHandlerIds.length === 0) return [envelope];
-  return [{ ...envelope, [mapHandlerIdsProperty]: mapHandlerIds }];
+  return [{
+    ...envelope,
+    [mapHandlerIdsProperty]: mapHandlerIds,
+    [mapHandlerKeysProperty]: mapHandlerKeys,
+  }];
 }
 
 function subscriptionIdentityKey(subscription: VxSubscriptionEnvelope): string {
-  const mapPrefix = mappedHandlerIds(subscription)
-    .map((id) => `map:${id}`)
+  const mapPrefix = mappedHandlerIdentityParts(subscription)
     .join("/");
   const explicitKey = subscription.key ?? subscription.id;
   const base = `${subscription.kind}:${String(explicitKey)}`;
@@ -1356,7 +1455,12 @@ function subscriptionIdentityKey(subscription: VxSubscriptionEnvelope): string {
 }
 
 function subscriptionSignature(subscription: VxSubscriptionEnvelope): string {
-  return stableStringify(subscription);
+  const normalized = { ...subscription };
+  delete normalized[mapHandlerIdsProperty];
+  delete normalized[mapHandlerKeysProperty];
+  const mappedIdentity = mappedHandlerIdentityParts(subscription);
+  if (mappedIdentity.length > 0) normalized[mapHandlerIdentityProperty] = mappedIdentity;
+  return stableStringify(normalized);
 }
 
 function optionalSubscriptionKey(subscription: VxSubscriptionEnvelope): string | undefined {
@@ -1541,19 +1645,45 @@ function mapExecutionContext(
   };
 }
 
-function mapSubscriptionContext(
+function mutableMappedSubscriptionContext(
   subscription: VxSubscriptionEnvelope,
   context: VxRuntimeExecutionContext,
-): VxRuntimeExecutionContext {
-  return mappedHandlerIds(subscription).reduce(
-    (next, handlerId) => mapExecutionContext(next, handlerId),
-    context,
-  );
+): {
+  context: VxRuntimeExecutionContext;
+  setMapHandlerIds: (ids: number[]) => void;
+} {
+  let mapHandlerIds = mappedHandlerIds(subscription);
+  return {
+    context: {
+      signal: context.signal,
+      deferAfterCommands: context.deferAfterCommands,
+      reportError: context.reportError,
+      dispatch: (message) => context.dispatch(mapRuntimeMessage(message, mapHandlerIds)),
+    },
+    setMapHandlerIds: (ids) => {
+      mapHandlerIds = ids;
+    },
+  };
 }
 
 function mappedHandlerIds(subscription: VxSubscriptionEnvelope): number[] {
   const raw = subscription[mapHandlerIdsProperty];
   return Array.isArray(raw) ? raw.filter((id): id is number => typeof id === "number") : [];
+}
+
+function mappedHandlerKeys(subscription: VxSubscriptionEnvelope): string[] {
+  const raw = subscription[mapHandlerKeysProperty];
+  return Array.isArray(raw)
+    ? raw
+        .filter((key): key is string | number => typeof key === "string" || typeof key === "number")
+        .map((key) => String(key))
+    : [];
+}
+
+function mappedHandlerIdentityParts(subscription: VxSubscriptionEnvelope): string[] {
+  const keys = mappedHandlerKeys(subscription);
+  if (keys.length > 0) return keys.map((key) => `key:${key}`);
+  return mappedHandlerIds(subscription).map((id) => `id:${id}`);
 }
 
 function readHandlerId(input: Record<string, unknown>): number | undefined {
@@ -1562,6 +1692,11 @@ function readHandlerId(input: Record<string, unknown>): number | undefined {
     : typeof input.handler_id === "number"
       ? input.handler_id
       : undefined;
+}
+
+function readHandlerKey(input: Record<string, unknown>): string | undefined {
+  const raw = input.handlerKey ?? input.handler_key;
+  return typeof raw === "string" || typeof raw === "number" ? String(raw) : undefined;
 }
 
 function readTaskId(input: Record<string, unknown>): number | undefined {
@@ -1646,7 +1781,7 @@ function toVxMessage(input: unknown): VxMessage {
 }
 
 function mapRuntimeMessage(message: VxRuntimeMessage, handlerIds: readonly number[]): VxRuntimeMessage {
-  return handlerIds.reduce<VxRuntimeMessage>(
+  return handlerIds.reduceRight<VxRuntimeMessage>(
     (child, handlerId) => ({ kind: "map", handlerId, message: child }),
     message,
   );

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -354,12 +354,12 @@ async function mountRuntimeApp(
       dispatchQueued({ kind: "event", handlerId, payload }),
     dispatchMapped: async (handlerId, payload, mapHandlerIds) => {
       if (!options.handlers?.dispatch) {
-        await dispatchQueued(mapRuntimeMessage({ kind: "event", handlerId, payload }, mapHandlerIds));
+        await dispatchQueued(mapDomEventMessage({ kind: "event", handlerId, payload }, mapHandlerIds));
         return;
       }
       const message = await options.handlers.dispatch(handlerId, payload);
       if (message !== undefined) {
-        await dispatchQueued(mapRuntimeMessage(toRuntimeMessage(message), mapHandlerIds));
+        await dispatchQueued(mapDomEventMessage(toRuntimeMessage(message), mapHandlerIds));
       }
     },
     dispatchMessage: (message) => dispatchQueued(toRuntimeMessage(message)),
@@ -698,7 +698,7 @@ function patchEvents(
             return;
           }
           settleAsyncDispatch(handlers?.dispatchMessage?.(
-            mapRuntimeMessage({
+            mapDomEventMessage({
               kind: "event",
               handlerId: event.handlerId,
               payload,
@@ -712,7 +712,7 @@ function patchEvents(
           if (message !== undefined) {
             return handlers?.dispatchMessage?.(
               event.mapHandlerIds?.length
-                ? mapRuntimeMessage(toVxMessage(message), event.mapHandlerIds)
+                ? mapDomEventMessage(toVxMessage(message), event.mapHandlerIds)
                 : message,
             );
           }
@@ -723,7 +723,7 @@ function patchEvents(
         const message = toVxMessage(event.message);
         settleAsyncDispatch(handlers?.dispatchMessage?.(
           event.mapHandlerIds?.length
-            ? mapRuntimeMessage(message, event.mapHandlerIds)
+            ? mapDomEventMessage(message, event.mapHandlerIds)
             : event.message,
         ));
       }
@@ -1610,9 +1610,13 @@ function subscriptionMessage(
     kind: "subscription",
     subscriptionKind: subscription.kind,
     key: optionalSubscriptionKey(subscription),
-    ...(Object.hasOwn(subscription, "value") ? { value: subscription.value } : {}),
+    ...(shouldDispatchSubscriptionValue(subscription) ? { value: subscription.value } : {}),
     payload,
   };
+}
+
+function shouldDispatchSubscriptionValue(subscription: VxSubscriptionEnvelope): boolean {
+  return Object.hasOwn(subscription, "value") && subscription.valueRole !== "config";
 }
 
 function dispatchLocationChange(): void {
@@ -1808,6 +1812,13 @@ function toVxMessage(input: unknown): VxMessage {
 
 function mapRuntimeMessage(message: VxRuntimeMessage, handlerIds: readonly number[]): VxRuntimeMessage {
   return handlerIds.reduceRight<VxRuntimeMessage>(
+    (child, handlerId) => ({ kind: "map", handlerId, message: child }),
+    message,
+  );
+}
+
+function mapDomEventMessage(message: VxRuntimeMessage, handlerIds: readonly number[]): VxRuntimeMessage {
+  return handlerIds.reduce<VxRuntimeMessage>(
     (child, handlerId) => ({ kind: "map", handlerId, message: child }),
     message,
   );

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -1299,7 +1299,7 @@ function runWindowEventSubscription(
   context: VxRuntimeExecutionContext,
 ): VxSubscriptionDisposer | void {
   if (typeof window === "undefined") return;
-  const eventName = typeof subscription.event === "string" ? subscription.event : subscription.kind;
+  const eventName = windowEventName(subscription);
   const listener = () => {
     if (context.signal.aborted) return;
     settleAsyncDispatch(context.dispatch(subscriptionMessage(subscription, {
@@ -1309,6 +1309,13 @@ function runWindowEventSubscription(
   };
   window.addEventListener(eventName, listener);
   return () => window.removeEventListener(eventName, listener);
+}
+
+function windowEventName(subscription: VxSubscriptionEnvelope): string {
+  if (typeof subscription.event === "string") return subscription.event;
+  if (subscription.kind === "window_focus") return "focus";
+  if (subscription.kind === "window_blur") return "blur";
+  return subscription.kind;
 }
 
 async function syncRuntimeSubscriptions(

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -316,10 +316,7 @@ async function mountRuntimeApp(
   const activeSubscriptions = new Map<string, ActiveSubscription>();
   const runtimeHost = createBrowserVxRuntimeHost(options.runtimeHost);
   const reportError = createRuntimeErrorReporter(options.onError ?? runtimeHost.onError);
-  const retainedHandlerReleaser: RetainedHandlerReleaser = {
-    release: app.retainedCallbacks?.release ?? options.handlers?.release,
-    releaseMany: app.retainedCallbacks?.releaseMany ?? options.handlers?.releaseMany,
-  };
+  const retainedHandlerReleaser = retainedHandlerReleaserFor(app, options.handlers);
   const afterCommandCallbacks: Array<Array<() => void>> = [];
   let queue = Promise.resolve();
   const queuedRetainedHandlerReleaser: RetainedHandlerReleaser = {
@@ -469,6 +466,22 @@ async function mountRuntimeApp(
     getSnapshot() {
       return app.getSnapshot?.() ?? renderer.getSnapshot();
     },
+  };
+}
+
+function retainedHandlerReleaserFor(
+  app: VxAppRuntime,
+  handlers: RetainedEventHandlerRegistry | undefined,
+): RetainedHandlerReleaser {
+  if (app.retainedCallbacks?.release || app.retainedCallbacks?.releaseMany) {
+    return {
+      release: app.retainedCallbacks.release,
+      releaseMany: app.retainedCallbacks.releaseMany,
+    };
+  }
+  return {
+    release: handlers?.release,
+    releaseMany: handlers?.releaseMany,
   };
 }
 

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -101,6 +101,7 @@ type ActiveSubscription = {
   signature: string;
   dispose: VxSubscriptionDisposer;
   mapHandlerIds: number[];
+  ownedMapHandlerIds: number[];
   setMapHandlerIds: (ids: number[]) => void;
 };
 
@@ -108,6 +109,7 @@ type RetainedHandlerReleaser = Pick<RetainedEventHandlerRegistry, "release" | "r
 
 const mapHandlerIdsProperty = "__vxMapHandlerIds";
 const mapHandlerKeysProperty = "__vxMapHandlerKeys";
+const ownedMapHandlerIdsProperty = "__vxOwnedMapHandlerIds";
 const mapHandlerIdentityProperty = "__vxMapHandlerIdentity";
 const taskObserverProperty = Symbol.for("voyd.taskObserver");
 const locationChangeEvent = "vxlocationchange";
@@ -1037,7 +1039,7 @@ async function runReadClipboardCommand(
   }
   const value = await clipboard.readText();
   if (context.signal.aborted) return;
-  await context.dispatch({ kind: "map", handlerId, message: toVxMessage(value) });
+  settleAsyncDispatch(context.dispatch({ kind: "map", handlerId, message: toVxMessage(value) }));
 }
 
 function runReplaceUrlCommand(command: VxCommandEnvelope): void {
@@ -1338,9 +1340,10 @@ async function syncRuntimeSubscriptions(
     const key = subscriptionIdentityKey(subscription);
     const signature = subscriptionSignature(subscription);
     const mapHandlerIds = mappedHandlerIds(subscription);
+    const ownedMapHandlerIds = mappedOwnedHandlerIds(subscription);
     const previous = active.get(key);
     if (previous?.signature === signature) {
-      updateActiveSubscriptionMapHandlers(previous, mapHandlerIds, releaser, active);
+      updateActiveSubscriptionMapHandlers(previous, mapHandlerIds, ownedMapHandlerIds, releaser, active);
       continue;
     }
     if (previous) {
@@ -1355,6 +1358,7 @@ async function syncRuntimeSubscriptions(
       signature,
       dispose: dispose ?? (() => undefined),
       mapHandlerIds,
+      ownedMapHandlerIds,
       setMapHandlerIds: mappedContext.setMapHandlerIds,
     });
   }
@@ -1377,18 +1381,20 @@ async function disposeActiveSubscription(
   try {
     await record.dispose();
   } finally {
-    releaseRetainedHandlers(record.mapHandlerIds, releaser, active);
+    releaseRetainedHandlers(record.ownedMapHandlerIds, releaser, active);
   }
 }
 
 function updateActiveSubscriptionMapHandlers(
   record: ActiveSubscription,
   nextIds: number[],
+  nextOwnedIds: number[],
   releaser: RetainedHandlerReleaser | undefined,
   active: Map<string, ActiveSubscription>,
 ): void {
-  const removed = record.mapHandlerIds.filter((id) => !nextIds.includes(id));
+  const removed = record.ownedMapHandlerIds.filter((id) => !nextOwnedIds.includes(id));
   record.mapHandlerIds = nextIds;
+  record.ownedMapHandlerIds = nextOwnedIds;
   record.setMapHandlerIds(nextIds);
   releaseRetainedHandlers(removed, releaser, active);
 }
@@ -1412,17 +1418,20 @@ function activeSubscriptionUsesHandler(
   active: Map<string, ActiveSubscription>,
   id: number,
 ): boolean {
-  return Array.from(active.values()).some((record) => record.mapHandlerIds.includes(id));
+  return Array.from(active.values()).some((record) => record.ownedMapHandlerIds.includes(id));
 }
 
 function flattenSubscriptions(
   input: unknown,
   mapHandlerIds: number[] = [],
   mapHandlerKeys: string[] = [],
+  ownedMapHandlerIds: number[] = [],
 ): VxSubscriptionEnvelope[] {
   if (input === undefined || input === null) return [];
   if (Array.isArray(input)) {
-    return input.flatMap((child) => flattenSubscriptions(child, mapHandlerIds, mapHandlerKeys));
+    return input.flatMap((child) =>
+      flattenSubscriptions(child, mapHandlerIds, mapHandlerKeys, ownedMapHandlerIds)
+    );
   }
   const envelope = readRuntimeEnvelope(input, "sub", "subscriptions");
   if (envelope.kind === "none") return [];
@@ -1430,16 +1439,17 @@ function flattenSubscriptions(
     if (!Object.hasOwn(envelope, "children")) {
       throw new Error("vx-dom: subscription batch missing required children");
     }
-    return flattenSubscriptions(envelope.children, mapHandlerIds, mapHandlerKeys);
+    return flattenSubscriptions(envelope.children, mapHandlerIds, mapHandlerKeys, ownedMapHandlerIds);
   }
   if (envelope.kind === "map") {
     const handlerId = readHandlerId(envelope);
     if (handlerId === undefined) throw new Error("vx-dom: subscription map missing numeric handlerId");
-    const handlerKey = readHandlerKey(envelope) ?? `id:${handlerId}`;
+    const handlerKey = readHandlerKey(envelope);
     return flattenSubscriptions(
       readRequiredMappedChild(envelope, "subscription map"),
       [...mapHandlerIds, handlerId],
-      [...mapHandlerKeys, handlerKey],
+      [...mapHandlerKeys, handlerKey ?? `id:${handlerId}`],
+      handlerKey === undefined ? ownedMapHandlerIds : [...ownedMapHandlerIds, handlerId],
     );
   }
   if (!optionalSubscriptionKey(envelope)) {
@@ -1450,6 +1460,9 @@ function flattenSubscriptions(
     ...envelope,
     [mapHandlerIdsProperty]: mapHandlerIds,
     [mapHandlerKeysProperty]: mapHandlerKeys,
+    ...(ownedMapHandlerIds.length > 0
+      ? { [ownedMapHandlerIdsProperty]: ownedMapHandlerIds }
+      : {}),
   }];
 }
 
@@ -1465,6 +1478,7 @@ function subscriptionSignature(subscription: VxSubscriptionEnvelope): string {
   const normalized = { ...subscription };
   delete normalized[mapHandlerIdsProperty];
   delete normalized[mapHandlerKeysProperty];
+  delete normalized[ownedMapHandlerIdsProperty];
   const mappedIdentity = mappedHandlerIdentityParts(subscription);
   if (mappedIdentity.length > 0) normalized[mapHandlerIdentityProperty] = mappedIdentity;
   return stableStringify(normalized);
@@ -1675,6 +1689,11 @@ function mutableMappedSubscriptionContext(
 
 function mappedHandlerIds(subscription: VxSubscriptionEnvelope): number[] {
   const raw = subscription[mapHandlerIdsProperty];
+  return Array.isArray(raw) ? raw.filter((id): id is number => typeof id === "number") : [];
+}
+
+function mappedOwnedHandlerIds(subscription: VxSubscriptionEnvelope): number[] {
+  const raw = subscription[ownedMapHandlerIdsProperty];
   return Array.isArray(raw) ? raw.filter((id): id is number => typeof id === "number") : [];
 }
 

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -892,7 +892,6 @@ function collectHandlerIds(vnode: VNode): Set<number> {
     if (node.kind === "element") {
       (node.events ?? []).forEach((event) => {
         if (typeof event.handlerId === "number") ids.add(event.handlerId);
-        event.mapHandlerIds?.forEach((handlerId) => ids.add(handlerId));
       });
       (node.children ?? []).forEach(visit);
       return;
@@ -1121,7 +1120,7 @@ async function runReadClipboardCommand(
     if (context.signal.aborted) return;
     settleAsyncDispatch(context.dispatch({ kind: "map", handlerId, message: toVxMessage(value) }));
   } finally {
-    context.releaseRetainedHandler?.(handlerId);
+    mappedOwnedHandlerIds(command).forEach((id) => context.releaseRetainedHandler?.(id));
   }
 }
 
@@ -1553,8 +1552,15 @@ function subscriptionIdentityKey(subscription: VxSubscriptionEnvelope): string {
   const mapPrefix = mappedHandlerIdentityParts(subscription)
     .join("/");
   const explicitKey = subscription.key ?? subscription.id;
-  const base = `${subscription.kind}:${String(explicitKey)}`;
+  const base = `${subscriptionIdentityKind(subscription)}:${String(explicitKey)}`;
   return mapPrefix ? `${mapPrefix}|${base}` : base;
+}
+
+function subscriptionIdentityKind(subscription: VxSubscriptionEnvelope): string {
+  if (subscription.kind === "keyboard" && typeof subscription.event === "string") {
+    return `${subscription.kind}:${subscription.event}`;
+  }
+  return subscription.kind;
 }
 
 function subscriptionSignature(subscription: VxSubscriptionEnvelope): string {

--- a/packages/vx-dom/src/types.ts
+++ b/packages/vx-dom/src/types.ts
@@ -170,6 +170,7 @@ export type VxSubscriptionEnvelope = VxRuntimeEnvelope & {
 
 export type VxRuntimeExecutionContext = {
   dispatch(message: VxRuntimeMessage): Promise<void>;
+  deferAfterCommands?: (callback: () => void) => void;
   reportError?: VxRuntimeErrorHandler;
   signal: AbortSignal;
 };
@@ -219,6 +220,10 @@ export type VxAppRuntime = {
   init?: () => Promise<unknown> | unknown;
   render: () => Promise<unknown> | unknown;
   dispatch(message: VxRuntimeMessage): Promise<unknown> | unknown;
+  retainedCallbacks?: {
+    release?: (id: number) => void;
+    releaseMany?: (ids: Iterable<number>) => void;
+  };
   syncSubscriptions?: (
     next: unknown,
     context: VxSubscriptionSyncContext,

--- a/packages/vx-dom/src/types.ts
+++ b/packages/vx-dom/src/types.ts
@@ -171,6 +171,7 @@ export type VxSubscriptionEnvelope = VxRuntimeEnvelope & {
 export type VxRuntimeExecutionContext = {
   dispatch(message: VxRuntimeMessage): Promise<void>;
   deferAfterCommands?: (callback: () => void) => void;
+  releaseRetainedHandler?: (id: number) => void;
   reportError?: VxRuntimeErrorHandler;
   signal: AbortSignal;
 };

--- a/packages/vx-dom/src/types.ts
+++ b/packages/vx-dom/src/types.ts
@@ -172,6 +172,7 @@ export type VxRuntimeExecutionContext = {
   dispatch(message: VxRuntimeMessage): Promise<void>;
   deferAfterCommands?: (callback: () => void) => void;
   releaseRetainedHandler?: (id: number) => void;
+  trackRetainedHandlerUse?: (result: Promise<unknown> | unknown) => void;
   reportError?: VxRuntimeErrorHandler;
   signal: AbortSignal;
 };


### PR DESCRIPTION
## Summary

- Add named VX browser command constructors and default host handlers for clipboard, document title, history/navigation, URL hash, window scrolling, DOM text selection, opening URLs, and local/session storage writes/removals.
- Add typed payload subscription helpers for runtime/custom subscriptions, keyboard payload handlers, online/resize/visibility, location changes, window focus/blur, animation frames, media queries, storage events, and BroadcastChannel messages.
- Document the command/subscription host contracts and add unit plus smoke coverage for payload mapping from compiled Voyd code.

## Validation

- `npx vitest packages/vx-dom/src/__tests__/browser.test.ts packages/vx-dom/src/__tests__/app-runtime.test.ts apps/smoke/src/vx-dom.test.ts`
- `npm run typecheck`
- `npm test` (rerun with local socket access after sandbox blocked std-http listener creation on `127.0.0.1`)

## Review

- Agentic implementation-gap reviewer: no findings.
- Agentic correctness reviewer: no findings.
- Follow-up correctness reviewer before final push: found URL notification and storage nullability issues; both fixed.
- Final follow-up correctness reviewer after fixes: no findings.