### PR TITLE
Fix overloaded return-only type argument inference

### DIFF
--- a/apps/cli/src/bootstrap/loaders/vx-spa.ts
+++ b/apps/cli/src/bootstrap/loaders/vx-spa.ts
@@ -251,11 +251,11 @@ pub fn init() -> Model
 pub fn step(model: Model, message: Msg) -> Program<Model, Msg>
   match(message)
     Msg::Increment:
-      next<Model, Msg>(Model { count: model.count + 1, title: model.title })
+      next(Model { count: model.count + 1, title: model.title })
     Msg::Decrement:
-      next<Model, Msg>(Model { count: model.count - 1, title: model.title })
+      next(Model { count: model.count - 1, title: model.title })
     Msg::Rename { value }:
-      next<Model, Msg>(Model { count: model.count, title: value })
+      next(Model { count: model.count, title: value })
 
 pub fn view(model: Model) -> Html<Msg>
   <main class="min-h-screen bg-slate-950 px-6 py-12 text-slate-100">

--- a/apps/cli/src/bootstrap/loaders/web-ssr.ts
+++ b/apps/cli/src/bootstrap/loaders/web-ssr.ts
@@ -873,7 +873,7 @@ fn init() -> ClientArticle
 fn step(model: ClientArticle, message: Msg): (http_client::HttpClient, tasks::TaskRuntime) -> Program<ClientArticle, Msg>
   match(message)
     Msg::Edit { value }:
-      next<ClientArticle, Msg>(ClientArticle {
+      next(ClientArticle {
         slug: model.slug,
         title: model.title,
         body: value,
@@ -884,7 +884,7 @@ fn step(model: ClientArticle, message: Msg): (http_client::HttpClient, tasks::Ta
         save_count: model.save_count
       })
     Msg::Reset:
-      next<ClientArticle, Msg>(ClientArticle {
+      next(ClientArticle {
         slug: model.slug,
         title: model.title,
         body: model.saved_body,
@@ -895,7 +895,7 @@ fn step(model: ClientArticle, message: Msg): (http_client::HttpClient, tasks::Ta
         save_count: model.save_count
       })
     Msg::TogglePreview:
-      next<ClientArticle, Msg>(ClientArticle {
+      next(ClientArticle {
         slug: model.slug,
         title: model.title,
         body: model.body,
@@ -907,7 +907,7 @@ fn step(model: ClientArticle, message: Msg): (http_client::HttpClient, tasks::Ta
       })
     Msg::Save:
       if is_saving(model) or not is_dirty(model):
-        return next<ClientArticle, Msg>(model)
+        return next(model)
       program<ClientArticle, Msg>(
         model: ClientArticle {
           slug: model.slug,
@@ -926,7 +926,7 @@ fn step(model: ClientArticle, message: Msg): (http_client::HttpClient, tasks::Ta
       )
     Msg::SaveFinished { code }:
       if code == 1:
-        return next<ClientArticle, Msg>(ClientArticle {
+        return next(ClientArticle {
           slug: model.slug,
           title: model.title,
           body: model.body,
@@ -936,7 +936,7 @@ fn step(model: ClientArticle, message: Msg): (http_client::HttpClient, tasks::Ta
           preview_open: model.preview_open,
           save_count: model.save_count + 1
         })
-      next<ClientArticle, Msg>(ClientArticle {
+      next(ClientArticle {
         slug: model.slug,
         title: model.title,
         body: model.body,

--- a/apps/site/app/routes/playground.tsx
+++ b/apps/site/app/routes/playground.tsx
@@ -34,7 +34,7 @@ fn init() -> Model
 fn step(model: Model, message: Msg) -> Program<Model, Msg>
   match(message)
     Msg::Increment:
-      next<Model, Msg>(Model { count: model.count + 1 })
+      next(Model { count: model.count + 1 })
 
 fn view(model: Model) -> Html<Msg>
   <main style="

--- a/apps/site/examples/wiki/wiki.voyd
+++ b/apps/site/examples/wiki/wiki.voyd
@@ -51,7 +51,7 @@ fn init() -> WikiModel
 fn step(model: WikiModel, message: WikiMsg) -> Program<WikiModel, WikiMsg>
   match(message)
     WikiMsg::Select { page }:
-      next<WikiModel, WikiMsg>(WikiModel {
+      next(WikiModel {
         selected: page,
         query: model.query,
         title: page_title(page),
@@ -62,7 +62,7 @@ fn step(model: WikiModel, message: WikiMsg) -> Program<WikiModel, WikiMsg>
         status: "Page opened"
       })
     WikiMsg::Search { value }:
-      next<WikiModel, WikiMsg>(WikiModel {
+      next(WikiModel {
         selected: model.selected,
         query: value,
         title: model.title,
@@ -73,7 +73,7 @@ fn step(model: WikiModel, message: WikiMsg) -> Program<WikiModel, WikiMsg>
         status: search_status(value)
       })
     WikiMsg::New:
-      next<WikiModel, WikiMsg>(WikiModel {
+      next(WikiModel {
         selected: "draft",
         query: String::init(),
         title: "Untitled page",
@@ -84,7 +84,7 @@ fn step(model: WikiModel, message: WikiMsg) -> Program<WikiModel, WikiMsg>
         status: "New page"
       })
     WikiMsg::EditTitle { value }:
-      next<WikiModel, WikiMsg>(WikiModel {
+      next(WikiModel {
         selected: model.selected,
         query: model.query,
         title: value,
@@ -95,7 +95,7 @@ fn step(model: WikiModel, message: WikiMsg) -> Program<WikiModel, WikiMsg>
         status: "Unsaved changes"
       })
     WikiMsg::EditBody { value }:
-      next<WikiModel, WikiMsg>(WikiModel {
+      next(WikiModel {
         selected: model.selected,
         query: model.query,
         title: model.title,
@@ -106,7 +106,7 @@ fn step(model: WikiModel, message: WikiMsg) -> Program<WikiModel, WikiMsg>
         status: "Unsaved changes"
       })
     WikiMsg::Save:
-      next<WikiModel, WikiMsg>(
+      next(
         model: WikiModel {
           selected: model.selected,
           query: model.query,
@@ -120,7 +120,7 @@ fn step(model: WikiModel, message: WikiMsg) -> Program<WikiModel, WikiMsg>
         cmd: Cmd<WikiMsg>::delay(millis: 1i64, value: WikiMsg::Saved {})
       )
     WikiMsg::Saved:
-      next<WikiModel, WikiMsg>(WikiModel {
+      next(WikiModel {
         selected: model.selected,
         query: model.query,
         title: model.title,
@@ -131,7 +131,7 @@ fn step(model: WikiModel, message: WikiMsg) -> Program<WikiModel, WikiMsg>
         status: "Saved"
       })
     WikiMsg::Cancel:
-      next<WikiModel, WikiMsg>(WikiModel {
+      next(WikiModel {
         selected: model.selected,
         query: model.query,
         title: model.saved_title,
@@ -142,7 +142,7 @@ fn step(model: WikiModel, message: WikiMsg) -> Program<WikiModel, WikiMsg>
         status: "Draft restored"
       })
     WikiMsg::TogglePanel:
-      next<WikiModel, WikiMsg>(WikiModel {
+      next(WikiModel {
         selected: model.selected,
         query: model.query,
         title: model.title,

--- a/apps/smoke/fixtures/vx-async-task-command.voyd
+++ b/apps/smoke/fixtures/vx-async-task-command.voyd
@@ -23,7 +23,7 @@ fn init() -> Model
 fn step(model: Model, msg: Msg): tasks::TaskRuntime -> Program<Model, Msg>
   match(msg)
     Msg::Save:
-      next<Model, Msg>(
+      next(
         model: Model { status: "Saving..." },
         cmd: Cmd<Msg>::task(
           work: () -> MsgPack => msgpack::make_i32(41),
@@ -31,7 +31,7 @@ fn step(model: Model, msg: Msg): tasks::TaskRuntime -> Program<Model, Msg>
         )
       )
     Msg::Saved { value }:
-      next<Model, Msg>(Model { status: saved_label(value) })
+      next(Model { status: saved_label(value) })
 
 fn view(model: Model) -> Html<Msg>
   <button type="button" on_click={Msg::Save {}}>{model.status}</button>

--- a/apps/smoke/fixtures/vx-typed-counter.voyd
+++ b/apps/smoke/fixtures/vx-typed-counter.voyd
@@ -33,9 +33,9 @@ fn init() -> Model
 fn step(model: Model, msg: Msg) -> Program<Model, Msg>
   match(msg)
     Msg::Increment:
-      next<Model, Msg>(Model { count: model.count + 1, title: model.title })
+      next(Model { count: model.count + 1, title: model.title })
     Msg::Rename { value }:
-      next<Model, Msg>(Model { count: model.count, title: value })
+      next(Model { count: model.count, title: value })
 
 fn view(model: Model) -> Html<Msg>
   <div>
@@ -50,10 +50,10 @@ pub fn delayed() -> Cmd<Msg>
   Cmd<Msg>::delay(millis: 25i64, value: Msg::Increment {})
 
 pub fn program_command(model: Model) -> Program<Model, Msg>
-  next<Model, Msg>(model: model, cmd: Cmd<Msg>::message(Msg::Increment {}))
+  next(model: model, cmd: Cmd<Msg>::message(Msg::Increment {}))
 
 pub fn mapped_program_result() -> Program<Model, Msg>
-  let child = next<Model, Msg>(
+  let child = next(
     model: Model { count: 3, title: "Mapped" },
     cmd: Cmd<Msg>::message(Msg::Increment {})
   )

--- a/examples/mini-wikipedia/src/client.voyd
+++ b/examples/mini-wikipedia/src/client.voyd
@@ -46,7 +46,7 @@ fn init() -> ClientArticle
 fn step(model: ClientArticle, message: Msg): (http_client::HttpClient, tasks::TaskRuntime) -> Program<ClientArticle, Msg>
   match(message)
     Msg::Edit { value }:
-      next<ClientArticle, Msg>(ClientArticle {
+      next(ClientArticle {
         slug: model.slug,
         title: model.title,
         body: value,
@@ -57,7 +57,7 @@ fn step(model: ClientArticle, message: Msg): (http_client::HttpClient, tasks::Ta
         save_count: model.save_count
       })
     Msg::Reset:
-      next<ClientArticle, Msg>(ClientArticle {
+      next(ClientArticle {
         slug: model.slug,
         title: model.title,
         body: model.saved_body,
@@ -68,7 +68,7 @@ fn step(model: ClientArticle, message: Msg): (http_client::HttpClient, tasks::Ta
         save_count: model.save_count
       })
     Msg::TogglePreview:
-      next<ClientArticle, Msg>(ClientArticle {
+      next(ClientArticle {
         slug: model.slug,
         title: model.title,
         body: model.body,
@@ -80,8 +80,8 @@ fn step(model: ClientArticle, message: Msg): (http_client::HttpClient, tasks::Ta
       })
     Msg::Save:
       if is_saving(model) or not is_dirty(model):
-        return next<ClientArticle, Msg>(model)
-      next<ClientArticle, Msg>(
+        return next(model)
+      next(
         model: ClientArticle {
           slug: model.slug,
           title: model.title,
@@ -99,7 +99,7 @@ fn step(model: ClientArticle, message: Msg): (http_client::HttpClient, tasks::Ta
       )
     Msg::SaveFinished { code }:
       if code == 1:
-        return next<ClientArticle, Msg>(ClientArticle {
+        return next(ClientArticle {
           slug: model.slug,
           title: model.title,
           body: model.body,
@@ -109,7 +109,7 @@ fn step(model: ClientArticle, message: Msg): (http_client::HttpClient, tasks::Ta
           preview_open: model.preview_open,
           save_count: model.save_count + 1
         })
-      next<ClientArticle, Msg>(ClientArticle {
+      next(ClientArticle {
         slug: model.slug,
         title: model.title,
         body: model.body,

--- a/packages/compiler/src/__tests__/__fixtures__/overload_generic_expected_return_match.voyd
+++ b/packages/compiler/src/__tests__/__fixtures__/overload_generic_expected_return_match.voyd
@@ -1,0 +1,34 @@
+pub obj Cmd<T> {
+  value: T
+}
+
+pub obj Program<T, U> {
+  model: T
+}
+
+pub fn message<Msg>(value: Msg) -> Cmd<Msg>
+  Cmd<Msg> { value }
+
+pub fn next<Model, Msg>(model: Model) -> Program<Model, Msg>
+  Program<Model, Msg> { model }
+
+pub fn next<Model, Msg>({ model: Model, cmd: Cmd<Msg> }) -> Program<Model, Msg>
+  Program<Model, Msg> { model }
+
+pub obj Model {
+  count: i32
+}
+
+pub obj Tick {}
+pub obj Done {}
+pub type Msg = Tick | Done
+
+fn step(model: Model, msg: Msg) -> Program<Model, Msg>
+  match(msg)
+    Tick:
+      next(model: Model { count: model.count + 1 }, cmd: message(Done {}))
+    Done:
+      next(model)
+
+pub fn main() -> i32
+  0

--- a/packages/compiler/src/__tests__/static-access.test.ts
+++ b/packages/compiler/src/__tests__/static-access.test.ts
@@ -178,6 +178,22 @@ describe("static access e2e", () => {
     expect((instance.exports.main as () => number)()).toBe(1);
   });
 
+  it("infers return-only generic type arguments for overloaded calls in expected branch contexts", async () => {
+    const root = resolve("/proj/src");
+    const mainPath = `${root}${sep}main.voyd`;
+    const host = createFixtureHost({
+      [mainPath]: loadFixture("overload_generic_expected_return_match.voyd"),
+    });
+
+    const result = expectCompileSuccess(await compileProgram({
+      entryPath: mainPath,
+      roots: { src: root },
+      host,
+    }));
+    const instance = getWasmInstance(result.wasm!);
+    expect((instance.exports.main as () => number)()).toBe(0);
+  });
+
   it("keeps codegen call argument planning aligned with typing labels", async () => {
     const root = resolve("/proj/src");
     const mainPath = `${root}${sep}main.voyd`;

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export-contract.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export-contract.voyd
@@ -17,7 +17,7 @@ fn init() -> Model
 fn step(model: Model, msg: Msg) -> Program<Model, Msg>
   match(msg)
     Msg::Increment:
-      next<Model, Msg>(Model { count: model.count + 1 })
+      next(Model { count: model.count + 1 })
 
 fn view(model: Model) -> Html<Msg>
   <button on_click={Msg::Increment {}}>

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export-unsupported.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export-unsupported.voyd
@@ -15,7 +15,7 @@ fn init() -> CallbackModel
   CallbackModel { apply: read_value }
 
 fn step(model: CallbackModel, _msg: Msg) -> Program<CallbackModel, Msg>
-  next<CallbackModel, Msg>(model)
+  next(model)
 
 fn view(_model: CallbackModel) -> Html<Msg>
   <div></div>

--- a/packages/compiler/src/semantics/typing/expressions/if.ts
+++ b/packages/compiler/src/semantics/typing/expressions/if.ts
@@ -14,6 +14,7 @@ export const typeIfExpr = (
 ): TypeId => {
   const hasDefault = typeof expr.defaultBranch === "number";
   const discardValue = options.discardValue === true || !hasDefault;
+  const expectedBranchType = discardValue ? undefined : options.expectedType;
   let branchType: TypeId | undefined;
   let effectRow = ctx.effects.emptyRow;
 
@@ -30,7 +31,10 @@ export const typeIfExpr = (
       conditionSpan,
     );
 
-    const valueType = typeExpression(branch.value, ctx, state, { discardValue });
+    const valueType = typeExpression(branch.value, ctx, state, {
+      discardValue,
+      expectedType: expectedBranchType,
+    });
     effectRow = ctx.effects.compose(
       effectRow,
       composeEffectRows(ctx.effects, [
@@ -53,6 +57,7 @@ export const typeIfExpr = (
   if (hasDefault) {
     const defaultType = typeExpression(expr.defaultBranch!, ctx, state, {
       discardValue,
+      expectedType: expectedBranchType,
     });
     effectRow = ctx.effects.compose(
       effectRow,

--- a/packages/compiler/src/semantics/typing/expressions/match.ts
+++ b/packages/compiler/src/semantics/typing/expressions/match.ts
@@ -36,6 +36,7 @@ export const typeMatchExpr = (
   options: TypeExpressionOptions
 ): TypeId => {
   const discardValue = options.discardValue === true;
+  const expectedArmType = discardValue ? undefined : options.expectedType;
   const rawDiscriminantType = typeExpression(expr.discriminant, ctx, state);
   const discriminantType = ctx.arena.unfoldRecursive(rawDiscriminantType);
   const discriminantExpr = ctx.hir.expressions.get(expr.discriminant);
@@ -89,7 +90,11 @@ export const typeMatchExpr = (
       discriminantSymbol,
       narrowed,
       ctx,
-      () => typeExpression(arm.value, ctx, state, { discardValue })
+      () =>
+        typeExpression(arm.value, ctx, state, {
+          discardValue,
+          expectedType: expectedArmType,
+        })
     );
     armEffectRow = ctx.effects.compose(
       armEffectRow,

--- a/packages/reference/docs/vx.md
+++ b/packages/reference/docs/vx.md
@@ -89,9 +89,9 @@ fn init() -> Model
 fn step(model: Model, msg: Msg) -> Program<Model, Msg>
   match(msg)
     Msg::Increment:
-      next<Model, Msg>(Model { count: model.count + 1 })
+      next(Model { count: model.count + 1 })
     Msg::Decrement:
-      next<Model, Msg>(Model { count: model.count - 1 })
+      next(Model { count: model.count - 1 })
 
 fn view(model: Model) -> Html<Msg>
   <main>
@@ -151,7 +151,7 @@ case `init` returns `next(model: initial_model, cmd: load())`.
 Inside `step`, return `next`:
 
 ```voyd
-next<Model, Msg>(next_model)
+next(next_model)
 next(model: next_model, cmd: save_title(next_model.title))
 ```
 
@@ -184,7 +184,7 @@ This keeps `step` readable. Each branch answers two questions:
 fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
   match(msg)
     Msg::DraftChanged { value }:
-      next<Model, Msg>(Model { draft: value, saving: model.saving })
+      next(Model { draft: value, saving: model.saving })
     Msg::Submit:
       next(
         model: Model { draft: model.draft, saving: true },
@@ -213,12 +213,12 @@ Most branches have this shape:
 
 ```voyd
 Msg::DraftChanged { value }:
-  next<Model, Msg>(with_draft(model, value))
+  next(with_draft(model, value))
 Msg::Submit:
   next(model: saving_now(model), cmd: save_draft(model.draft))
 ```
 
-Use `next<Model, Msg>(next_model)` for a pure state transition. Use
+Use `next(next_model)` for a pure state transition. Use
 `next(model:, cmd:)` when the transition also starts one-off work.
 
 Commands returned from `step` are descriptions. The runtime runs them after it
@@ -232,9 +232,9 @@ When a branch becomes large, extract the model update into a named helper:
 Msg::Saved { result }:
   match(result)
     Ok { value }:
-      next<Model, Msg>(saved(model, value))
+      next(saved(model, value))
     Err { error }:
-      next<Model, Msg>(with_error(model, error))
+      next(with_error(model, error))
 
 fn saved(model: Model, todo: Todo) -> Model
   Model {
@@ -876,7 +876,7 @@ button click or command result:
 fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
   match(msg)
     Msg::Tick:
-      next<Model, Msg>(Model { ticks: model.ticks + 1 })
+      next(Model { ticks: model.ticks + 1 })
     Msg::Autosave:
       next(model: model, cmd: save_draft(model.draft))
 ```
@@ -1014,9 +1014,9 @@ fn subscriptions(model: Model) -> Sub<Msg>
 fn step(model: Model, msg: Msg) -> Program<Model, Msg>
   match(msg)
     Msg::StartEdit { id }:
-      next<Model, Msg>(Model { editing_id: id })
+      next(Model { editing_id: id })
     Msg::CancelEdit:
-      next<Model, Msg>(Model { editing_id: String::init() })
+      next(Model { editing_id: String::init() })
 ```
 
 When `StartEdit` sets `editing_id`, the next subscription pass starts the Escape
@@ -1047,15 +1047,15 @@ enum Msg
 pub fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
   match(msg)
     Msg::DraftChanged { value }:
-      next<Model, Msg>(with_draft(model, value))
+      next(with_draft(model, value))
     Msg::Submit:
       next(model: saving_now(model), cmd: create_todo(model.draft))
     Msg::Created { result }:
       match(result)
         Ok { value }:
-          next<Model, Msg>(adding(model, value))
+          next(adding(model, value))
         Err { error }:
-          next<Model, Msg>(with_error(model, error))
+          next(with_error(model, error))
 ```
 
 The parent model keeps the feature model as a field:
@@ -1338,23 +1338,23 @@ fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
     Msg::Loaded { result }:
       match(result)
         Ok { value }:
-          next<Model, Msg>(with_todos(model, value))
+          next(with_todos(model, value))
         Err { error }:
-          next<Model, Msg>(with_error(model, error))
+          next(with_error(model, error))
     Msg::DraftChanged { value }:
-      next<Model, Msg>(with_draft(model, value))
+      next(with_draft(model, value))
     Msg::Submit:
       next(model: saving_now(model), cmd: create_todo(model.draft))
     Msg::Created { result }:
       match(result)
         Ok { value }:
-          next<Model, Msg>(adding(model, value))
+          next(adding(model, value))
         Err { error }:
-          next<Model, Msg>(with_error(model, error))
+          next(with_error(model, error))
     Msg::StartEdit { id, title }:
-      next<Model, Msg>(start_edit(model, id, title))
+      next(start_edit(model, id, title))
     Msg::EditChanged { value }:
-      next<Model, Msg>(with_edit(model, value))
+      next(with_edit(model, value))
     Msg::SaveEdit:
       next(
         model: saving_now(model),
@@ -1363,19 +1363,19 @@ fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
     Msg::Saved { result }:
       match(result)
         Ok { value }:
-          next<Model, Msg>(replacing(model, value))
+          next(replacing(model, value))
         Err { error }:
-          next<Model, Msg>(with_error(model, error))
+          next(with_error(model, error))
     Msg::Delete { id }:
       next(model: saving_now(model), cmd: delete_todo(id))
     Msg::Deleted { result }:
       match(result)
         Ok { value }:
-          next<Model, Msg>(removing(model, value))
+          next(removing(model, value))
         Err { error }:
-          next<Model, Msg>(with_error(model, error))
+          next(with_error(model, error))
     Msg::CancelEdit:
-      next<Model, Msg>(cancel_edit(model))
+      next(cancel_edit(model))
 ```
 
 This example is pessimistic: it waits for persistence to succeed before changing
@@ -1527,23 +1527,23 @@ fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
     Msg::Loaded { result }:
       match(result)
         Ok { value }:
-          next<Model, Msg>(with_todos(model, value))
+          next(with_todos(model, value))
         Err { error }:
-          next<Model, Msg>(with_error(model, error))
+          next(with_error(model, error))
     Msg::DraftChanged { value }:
-      next<Model, Msg>(with_draft(model, value))
+      next(with_draft(model, value))
     Msg::Submit:
       next(model: saving_now(model), cmd: create_todo(model.draft))
     Msg::Created { result }:
       match(result)
         Ok { value }:
-          next<Model, Msg>(adding(model, value))
+          next(adding(model, value))
         Err { error }:
-          next<Model, Msg>(with_error(model, error))
+          next(with_error(model, error))
     Msg::StartEdit { id, title }:
-      next<Model, Msg>(start_edit(model, id, title))
+      next(start_edit(model, id, title))
     Msg::EditChanged { value }:
-      next<Model, Msg>(with_edit(model, value))
+      next(with_edit(model, value))
     Msg::SaveEdit:
       next(
         model: saving_now(model),
@@ -1552,19 +1552,19 @@ fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
     Msg::Saved { result }:
       match(result)
         Ok { value }:
-          next<Model, Msg>(replacing(model, value))
+          next(replacing(model, value))
         Err { error }:
-          next<Model, Msg>(with_error(model, error))
+          next(with_error(model, error))
     Msg::Delete { id }:
       next(model: saving_now(model), cmd: delete_todo(id))
     Msg::Deleted { result }:
       match(result)
         Ok { value }:
-          next<Model, Msg>(removing(model, value))
+          next(removing(model, value))
         Err { error }:
-          next<Model, Msg>(with_error(model, error))
+          next(with_error(model, error))
     Msg::CancelEdit:
-      next<Model, Msg>(cancel_edit(model))
+      next(cancel_edit(model))
 
 fn load_todos(): TaskRuntime -> Cmd<Msg>
   Cmd::task(


### PR DESCRIPTION
## Summary

Fixes V-409 by propagating contextual expected types into valued `match` and `if` branches, allowing overloaded generic calls like `next(model)` to infer return-only type arguments from the enclosing `Program<Model, Msg>` return type.

Also updates VX docs, examples, smoke fixtures, bootstrap templates, playground/default examples, and related VX codegen fixtures to use `next(...)` without redundant explicit type arguments where inference is now clear.

## Root Cause

The generic call instantiation path could infer type parameters from an expected return type, but valued branch expressions were typed without the enclosing expected type. In VX `step` functions, that meant the pure `next(model)` match arm never received `Program<Model, Msg>` as context, so `Msg` stayed unbound.

## Validation

- `npx vt --run /private/tmp/v409-repro.voyd`
- `npx vitest packages/compiler/src/__tests__/static-access.test.ts --run`
- `npx vitest apps/smoke/src/vx-dom.test.ts --run`
- `npx vitest apps/cli/src/__tests__/bootstrap.test.ts --run`
- `npx vitest packages/compiler/src/codegen/__tests__/export-abi.test.ts --run`
- `git diff --check`
- `npm test` (rerun with escalation after sandbox blocked local HTTP listener tests)
- `npm run typecheck`
