### PR TITLE
V-375: Reuse dependency semantic snapshots for app edits

### DIFF
--- a/docs/compiler-performance.md
+++ b/docs/compiler-performance.md
@@ -24,10 +24,10 @@ Snapshot safety:
 - The snapshot freezes a cloned dependency semantics map at the pre-`src`
   boundary. This avoids source-time generic/type mutations leaking back into the
   cached std/pkg state.
-- `TypeArena` is cloneable through an internal snapshot of descriptors, schemes,
-  recursive unfold cache, and ID counters. Its descriptor cache is rebuilt with
-  first occurrence wins so noncanonical duplicate descriptor slots do not become
-  canonical after cloning.
+- `TypeArena` is cloneable through an internal snapshot of descriptors,
+  descriptor cache canonical ids, schemes, recursive unfold cache, and ID
+  counters. Restored arenas preserve the same canonical type ids as the
+  original arena.
 - `EffectInterner`, `EffectTable`, `TypeTable`, and the typing stores are
   cloned into the per-compile arena/effect state. Source modules get an overlay
   typing state; cached dependency modules never share mutable emit-time state

--- a/docs/compiler-performance.md
+++ b/docs/compiler-performance.md
@@ -1,5 +1,87 @@
 # Performance Log
 
+**21 Jun 2026 - V-375 dependency semantic snapshots**
+
+Added compiler-owned dependency semantic snapshots for repeated
+`createSdk().compile(...)` calls where app code changes between compiles:
+
+- The cache snapshots only non-`src` modules (`std` and installed `pkg`
+  modules). A one-line app edit reuses the dependency snapshot and recomputes
+  `src` modules against a cloned typing state.
+- The key includes a compiler snapshot version, `includeTests`, dependency root
+  inputs (`std`, `pkg`, `pkgDirs`), and fingerprints of every non-`src` module:
+  source, source files, origin, dependencies, source package root, and macro
+  exports.
+- App source is intentionally not part of the dependency snapshot key. App
+  changes reuse the snapshot; std/package source changes miss and rebuild it.
+- Dynamic `resolvePackageRoot` disables reuse because resolver state is not
+  safely fingerprintable.
+- There is no whole-graph wasm artifact cache in this path. Every app edit still
+  re-emits wasm, so runtime bytes may change even when behavior does not.
+
+Snapshot safety:
+
+- The snapshot freezes a cloned dependency semantics map at the pre-`src`
+  boundary. This avoids source-time generic/type mutations leaking back into the
+  cached std/pkg state.
+- `TypeArena` is cloneable through an internal snapshot of descriptors, schemes,
+  recursive unfold cache, and ID counters. Its descriptor cache is rebuilt with
+  first occurrence wins so noncanonical duplicate descriptor slots do not become
+  canonical after cloning.
+- `EffectInterner`, `EffectTable`, `TypeTable`, and the typing stores are
+  cloned into the per-compile arena/effect state. Source modules get an overlay
+  typing state; cached dependency modules never share mutable emit-time state
+  with the next compile.
+- The SDK tests cover app edits, std edits, installed package edits, and a
+  generic-heavy vtrace app edit that validates and runs the warm wasm.
+
+The warm edit appends a tiny private marker function to the app source, so the
+benchmark mutates the parsed AST while preserving the measured entrypoint result.
+
+Benchmark command:
+
+```sh
+VOYD_COMPILER_LATENCY_REPEATS=2 VOYD_COMPILER_LATENCY_VTRACE_RUNTIME_SAMPLES=0 npm run bench:compiler-latency
+```
+
+Baseline mode approximating no dependency snapshot reuse:
+
+```sh
+VOYD_COMPILER_LATENCY_FRESH_SDK=1 VOYD_COMPILER_LATENCY_REPEATS=2 VOYD_COMPILER_LATENCY_VTRACE_RUNTIME_SAMPLES=0 npm run bench:compiler-latency
+```
+
+Local M-series run, optimized mode, one-line app edit between iterations:
+
+| Scenario | Fresh app-edit ms | Snapshot app-edit ms | Saved ms | Saved |
+| --- | ---: | ---: | ---: | ---: |
+| `smoke/std-math-transcendentals` | 2718.375 | 1959.845 | 758.530 | 27.9% |
+| `smoke/scalar-aggregate-representative` | 2218.074 | 1608.122 | 609.952 | 27.5% |
+| `smoke/vtrace-compute-main` | 5369.959 | 4756.137 | 613.822 | 11.4% |
+| `smoke/vtrace-compute-benchmark` | 5384.718 | 4687.184 | 697.534 | 13.0% |
+| `voyd_examples/ray-vtrace-tuned` | 5787.530 | 5157.944 | 629.586 | 10.9% |
+
+`VOYD_COMPILER_PERF=1` on `smoke/vtrace-compute-main` showed the warm app-edit
+compile hitting the snapshot for all 49 std modules. The profiled cold compile
+spent about 970 ms in semantic analysis and 4689 ms in emit; the warm app-edit
+spent about 172 ms in semantic analysis and 4411 ms in emit. The remaining
+optimized latency is therefore dominated by whole-program emit/codegen rather
+than std typing.
+
+The optional suite benchmark at
+`/Users/drew/projects/voyd_examples/benchmarks/suite/voyd/benchmarks.voyd`
+still fails before codegen with `cannot overload log; module with the same name
+already exists`, so it is skipped by the harness. The ray vtrace external
+scenario at
+`/Users/drew/projects/voyd_examples/benchmarks/ray/voyd/vtrace_tuned.voyd`
+compiled successfully.
+
+Existing compiler perf benchmark baseline from the same run shape:
+
+| Compiler benchmark | hz | mean ms | p75 ms | p99 ms | samples |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `typing overload fanout (48 candidates)` | 4979.64 | 0.2008 | 0.2085 | 0.3980 | 2490 |
+| `typing union-heavy type satisfaction (80 members)` | 2520.85 | 0.3967 | 0.3934 | 1.2552 | 1261 |
+
 **20 Feb 2026**
 
 Added debug-only compiler perf instrumentation behind `VOYD_COMPILER_PERF=1`.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:codegen": "npm run --workspace @voyd-lang/compiler test:codegen --",
     "test:full": "npm test && npm run test:codegen && npm run --workspace @voyd-lang/cli test:e2e",
     "test:perf:smoke": "npm --workspace @voyd-lang/smoke run test:perf",
+    "bench:compiler-latency": "tsx --conditions=development scripts/bench-v375-compiler-latency.ts && npm run --workspace @voyd-lang/compiler bench:typing",
     "typecheck": "turbo run typecheck --affected",
     "lint": "turbo run lint --affected --parallel",
     "dev": "turbo run dev --affected --parallel",

--- a/packages/compiler/src/__tests__/dependency-snapshot-cache.test.ts
+++ b/packages/compiler/src/__tests__/dependency-snapshot-cache.test.ts
@@ -35,6 +35,7 @@ const loadAndAnalyze = async ({
   });
   const analyzed = analyzeModules({
     graph,
+    captureDependencySnapshot: Boolean(prepared.key),
     previousSemantics: prepared.previousSemantics,
     typingState: prepared.typingState,
   });
@@ -89,6 +90,20 @@ const buildFiles = ({
 };
 
 describe("compiler dependency snapshots", () => {
+  it("does not capture dependency semantics unless requested", async () => {
+    const initial = buildFiles({ appValue: 1, stdValue: 10, pkgValue: 100 });
+    const host = createMemoryHost(initial.files);
+    const graph = await loadModuleGraph({
+      entryPath: `${initial.roots.src}${sep}main.voyd`,
+      roots: initial.roots,
+      host,
+    });
+
+    const analyzed = analyzeModules({ graph });
+
+    expect(analyzed.dependencySnapshot).toBeUndefined();
+  });
+
   it("reuses std and installed package semantics after a source edit", async () => {
     const cache = createCompilerDependencySnapshotCache();
     const initial = buildFiles({ appValue: 1, stdValue: 10, pkgValue: 100 });
@@ -187,5 +202,60 @@ describe("compiler dependency snapshots", () => {
       "src::helper",
       "src::main",
     ]);
+  });
+
+  it("does not snapshot package modules with unresolved transitive dependencies", async () => {
+    const cache = createCompilerDependencySnapshotCache();
+    const srcRoot = resolve("/unsafe/src");
+    const pkgRoot = resolve("/unsafe/packages");
+    const roots = { src: srcRoot, pkgDirs: [pkgRoot] };
+    const files = {
+      [`${srcRoot}${sep}main.voyd`]: [
+        "#!no_prelude",
+        "use pkg::dep::all",
+        "",
+        "pub fn main() -> i32",
+        "  outer_value()",
+      ].join("\n"),
+      [`${srcRoot}${sep}helper.voyd`]: [
+        "#!no_prelude",
+        "pub fn helper_value() -> i32",
+        "  1",
+      ].join("\n"),
+      [`${pkgRoot}${sep}dep${sep}src${sep}pkg.voyd`]: [
+        "#!no_prelude",
+        "pub use src::outer::outer_value",
+      ].join("\n"),
+      [`${pkgRoot}${sep}dep${sep}src${sep}outer.voyd`]: [
+        "#!no_prelude",
+        "use pkg::dep::inner::{ inner_value }",
+        "",
+        "pub fn outer_value() -> i32",
+        "  inner_value() + 1",
+      ].join("\n"),
+      [`${pkgRoot}${sep}dep${sep}src${sep}inner.voyd`]: [
+        "#!no_prelude",
+        "use src::missing::{ missing_value }",
+        "",
+        "pub fn inner_value() -> i32",
+        "  missing_value() + 1",
+      ].join("\n"),
+    };
+
+    const host = createMemoryHost(files);
+    const graph = await loadModuleGraph({
+      entryPath: `${roots.src}${sep}main.voyd`,
+      roots,
+      host,
+    });
+    const prepared = prepareDependencySnapshotReuse({ cache, graph, roots });
+    const analyzed = analyzeModules({
+      graph,
+      captureDependencySnapshot: Boolean(prepared.key),
+    });
+    const diagnostics = [...graph.diagnostics, ...analyzed.diagnostics];
+
+    expect(diagnostics.length).toBeGreaterThan(0);
+    expect(analyzed.dependencySnapshot).toBeUndefined();
   });
 });

--- a/packages/compiler/src/__tests__/dependency-snapshot-cache.test.ts
+++ b/packages/compiler/src/__tests__/dependency-snapshot-cache.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import { resolve, sep } from "node:path";
+import { createMemoryModuleHost } from "../modules/memory-host.js";
+import { createNodePathAdapter } from "../modules/node-path-adapter.js";
+import type { ModuleHost, ModuleRoots } from "../modules/types.js";
+import {
+  commitDependencySnapshot,
+  createCompilerDependencySnapshotCache,
+  prepareDependencySnapshotReuse,
+} from "../modules/dependency-snapshot-cache.js";
+import { analyzeModules, loadModuleGraph } from "../pipeline.js";
+
+const createMemoryHost = (files: Record<string, string>): ModuleHost =>
+  createMemoryModuleHost({ files, pathAdapter: createNodePathAdapter() });
+
+const loadAndAnalyze = async ({
+  files,
+  roots,
+  cache,
+}: {
+  files: Record<string, string>;
+  roots: ModuleRoots;
+  cache: ReturnType<typeof createCompilerDependencySnapshotCache>;
+}) => {
+  const host = createMemoryHost(files);
+  const graph = await loadModuleGraph({
+    entryPath: `${roots.src}${sep}main.voyd`,
+    roots,
+    host,
+  });
+  const prepared = prepareDependencySnapshotReuse({
+    cache,
+    graph,
+    roots,
+  });
+  const analyzed = analyzeModules({
+    graph,
+    previousSemantics: prepared.previousSemantics,
+    typingState: prepared.typingState,
+  });
+  const diagnostics = [...graph.diagnostics, ...analyzed.diagnostics];
+  expect(diagnostics).toHaveLength(0);
+  commitDependencySnapshot({
+    prepared,
+    dependencySnapshot: analyzed.dependencySnapshot,
+  });
+  return { prepared, analyzed };
+};
+
+const buildFiles = ({
+  appValue,
+  stdValue,
+  pkgValue,
+}: {
+  appValue: number;
+  stdValue: number;
+  pkgValue: number;
+}) => {
+  const srcRoot = resolve("/proj/src");
+  const stdRoot = resolve("/proj/std");
+  const pkgRoot = resolve("/proj/packages");
+  return {
+    roots: { src: srcRoot, std: stdRoot, pkgDirs: [pkgRoot] },
+    files: {
+      [`${srcRoot}${sep}main.voyd`]: [
+        "#!no_prelude",
+        "use std::mathdep::{ std_value }",
+        "use pkg::dep::all",
+        "",
+        "pub fn main() -> i32",
+        `  std_value() + pkg_value() + ${appValue}`,
+      ].join("\n"),
+      [`${stdRoot}${sep}mathdep.voyd`]: [
+        "#!no_prelude",
+        "pub fn std_value() -> i32",
+        `  ${stdValue}`,
+      ].join("\n"),
+      [`${pkgRoot}${sep}dep${sep}src${sep}pkg.voyd`]: [
+        "#!no_prelude",
+        "pub use src::api::pkg_value",
+      ].join("\n"),
+      [`${pkgRoot}${sep}dep${sep}src${sep}api.voyd`]: [
+        "#!no_prelude",
+        "pub fn pkg_value() -> i32",
+        `  ${pkgValue}`,
+      ].join("\n"),
+    },
+  };
+};
+
+describe("compiler dependency snapshots", () => {
+  it("reuses std and installed package semantics after a source edit", async () => {
+    const cache = createCompilerDependencySnapshotCache();
+    const initial = buildFiles({ appValue: 1, stdValue: 10, pkgValue: 100 });
+    const first = await loadAndAnalyze({
+      files: initial.files,
+      roots: initial.roots,
+      cache,
+    });
+    expect(first.prepared.hit).toBe(false);
+
+    const edited = buildFiles({ appValue: 2, stdValue: 10, pkgValue: 100 });
+    const second = await loadAndAnalyze({
+      files: edited.files,
+      roots: edited.roots,
+      cache,
+    });
+
+    expect(second.prepared.hit).toBe(true);
+    expect(second.analyzed.recomputedModuleIds).toEqual(["src::main"]);
+  });
+
+  it("invalidates the dependency snapshot when std source changes", async () => {
+    const cache = createCompilerDependencySnapshotCache();
+    const initial = buildFiles({ appValue: 1, stdValue: 10, pkgValue: 100 });
+    await loadAndAnalyze({ files: initial.files, roots: initial.roots, cache });
+
+    const editedStd = buildFiles({ appValue: 1, stdValue: 11, pkgValue: 100 });
+    const result = await loadAndAnalyze({
+      files: editedStd.files,
+      roots: editedStd.roots,
+      cache,
+    });
+
+    expect(result.prepared.hit).toBe(false);
+    expect(result.analyzed.recomputedModuleIds).toContain("std::mathdep");
+  });
+
+  it("invalidates the dependency snapshot when installed package source changes", async () => {
+    const cache = createCompilerDependencySnapshotCache();
+    const initial = buildFiles({ appValue: 1, stdValue: 10, pkgValue: 100 });
+    await loadAndAnalyze({ files: initial.files, roots: initial.roots, cache });
+
+    const editedPkg = buildFiles({ appValue: 1, stdValue: 10, pkgValue: 101 });
+    const result = await loadAndAnalyze({
+      files: editedPkg.files,
+      roots: editedPkg.roots,
+      cache,
+    });
+
+    expect(result.prepared.hit).toBe(false);
+    expect(result.analyzed.recomputedModuleIds).toContain("pkg:dep::api");
+  });
+
+  it("captures all dependency modules before mixed-order source modules", async () => {
+    const cache = createCompilerDependencySnapshotCache();
+    const srcRoot = resolve("/mixed/src");
+    const stdRoot = resolve("/mixed/std");
+    const roots = { src: srcRoot, std: stdRoot };
+    const files = {
+      [`${srcRoot}${sep}main.voyd`]: [
+        "#!no_prelude",
+        "use std::left::{ left_value }",
+        "use src::helper::{ helper_value }",
+        "use std::right::{ right_value }",
+        "",
+        "pub fn main() -> i32",
+        "  left_value() + helper_value() + right_value()",
+      ].join("\n"),
+      [`${srcRoot}${sep}helper.voyd`]: [
+        "#!no_prelude",
+        "pub fn helper_value() -> i32",
+        "  2",
+      ].join("\n"),
+      [`${stdRoot}${sep}left.voyd`]: [
+        "#!no_prelude",
+        "pub fn left_value() -> i32",
+        "  1",
+      ].join("\n"),
+      [`${stdRoot}${sep}right.voyd`]: [
+        "#!no_prelude",
+        "pub fn right_value() -> i32",
+        "  3",
+      ].join("\n"),
+    };
+
+    await loadAndAnalyze({ files, roots, cache });
+
+    const editedFiles = {
+      ...files,
+      [`${srcRoot}${sep}main.voyd`]: `${files[`${srcRoot}${sep}main.voyd`]}\nfn app_edit_marker() -> i32\n  4\n`,
+    };
+    const second = await loadAndAnalyze({ files: editedFiles, roots, cache });
+
+    expect(second.prepared.hit).toBe(true);
+    expect(second.analyzed.recomputedModuleIds).toEqual([
+      "src::helper",
+      "src::main",
+    ]);
+  });
+});

--- a/packages/compiler/src/modules/dependency-snapshot-cache.ts
+++ b/packages/compiler/src/modules/dependency-snapshot-cache.ts
@@ -1,0 +1,225 @@
+import {
+  createEffectInterner,
+  type EffectInterner,
+  type EffectInternerSnapshot,
+} from "../semantics/effects/effect-table.js";
+import type { SemanticsPipelineResult } from "../semantics/pipeline.js";
+import {
+  createTypeArena,
+  type TypeArenaSnapshot,
+} from "../semantics/typing/type-arena.js";
+import { incrementCompilerPerfCounter } from "../perf.js";
+import {
+  cloneSemanticsMapForTypingState,
+} from "./semantic-snapshot.js";
+import type {
+  ModuleDependency,
+  ModuleGraph,
+  ModuleNode,
+  ModulePath,
+  ModuleRoots,
+} from "./types.js";
+import type {
+  ReusableDependencySemanticsSnapshot,
+} from "./semantic-analysis.js";
+
+const COMPILER_DEPENDENCY_SNAPSHOT_VERSION =
+  "0.2.0:v375-dependency-snapshot-v1";
+
+export type CompilerDependencySnapshotCache = {
+  dependency?: CompilerDependencySnapshotEntry;
+};
+
+type CompilerDependencySnapshotEntry = {
+  key: string;
+  moduleFingerprints: ReadonlyMap<string, string>;
+  moduleIds: readonly string[];
+  arena: TypeArenaSnapshot;
+  effectInterner: EffectInternerSnapshot;
+  semantics: ReadonlyMap<string, SemanticsPipelineResult>;
+};
+
+export type PreparedDependencySnapshotReuse = {
+  cache?: CompilerDependencySnapshotCache;
+  key?: string;
+  moduleFingerprints?: ReadonlyMap<string, string>;
+  previousSemantics?: ReadonlyMap<string, SemanticsPipelineResult>;
+  typingState?: {
+    arena: SemanticsPipelineResult["typing"]["arena"];
+    effectInterner: EffectInterner;
+  };
+  hit: boolean;
+};
+
+export const createCompilerDependencySnapshotCache =
+  (): CompilerDependencySnapshotCache => ({});
+
+export const prepareDependencySnapshotReuse = ({
+  cache,
+  graph,
+  roots,
+  includeTests,
+}: {
+  cache: CompilerDependencySnapshotCache | undefined;
+  graph: ModuleGraph;
+  roots: ModuleRoots;
+  includeTests?: boolean;
+}): PreparedDependencySnapshotReuse => {
+  if (!cache || roots.resolvePackageRoot) {
+    return { hit: false };
+  }
+
+  const moduleFingerprints = dependencyModuleFingerprintsFor(graph);
+  if (moduleFingerprints.size === 0) {
+    return { cache, hit: false };
+  }
+
+  const key = stableSerialize({
+    compiler: COMPILER_DEPENDENCY_SNAPSHOT_VERSION,
+    includeTests: includeTests === true,
+    roots: serializableDependencyRoots(roots),
+    modules: Array.from(moduleFingerprints.entries()),
+  });
+  const cached = cache.dependency;
+  if (!cached || cached.key !== key) {
+    incrementCompilerPerfCounter("compiler.dependency_snapshot.miss");
+    return { cache, key, moduleFingerprints, hit: false };
+  }
+
+  const arena = createTypeArena(cached.arena);
+  const effectInterner = createEffectInterner(cached.effectInterner);
+  const previousSemantics = cloneSemanticsMapForTypingState({
+    semantics: cached.semantics,
+    arena,
+    effectInterner,
+  });
+
+  incrementCompilerPerfCounter("compiler.dependency_snapshot.hit");
+  cached.moduleIds.forEach((moduleId) =>
+    incrementCompilerPerfCounter(
+      `compiler.dependency_snapshot.reuse.${moduleNamespaceForId(moduleId)}.count`,
+    ),
+  );
+
+  return {
+    cache,
+    key,
+    moduleFingerprints,
+    previousSemantics,
+    typingState: { arena, effectInterner },
+    hit: true,
+  };
+};
+
+export const commitDependencySnapshot = ({
+  prepared,
+  dependencySnapshot,
+}: {
+  prepared: PreparedDependencySnapshotReuse | undefined;
+  dependencySnapshot: ReusableDependencySemanticsSnapshot | undefined;
+}): void => {
+  if (
+    !prepared?.cache ||
+    !prepared.key ||
+    !prepared.moduleFingerprints ||
+    !dependencySnapshot
+  ) {
+    return;
+  }
+
+  const snapshotIds = new Set(dependencySnapshot.moduleIds);
+  const fingerprintIds = new Set(prepared.moduleFingerprints.keys());
+  if (
+    snapshotIds.size !== fingerprintIds.size ||
+    Array.from(fingerprintIds).some((moduleId) => !snapshotIds.has(moduleId))
+  ) {
+    return;
+  }
+
+  const arena = createTypeArena(dependencySnapshot.arena);
+  const effectInterner = createEffectInterner(dependencySnapshot.effectInterner);
+  const semantics = cloneSemanticsMapForTypingState({
+    semantics: dependencySnapshot.semantics,
+    arena,
+    effectInterner,
+  });
+
+  prepared.cache.dependency = {
+    key: prepared.key,
+    moduleFingerprints: prepared.moduleFingerprints,
+    moduleIds: dependencySnapshot.moduleIds,
+    arena: dependencySnapshot.arena,
+    effectInterner: dependencySnapshot.effectInterner,
+    semantics,
+  };
+  incrementCompilerPerfCounter("compiler.dependency_snapshot.write");
+};
+
+const dependencyModuleFingerprintsFor = (
+  graph: ModuleGraph,
+): ReadonlyMap<string, string> =>
+  new Map(
+    Array.from(graph.modules.entries())
+      .filter(([, module]) => module.path.namespace !== "src")
+      .sort(([left], [right]) => left.localeCompare(right, undefined, {
+        numeric: true,
+      }))
+      .map(([moduleId, module]) => [moduleId, moduleFingerprint(module)]),
+  );
+
+const moduleFingerprint = (module: ModuleNode): string =>
+  stableSerialize({
+    id: module.id,
+    path: serializableModulePath(module.path),
+    origin: module.origin,
+    source: module.source,
+    sourceFiles: module.sourceFiles ?? [],
+    sourcePackageRoot: module.sourcePackageRoot ?? [],
+    dependencies: module.dependencies
+      .map(serializableDependency)
+      .sort((left, right) =>
+        stableSerialize(left).localeCompare(stableSerialize(right)),
+      ),
+    macroExports: [...(module.macroExports ?? [])].sort(),
+  });
+
+const serializableDependency = (dependency: ModuleDependency) => ({
+  kind: dependency.kind,
+  path: serializableModulePath(dependency.path),
+});
+
+const serializableModulePath = (modulePath: ModulePath) => ({
+  namespace: modulePath.namespace,
+  packageName: modulePath.packageName,
+  segments: [...modulePath.segments],
+});
+
+const serializableDependencyRoots = (roots: ModuleRoots) => ({
+  std: roots.std,
+  pkg: roots.pkg,
+  pkgDirs: [...(roots.pkgDirs ?? [])],
+});
+
+const stableSerialize = (value: unknown): string =>
+  JSON.stringify(sortForStableSerialization(value));
+
+const sortForStableSerialization = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(sortForStableSerialization);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  if (value instanceof Uint8Array) {
+    return Array.from(value);
+  }
+  const record = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.keys(record)
+      .sort()
+      .map((key) => [key, sortForStableSerialization(record[key])]),
+  );
+};
+
+const moduleNamespaceForId = (moduleId: string): string =>
+  moduleId.startsWith("pkg:") ? "pkg" : moduleId.split("::")[0] ?? "unknown";

--- a/packages/compiler/src/modules/dependency-snapshot-cache.ts
+++ b/packages/compiler/src/modules/dependency-snapshot-cache.ts
@@ -24,7 +24,7 @@ import type {
 } from "./semantic-analysis.js";
 
 const COMPILER_DEPENDENCY_SNAPSHOT_VERSION =
-  "0.2.0:v375-dependency-snapshot-v1";
+  "0.2.0:v375-dependency-snapshot-v2";
 
 export type CompilerDependencySnapshotCache = {
   dependency?: CompilerDependencySnapshotEntry;

--- a/packages/compiler/src/modules/graph.ts
+++ b/packages/compiler/src/modules/graph.ts
@@ -37,6 +37,7 @@ import type { SourceSpan } from "../semantics/ids.js";
 import {
   incrementCompilerPerfCounter,
   isCompilerPerfEnabled,
+  recordCompilerPerfDuration,
 } from "../perf.js";
 
 type BuildGraphOptions = {
@@ -124,9 +125,14 @@ export const buildModuleGraph = async ({
     missingModules.set(importer, new Set([pathKey]));
   };
 
+  const preludeStartedAt = COMPILER_PERF_ENABLED ? performance.now() : 0;
   const hasStdPreludeModule = await supportsStdPreludeAutoImport({
     roots,
     host,
+  });
+  recordCompilerPerfDuration({
+    name: "graph.supports_std_prelude.ms",
+    startedAt: preludeStartedAt,
   });
 
   const entryFile = host.path.resolve(entryPath);
@@ -448,13 +454,28 @@ const loadFileModule = async ({
   includeTests: boolean;
   hasStdPreludeModule: boolean;
 }): Promise<LoadedModule> => {
+  const moduleStartedAt = COMPILER_PERF_ENABLED ? performance.now() : 0;
+  incrementCompilerPerfCounter(`graph.load_module.${modulePath.namespace}.count`);
+
+  const readStartedAt = COMPILER_PERF_ENABLED ? performance.now() : 0;
   const source = await host.readFile(filePath);
+  recordCompilerPerfDuration({
+    name: `graph.read_file.${modulePath.namespace}.ms`,
+    startedAt: readStartedAt,
+  });
+
+  const parseStartedAt = COMPILER_PERF_ENABLED ? performance.now() : 0;
   const primaryParsed = parseModuleDirectives(source);
   const primaryAst = parseModuleAst({
     source: primaryParsed.sanitizedSource,
     filePath,
     modulePath,
   });
+  recordCompilerPerfDuration({
+    name: `graph.parse.${modulePath.namespace}.ms`,
+    startedAt: parseStartedAt,
+  });
+
   let ast = primaryAst.ast;
   const parseDiagnostics: Diagnostic[] = [...primaryAst.diagnostics];
   let noPrelude = primaryParsed.noPrelude;
@@ -465,6 +486,7 @@ const loadFileModule = async ({
   if (includeTests && !isCompanionTestFile(filePath)) {
     const companionFilePath = companionFileFor(filePath);
     if (await host.fileExists(companionFilePath)) {
+      const companionStartedAt = COMPILER_PERF_ENABLED ? performance.now() : 0;
       const companionSource = await host.readFile(companionFilePath);
       const companionParsed = parseModuleDirectives(companionSource);
       noPrelude = noPrelude || companionParsed.noPrelude;
@@ -476,6 +498,10 @@ const loadFileModule = async ({
       parseDiagnostics.push(...companion.diagnostics);
       ast = mergeCompanionAst({ primary: ast, companion: companion.ast });
       sourceByFile.set(companionFilePath, companionParsed.sanitizedSource);
+      recordCompilerPerfDuration({
+        name: `graph.parse_companion.${modulePath.namespace}.ms`,
+        startedAt: companionStartedAt,
+      });
     }
   }
 
@@ -485,12 +511,18 @@ const loadFileModule = async ({
     hasStdPreludeModule,
     noPrelude,
   });
+  const packageRootStartedAt = COMPILER_PERF_ENABLED ? performance.now() : 0;
   const sourcePackageRoot = await discoverSourcePackageRoot({
     modulePath,
     host,
     roots,
   });
+  recordCompilerPerfDuration({
+    name: `graph.discover_package_root.${modulePath.namespace}.ms`,
+    startedAt: packageRootStartedAt,
+  });
 
+  const collectStartedAt = COMPILER_PERF_ENABLED ? performance.now() : 0;
   const info = collectModuleInfo({
     modulePath,
     ast,
@@ -501,10 +533,20 @@ const loadFileModule = async ({
     hasStdPreludeModule,
     noPrelude,
   });
+  recordCompilerPerfDuration({
+    name: `graph.collect_module_info.${modulePath.namespace}.ms`,
+    startedAt: collectStartedAt,
+  });
+
+  const submodulesStartedAt = COMPILER_PERF_ENABLED ? performance.now() : 0;
   const submoduleDeps = await discoverSubmodules({
     filePath,
     modulePath,
     host,
+  });
+  recordCompilerPerfDuration({
+    name: `graph.discover_submodules.${modulePath.namespace}.ms`,
+    startedAt: submodulesStartedAt,
   });
 
   const node: ModuleNode = {
@@ -514,9 +556,15 @@ const loadFileModule = async ({
     origin: { kind: "file", filePath },
     ast,
     source,
+    sourceFiles: sourceFilesFrom(sourceByFile),
     docs: info.docs,
     dependencies: [...info.dependencies, ...submoduleDeps],
   };
+
+  recordCompilerPerfDuration({
+    name: `graph.load_module.${modulePath.namespace}.ms`,
+    startedAt: moduleStartedAt,
+  });
 
   return {
     node,
@@ -771,6 +819,7 @@ const parseInlineModuleDecl = ({
     },
     ast,
     source: sliceSource(sourceForModule, span),
+    sourceFiles: sourceFilesFrom(sourceByFile),
     docs: {
       ...info.docs,
       module: combineDocumentation(outerModuleDoc, info.docs.module),
@@ -795,6 +844,13 @@ const toModuleAst = (block: Form): Form => {
 
 const sliceSource = (source: string, span: SourceSpan): string =>
   source.slice(span.start, span.end);
+
+const sourceFilesFrom = (
+  sourceByFile: ReadonlyMap<string, string>,
+): readonly { filePath: string; source: string }[] =>
+  Array.from(sourceByFile.entries())
+    .map(([filePath, source]) => ({ filePath, source }))
+    .sort((left, right) => left.filePath.localeCompare(right.filePath));
 
 const sourceForModuleAst = ({
   ast,

--- a/packages/compiler/src/modules/semantic-analysis.ts
+++ b/packages/compiler/src/modules/semantic-analysis.ts
@@ -29,6 +29,7 @@ export type AnalyzeModuleSemanticsOptions = {
   graph: ModuleGraph;
   includeTests?: boolean;
   recoverFromTypingErrors?: boolean;
+  captureDependencySnapshot?: boolean;
   previousSemantics?: ReadonlyMap<string, SemanticsPipelineResult>;
   changedModuleIds?: ReadonlySet<string>;
   typingState?: {
@@ -83,6 +84,7 @@ export const analyzeModuleSemantics = ({
   graph,
   includeTests,
   recoverFromTypingErrors,
+  captureDependencySnapshot,
   previousSemantics,
   changedModuleIds,
   typingState,
@@ -96,6 +98,16 @@ export const analyzeModuleSemantics = ({
   const arena = typingState?.arena ?? createTypeArena();
   const effectInterner = typingState?.effectInterner ?? createEffectInterner();
   let dependencySnapshot: ReusableDependencySemanticsSnapshot | undefined;
+  const shouldCaptureDependencySnapshot = captureDependencySnapshot === true;
+  const isReusableDependencyScc = createReusableDependencySccPredicate({
+    graph,
+    groups: sccGroups,
+  });
+  const reusableDependencyModuleIds = new Set(
+    sccGroups
+      .filter(isReusableDependencyScc)
+      .flatMap((group) => group.moduleIds),
+  );
 
   const cycleModuleIdsByModuleId = new Map<string, readonly string[]>();
   sccGroups.forEach((group) => {
@@ -128,23 +140,27 @@ export const analyzeModuleSemantics = ({
     });
   }
 
-  const analysisGroups = orderSccGroupsForDependencySnapshot({
-    graph,
-    groups: sccGroups,
-  });
+  const analysisGroups = shouldCaptureDependencySnapshot
+    ? orderSccGroupsForDependencySnapshot({
+        groups: sccGroups,
+        isReusableDependencyScc,
+      })
+    : sccGroups;
 
   analysisGroups.forEach((group) => {
     throwIfCancelled(isCancelled);
 
     if (
+      shouldCaptureDependencySnapshot &&
       !dependencySnapshot &&
-      !isReusableDependencyScc({ graph, group })
+      !isReusableDependencyScc(group)
     ) {
       dependencySnapshot = captureReusableDependencySnapshot({
         graph,
         semantics,
         arena,
         effectInterner,
+        reusableModuleIds: reusableDependencyModuleIds,
       });
     }
 
@@ -203,12 +219,15 @@ export const analyzeModuleSemantics = ({
     exports.set(moduleId, result.exports);
   });
 
-  dependencySnapshot ??= captureReusableDependencySnapshot({
-    graph,
-    semantics,
-    arena,
-    effectInterner,
-  });
+  if (shouldCaptureDependencySnapshot) {
+    dependencySnapshot ??= captureReusableDependencySnapshot({
+      graph,
+      semantics,
+      arena,
+      effectInterner,
+      reusableModuleIds: reusableDependencyModuleIds,
+    });
+  }
 
   return {
     semantics,
@@ -219,51 +238,103 @@ export const analyzeModuleSemantics = ({
 };
 
 const orderSccGroupsForDependencySnapshot = ({
+  groups,
+  isReusableDependencyScc,
+}: {
+  groups: readonly ReturnType<typeof getModuleSccGroups>[number][];
+  isReusableDependencyScc: ReusableDependencySccPredicate;
+}): ReturnType<typeof getModuleSccGroups> => {
+  const reusableDependencyGroups = groups.filter(isReusableDependencyScc);
+  const sourceOrUnsafeGroups = groups.filter(
+    (group) => !isReusableDependencyScc(group),
+  );
+  return [...reusableDependencyGroups, ...sourceOrUnsafeGroups];
+};
+
+type ReusableDependencySccPredicate = (
+  group: ReturnType<typeof getModuleSccGroups>[number],
+) => boolean;
+
+const createReusableDependencySccPredicate = ({
   graph,
   groups,
 }: {
   graph: ModuleGraph;
   groups: readonly ReturnType<typeof getModuleSccGroups>[number][];
-}): ReturnType<typeof getModuleSccGroups> => {
-  const reusableDependencyGroups = groups.filter((group) =>
-    isReusableDependencyScc({ graph, group }),
-  );
-  const sourceOrUnsafeGroups = groups.filter(
-    (group) => !isReusableDependencyScc({ graph, group }),
-  );
-  return [...reusableDependencyGroups, ...sourceOrUnsafeGroups];
-};
+}): ReusableDependencySccPredicate => {
+  const groupIndexByModuleId = new Map<string, number>();
+  groups.forEach((group, groupIndex) => {
+    group.moduleIds.forEach((moduleId) => {
+      groupIndexByModuleId.set(moduleId, groupIndex);
+    });
+  });
 
-const isReusableDependencyScc = ({
-  graph,
-  group,
-}: {
-  graph: ModuleGraph;
-  group: ReturnType<typeof getModuleSccGroups>[number];
-}): boolean =>
-  group.moduleIds.every((moduleId) => {
-    const module = graph.modules.get(moduleId);
-    if (!module || module.path.namespace === "src") {
+  const reusableByGroupIndex = new Map<number, boolean>();
+
+  const isReusableGroup = (groupIndex: number): boolean => {
+    const cached = reusableByGroupIndex.get(groupIndex);
+    if (typeof cached === "boolean") {
+      return cached;
+    }
+
+    const group = groups[groupIndex];
+    if (!group) {
       return false;
     }
-    return module.dependencies.every(
-      (dependency) => dependency.path.namespace !== "src",
-    );
-  });
+
+    const reusable = group.moduleIds.every((moduleId) => {
+      const module = graph.modules.get(moduleId);
+      if (!module || module.path.namespace === "src") {
+        return false;
+      }
+
+      return module.dependencies.every((dependency) => {
+        if (dependency.path.namespace === "src") {
+          return false;
+        }
+        const dependencyId = modulePathToString(dependency.path);
+        const dependencyGroupIndex = groupIndexByModuleId.get(dependencyId);
+        if (dependencyGroupIndex === undefined) {
+          return false;
+        }
+        if (dependencyGroupIndex === groupIndex) {
+          return true;
+        }
+        return isReusableGroup(dependencyGroupIndex);
+      });
+    });
+
+    reusableByGroupIndex.set(groupIndex, reusable);
+    return reusable;
+  };
+
+  return (group) => {
+    const moduleId = group.moduleIds[0];
+    const groupIndex =
+      moduleId === undefined ? undefined : groupIndexByModuleId.get(moduleId);
+    return groupIndex === undefined ? false : isReusableGroup(groupIndex);
+  };
+};
 
 const captureReusableDependencySnapshot = ({
   graph,
   semantics,
   arena,
   effectInterner,
+  reusableModuleIds,
 }: {
   graph: ModuleGraph;
   semantics: Map<string, SemanticsPipelineResult>;
   arena: TypeArena;
   effectInterner: EffectInterner;
+  reusableModuleIds: ReadonlySet<string>;
 }): ReusableDependencySemanticsSnapshot | undefined => {
   const entries = Array.from(semantics.entries())
-    .filter(([moduleId]) => graph.modules.get(moduleId)?.path.namespace !== "src")
+    .filter(
+      ([moduleId]) =>
+        reusableModuleIds.has(moduleId) &&
+        graph.modules.get(moduleId)?.path.namespace !== "src",
+    )
     .sort(([left], [right]) => left.localeCompare(right, undefined, {
       numeric: true,
     }));

--- a/packages/compiler/src/modules/semantic-analysis.ts
+++ b/packages/compiler/src/modules/semantic-analysis.ts
@@ -10,10 +10,20 @@ import type {
   ModuleExportSurfaceTable,
   ModuleExportTable,
 } from "../semantics/modules.js";
-import { createTypeArena } from "../semantics/typing/type-arena.js";
-import { createEffectInterner, createEffectTable } from "../semantics/effects/effect-table.js";
+import {
+  createTypeArena,
+  type TypeArena,
+  type TypeArenaSnapshot,
+} from "../semantics/typing/type-arena.js";
+import {
+  createEffectInterner,
+  createEffectTable,
+  type EffectInterner,
+  type EffectInternerSnapshot,
+} from "../semantics/effects/effect-table.js";
 import { getModuleSccGroups } from "./scc.js";
 import { collectCyclicModuleExportSurfaces } from "./cyclic-export-surfaces.js";
+import { cloneSemanticsMapForTypingState } from "./semantic-snapshot.js";
 
 export type AnalyzeModuleSemanticsOptions = {
   graph: ModuleGraph;
@@ -21,13 +31,25 @@ export type AnalyzeModuleSemanticsOptions = {
   recoverFromTypingErrors?: boolean;
   previousSemantics?: ReadonlyMap<string, SemanticsPipelineResult>;
   changedModuleIds?: ReadonlySet<string>;
+  typingState?: {
+    arena: TypeArena;
+    effectInterner: EffectInterner;
+  };
   isCancelled?: () => boolean;
+};
+
+export type ReusableDependencySemanticsSnapshot = {
+  moduleIds: readonly string[];
+  semantics: ReadonlyMap<string, SemanticsPipelineResult>;
+  arena: TypeArenaSnapshot;
+  effectInterner: EffectInternerSnapshot;
 };
 
 export type AnalyzeModuleSemanticsResult = {
   semantics: Map<string, SemanticsPipelineResult>;
   diagnostics: Diagnostic[];
   recomputedModuleIds: readonly string[];
+  dependencySnapshot?: ReusableDependencySemanticsSnapshot;
 };
 
 const SEMANTICS_ANALYSIS_CANCELLED_CODE = "VOYD_SEMANTICS_ANALYSIS_CANCELLED";
@@ -63,6 +85,7 @@ export const analyzeModuleSemantics = ({
   recoverFromTypingErrors,
   previousSemantics,
   changedModuleIds,
+  typingState,
   isCancelled,
 }: AnalyzeModuleSemanticsOptions): AnalyzeModuleSemanticsResult => {
   const sccGroups = getModuleSccGroups({ graph });
@@ -70,8 +93,9 @@ export const analyzeModuleSemantics = ({
   const exports = new Map<string, ModuleExportTable>();
   const diagnostics: Diagnostic[] = [];
   const recomputedModuleIds: string[] = [];
-  const arena = createTypeArena();
-  const effectInterner = createEffectInterner();
+  const arena = typingState?.arena ?? createTypeArena();
+  const effectInterner = typingState?.effectInterner ?? createEffectInterner();
+  let dependencySnapshot: ReusableDependencySemanticsSnapshot | undefined;
 
   const cycleModuleIdsByModuleId = new Map<string, readonly string[]>();
   sccGroups.forEach((group) => {
@@ -104,8 +128,25 @@ export const analyzeModuleSemantics = ({
     });
   }
 
-  sccGroups.forEach((group) => {
+  const analysisGroups = orderSccGroupsForDependencySnapshot({
+    graph,
+    groups: sccGroups,
+  });
+
+  analysisGroups.forEach((group) => {
     throwIfCancelled(isCancelled);
+
+    if (
+      !dependencySnapshot &&
+      !isReusableDependencyScc({ graph, group })
+    ) {
+      dependencySnapshot = captureReusableDependencySnapshot({
+        graph,
+        semantics,
+        arena,
+        effectInterner,
+      });
+    }
 
     const shouldRecomputeGroup = group.moduleIds.some((moduleId) =>
       recomputeSet.has(moduleId),
@@ -162,10 +203,90 @@ export const analyzeModuleSemantics = ({
     exports.set(moduleId, result.exports);
   });
 
+  dependencySnapshot ??= captureReusableDependencySnapshot({
+    graph,
+    semantics,
+    arena,
+    effectInterner,
+  });
+
   return {
     semantics,
     diagnostics,
     recomputedModuleIds,
+    dependencySnapshot,
+  };
+};
+
+const orderSccGroupsForDependencySnapshot = ({
+  graph,
+  groups,
+}: {
+  graph: ModuleGraph;
+  groups: readonly ReturnType<typeof getModuleSccGroups>[number][];
+}): ReturnType<typeof getModuleSccGroups> => {
+  const reusableDependencyGroups = groups.filter((group) =>
+    isReusableDependencyScc({ graph, group }),
+  );
+  const sourceOrUnsafeGroups = groups.filter(
+    (group) => !isReusableDependencyScc({ graph, group }),
+  );
+  return [...reusableDependencyGroups, ...sourceOrUnsafeGroups];
+};
+
+const isReusableDependencyScc = ({
+  graph,
+  group,
+}: {
+  graph: ModuleGraph;
+  group: ReturnType<typeof getModuleSccGroups>[number];
+}): boolean =>
+  group.moduleIds.every((moduleId) => {
+    const module = graph.modules.get(moduleId);
+    if (!module || module.path.namespace === "src") {
+      return false;
+    }
+    return module.dependencies.every(
+      (dependency) => dependency.path.namespace !== "src",
+    );
+  });
+
+const captureReusableDependencySnapshot = ({
+  graph,
+  semantics,
+  arena,
+  effectInterner,
+}: {
+  graph: ModuleGraph;
+  semantics: Map<string, SemanticsPipelineResult>;
+  arena: TypeArena;
+  effectInterner: EffectInterner;
+}): ReusableDependencySemanticsSnapshot | undefined => {
+  const entries = Array.from(semantics.entries())
+    .filter(([moduleId]) => graph.modules.get(moduleId)?.path.namespace !== "src")
+    .sort(([left], [right]) => left.localeCompare(right, undefined, {
+      numeric: true,
+    }));
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  const arenaSnapshot = arena.snapshot();
+  const effectInternerSnapshot = effectInterner.snapshotInterner();
+  const snapshotArena = createTypeArena(arenaSnapshot);
+  const snapshotEffectInterner = createEffectInterner(effectInternerSnapshot);
+  const semanticsSnapshot = cloneSemanticsMapForTypingState({
+    semantics: new Map(entries),
+    arena: snapshotArena,
+    effectInterner: snapshotEffectInterner,
+  });
+
+  return {
+    moduleIds: entries.map(([moduleId]) => moduleId),
+    semantics: semanticsSnapshot,
+    arena: arenaSnapshot,
+    effectInterner: effectInternerSnapshot,
   };
 };
 
@@ -465,18 +586,22 @@ const resolveIncrementalModuleIds = ({
   const currentModuleIds = new Set(graph.modules.keys());
   const previousModuleIds = new Set(previousSemantics.keys());
 
-  if (
-    currentModuleIds.size !== previousModuleIds.size ||
-    Array.from(currentModuleIds).some((moduleId) => !previousModuleIds.has(moduleId))
-  ) {
+  if (Array.from(previousModuleIds).some((moduleId) => !currentModuleIds.has(moduleId))) {
     return undefined;
   }
 
-  if (!changedModuleIds || changedModuleIds.size === 0) {
+  const missingCurrentModuleIds = new Set(
+    Array.from(currentModuleIds).filter((moduleId) => !previousModuleIds.has(moduleId)),
+  );
+
+  if (
+    (!changedModuleIds || changedModuleIds.size === 0) &&
+    missingCurrentModuleIds.size === 0
+  ) {
     return new Set();
   }
 
-  const unknownChange = Array.from(changedModuleIds).some(
+  const unknownChange = Array.from(changedModuleIds ?? []).some(
     (moduleId) => !currentModuleIds.has(moduleId),
   );
   if (unknownChange) {
@@ -485,7 +610,10 @@ const resolveIncrementalModuleIds = ({
 
   return collectReverseDependencyClosure({
     graph,
-    seedModuleIds: changedModuleIds,
+    seedModuleIds: new Set([
+      ...missingCurrentModuleIds,
+      ...(changedModuleIds ?? []),
+    ]),
   });
 };
 

--- a/packages/compiler/src/modules/semantic-snapshot.ts
+++ b/packages/compiler/src/modules/semantic-snapshot.ts
@@ -1,0 +1,106 @@
+import {
+  createEffectTable,
+  type EffectInterner,
+} from "../semantics/effects/effect-table.js";
+import { getSymbolTable } from "../semantics/_internal/symbol-table.js";
+import { cloneNestedMap } from "../semantics/typing/call-resolution.js";
+import type { SemanticsPipelineResult } from "../semantics/pipeline.js";
+import type { TypeArena } from "../semantics/typing/type-arena.js";
+
+export const cloneSemanticsForTypingState = ({
+  semantics,
+  arena,
+  effectInterner,
+}: {
+  semantics: SemanticsPipelineResult;
+  arena: TypeArena;
+  effectInterner: EffectInterner;
+}): SemanticsPipelineResult => {
+  const symbolTable = getSymbolTable(semantics);
+  const typing = semantics.typing;
+
+  return {
+    binding: semantics.binding,
+    symbols: semantics.symbols,
+    hir: semantics.hir,
+    typing: {
+      arena,
+      table: typing.table.clone(),
+      functions: typing.functions.clone(),
+      typeAliases: typing.typeAliases.clone(),
+      objects: typing.objects.clone(),
+      traits: typing.traits.clone(),
+      primitives: {
+        cache: new Map(typing.primitives.cache),
+        bool: typing.primitives.bool,
+        void: typing.primitives.void,
+        unknown: typing.primitives.unknown,
+        defaultEffectRow: typing.primitives.defaultEffectRow,
+        i32: typing.primitives.i32,
+        i64: typing.primitives.i64,
+        f32: typing.primitives.f32,
+        f64: typing.primitives.f64,
+      },
+      effects: createEffectTable({
+        interner: effectInterner,
+        snapshot: typing.effects.snapshotTable(),
+      }),
+      intrinsicTypes: new Map(typing.intrinsicTypes),
+      resolvedExprTypes: new Map(typing.resolvedExprTypes),
+      valueTypes: new Map(typing.valueTypes),
+      tailResumptions: new Map(typing.tailResumptions),
+      objectsByNominal: new Map(typing.objectsByNominal),
+      callTargets: cloneNestedMap(typing.callTargets),
+      callArgumentPlans: cloneNestedMap(typing.callArgumentPlans),
+      functionInstances: new Map(typing.functionInstances),
+      callTypeArguments: cloneNestedMap(typing.callTypeArguments),
+      callInstanceKeys: cloneNestedMap(typing.callInstanceKeys),
+      callTraitDispatches: new Set(typing.callTraitDispatches),
+      functionInstantiationInfo: cloneNestedMap(typing.functionInstantiationInfo),
+      functionInstanceExprTypes: cloneNestedMap(typing.functionInstanceExprTypes),
+      functionInstanceValueTypes: cloneNestedMap(typing.functionInstanceValueTypes),
+      traitImplsByNominal: new Map(
+        Array.from(typing.traitImplsByNominal.entries()).map(
+          ([nominal, impls]) => [nominal, [...impls]],
+        ),
+      ),
+      traitImplsByTrait: new Map(
+        Array.from(typing.traitImplsByTrait.entries()).map(
+          ([symbol, impls]) => [symbol, [...impls]],
+        ),
+      ),
+      traitMethodImpls: new Map(typing.traitMethodImpls),
+      memberMetadata: new Map(
+        Array.from(typing.memberMetadata.entries()).map(([symbol, metadata]) => [
+          symbol,
+          { ...metadata },
+        ]),
+      ),
+      diagnostics: [...typing.diagnostics],
+    },
+    moduleId: semantics.moduleId,
+    exports: new Map(semantics.exports),
+    diagnostics: [...semantics.diagnostics],
+    ...({ symbolTable } as unknown as {}),
+  } as SemanticsPipelineResult;
+};
+
+export const cloneSemanticsMapForTypingState = ({
+  semantics,
+  arena,
+  effectInterner,
+}: {
+  semantics: ReadonlyMap<string, SemanticsPipelineResult>;
+  arena: TypeArena;
+  effectInterner: EffectInterner;
+}): Map<string, SemanticsPipelineResult> =>
+  new Map(
+    Array.from(semantics.entries()).map(([moduleId, entry]) => [
+      moduleId,
+      cloneSemanticsForTypingState({
+        semantics: entry,
+        arena,
+        effectInterner,
+      }),
+    ]),
+  );

--- a/packages/compiler/src/modules/types.ts
+++ b/packages/compiler/src/modules/types.ts
@@ -70,6 +70,11 @@ export interface ModuleNode {
   origin: ModuleOrigin;
   ast: Form;
   source: string;
+  /**
+   * Source files that contributed to this module's AST. This includes merged
+   * companion test files when test modules are loaded.
+   */
+  sourceFiles?: readonly { filePath: string; source: string }[];
   docs?: ModuleDocumentation;
   dependencies: readonly ModuleDependency[];
   /**

--- a/packages/compiler/src/optimize/pipeline.ts
+++ b/packages/compiler/src/optimize/pipeline.ts
@@ -28,6 +28,11 @@ import type {
 import type { SemanticsPipelineResult } from "../semantics/pipeline.js";
 import type { CodegenOptions } from "../codegen/context.js";
 import {
+  incrementCompilerPerfCounter,
+  isCompilerPerfEnabled,
+  recordCompilerPerfDuration,
+} from "../perf.js";
+import {
   type ProgramOptimizationContext,
   type ProgramOptimizationPass,
   type OptimizationAnalysisKey,
@@ -6042,9 +6047,25 @@ export const optimizeProgram = ({
   void entryModuleId;
   void options;
 
-  OPTIMIZATION_PASSES.forEach((pass) => {
+  OPTIMIZATION_PASSES.forEach((pass, index) => {
+    const passStartedAt = isCompilerPerfEnabled() ? performance.now() : 0;
     const result = pass.run(context);
+    recordCompilerPerfDuration({
+      name: `optimize.pass.${pass.name}.ms`,
+      startedAt: passStartedAt,
+    });
+    recordCompilerPerfDuration({
+      name: `optimize.pass.${index}.${pass.name}.ms`,
+      startedAt: passStartedAt,
+    });
+    if (result.changed) {
+      incrementCompilerPerfCounter(`optimize.pass.${pass.name}.changed`);
+    }
     if (result.invalidates?.length) {
+      incrementCompilerPerfCounter(
+        `optimize.pass.${pass.name}.invalidates`,
+        result.invalidates.length,
+      );
       context.invalidateAnalyses(result.invalidates);
     }
   });

--- a/packages/compiler/src/perf.ts
+++ b/packages/compiler/src/perf.ts
@@ -50,6 +50,19 @@ export const incrementCompilerPerfCounter = (
   counters.set(name, (counters.get(name) ?? 0) + amount);
 };
 
+export const recordCompilerPerfDuration = ({
+  name,
+  startedAt,
+}: {
+  name: string;
+  startedAt: number;
+}): void => {
+  if (!PERF_ENABLED) {
+    return;
+  }
+  incrementCompilerPerfCounter(name, performance.now() - startedAt);
+};
+
 export const snapshotCompilerPerfCounters = (): CompilerPerfCounterSnapshot =>
   PERF_ENABLED ? new Map(counters) : new Map();
 

--- a/packages/compiler/src/pipeline-browser.ts
+++ b/packages/compiler/src/pipeline-browser.ts
@@ -19,6 +19,7 @@ export const loadModuleGraph = async (
     entryPath: options.entryPath,
     host: options.host,
     roots: options.roots,
+    includeTests: options.includeTests,
   });
 };
 

--- a/packages/compiler/src/pipeline-shared.ts
+++ b/packages/compiler/src/pipeline-shared.ts
@@ -17,6 +17,15 @@ import type { ContinuationBackendKind } from "./codegen/codegen.js";
 import { buildProgramCodegenView } from "./semantics/codegen-view/index.js";
 import { optimizeProgram } from "./optimize/pipeline.js";
 import { analyzeModuleSemantics } from "./modules/semantic-analysis.js";
+import type { ReusableDependencySemanticsSnapshot } from "./modules/semantic-analysis.js";
+import {
+  commitDependencySnapshot,
+  createCompilerDependencySnapshotCache,
+  prepareDependencySnapshotReuse,
+  type CompilerDependencySnapshotCache,
+} from "./modules/dependency-snapshot-cache.js";
+import type { EffectInterner } from "./semantics/effects/effect-table.js";
+import type { TypeArena } from "./semantics/typing/type-arena.js";
 import { formatTestExportName } from "./tests/exports.js";
 import type { SourceSpan, SymbolId } from "./semantics/ids.js";
 import { getSymbolTable } from "./semantics/_internal/symbol-table.js";
@@ -25,8 +34,14 @@ import {
   diffCompilerPerfCounters,
   isCompilerPerfEnabled,
   logCompilerPerfSummary,
+  recordCompilerPerfDuration,
   snapshotCompilerPerfCounters,
 } from "./perf.js";
+
+export {
+  createCompilerDependencySnapshotCache,
+  type CompilerDependencySnapshotCache,
+};
 
 export type LoadModulesOptions = {
   entryPath: string;
@@ -42,6 +57,10 @@ export type AnalyzeModulesOptions = {
   recoverFromTypingErrors?: boolean;
   previousSemantics?: ReadonlyMap<string, SemanticsPipelineResult>;
   changedModuleIds?: ReadonlySet<string>;
+  typingState?: {
+    arena: TypeArena;
+    effectInterner: EffectInterner;
+  };
   isCancelled?: () => boolean;
 };
 
@@ -50,6 +69,7 @@ export type AnalyzeModulesResult = {
   diagnostics: Diagnostic[];
   tests: readonly TestCase[];
   recomputedModuleIds: readonly string[];
+  dependencySnapshot?: ReusableDependencySemanticsSnapshot;
 };
 
 export type TestScope = "all" | "entry";
@@ -89,6 +109,7 @@ export type CompileProgramOptions = LoadModulesOptions &
      * graph. Defaults to false.
      */
     skipSemantics?: boolean;
+    dependencySnapshotCache?: CompilerDependencySnapshotCache;
   };
 
 export type CompileProgramSuccessResult = {
@@ -114,14 +135,21 @@ export const analyzeModules = ({
   recoverFromTypingErrors,
   previousSemantics,
   changedModuleIds,
+  typingState,
   isCancelled,
 }: AnalyzeModulesOptions): AnalyzeModulesResult => {
-  const { semantics, diagnostics, recomputedModuleIds } = analyzeModuleSemantics({
+  const {
+    semantics,
+    diagnostics,
+    recomputedModuleIds,
+    dependencySnapshot,
+  } = analyzeModuleSemantics({
     graph,
     includeTests,
     recoverFromTypingErrors,
     previousSemantics,
     changedModuleIds,
+    typingState,
     isCancelled,
   });
 
@@ -135,6 +163,7 @@ export const analyzeModules = ({
     diagnostics,
     tests,
     recomputedModuleIds,
+    dependencySnapshot,
   };
 };
 
@@ -404,7 +433,12 @@ export const emitProgram = async ({
   module: binaryen.Module;
   diagnostics: Diagnostic[];
 }> => {
+  const lowerStartedAt = isCompilerPerfEnabled() ? performance.now() : 0;
   const { orderedModules, entry } = lowerProgram({ graph, semantics });
+  recordCompilerPerfDuration({
+    name: "emit.lower_program.ms",
+    startedAt: lowerStartedAt,
+  });
   const targetModuleId = entryModuleId ?? entry;
   const modules = orderedModules
     .map((id) => semantics.get(id))
@@ -413,15 +447,34 @@ export const emitProgram = async ({
     throw new Error("No semantics available for codegen");
   }
 
+  const loadCodegenStartedAt = isCompilerPerfEnabled() ? performance.now() : 0;
   const codegen = await lazyCodegen();
+  recordCompilerPerfDuration({
+    name: "emit.load_codegen.ms",
+    startedAt: loadCodegenStartedAt,
+  });
+
+  const linkStartedAt = isCompilerPerfEnabled() ? performance.now() : 0;
   const monomorphized =
     linkSemantics !== false
       ? monomorphizeProgram({ modules, semantics })
       : { instances: [], moduleTyping: new Map() };
+  recordCompilerPerfDuration({
+    name: "emit.link_semantics.ms",
+    startedAt: linkStartedAt,
+  });
+
+  const codegenViewStartedAt = isCompilerPerfEnabled() ? performance.now() : 0;
   const program = buildProgramCodegenView(modules, {
     instances: monomorphized.instances,
     moduleTyping: monomorphized.moduleTyping,
   });
+  recordCompilerPerfDuration({
+    name: "emit.build_codegen_view.ms",
+    startedAt: codegenViewStartedAt,
+  });
+
+  const optimizeStartedAt = isCompilerPerfEnabled() ? performance.now() : 0;
   const optimized = codegenOptions?.optimize
     ? optimizeProgram({
         program,
@@ -430,13 +483,31 @@ export const emitProgram = async ({
         options: codegenOptions,
       })
     : undefined;
+  if (codegenOptions?.optimize) {
+    recordCompilerPerfDuration({
+      name: "emit.optimize_program.ms",
+      startedAt: optimizeStartedAt,
+    });
+  }
+
+  const codegenStartedAt = isCompilerPerfEnabled() ? performance.now() : 0;
   const result = codegen.codegenProgram({
     program: optimized?.program ?? program,
     entryModuleId: targetModuleId,
     options: codegenOptions,
     optimization: optimized?.facts,
   });
+  recordCompilerPerfDuration({
+    name: "emit.codegen_program.ms",
+    startedAt: codegenStartedAt,
+  });
+
+  const emitBinaryStartedAt = isCompilerPerfEnabled() ? performance.now() : 0;
   const wasm = result.wasm ?? emitBinary(result.module);
+  recordCompilerPerfDuration({
+    name: "emit.emit_binary.ms",
+    startedAt: emitBinaryStartedAt,
+  });
   return { wasm, module: result.module, diagnostics: result.diagnostics };
 };
 
@@ -453,7 +524,12 @@ export const emitProgramWithContinuationFallback = async ({
   entryModuleId,
   linkSemantics,
 }: EmitProgramOptions): Promise<ContinuationFallbackBundle> => {
+  const lowerStartedAt = isCompilerPerfEnabled() ? performance.now() : 0;
   const { orderedModules, entry } = lowerProgram({ graph, semantics });
+  recordCompilerPerfDuration({
+    name: "emit_fallback.lower_program.ms",
+    startedAt: lowerStartedAt,
+  });
   const targetModuleId = entryModuleId ?? entry;
   const modules = orderedModules
     .map((id) => semantics.get(id))
@@ -462,14 +538,27 @@ export const emitProgramWithContinuationFallback = async ({
     throw new Error("No semantics available for codegen");
   }
 
+  const linkStartedAt = isCompilerPerfEnabled() ? performance.now() : 0;
   const monomorphized =
     linkSemantics !== false
       ? monomorphizeProgram({ modules, semantics })
       : { instances: [], moduleTyping: new Map() };
+  recordCompilerPerfDuration({
+    name: "emit_fallback.link_semantics.ms",
+    startedAt: linkStartedAt,
+  });
+
+  const codegenViewStartedAt = isCompilerPerfEnabled() ? performance.now() : 0;
   const program = buildProgramCodegenView(modules, {
     instances: monomorphized.instances,
     moduleTyping: monomorphized.moduleTyping,
   });
+  recordCompilerPerfDuration({
+    name: "emit_fallback.build_codegen_view.ms",
+    startedAt: codegenViewStartedAt,
+  });
+
+  const optimizeStartedAt = isCompilerPerfEnabled() ? performance.now() : 0;
   const optimized = codegenOptions?.optimize
     ? optimizeProgram({
         program,
@@ -478,8 +567,20 @@ export const emitProgramWithContinuationFallback = async ({
         options: codegenOptions,
       })
     : undefined;
+  if (codegenOptions?.optimize) {
+    recordCompilerPerfDuration({
+      name: "emit_fallback.optimize_program.ms",
+      startedAt: optimizeStartedAt,
+    });
+  }
 
+  const loadCodegenStartedAt = isCompilerPerfEnabled() ? performance.now() : 0;
   const codegenImpl = await lazyCodegen();
+  recordCompilerPerfDuration({
+    name: "emit_fallback.load_codegen.ms",
+    startedAt: loadCodegenStartedAt,
+  });
+  const codegenStartedAt = isCompilerPerfEnabled() ? performance.now() : 0;
   const { preferredKind, preferred, fallback } =
     codegenImpl.codegenProgramWithContinuationFallback({
       program: optimized?.program ?? program,
@@ -487,11 +588,21 @@ export const emitProgramWithContinuationFallback = async ({
       options: codegenOptions,
       optimization: optimized?.facts,
     });
+  recordCompilerPerfDuration({
+    name: "emit_fallback.codegen_program.ms",
+    startedAt: codegenStartedAt,
+  });
 
   const toWasmBytes = (result: { module: binaryen.Module }): Uint8Array => {
-    return "wasm" in result && result.wasm instanceof Uint8Array
+    const emitBinaryStartedAt = isCompilerPerfEnabled() ? performance.now() : 0;
+    const wasm = "wasm" in result && result.wasm instanceof Uint8Array
       ? result.wasm
       : emitBinary(result.module);
+    recordCompilerPerfDuration({
+      name: "emit_fallback.emit_binary.ms",
+      startedAt: emitBinaryStartedAt,
+    });
+    return wasm;
   };
 
   return {
@@ -624,9 +735,21 @@ export const compileProgramWithLoader = async (
   }
 
   const analyzeStartedAt = perfEnabled ? performance.now() : 0;
-  const { semantics, diagnostics: semanticDiagnostics } = analyzeModules({
+  const dependencySnapshotReuse = prepareDependencySnapshotReuse({
+    cache: options.dependencySnapshotCache,
+    graph,
+    roots: options.roots,
+    includeTests: options.includeTests,
+  });
+  const {
+    semantics,
+    diagnostics: semanticDiagnostics,
+    dependencySnapshot,
+  } = analyzeModules({
     graph,
     includeTests: options.includeTests,
+    previousSemantics: dependencySnapshotReuse.previousSemantics,
+    typingState: dependencySnapshotReuse.typingState,
   });
   markPhaseDuration("analyzeModules", analyzeStartedAt);
   const diagnostics = [...graph.diagnostics, ...semanticDiagnostics];
@@ -634,6 +757,11 @@ export const compileProgramWithLoader = async (
   if (hasErrorDiagnostics(diagnostics)) {
     return complete(compileProgramFailure(diagnostics));
   }
+
+  commitDependencySnapshot({
+    prepared: dependencySnapshotReuse,
+    dependencySnapshot,
+  });
 
   const shouldLinkSemantics = options.linkSemantics !== false;
 

--- a/packages/compiler/src/pipeline-shared.ts
+++ b/packages/compiler/src/pipeline-shared.ts
@@ -55,6 +55,7 @@ export type AnalyzeModulesOptions = {
   includeTests?: boolean;
   testScope?: TestScope;
   recoverFromTypingErrors?: boolean;
+  captureDependencySnapshot?: boolean;
   previousSemantics?: ReadonlyMap<string, SemanticsPipelineResult>;
   changedModuleIds?: ReadonlySet<string>;
   typingState?: {
@@ -133,6 +134,7 @@ export const analyzeModules = ({
   includeTests,
   testScope,
   recoverFromTypingErrors,
+  captureDependencySnapshot,
   previousSemantics,
   changedModuleIds,
   typingState,
@@ -147,6 +149,7 @@ export const analyzeModules = ({
     graph,
     includeTests,
     recoverFromTypingErrors,
+    captureDependencySnapshot,
     previousSemantics,
     changedModuleIds,
     typingState,
@@ -748,6 +751,7 @@ export const compileProgramWithLoader = async (
   } = analyzeModules({
     graph,
     includeTests: options.includeTests,
+    captureDependencySnapshot: Boolean(dependencySnapshotReuse.key),
     previousSemantics: dependencySnapshotReuse.previousSemantics,
     typingState: dependencySnapshotReuse.typingState,
   });

--- a/packages/compiler/src/semantics/effects/effect-table.ts
+++ b/packages/compiler/src/semantics/effects/effect-table.ts
@@ -23,6 +23,22 @@ export interface EffectRowDesc {
   tailVar?: EffectRowVariable;
 }
 
+export interface EffectInternerSnapshot {
+  nextRowId: EffectRowId;
+  nextTailVarId: number;
+  emptyRow: EffectRowId;
+  unknownRow: EffectRowId;
+  rows: readonly EffectRowDesc[];
+}
+
+export interface EffectTableSnapshot {
+  exprEffects: readonly [HirExprId, EffectRowId][];
+  functionEffects: readonly [
+    SymbolId,
+    { scheme: TypeSchemeId; row: EffectRowId },
+  ][];
+}
+
 export interface UnificationContext {
   location: NodeId;
   reason: string;
@@ -56,12 +72,15 @@ export interface EffectTable {
   isEmpty(id: EffectRowId): boolean;
   isOpen(id: EffectRowId): boolean;
   freshTailVar(options?: { rigid?: boolean }): EffectRowVariable;
+  snapshotInterner(): EffectInternerSnapshot;
+  cloneInterner(): EffectInterner;
   setExprEffect(expr: HirExprId, row: EffectRowId): void;
   getExprEffect(expr: HirExprId): EffectRowId | undefined;
   snapshotExprEffects(): ReadonlyMap<HirExprId, EffectRowId>;
   restoreExprEffects(snapshot: ReadonlyMap<HirExprId, EffectRowId>): void;
   setFunctionEffect(symbol: SymbolId, scheme: TypeSchemeId, row: EffectRowId): void;
   getFunctionEffect(symbol: SymbolId): EffectRowId | undefined;
+  snapshotTable(): EffectTableSnapshot;
 }
 
 export type EffectInterner = Omit<
@@ -72,12 +91,15 @@ export type EffectInterner = Omit<
   | "restoreExprEffects"
   | "setFunctionEffect"
   | "getFunctionEffect"
+  | "snapshotTable"
 >;
 
-export const createEffectInterner = (): EffectInterner => {
-  let nextRowId: EffectRowId = 0;
-  let nextTailVarId = 0;
-  const rows: EffectRowDesc[] = [];
+export const createEffectInterner = (
+  snapshot?: EffectInternerSnapshot,
+): EffectInterner => {
+  let nextRowId: EffectRowId = snapshot?.nextRowId ?? 0;
+  let nextTailVarId = snapshot?.nextTailVarId ?? 0;
+  const rows: EffectRowDesc[] = snapshot?.rows.map(cloneEffectRowDesc) ?? [];
   const rowCache = new Map<string, EffectRowId>();
 
   const opKey = (op: EffectOp): string =>
@@ -125,6 +147,10 @@ export const createEffectInterner = (): EffectInterner => {
 
   const rowKey = (desc: EffectRowDesc): string =>
     JSON.stringify(desc, (_, value) => value);
+
+  rows.forEach((row, id) => {
+    rowCache.set(rowKey(row), id as EffectRowId);
+  });
 
   const getRow = (id: EffectRowId): Readonly<EffectRowDesc> => {
     const row = rows[id];
@@ -256,10 +282,20 @@ export const createEffectInterner = (): EffectInterner => {
 
   const isOpen = (row: EffectRowId): boolean => Boolean(getRow(row).tailVar);
 
-  const emptyRow = internRow({ operations: [] });
-  const unknownRow = internRow({
-    operations: [],
-    tailVar: freshTailVar(),
+  const emptyRow = snapshot?.emptyRow ?? internRow({ operations: [] });
+  const unknownRow =
+    snapshot?.unknownRow ??
+    internRow({
+      operations: [],
+      tailVar: freshTailVar(),
+    });
+
+  const snapshotInterner = (): EffectInternerSnapshot => ({
+    nextRowId,
+    nextTailVarId,
+    emptyRow,
+    unknownRow,
+    rows: rows.map(cloneEffectRowDesc),
   });
 
   return {
@@ -272,18 +308,28 @@ export const createEffectInterner = (): EffectInterner => {
     isEmpty,
     isOpen,
     freshTailVar,
+    snapshotInterner,
+    cloneInterner: () => createEffectInterner(snapshotInterner()),
   };
 };
 
 export const createEffectTable = ({
   interner,
-}: { interner?: EffectInterner } = {}): EffectTable => {
+  snapshot,
+}: { interner?: EffectInterner; snapshot?: EffectTableSnapshot } = {}): EffectTable => {
   const shared = interner ?? createEffectInterner();
-  const exprEffects = new Map<HirExprId, EffectRowId>();
+  const exprEffects = new Map<HirExprId, EffectRowId>(
+    snapshot?.exprEffects ?? [],
+  );
   const functionEffects = new Map<
     SymbolId,
     { scheme: TypeSchemeId; row: EffectRowId }
-  >();
+  >(
+    snapshot?.functionEffects.map(([symbol, effect]) => [
+      symbol,
+      { scheme: effect.scheme, row: effect.row },
+    ]) ?? [],
+  );
 
   const setExprEffect = (expr: HirExprId, row: EffectRowId): void => {
     const existing = exprEffects.get(expr);
@@ -328,6 +374,14 @@ export const createEffectTable = ({
   const getFunctionEffect = (symbol: SymbolId): EffectRowId | undefined =>
     functionEffects.get(symbol)?.row;
 
+  const snapshotTable = (): EffectTableSnapshot => ({
+    exprEffects: Array.from(exprEffects.entries()),
+    functionEffects: Array.from(functionEffects.entries(), ([symbol, effect]) => [
+      symbol,
+      { scheme: effect.scheme, row: effect.row },
+    ]),
+  });
+
   return {
     ...shared,
     setExprEffect,
@@ -336,5 +390,16 @@ export const createEffectTable = ({
     restoreExprEffects,
     setFunctionEffect,
     getFunctionEffect,
+    snapshotTable,
   };
 };
+
+const cloneEffectRowDesc = (desc: EffectRowDesc): EffectRowDesc => ({
+  operations: desc.operations.map((op) => ({
+    name: op.name,
+    region: typeof op.region === "number" ? op.region : undefined,
+  })),
+  tailVar: desc.tailVar
+    ? { id: desc.tailVar.id, rigid: desc.tailVar.rigid }
+    : undefined,
+});

--- a/packages/compiler/src/semantics/typing/__tests__/type-arena.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/type-arena.test.ts
@@ -80,4 +80,27 @@ describe("TypeArena shape normalization", () => {
 
     expect(restrictedShape).not.toBe(publicShape);
   });
+
+  it("preserves canonical descriptor ids across snapshot restore", () => {
+    const arena = createTypeArena();
+    const i32 = arena.internPrimitive("i32");
+    const canonical = arena.createRecursiveType(() => ({
+      kind: "structural-object",
+      fields: [{ name: "value", type: i32 }],
+    }));
+
+    expect(
+      arena.internStructuralObject({
+        fields: [{ name: "value", type: i32 }],
+      }),
+    ).toBe(canonical);
+
+    const restored = createTypeArena(arena.snapshot());
+
+    expect(
+      restored.internStructuralObject({
+        fields: [{ name: "value", type: i32 }],
+      }),
+    ).toBe(canonical);
+  });
 });

--- a/packages/compiler/src/semantics/typing/type-arena.ts
+++ b/packages/compiler/src/semantics/typing/type-arena.ts
@@ -123,6 +123,15 @@ export interface TypeScheme {
   constraints?: ConstraintSet;
 }
 
+export interface TypeArenaSnapshot {
+  nextTypeId: TypeId;
+  nextSchemeId: TypeSchemeId;
+  nextTypeParamId: TypeParamId;
+  descriptors: readonly TypeDescriptor[];
+  schemes: readonly TypeScheme[];
+  recursiveUnfoldCache: readonly [TypeId, TypeId][];
+}
+
 export type Variance = "invariant" | "covariant" | "contravariant";
 
 export interface UnificationStepBudget {
@@ -188,17 +197,24 @@ export interface TypeArena {
   unify(a: TypeId, b: TypeId, ctx: UnificationContext): UnificationResult;
   substitute(type: TypeId, subst: Substitution): TypeId;
   widen(type: TypeId, constraint: ConstraintSet): TypeId;
+  snapshot(): TypeArenaSnapshot;
+  clone(): TypeArena;
 }
 
-export const createTypeArena = (): TypeArena => {
-  let nextTypeId: TypeId = 0;
-  let nextSchemeId: TypeSchemeId = 0;
-  let nextTypeParamId: TypeParamId = 0;
+export const createTypeArena = (snapshot?: TypeArenaSnapshot): TypeArena => {
+  let nextTypeId: TypeId = snapshot?.nextTypeId ?? 0;
+  let nextSchemeId: TypeSchemeId = snapshot?.nextSchemeId ?? 0;
+  let nextTypeParamId: TypeParamId = snapshot?.nextTypeParamId ?? 0;
 
-  const descriptors: TypeDescriptor[] = [];
+  const descriptors: TypeDescriptor[] =
+    snapshot?.descriptors.map(cloneTypeDescriptor) ?? [];
   const descriptorCache = new Map<string, TypeId>();
-  const schemes = new Map<TypeSchemeId, TypeScheme>();
-  const recursiveUnfoldCache = new Map<TypeId, TypeId>();
+  const schemes = new Map<TypeSchemeId, TypeScheme>(
+    snapshot?.schemes.map((scheme) => [scheme.id, cloneTypeScheme(scheme)]) ?? [],
+  );
+  const recursiveUnfoldCache = new Map<TypeId, TypeId>(
+    snapshot?.recursiveUnfoldCache ?? [],
+  );
 
   const jsonStringKey = (value: string): string => JSON.stringify(value);
 
@@ -280,6 +296,13 @@ export const createTypeArena = (): TypeArena => {
       }
     }
   };
+
+  descriptors.forEach((desc, id) => {
+    const key = keyFor(desc);
+    if (!descriptorCache.has(key)) {
+      descriptorCache.set(key, id as TypeId);
+    }
+  });
 
   const storeDescriptor = (desc: TypeDescriptor): TypeId => {
     const key = keyFor(desc);
@@ -1901,6 +1924,15 @@ export const createTypeArena = (): TypeArena => {
 
   const get = (id: TypeId): Readonly<TypeDescriptor> => getDescriptor(id);
 
+  const snapshotArena = (): TypeArenaSnapshot => ({
+    nextTypeId,
+    nextSchemeId,
+    nextTypeParamId,
+    descriptors: descriptors.map(cloneTypeDescriptor),
+    schemes: Array.from(schemes.values(), cloneTypeScheme),
+    recursiveUnfoldCache: Array.from(recursiveUnfoldCache.entries()),
+  });
+
   return {
     get,
     getScheme,
@@ -1925,7 +1957,104 @@ export const createTypeArena = (): TypeArena => {
     unify,
     substitute,
     widen,
+    snapshot: snapshotArena,
+    clone: () => createTypeArena(snapshotArena()),
   };
+};
+
+const cloneConstraintSet = (
+  constraints: ConstraintSet | undefined,
+): ConstraintSet | undefined =>
+  constraints
+    ? {
+        traits: constraints.traits ? [...constraints.traits] : undefined,
+        structural: constraints.structural
+          ? constraints.structural.map((entry) => ({
+              field: entry.field,
+              type: entry.type,
+            }))
+          : undefined,
+      }
+    : undefined;
+
+const cloneTypeScheme = (scheme: TypeScheme): TypeScheme => ({
+  id: scheme.id,
+  params: [...scheme.params],
+  body: scheme.body,
+  constraints: cloneConstraintSet(scheme.constraints),
+});
+
+const cloneTypeDescriptor = (desc: TypeDescriptor): TypeDescriptor => {
+  switch (desc.kind) {
+    case "primitive":
+      return { kind: "primitive", name: desc.name };
+    case "recursive":
+      return { kind: "recursive", binder: desc.binder, body: desc.body };
+    case "trait":
+      return {
+        kind: "trait",
+        owner: { ...desc.owner },
+        name: desc.name,
+        typeArgs: [...desc.typeArgs],
+      };
+    case "nominal-object":
+      return {
+        kind: "nominal-object",
+        owner: { ...desc.owner },
+        name: desc.name,
+        typeArgs: [...desc.typeArgs],
+      };
+    case "value-object":
+      return {
+        kind: "value-object",
+        owner: { ...desc.owner },
+        name: desc.name,
+        typeArgs: [...desc.typeArgs],
+      };
+    case "structural-object":
+      return {
+        kind: "structural-object",
+        fields: desc.fields.map((field) => ({
+          name: field.name,
+          type: field.type,
+          optional: field.optional,
+          declaringParams: field.declaringParams
+            ? [...field.declaringParams]
+            : undefined,
+          visibility: field.visibility ? { ...field.visibility } : undefined,
+          owner: field.owner,
+          packageId: field.packageId,
+        })),
+      };
+    case "function":
+      return {
+        kind: "function",
+        parameters: desc.parameters.map((param) => ({
+          type: param.type,
+          label: param.label,
+          optional: param.optional,
+        })),
+        returnType: desc.returnType,
+        effectRow: desc.effectRow,
+      };
+    case "union":
+      return { kind: "union", members: [...desc.members] };
+    case "intersection":
+      return {
+        kind: "intersection",
+        nominal: desc.nominal,
+        structural: desc.structural,
+        traits: desc.traits ? [...desc.traits] : undefined,
+      };
+    case "fixed-array":
+      return { kind: "fixed-array", element: desc.element };
+    case "type-param-ref":
+      return { kind: "type-param-ref", param: desc.param };
+    default: {
+      const exhaustive: never = desc;
+      return exhaustive;
+    }
+  }
 };
 
 export const typeDescriptorToUserString = (

--- a/packages/compiler/src/semantics/typing/type-arena.ts
+++ b/packages/compiler/src/semantics/typing/type-arena.ts
@@ -128,6 +128,7 @@ export interface TypeArenaSnapshot {
   nextSchemeId: TypeSchemeId;
   nextTypeParamId: TypeParamId;
   descriptors: readonly TypeDescriptor[];
+  descriptorCache: readonly [string, TypeId][];
   schemes: readonly TypeScheme[];
   recursiveUnfoldCache: readonly [TypeId, TypeId][];
 }
@@ -297,12 +298,18 @@ export const createTypeArena = (snapshot?: TypeArenaSnapshot): TypeArena => {
     }
   };
 
-  descriptors.forEach((desc, id) => {
-    const key = keyFor(desc);
-    if (!descriptorCache.has(key)) {
-      descriptorCache.set(key, id as TypeId);
-    }
-  });
+  if (snapshot) {
+    snapshot.descriptorCache.forEach(([key, id]) =>
+      descriptorCache.set(key, id),
+    );
+  } else {
+    descriptors.forEach((desc, id) => {
+      const key = keyFor(desc);
+      if (!descriptorCache.has(key)) {
+        descriptorCache.set(key, id as TypeId);
+      }
+    });
+  }
 
   const storeDescriptor = (desc: TypeDescriptor): TypeId => {
     const key = keyFor(desc);
@@ -1929,6 +1936,7 @@ export const createTypeArena = (snapshot?: TypeArenaSnapshot): TypeArena => {
     nextSchemeId,
     nextTypeParamId,
     descriptors: descriptors.map(cloneTypeDescriptor),
+    descriptorCache: Array.from(descriptorCache.entries()),
     schemes: Array.from(schemes.values(), cloneTypeScheme),
     recursiveUnfoldCache: Array.from(recursiveUnfoldCache.entries()),
   });

--- a/packages/compiler/src/semantics/typing/type-table.ts
+++ b/packages/compiler/src/semantics/typing/type-table.ts
@@ -10,6 +10,11 @@ export interface ExprTypeEntry {
   weak: boolean;
 }
 
+export interface TypeTableSnapshot {
+  exprTypes: readonly [HirExprId, ExprTypeEntry][];
+  symbolSchemes: readonly [SymbolId, TypeSchemeId][];
+}
+
 export interface TypeTable {
   setExprType(
     id: HirExprId,
@@ -24,11 +29,22 @@ export interface TypeTable {
   setSymbolScheme(symbol: SymbolId, scheme: TypeSchemeId): void;
   getSymbolScheme(symbol: SymbolId): TypeSchemeId | undefined;
   entries(): Iterable<[HirExprId, TypeId]>;
+  snapshot(): TypeTableSnapshot;
+  clone(): TypeTable;
 }
 
-export const createTypeTable = (): TypeTable => {
-  const exprTypeStack = [new Map<HirExprId, ExprTypeEntry>()];
-  const symbolSchemes = new Map<SymbolId, TypeSchemeId>();
+export const createTypeTable = (snapshot?: TypeTableSnapshot): TypeTable => {
+  const exprTypeStack = [
+    new Map<HirExprId, ExprTypeEntry>(
+      snapshot?.exprTypes.map(([id, entry]) => [
+        id,
+        { type: entry.type, weak: entry.weak },
+      ]) ?? [],
+    ),
+  ];
+  const symbolSchemes = new Map<SymbolId, TypeSchemeId>(
+    snapshot?.symbolSchemes ?? [],
+  );
 
   const currentExprTypes = (): Map<HirExprId, ExprTypeEntry> =>
     exprTypeStack[exprTypeStack.length - 1]!;
@@ -73,6 +89,14 @@ export const createTypeTable = (): TypeTable => {
   const entries = (): Iterable<[HirExprId, TypeId]> =>
     Array.from(currentExprTypes().entries(), ([id, entry]) => [id, entry.type]);
 
+  const snapshotTable = (): TypeTableSnapshot => ({
+    exprTypes: Array.from(currentExprTypes().entries(), ([id, entry]) => [
+      id,
+      { type: entry.type, weak: entry.weak },
+    ]),
+    symbolSchemes: Array.from(symbolSchemes.entries()),
+  });
+
   return {
     setExprType,
     getExprType,
@@ -83,5 +107,7 @@ export const createTypeTable = (): TypeTable => {
     setSymbolScheme,
     getSymbolScheme,
     entries,
+    snapshot: snapshotTable,
+    clone: () => createTypeTable(snapshotTable()),
   };
 };

--- a/packages/compiler/src/semantics/typing/types.ts
+++ b/packages/compiler/src/semantics/typing/types.ts
@@ -293,6 +293,15 @@ export class FunctionStore {
       ])
     );
   }
+
+  clone(): FunctionStore {
+    const copy = new FunctionStore();
+    this.#bySymbol.forEach((fn, symbol) => copy.#bySymbol.set(symbol, fn));
+    this.#signatures.forEach((signature, symbol) =>
+      copy.#signatures.set(symbol, cloneFunctionSignature(signature)),
+    );
+    return copy;
+  }
 }
 
 export interface BaseObjectInfo {
@@ -408,6 +417,23 @@ export class ObjectStore {
   isResolving(symbol: SymbolId): boolean {
     return this.#resolving.has(symbol);
   }
+
+  clone(): ObjectStore {
+    const copy = new ObjectStore();
+    copy.#base = { ...this.#base };
+    this.#templates.forEach((template, symbol) =>
+      copy.#templates.set(symbol, cloneObjectTemplate(template)),
+    );
+    this.#instances.forEach((info, key) =>
+      copy.#instances.set(key, cloneObjectTypeInfo(info)),
+    );
+    this.#byName.forEach((symbol, name) => copy.#byName.set(name, symbol));
+    this.#byNominal.forEach((info, nominal) =>
+      copy.#byNominal.set(nominal, cloneObjectTypeInfo(info)),
+    );
+    this.#decls.forEach((decl, symbol) => copy.#decls.set(symbol, decl));
+    return copy;
+  }
 }
 
 export class TraitStore {
@@ -469,6 +495,16 @@ export class TraitStore {
 
   getImplTemplatesForTrait(symbol: SymbolId): readonly TraitImplTemplate[] {
     return this.#implTemplatesByTrait.get(symbol) ?? [];
+  }
+
+  clone(): TraitStore {
+    const copy = new TraitStore();
+    this.#decls.forEach((decl, symbol) => copy.#decls.set(symbol, decl));
+    this.#byName.forEach((symbol, name) => copy.#byName.set(name, symbol));
+    this.#implTemplates.forEach((template) =>
+      copy.registerImplTemplate(cloneTraitImplTemplate(template)),
+    );
+    return copy;
   }
 }
 
@@ -583,6 +619,27 @@ export class TypeAliasStore {
 
   instanceEntries(): IterableIterator<[string, TypeId]> {
     return this.#instances.entries();
+  }
+
+  clone(): TypeAliasStore {
+    const copy = new TypeAliasStore();
+    this.#templates.forEach((template, symbol) =>
+      copy.#templates.set(symbol, {
+        symbol: template.symbol,
+        params: template.params.map((param) => ({ ...param })),
+        target: template.target,
+      }),
+    );
+    this.#instances.forEach((type, key) => copy.#instances.set(key, type));
+    this.#instanceSymbols.forEach((symbols, type) =>
+      copy.#instanceSymbols.set(type, new Set(symbols)),
+    );
+    this.#validatedInstances.forEach((key) => copy.#validatedInstances.add(key));
+    this.#byName.forEach((symbol, name) => copy.#byName.set(name, symbol));
+    this.#failedInstantiations.forEach((key) =>
+      copy.#failedInstantiations.add(key),
+    );
+    return copy;
   }
 }
 
@@ -722,3 +779,76 @@ export interface TraitImplInstance {
 
 export const DEFAULT_EFFECT_ROW: EffectRowId = 0;
 export const BASE_OBJECT_NAME = "Object";
+
+const cloneFunctionSignature = (
+  signature: FunctionSignature,
+): FunctionSignature => ({
+  typeId: signature.typeId,
+  parameters: signature.parameters.map((param) => ({ ...param })),
+  returnType: signature.returnType,
+  declaredReturnType: signature.declaredReturnType,
+  declaredReturnSerializer: signature.declaredReturnSerializer,
+  hasExplicitReturn: signature.hasExplicitReturn,
+  annotatedReturn: signature.annotatedReturn,
+  effectRow: signature.effectRow,
+  annotatedEffects: signature.annotatedEffects,
+  typeParams: signature.typeParams?.map((param) => ({ ...param })),
+  scheme: signature.scheme,
+  typeParamMap: signature.typeParamMap
+    ? new Map(signature.typeParamMap)
+    : undefined,
+});
+
+const cloneObjectField = (field: ObjectField): ObjectField => ({
+  name: field.name,
+  type: field.type,
+  optional: field.optional,
+  declaringParams: field.declaringParams ? [...field.declaringParams] : undefined,
+  visibility: field.visibility ? { ...field.visibility } : undefined,
+  owner: field.owner,
+  packageId: field.packageId,
+});
+
+const cloneObjectTypeInfo = (info: ObjectTypeInfo): ObjectTypeInfo => ({
+  objectKind: info.objectKind,
+  nominal: info.nominal,
+  structural: info.structural,
+  type: info.type,
+  fields: info.fields.map(cloneObjectField),
+  visibility: info.visibility ? { ...info.visibility } : undefined,
+  baseNominal: info.baseNominal,
+  traitImpls: info.traitImpls?.map(cloneTraitImplInstance),
+});
+
+const cloneObjectTemplate = (template: ObjectTemplate): ObjectTemplate => ({
+  symbol: template.symbol,
+  objectKind: template.objectKind,
+  params: template.params.map((param) => ({ ...param })),
+  nominal: template.nominal,
+  structural: template.structural,
+  type: template.type,
+  fields: template.fields.map(cloneObjectField),
+  visibility: template.visibility ? { ...template.visibility } : undefined,
+  baseNominal: template.baseNominal,
+});
+
+const cloneTraitImplTemplate = (
+  template: TraitImplTemplate,
+): TraitImplTemplate => ({
+  trait: template.trait,
+  traitSymbol: template.traitSymbol,
+  target: template.target,
+  typeParams: template.typeParams.map((param) => ({ ...param })),
+  methods: new Map(template.methods),
+  implSymbol: template.implSymbol,
+});
+
+const cloneTraitImplInstance = (
+  impl: TraitImplInstance,
+): TraitImplInstance => ({
+  trait: impl.trait,
+  traitSymbol: impl.traitSymbol,
+  target: impl.target,
+  methods: new Map(impl.methods),
+  implSymbol: impl.implSymbol,
+});

--- a/packages/compiler/src/semantics/typing/types.ts
+++ b/packages/compiler/src/semantics/typing/types.ts
@@ -300,6 +300,24 @@ export class FunctionStore {
     this.#signatures.forEach((signature, symbol) =>
       copy.#signatures.set(symbol, cloneFunctionSignature(signature)),
     );
+    this.#instances.forEach((type, key) => copy.#instances.set(key, type));
+    this.#instantiationInfo.forEach((info, symbolRefKey) =>
+      copy.#instantiationInfo.set(
+        symbolRefKey,
+        new Map(
+          Array.from(info.entries()).map(([key, typeArgs]) => [
+            key,
+            [...typeArgs],
+          ]),
+        ),
+      ),
+    );
+    this.#instanceExprTypes.forEach((exprs, key) =>
+      copy.#instanceExprTypes.set(key, new Map(exprs)),
+    );
+    this.#instanceValueTypes.forEach((types, key) =>
+      copy.#instanceValueTypes.set(key, new Map(types)),
+    );
     return copy;
   }
 }

--- a/packages/sdk/src/__tests__/sdk-node.test.ts
+++ b/packages/sdk/src/__tests__/sdk-node.test.ts
@@ -366,6 +366,172 @@ pub fn main(): (HttpServer, task::TaskRuntime, env::Env, time::Time) -> i32
     expect(output).toBe(42);
   });
 
+  it("does not expose mutable cached wasm across repeat compiles", async () => {
+    const sdk = createSdk();
+    const options = {
+      source: `#!no_prelude
+pub fn main() -> i32
+  42
+`,
+    };
+    const first = expectCompileSuccess(await sdk.compile(options));
+    const originalFirstByte = first.wasm[0]!;
+    first.wasm[0] = originalFirstByte ^ 0xff;
+
+    const second = expectCompileSuccess(await sdk.compile(options));
+
+    expect(second.wasm).not.toBe(first.wasm);
+    expect(second.wasm[0]).toBe(originalFirstByte);
+    await expect(second.run<number>({ entryName: "main" })).resolves.toBe(42);
+  });
+
+  it("invalidates SDK compile reuse when an imported source file changes", async () => {
+    const sdk = createSdk();
+    const source = `#!no_prelude
+use src::util::value
+
+pub fn main() -> i32
+  value()
+`;
+    const compile = (value: number) =>
+      sdk.compile({
+        entryPath: "main.voyd",
+        source,
+        files: {
+          "util.voyd": `#!no_prelude
+pub fn value() -> i32
+  ${value}
+`,
+        },
+      });
+
+    const first = expectCompileSuccess(await compile(1));
+    await expect(first.run<number>({ entryName: "main" })).resolves.toBe(1);
+
+    const second = expectCompileSuccess(await compile(2));
+    await expect(second.run<number>({ entryName: "main" })).resolves.toBe(2);
+
+    const repeatedSecond = expectCompileSuccess(await compile(2));
+    await expect(repeatedSecond.run<number>({ entryName: "main" })).resolves.toBe(2);
+  });
+
+  it("re-emits across codegen option changes", async () => {
+    const sdk = createSdk();
+    const source = `#!no_prelude
+pub fn main() -> i32
+  1
+`;
+
+    const withoutRuntimeDiagnostics = expectCompileSuccess(
+      await sdk.compile({ source, runtimeDiagnostics: false }),
+    );
+    const withRuntimeDiagnostics = expectCompileSuccess(
+      await sdk.compile({ source, runtimeDiagnostics: true }),
+    );
+
+    expect(hasRuntimeDiagnosticsSection(withoutRuntimeDiagnostics.wasm)).toBe(false);
+    expect(hasRuntimeDiagnosticsSection(withRuntimeDiagnostics.wasm)).toBe(true);
+  });
+
+  it("reuses dependency snapshots for app edits and invalidates std/pkg edits", async () => {
+    const sdk = createSdk();
+    const projectRoot = await fs.mkdtemp(
+      path.join(repoRoot, ".tmp-voyd-sdk-dependency-snapshot-"),
+    );
+    const srcDir = path.join(projectRoot, "src");
+    const stdDir = path.join(projectRoot, "std");
+    const packageRoot = path.join(projectRoot, "packages");
+    const packageSrcDir = path.join(packageRoot, "dep", "src");
+    const entryPath = path.join(srcDir, "main.voyd");
+    const stdPath = path.join(stdDir, "mathdep.voyd");
+    const pkgApiPath = path.join(packageSrcDir, "api.voyd");
+
+    const writeApp = (value: number) =>
+      fs.writeFile(
+        entryPath,
+        [
+          "#!no_prelude",
+          "use std::mathdep::{ std_value }",
+          "use pkg::dep::all",
+          "",
+          "pub fn main() -> i32",
+          `  std_value() + pkg_value() + ${value}`,
+        ].join("\n"),
+      );
+    const writeStd = (value: number) =>
+      fs.writeFile(
+        stdPath,
+        ["#!no_prelude", "pub fn std_value() -> i32", `  ${value}`].join("\n"),
+      );
+    const writePkg = (value: number) =>
+      fs.writeFile(
+        pkgApiPath,
+        ["#!no_prelude", "pub fn pkg_value() -> i32", `  ${value}`].join("\n"),
+      );
+    const compileAndRun = async () => {
+      const result = expectCompileSuccess(
+        await sdk.compile({
+          entryPath,
+          roots: { src: srcDir, std: stdDir, pkgDirs: [packageRoot] },
+        }),
+      );
+      return result.run<number>({ entryName: "main" });
+    };
+
+    try {
+      await fs.mkdir(srcDir, { recursive: true });
+      await fs.mkdir(stdDir, { recursive: true });
+      await fs.mkdir(packageSrcDir, { recursive: true });
+      await fs.writeFile(
+        path.join(packageSrcDir, "pkg.voyd"),
+        ["#!no_prelude", "pub use src::api::pkg_value"].join("\n"),
+      );
+      await writeApp(1);
+      await writeStd(10);
+      await writePkg(100);
+
+      await expect(compileAndRun()).resolves.toBe(111);
+
+      await writeApp(2);
+      await expect(compileAndRun()).resolves.toBe(112);
+
+      await writeStd(11);
+      await expect(compileAndRun()).resolves.toBe(113);
+
+      await writePkg(101);
+      await expect(compileAndRun()).resolves.toBe(114);
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps dependency snapshot app edits valid for generic-heavy programs", async () => {
+    const sdk = createSdk();
+    const entryPath = path.join(
+      repoRoot,
+      "apps",
+      "smoke",
+      "fixtures",
+      "vtrace-compute-benchmark.voyd",
+    );
+    const source = await fs.readFile(entryPath, "utf8");
+
+    const cold = expectCompileSuccess(
+      await sdk.compile({ entryPath, source }),
+    );
+    expect(cold.wasm.byteLength).toBeGreaterThan(0);
+
+    const warm = expectCompileSuccess(
+      await sdk.compile({
+        entryPath,
+        source: `${source}\nfn dependency_snapshot_app_edit_marker() -> i32\n  1\n`,
+      }),
+    );
+    await expect(warm.run<number>({ entryName: "main" })).resolves.toBe(
+      3_825_271,
+    );
+  });
+
   it("runs typed boundary exports through the existing host and sdk APIs", async () => {
     const sdk = createSdk();
     const result = expectCompileSuccess(

--- a/packages/sdk/src/__tests__/sdk-node.test.ts
+++ b/packages/sdk/src/__tests__/sdk-node.test.ts
@@ -532,6 +532,37 @@ pub fn main() -> i32
     );
   });
 
+  it("emits the same optimized wasm for fresh and dependency snapshot app edits", async () => {
+    const sdk = createSdk();
+    const entryPath = path.join(
+      repoRoot,
+      "apps",
+      "smoke",
+      "fixtures",
+      "std-math-transcendentals.voyd",
+    );
+    const source = await fs.readFile(entryPath, "utf8");
+    const editedSource = `${source}\nfn dependency_snapshot_app_edit_marker() -> i32\n  1\n`;
+
+    expectCompileSuccess(
+      await sdk.compile({ entryPath, source, optimize: true }),
+    );
+    const warm = expectCompileSuccess(
+      await sdk.compile({ entryPath, source: editedSource, optimize: true }),
+    );
+    const fresh = expectCompileSuccess(
+      await createSdk().compile({
+        entryPath,
+        source: editedSource,
+        optimize: true,
+      }),
+    );
+
+    expect(warm.wasm.byteLength).toBe(fresh.wasm.byteLength);
+    await expect(warm.run<number>({ entryName: "main" })).resolves.toBe(1);
+    await expect(fresh.run<number>({ entryName: "main" })).resolves.toBe(1);
+  });
+
   it("runs typed boundary exports through the existing host and sdk APIs", async () => {
     const sdk = createSdk();
     const result = expectCompileSuccess(

--- a/packages/sdk/src/__tests__/sdk-tests.test.ts
+++ b/packages/sdk/src/__tests__/sdk-tests.test.ts
@@ -4,14 +4,41 @@ import { createSdk, type CompileResult, type TestEvent } from "@voyd-lang/sdk";
 const expectCompileSuccess = (
   result: CompileResult,
 ): Extract<CompileResult, { success: true }> => {
-  expect(result.success).toBe(true);
   if (!result.success) {
     throw new Error(result.diagnostics.map((diagnostic) => diagnostic.message).join("\n"));
   }
+  expect(result.success).toBe(true);
   return result;
 };
 
 describe("sdk tests collection", { timeout: 120_000 }, () => {
+  it("invalidates compile reuse when a companion test file changes", async () => {
+    const sdk = createSdk();
+    const compile = (description: string) =>
+      sdk.compile({
+        includeTests: true,
+        entryPath: "main.voyd",
+        source: `pub fn main() -> i32
+  1
+`,
+        files: {
+          "main.test.voyd": `test "${description}":
+  1
+`,
+        },
+      });
+
+    const first = expectCompileSuccess(await compile("first companion test"));
+    expect(first.tests?.cases.map((test) => test.description)).toEqual([
+      "first companion test",
+    ]);
+
+    const second = expectCompileSuccess(await compile("updated companion test"));
+    expect(second.tests?.cases.map((test) => test.description)).toEqual([
+      "updated companion test",
+    ]);
+  });
+
   it("keeps explicit boundary export includes scoped to the runnable module", async () => {
     const sdk = createSdk();
     const result = expectCompileSuccess(await sdk.compile({

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -1,6 +1,11 @@
 import { createMemoryModuleHost } from "@voyd-lang/compiler/modules/memory-host.js";
 import { loadModuleGraph } from "@voyd-lang/compiler/pipeline-browser.js";
-import { compileWithLoader } from "./shared/compile.js";
+import { isCompilerPerfEnabled } from "@voyd-lang/compiler/perf.js";
+import {
+  compileWithLoader,
+  createCompilerReuseCache,
+  type CompilerReuseCache,
+} from "./shared/compile.js";
 import { runWithHandlers } from "./shared/host.js";
 import { createCompileResult } from "./shared/result.js";
 import {
@@ -25,11 +30,14 @@ import {
   type ParsedModule,
 } from "./compiler-browser.js";
 
-export const createSdk = (): VoydSdk => ({
-  compile: compileSdk,
-  run: runWithHandlers,
-  serveWebApp,
-});
+export const createSdk = (): VoydSdk => {
+  const compilerCache = createCompilerReuseCache();
+  return {
+    compile: (options) => compileSdk(options, compilerCache),
+    run: runWithHandlers,
+    serveWebApp,
+  };
+};
 
 export const serveWebApp = async (
   options: ServeWebAppOptions,
@@ -45,7 +53,10 @@ export const serveWebApp = async (
   };
 };
 
-const compileSdk = async (options: CompileOptions): Promise<CompileResult> => {
+const compileSdk = async (
+  options: CompileOptions,
+  compilerCache?: CompilerReuseCache,
+): Promise<CompileResult> => {
   const fallbackFile = options.entryPath ?? "index.voyd";
 
   if (options.emitWasmText) {
@@ -73,11 +84,23 @@ const compileSdk = async (options: CompileOptions): Promise<CompileResult> => {
   }
 
   try {
+    const setupPhasesMs: Record<string, number> = {};
+    const perfEnabled = isCompilerPerfEnabled();
+    const setupStartedAt = perfEnabled ? performance.now() : 0;
+    const parseStartedAt = perfEnabled ? performance.now() : 0;
     const parsed = await browserParseModule(options.source, {
       entryPath: options.entryPath,
       files: options.files,
       roots: options.roots,
     });
+    recordSetupPhase({
+      phasesMs: setupPhasesMs,
+      enabled: perfEnabled,
+      name: "sdkSetup.browserParseModule",
+      startedAt: parseStartedAt,
+    });
+
+    const rootStartedAt = perfEnabled ? performance.now() : 0;
     const roots = parsed.roots ?? options.roots;
     if (!roots) {
       return {
@@ -90,8 +113,28 @@ const compileSdk = async (options: CompileOptions): Promise<CompileResult> => {
         ],
       };
     }
+    recordSetupPhase({
+      phasesMs: setupPhasesMs,
+      enabled: perfEnabled,
+      name: "sdkSetup.resolveRoots",
+      startedAt: rootStartedAt,
+    });
 
+    const hostStartedAt = perfEnabled ? performance.now() : 0;
     const host = createMemoryModuleHost({ files: parsed.files });
+    recordSetupPhase({
+      phasesMs: setupPhasesMs,
+      enabled: perfEnabled,
+      name: "sdkSetup.createHost",
+      startedAt: hostStartedAt,
+    });
+    recordSetupPhase({
+      phasesMs: setupPhasesMs,
+      enabled: perfEnabled,
+      name: "sdkSetup.total",
+      startedAt: setupStartedAt,
+    });
+
     const result = await compileWithLoader({
       entryPath: parsed.entryPath,
       roots,
@@ -103,6 +146,8 @@ const compileSdk = async (options: CompileOptions): Promise<CompileResult> => {
       optimize: options.optimize,
       loadModuleGraph,
       boundaryExports: options.boundaryExports,
+      cache: compilerCache,
+      setupPhasesMs,
     });
     if (!result.success) {
       return result;
@@ -118,6 +163,23 @@ const compileSdk = async (options: CompileOptions): Promise<CompileResult> => {
       }),
     };
   }
+};
+
+const recordSetupPhase = ({
+  phasesMs,
+  enabled,
+  name,
+  startedAt,
+}: {
+  phasesMs: Record<string, number>;
+  enabled: boolean;
+  name: string;
+  startedAt: number;
+}): void => {
+  if (!enabled) {
+    return;
+  }
+  phasesMs[name] = performance.now() - startedAt;
 };
 
 export {

--- a/packages/sdk/src/node.ts
+++ b/packages/sdk/src/node.ts
@@ -6,8 +6,13 @@ import { createMemoryModuleHost } from "@voyd-lang/compiler/modules/memory-host.
 import { createNodePathAdapter } from "@voyd-lang/compiler/modules/node-path-adapter.js";
 import type { ModuleHost, ModuleRoots } from "@voyd-lang/compiler/modules/types.js";
 import { loadModuleGraph } from "@voyd-lang/compiler/pipeline.js";
+import { isCompilerPerfEnabled } from "@voyd-lang/compiler/perf.js";
 import { resolveStdRoot } from "@voyd-lang/lib/resolve-std.js";
-import { compileWithLoader } from "./shared/compile.js";
+import {
+  compileWithLoader,
+  createCompilerReuseCache,
+  type CompilerReuseCache,
+} from "./shared/compile.js";
 import {
   createHost,
   registerHandlers,
@@ -35,16 +40,20 @@ export { detectSrcRootForPath } from "./shared/source-root.js";
 const DEFAULT_ENTRY = "index.voyd";
 const DEFAULT_VIRTUAL_ROOT = ".voyd";
 
-export const createSdk = (): VoydSdk => ({
-  compile: compileSdk,
-  run: runWithHandlers,
-  serveWebApp,
-});
+export const createSdk = (): VoydSdk => {
+  const compilerCache = createCompilerReuseCache();
+  return {
+    compile: (options) => compileSdk(options, compilerCache),
+    run: runWithHandlers,
+    serveWebApp: (options) => serveWebApp(options, compilerCache),
+  };
+};
 
 export const serveWebApp = async (
   options: ServeWebAppOptions,
+  compilerCache?: CompilerReuseCache,
 ): Promise<ServeWebAppResult> => {
-  const result = await compileSdk(options);
+  const result = await compileSdk(options, compilerCache);
   if (!result.success) {
     return result;
   }
@@ -187,7 +196,27 @@ const restoreEnv = (key: string, value: string | undefined): void => {
   process.env[key] = value;
 };
 
-const compileSdk = async (options: CompileOptions): Promise<CompileResult> => {
+const recordSetupPhase = ({
+  phasesMs,
+  enabled,
+  name,
+  startedAt,
+}: {
+  phasesMs: Record<string, number>;
+  enabled: boolean;
+  name: string;
+  startedAt: number;
+}): void => {
+  if (!enabled) {
+    return;
+  }
+  phasesMs[name] = performance.now() - startedAt;
+};
+
+const compileSdk = async (
+  options: CompileOptions,
+  compilerCache?: CompilerReuseCache,
+): Promise<CompileResult> => {
   if (!options.entryPath && options.source === undefined) {
     return {
       success: false,
@@ -203,6 +232,10 @@ const compileSdk = async (options: CompileOptions): Promise<CompileResult> => {
   const entryName = options.entryPath ?? DEFAULT_ENTRY;
 
   try {
+    const setupPhasesMs: Record<string, number> = {};
+    const perfEnabled = isCompilerPerfEnabled();
+    const setupStartedAt = perfEnabled ? performance.now() : 0;
+    const rootResolutionStartedAt = perfEnabled ? performance.now() : 0;
     const srcRoot = resolveSrcRoot({
       roots: options.roots,
       entryPath: entryName,
@@ -214,6 +247,14 @@ const compileSdk = async (options: CompileOptions): Promise<CompileResult> => {
       source: options.source,
     });
     const roots = resolveRoots({ roots: options.roots, srcRoot });
+    recordSetupPhase({
+      phasesMs: setupPhasesMs,
+      enabled: perfEnabled,
+      name: "sdkSetup.resolveRoots",
+      startedAt: rootResolutionStartedAt,
+    });
+
+    const hostStartedAt = perfEnabled ? performance.now() : 0;
     const host = options.source
       ? createOverlayModuleHost({
           primary: createMemoryModuleHost({
@@ -228,6 +269,18 @@ const compileSdk = async (options: CompileOptions): Promise<CompileResult> => {
           fallback: createFsModuleHost(),
         })
       : createFsModuleHost();
+    recordSetupPhase({
+      phasesMs: setupPhasesMs,
+      enabled: perfEnabled,
+      name: "sdkSetup.createHost",
+      startedAt: hostStartedAt,
+    });
+    recordSetupPhase({
+      phasesMs: setupPhasesMs,
+      enabled: perfEnabled,
+      name: "sdkSetup.total",
+      startedAt: setupStartedAt,
+    });
 
     const testScope = options.testScope ?? (options.source ? "entry" : "all");
     const runtimeDiagnostics = resolveRuntimeDiagnostics({
@@ -244,6 +297,8 @@ const compileSdk = async (options: CompileOptions): Promise<CompileResult> => {
       runtimeDiagnostics,
       loadModuleGraph,
       boundaryExports: options.boundaryExports,
+      cache: compilerCache,
+      setupPhasesMs,
     });
 
     if (!result.success) {

--- a/packages/sdk/src/shared/compile.ts
+++ b/packages/sdk/src/shared/compile.ts
@@ -134,6 +134,7 @@ export const compileWithLoader = async ({
     graph,
     includeTests: shouldIncludeTests,
     testScope: scopedTestScope,
+    captureDependencySnapshot: Boolean(dependencySnapshotReuse.key),
     previousSemantics: dependencySnapshotReuse.previousSemantics,
     typingState: dependencySnapshotReuse.typingState,
   });

--- a/packages/sdk/src/shared/compile.ts
+++ b/packages/sdk/src/shared/compile.ts
@@ -1,6 +1,12 @@
 import { codegenErrorToDiagnostic } from "@voyd-lang/compiler/codegen/diagnostics.js";
 import type { Diagnostic } from "@voyd-lang/compiler/diagnostics/index.js";
 import { DiagnosticError } from "@voyd-lang/compiler/diagnostics/index.js";
+import {
+  commitDependencySnapshot,
+  createCompilerDependencySnapshotCache,
+  prepareDependencySnapshotReuse,
+  type CompilerDependencySnapshotCache,
+} from "@voyd-lang/compiler/modules/dependency-snapshot-cache.js";
 import type { ModuleHost, ModuleRoots } from "@voyd-lang/compiler/modules/types.js";
 import {
   analyzeModules,
@@ -9,6 +15,12 @@ import {
   type LoadModuleGraphFn,
   type TestScope,
 } from "@voyd-lang/compiler/pipeline-shared.js";
+import {
+  diffCompilerPerfCounters,
+  isCompilerPerfEnabled,
+  logCompilerPerfSummary,
+  snapshotCompilerPerfCounters,
+} from "@voyd-lang/compiler/perf.js";
 import type { BoundaryExportsOption } from "@voyd-lang/compiler/codegen/context.js";
 import type { TestCase } from "./types.js";
 import { diagnosticsFromUnknownError } from "./diagnostics.js";
@@ -28,8 +40,12 @@ export type CompileArtifactsFailure = {
 
 export type CompileArtifacts = CompileArtifactsSuccess | CompileArtifactsFailure;
 
+export type CompilerReuseCache = CompilerDependencySnapshotCache;
+
 const hasErrorDiagnostics = (diagnostics: readonly Diagnostic[]): boolean =>
   diagnostics.some((diagnostic) => diagnostic.severity === "error");
+
+export const createCompilerReuseCache = createCompilerDependencySnapshotCache;
 
 export const compileWithLoader = async ({
   entryPath,
@@ -42,6 +58,8 @@ export const compileWithLoader = async ({
   loadModuleGraph,
   testScope,
   boundaryExports,
+  cache,
+  setupPhasesMs,
 }: {
   entryPath: string;
   roots: ModuleRoots;
@@ -53,26 +71,32 @@ export const compileWithLoader = async ({
   loadModuleGraph: LoadModuleGraphFn;
   testScope?: TestScope;
   boundaryExports?: BoundaryExportsOption;
+  cache?: CompilerReuseCache;
+  setupPhasesMs?: Readonly<Record<string, number>>;
 }): Promise<CompileArtifacts> => {
+  const perf = createCompilePerfScope({ entryPath, setupPhasesMs });
   const shouldIncludeTests = includeTests || testsOnly;
   const codegenLoadPromise = preloadCodegen();
   void codegenLoadPromise.catch(() => undefined);
   let graph: Awaited<ReturnType<LoadModuleGraphFn>>;
   try {
+    const loadStartedAt = perf.start();
     graph = await loadModuleGraph({
       entryPath,
       roots,
       host,
       includeTests: shouldIncludeTests,
     });
+    perf.mark("loadModuleGraph", loadStartedAt);
   } catch (error) {
-    return {
+    const failure = {
       success: false,
       diagnostics: diagnosticsFromUnknownError({
         error,
         fallbackFile: entryPath,
       }),
-    };
+    } as const;
+    return perf.complete(failure);
   }
 
   const scopedTestScope = testScope ?? "all";
@@ -92,23 +116,46 @@ export const compileWithLoader = async ({
     ...runtimeDiagnosticsCodegenOption,
     boundaryExports: false,
   } as const;
-  const { semantics, diagnostics: semanticDiagnostics, tests } = analyzeModules({
+
+  const dependencySnapshotReuse = prepareDependencySnapshotReuse({
+    cache,
+    graph,
+    roots,
+    includeTests: shouldIncludeTests,
+  });
+
+  const analyzeStartedAt = perf.start();
+  const {
+    semantics,
+    diagnostics: semanticDiagnostics,
+    tests,
+    dependencySnapshot,
+  } = analyzeModules({
     graph,
     includeTests: shouldIncludeTests,
     testScope: scopedTestScope,
+    previousSemantics: dependencySnapshotReuse.previousSemantics,
+    typingState: dependencySnapshotReuse.typingState,
   });
+  perf.mark("analyzeModules", analyzeStartedAt);
   const diagnostics = [...graph.diagnostics, ...semanticDiagnostics];
   const testCases = shouldIncludeTests ? tests : undefined;
 
   if (hasErrorDiagnostics(diagnostics)) {
-    return {
+    return perf.complete({
       success: false,
       diagnostics,
-    };
+    });
   }
+
+  commitDependencySnapshot({
+    prepared: dependencySnapshotReuse,
+    dependencySnapshot,
+  });
 
   try {
     if (testsOnly) {
+      const emitStartedAt = perf.start();
       const testResult = await emitProgram({
         graph,
         semantics,
@@ -118,32 +165,36 @@ export const compileWithLoader = async ({
           ...testCodegenOption,
         },
       });
+      perf.mark("emitProgram.tests", emitStartedAt);
       const allDiagnostics = [...diagnostics, ...testResult.diagnostics];
       if (hasErrorDiagnostics(allDiagnostics)) {
-        return { success: false, diagnostics: allDiagnostics };
+        return perf.complete({ success: false, diagnostics: allDiagnostics });
       }
 
-      return {
-        success: true,
-        wasm: testResult.wasm,
-        tests: testCases,
-        testsWasm: testResult.wasm,
-      };
+      return perf.complete({
+          success: true,
+          wasm: testResult.wasm,
+          tests: testCases,
+          testsWasm: testResult.wasm,
+      });
     }
 
+    const emitStartedAt = perf.start();
     const wasmResult = await emitProgram({
       graph,
       semantics,
       codegenOptions: codegenOption,
     });
+    perf.mark("emitProgram", emitStartedAt);
     const baseDiagnostics = [...diagnostics, ...wasmResult.diagnostics];
     if (hasErrorDiagnostics(baseDiagnostics)) {
-      return { success: false, diagnostics: baseDiagnostics };
+      return perf.complete({ success: false, diagnostics: baseDiagnostics });
     }
 
     let testsWasm: Uint8Array | undefined;
 
     if (shouldIncludeTests && tests.length > 0) {
+      const testEmitStartedAt = perf.start();
       const testResult = await emitProgram({
         graph,
         semantics,
@@ -153,19 +204,20 @@ export const compileWithLoader = async ({
           ...testCodegenOption,
         },
       });
+      perf.mark("emitProgram.tests", testEmitStartedAt);
       const allDiagnostics = [...baseDiagnostics, ...testResult.diagnostics];
       if (hasErrorDiagnostics(allDiagnostics)) {
-        return { success: false, diagnostics: allDiagnostics };
+        return perf.complete({ success: false, diagnostics: allDiagnostics });
       }
       testsWasm = testResult.wasm;
     }
 
-    return {
-      success: true,
-      wasm: wasmResult.wasm,
-      tests: testCases,
-      testsWasm,
-    };
+    return perf.complete({
+        success: true,
+        wasm: wasmResult.wasm,
+        tests: testCases,
+        testsWasm,
+    });
   } catch (error) {
     const codegenDiagnostics =
       error instanceof DiagnosticError
@@ -175,9 +227,50 @@ export const compileWithLoader = async ({
               moduleId: graph.entry ?? entryPath,
             }),
           ];
-    return {
+    return perf.complete({
       success: false,
       diagnostics: [...diagnostics, ...codegenDiagnostics],
-    };
+    });
   }
+};
+
+const createCompilePerfScope = ({
+  entryPath,
+  setupPhasesMs,
+}: {
+  entryPath: string;
+  setupPhasesMs?: Readonly<Record<string, number>>;
+}) => {
+  const enabled = isCompilerPerfEnabled();
+  const startedAt = enabled ? performance.now() : 0;
+  const countersBefore = enabled ? snapshotCompilerPerfCounters() : undefined;
+  const phasesMs: Record<string, number> = { ...(setupPhasesMs ?? {}) };
+  const start = (): number => (enabled ? performance.now() : 0);
+  const mark = (phase: string, phaseStartedAt: number): void => {
+    if (!enabled) {
+      return;
+    }
+    phasesMs[phase] = performance.now() - phaseStartedAt;
+  };
+  const complete = <T extends CompileArtifacts>(result: T): T => {
+    if (!enabled || !countersBefore) {
+      return result;
+    }
+
+    phasesMs.total =
+      performance.now() - startedAt + (setupPhasesMs?.["sdkSetup.total"] ?? 0);
+    logCompilerPerfSummary({
+      entryPath,
+      success: result.success,
+      diagnostics: result.success ? 0 : result.diagnostics.length,
+      phasesMs,
+      counters: diffCompilerPerfCounters({
+        before: countersBefore,
+        after: snapshotCompilerPerfCounters(),
+      }),
+    });
+    return result;
+  };
+
+  return { start, mark, complete };
 };

--- a/scripts/bench-v375-compiler-latency.ts
+++ b/scripts/bench-v375-compiler-latency.ts
@@ -1,0 +1,288 @@
+import fs from "node:fs";
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { gzipSync } from "node:zlib";
+import { createSdk, type CompileResult } from "@voyd-lang/sdk";
+import { createVoydHost } from "@voyd-lang/sdk/js-host";
+
+type Scenario = {
+  name: string;
+  allowMissing?: boolean;
+  allowFailure?: boolean;
+  entryPath: string;
+  entryName?: string;
+  expected?: number;
+  runtimeSamples?: number;
+};
+
+type CompileRow = {
+  name: string;
+  optimize: boolean;
+  sdkReuse: boolean;
+  compileKind: "cold" | "warm-app-edit";
+  compileIndex: number;
+  compileMs: number;
+  wasmBytes: number;
+  gzipBytes: number;
+  heapUsedBytes: number;
+  wasmSha256: string;
+  runtimeMedianMs?: number;
+  runtimeSamplesMs: readonly number[];
+};
+
+const repeatCount = Number.parseInt(
+  process.env.VOYD_COMPILER_LATENCY_REPEATS ?? "3",
+  10,
+);
+const freshSdkPerCompile = ["1", "true", "yes"].includes(
+  (process.env.VOYD_COMPILER_LATENCY_FRESH_SDK ?? "").trim().toLowerCase(),
+);
+const optimizeModes = (process.env.VOYD_BENCH_OPTIMIZE_MODES ?? "true")
+  .split(",")
+  .map((value) => value.trim().toLowerCase())
+  .filter((value) => value.length > 0)
+  .map((value) => {
+    if (value === "true" || value === "1") return true;
+    if (value === "false" || value === "0") return false;
+      throw new Error(`invalid VOYD_BENCH_OPTIMIZE_MODES entry ${value}`);
+  });
+const scenarioFilter = new Set(
+  (process.env.VOYD_COMPILER_LATENCY_SCENARIOS ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0),
+);
+
+const scenarios: Scenario[] = [
+  {
+    name: "smoke/std-math-transcendentals",
+    entryPath: path.resolve("apps/smoke/fixtures/std-math-transcendentals.voyd"),
+    entryName: "main",
+    expected: 1,
+    runtimeSamples: 3,
+  },
+  {
+    name: "smoke/scalar-aggregate-representative",
+    entryPath: path.resolve("apps/smoke/fixtures/scalar-aggregate-representative.voyd"),
+    entryName: "main",
+    expected: 1_100_340_000,
+    runtimeSamples: 3,
+  },
+  {
+    name: "smoke/vtrace-compute-main",
+    entryPath: path.resolve("apps/smoke/fixtures/vtrace-compute-benchmark.voyd"),
+    entryName: "main",
+    expected: 3_825_271,
+    runtimeSamples: 1,
+  },
+  {
+    name: "smoke/vtrace-compute-benchmark",
+    entryPath: path.resolve("apps/smoke/fixtures/vtrace-compute-benchmark.voyd"),
+    entryName: "benchmark",
+    expected: 57_372_071,
+    runtimeSamples: Number.parseInt(
+      process.env.VOYD_COMPILER_LATENCY_VTRACE_RUNTIME_SAMPLES ?? "1",
+      10,
+    ),
+  },
+  {
+    name: "voyd_examples/ray-vtrace-tuned",
+    entryPath: "/Users/drew/projects/voyd_examples/benchmarks/ray/voyd/vtrace_tuned.voyd",
+    allowMissing: true,
+  },
+  {
+    name: "voyd_examples/suite-compile",
+    entryPath: "/Users/drew/projects/voyd_examples/benchmarks/suite/voyd/benchmarks.voyd",
+    allowMissing: true,
+    allowFailure: true,
+  },
+];
+
+const expectCompileSuccess = (
+  result: CompileResult,
+  name: string,
+): Extract<CompileResult, { success: true }> => {
+  if (result.success) {
+    return result;
+  }
+
+  throw new Error(
+    `${name} failed to compile:\n${result.diagnostics
+      .map((diagnostic) => formatDiagnosticMessage(diagnostic.message))
+      .join("\n")}`,
+  );
+};
+
+const formatDiagnosticMessage = (message: unknown): string => {
+  if (typeof message === "string") {
+    return message;
+  }
+  return JSON.stringify(message);
+};
+
+const median = (values: readonly number[]): number | undefined => {
+  if (values.length === 0) {
+    return undefined;
+  }
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1]! + sorted[middle]!) / 2
+    : sorted[middle];
+};
+
+const runRuntimeSamples = async ({
+  wasm,
+  scenario,
+}: {
+  wasm: Uint8Array;
+  scenario: Scenario;
+}): Promise<number[]> => {
+  if (!scenario.entryName || scenario.expected === undefined) {
+    return [];
+  }
+
+  const host = await createVoydHost({ wasm });
+  const samples: number[] = [];
+  const sampleCount = scenario.runtimeSamples ?? 1;
+  for (let index = 0; index < sampleCount; index += 1) {
+    const startedAt = performance.now();
+    const result = await host.run<number>(scenario.entryName);
+    const elapsed = performance.now() - startedAt;
+    if (result !== scenario.expected) {
+      throw new Error(
+        `${scenario.name} returned ${result}, expected ${scenario.expected}`,
+      );
+    }
+    samples.push(elapsed);
+  }
+  return samples;
+};
+
+const runScenario = async ({
+  scenario,
+  optimize,
+}: {
+  scenario: Scenario;
+  optimize: boolean;
+}): Promise<CompileRow[]> => {
+  const sharedSdk = freshSdkPerCompile ? undefined : createSdk();
+  const rows: CompileRow[] = [];
+  const repeats = Math.max(1, repeatCount);
+  const baseSource = fs.readFileSync(scenario.entryPath, "utf8");
+
+  for (let compileIndex = 0; compileIndex < repeats; compileIndex += 1) {
+    (globalThis as { gc?: () => void }).gc?.();
+    const sdk = sharedSdk ?? createSdk();
+    const startedAt = performance.now();
+    const compiled = expectCompileSuccess(
+      await sdk.compile({
+        entryPath: scenario.entryPath,
+        source:
+          compileIndex === 0
+            ? baseSource
+            : sourceWithAppEdit({ source: baseSource, compileIndex }),
+        optimize,
+      }),
+      scenario.name,
+    );
+    const compileMs = performance.now() - startedAt;
+    const heapUsedBytes = process.memoryUsage().heapUsed;
+    const runtimeSamplesMs =
+      compileIndex === 0
+        ? await runRuntimeSamples({ wasm: compiled.wasm, scenario })
+        : [];
+
+    rows.push({
+      name: scenario.name,
+      optimize,
+      sdkReuse: !freshSdkPerCompile,
+      compileKind: compileIndex === 0 ? "cold" : "warm-app-edit",
+      compileIndex,
+      compileMs,
+      wasmBytes: compiled.wasm.byteLength,
+      gzipBytes: gzipSync(compiled.wasm).byteLength,
+      heapUsedBytes,
+      wasmSha256: createHash("sha256").update(compiled.wasm).digest("hex"),
+      runtimeMedianMs: median(runtimeSamplesMs),
+      runtimeSamplesMs,
+    });
+  }
+
+  return rows;
+};
+
+const sourceWithAppEdit = ({
+  source,
+  compileIndex,
+}: {
+  source: string;
+  compileIndex: number;
+}): string =>
+  `${source}\nfn v375_app_edit_marker_${compileIndex}() -> i32\n  ${compileIndex}\n`;
+
+const printRows = (rows: readonly CompileRow[]): void => {
+  console.log(
+    [
+      "name",
+      "optimize",
+      "sdkReuse",
+      "compileKind",
+      "compileIndex",
+      "compileMs",
+      "wasmBytes",
+      "gzipBytes",
+      "heapUsedBytes",
+      "wasmSha256",
+      "runtimeMedianMs",
+      "runtimeSamplesMs",
+    ].join(","),
+  );
+  rows.forEach((row) => {
+    console.log(
+      [
+        row.name,
+        row.optimize ? "true" : "false",
+        row.sdkReuse ? "true" : "false",
+        row.compileKind,
+        row.compileIndex.toString(),
+        row.compileMs.toFixed(3),
+        row.wasmBytes.toString(),
+        row.gzipBytes.toString(),
+        row.heapUsedBytes.toString(),
+        row.wasmSha256,
+        row.runtimeMedianMs === undefined ? "" : row.runtimeMedianMs.toFixed(3),
+        row.runtimeSamplesMs.map((sample) => sample.toFixed(3)).join("|"),
+      ].join(","),
+    );
+  });
+};
+
+const main = async (): Promise<void> => {
+  const rows: CompileRow[] = [];
+  for (const scenario of scenarios.filter(
+    ({ name }) => scenarioFilter.size === 0 || scenarioFilter.has(name),
+  )) {
+    if (!fs.existsSync(scenario.entryPath)) {
+      if (scenario.allowMissing) {
+        continue;
+      }
+      throw new Error(`missing benchmark scenario ${scenario.entryPath}`);
+    }
+    for (const optimize of optimizeModes) {
+      try {
+        rows.push(...(await runScenario({ scenario, optimize })));
+      } catch (error) {
+        if (!scenario.allowFailure) {
+          throw error;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`[bench-v375] skipping optional ${scenario.name}: ${message}`);
+      }
+    }
+  }
+  printRows(rows);
+};
+
+void main();


### PR DESCRIPTION
## Summary
- Add compiler-owned dependency semantic snapshots for std/pkg modules and reuse them across app-source edits.
- Clone arena/effect/typing state safely so app compiles get fresh overlay state without mutating cached dependency semantics.
- Keep profiling and benchmark harness, now measuring real one-line app code edits instead of unchanged artifact hits.

## Validation
- npm run typecheck
- npm test
- VOYD_COMPILER_LATENCY_REPEATS=2 VOYD_COMPILER_LATENCY_VTRACE_RUNTIME_SAMPLES=0 VOYD_BENCH_OPTIMIZE_MODES=true npm run bench:compiler-latency
- Focused snapshot/sdk vitest suite: dependency snapshots, std/pkg invalidation, app edits, mixed-order SCCs, generic-heavy vtrace warm edit

## Notes
- Warm optimized app-edit compiles save ~10.9% to 27.9% in the recorded scenarios; vtrace remains dominated by whole-program emit/codegen.
- Linear: V-375