### PR TITLE
Clarify full and affected test scripts

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,7 +70,7 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: npm ci --include=optional
       # Main PR tests run in source mode for speed and broad coverage.
-      - run: VOYD_USE_SRC=1 npx turbo run test --affected --output-logs=errors-only --concurrency=75%
+      - run: VOYD_USE_SRC=1 npm run test:affected
       # Build-only checks for non-CLI artifacts that are not exercised by package tests.
       - name: Build non-CLI artifacts
         if: steps.changes.outputs.non_cli_build == 'true'

--- a/docs/testing-ci-modes.md
+++ b/docs/testing-ci-modes.md
@@ -17,7 +17,7 @@ If both `VOYD_USE_DIST=1` and `VOYD_USE_SRC=1` are set, source mode wins and a w
 PR workflow (`.github/workflows/pr.yml`) runs complementary checks:
 
 1. Main test sweep in source mode:
-   - `VOYD_USE_SRC=1 npx turbo run test --affected ...`
+   - `VOYD_USE_SRC=1 npm run test:affected`
    - Fast path for broad correctness checks. Compiler codegen tests are split
      into their own sharded CI job because they dominate wall-clock time.
 2. Compiler codegen in a separate sharded job (when compiler/runtime files change):
@@ -48,7 +48,7 @@ If you modify any of the following, ensure dist CLI e2e still runs:
 
 Recommended local commands before merging CLI/runtime changes:
 
-- `VOYD_USE_SRC=1 npm test`
+- `VOYD_USE_SRC=1 npm run test:full`
 - `npm run test:codegen`
 - `npx turbo run build --filter=@voyd-lang/cli...`
 - `VOYD_USE_DIST=1 VOYD_CLI_E2E_RUNTIME=dist npm run --workspace @voyd-lang/cli test:e2e`

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
   "packageManager": "npm@11.5.2",
   "scripts": {
     "build": "turbo run build --affected",
-    "test": "turbo run test --affected --output-logs=errors-only --concurrency=50%",
+    "test": "turbo run test --output-logs=errors-only",
+    "test:affected": "turbo run test --affected --output-logs=errors-only",
     "test:codegen": "npm run --workspace @voyd-lang/compiler test:codegen --",
-    "test:full": "npm test && npm run test:codegen && npm run --workspace @voyd-lang/cli test:e2e",
+    "test:full": "npm run test -- --force && npm run test:codegen && npm run --workspace @voyd-lang/cli test:e2e",
     "test:perf:smoke": "npm --workspace @voyd-lang/smoke run test:perf",
     "typecheck": "turbo run typecheck --affected",
     "lint": "turbo run lint --affected --parallel",


### PR DESCRIPTION
## Summary

- Make `npm test` run all package tests instead of the affected subset.
- Add `npm run test:affected` for the fast changed-package path used by PR CI.
- Make `npm run test:full` force package tests to execute without cache before running codegen and CLI e2e.
- Remove the Turbo test concurrency limiter from root scripts and PR CI.
- Update testing/CI docs to use the new script names.

## Validation

- `npm run test:full`
  - package tests: 14/14 successful, 0 cached
  - compiler codegen: 47 files, 277 tests passed
  - CLI e2e: 1 file, 17 tests passed
- `npm run typecheck`