### PR TITLE
Make string UTF-8 export return an isolated copy

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,7 +70,8 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: npm ci --include=optional
       # Main PR tests run in source mode for speed and broad coverage.
-      - run: VOYD_USE_SRC=1 npm run test:affected
+      # CI caps package-level Turbo concurrency to avoid oversubscribing hosted runners.
+      - run: VOYD_USE_SRC=1 npm run test:affected:ci
       # Build-only checks for non-CLI artifacts that are not exercised by package tests.
       - name: Build non-CLI artifacts
         if: steps.changes.outputs.non_cli_build == 'true'

--- a/docs/testing-ci-modes.md
+++ b/docs/testing-ci-modes.md
@@ -17,9 +17,12 @@ If both `VOYD_USE_DIST=1` and `VOYD_USE_SRC=1` are set, source mode wins and a w
 PR workflow (`.github/workflows/pr.yml`) runs complementary checks:
 
 1. Main test sweep in source mode:
-   - `VOYD_USE_SRC=1 npm run test:affected`
-   - Fast path for broad correctness checks. Compiler codegen tests are split
-     into their own sharded CI job because they dominate wall-clock time.
+   - `VOYD_USE_SRC=1 npm run test:affected:ci`
+   - Fast path for broad correctness checks. This uses the same affected
+     package selection as `npm run test:affected`, with a CI-specific Turbo
+     concurrency cap so hosted runners are not oversubscribed by many package
+     test tasks at once. Compiler codegen tests are split into their own
+     sharded CI job because they dominate wall-clock time.
 2. Compiler codegen in a separate sharded job (when compiler/runtime files change):
    - `npm run --workspace @voyd-lang/compiler test:codegen -- --shard=N/4`
    - Keeps the slowest compiler e2e-style tests off the main PR critical path.
@@ -49,6 +52,8 @@ If you modify any of the following, ensure dist CLI e2e still runs:
 Recommended local commands before merging CLI/runtime changes:
 
 - `VOYD_USE_SRC=1 npm run test:full`
+- `VOYD_USE_SRC=1 npm run test:affected:ci` when reproducing PR runner load
+  locally
 - `npm run test:codegen`
 - `npx turbo run build --filter=@voyd-lang/cli...`
 - `VOYD_USE_DIST=1 VOYD_CLI_E2E_RUNTIME=dist npm run --workspace @voyd-lang/cli test:e2e`

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "turbo run build --affected",
     "test": "turbo run test --output-logs=errors-only",
     "test:affected": "turbo run test --affected --output-logs=errors-only",
+    "test:affected:ci": "turbo run test --affected --output-logs=errors-only --concurrency=50%",
     "test:codegen": "npm run --workspace @voyd-lang/compiler test:codegen --",
     "test:full": "npm run test -- --force && npm run test:codegen && npm run --workspace @voyd-lang/cli test:e2e",
     "test:perf:smoke": "npm --workspace @voyd-lang/smoke run test:perf",

--- a/packages/std/src/array.voyd
+++ b/packages/std/src/array.voyd
@@ -328,9 +328,16 @@ impl<T> Array<T>
     })
     next_raw
 
-  /// Returns the underlying backing storage array.
+  /// Copies values into a fixed-size array.
   api fn raw_storage(self) -> FixedArray<T>
     self.to_fixed_array()
+
+  /// Returns the backing storage for std-internal read paths.
+  ///
+  /// Callers must not mutate the returned storage unless they own the array
+  /// and have first established unique access.
+  fn internal_storage(self) -> FixedArray<T>
+    self.storage
 
   /// Returns pairs of `(index, value)` for each element.
   api fn enumerate(self) -> Array<(i32, T)>

--- a/packages/std/src/string/type.test.voyd
+++ b/packages/std/src/string/type.test.voyd
@@ -63,6 +63,21 @@ test "string utf8 decode and encode":
       assert(error.code, eq: 1)
       assert(error.message.equals("utf8 decode failed: invalid utf-8 byte sequence"), eq: true)
 
+test "string to_utf8 returns an isolated mutable copy":
+  let source = "alpha"
+  let slice = source.as_slice().slice(bytes: 1, len: 3)
+  let ~bytes = source.to_utf8()
+
+  assert(bytes.replace(0, with: 90), eq: true)
+  match(bytes.get(0))
+    Some<i32> { value }:
+      assert(value, eq: 90)
+    None:
+      assert(false)
+
+  assert(source.equals("alpha"), eq: true)
+  assert(slice.to_string().equals("lph"), eq: true)
+
 test "string slice and as_slice":
   let value = "a😀b"
   let sliced = value.slice(Range<i32> {

--- a/packages/std/src/string/type.voyd
+++ b/packages/std/src/string/type.voyd
@@ -478,16 +478,14 @@ impl String
   /// Returns a UTF-8 byte array copy.
   ///
   /// This allocates a new `Array<i32>` containing the exact encoded bytes.
+  /// Mutating the returned array never changes the string or slices derived
+  /// from it.
   ///
   /// Example:
   /// `String::from_utf8(text.to_utf8())`
   /// round-trips `text` through bytes validation.
   api fn to_utf8(self): () -> Array<i32>
-    match(Array<i32>::from(self.raw_bytes()))
-      Some<Array<i32>> { value }:
-        value
-      None:
-        Array<i32>::init()
+    new_array_unchecked<i32>({ from: self.copy_raw_bytes() })
 
   /// Returns this value as an owned string.
   api fn to_string(self): () -> String
@@ -584,9 +582,23 @@ impl String
       None:
         None {}
 
-  /// Returns the underlying UTF-8 byte storage.
-  api fn raw_bytes(self): () -> FixedArray<i32>
-    self.bytes.raw_storage()
+  /// Copies the underlying UTF-8 bytes.
+  fn copy_raw_bytes(self): () -> FixedArray<i32>
+    let out = new_fixed_array<i32>(self.byte_count)
+    __array_copy(out, {
+      from: self.raw_bytes(),
+      to_index: 0,
+      from_index: 0,
+      count: self.byte_count
+    })
+    out
+
+  /// Returns the backing UTF-8 storage for std-internal read-only scans.
+  ///
+  /// This is intentionally not `api`: public byte access must go through
+  /// `to_utf8()`, which returns a mutable copy.
+  fn raw_bytes(self): () -> FixedArray<i32>
+    self.bytes.internal_storage()
 
   /// Returns true when both strings have identical bytes.
   api fn equals(self, other: String): () -> bool


### PR DESCRIPTION
## Summary

Fixes V-389 by tightening the string byte-access contract:

- `String.to_utf8()` now returns an isolated mutable byte-array copy instead of wrapping the string backing storage.
- `String.raw_bytes()` is no longer public API and is documented as std-internal read-only backing access.
- `Array.raw_storage()` remains public but is documented as copying, with a separate internal storage path for std read scans.
- Adds regression coverage showing mutating `to_utf8()` output does not change the source `String` or an existing `StringSlice`.

## Root Cause

`String.to_utf8()` previously called `Array<i32>::from(self.raw_bytes())`. `Array::from(FixedArray)` wraps the supplied fixed storage directly, and public `String.raw_bytes()` exposed the string backing storage, so callers could mutate returned bytes and violate string/slice invariants.

## Validation

- `env VOYD_USE_SRC=1 node ../../scripts/voyd test ./src --fail-empty-tests` from `packages/std` passed: 236 passed, 0 failed.

Note: the exact root `npm test` / `npm run typecheck` commands could not be run in this shell because `npm` is not available here.