### PR TITLE
Fix generic escaped closure continuations

### DIFF
--- a/packages/compiler/src/codegen/__tests__/__fixtures__/effects-generic-escaped-closure-result.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/effects-generic-escaped-closure-result.voyd
@@ -1,0 +1,57 @@
+use std::string::type::{ String }
+
+eff Async
+  await(resume, value: i32) -> i32
+
+obj Response {
+  value: String
+}
+
+obj Context {
+  marker: i32
+}
+
+trait IntoResponse<T>
+  fn into_response(self) -> Response
+
+impl IntoResponse<String> for String
+  fn into_response(self) -> Response
+    Response { value: self }
+
+type Handler = fn(Context) : (open) -> Response
+
+fn to_response<T: IntoResponse<T>>(value: T) -> Response
+  value.into_response()
+
+fn wrap_handler<R: IntoResponse<R>>(
+  handler: fn() : (open) -> R
+) -> Handler
+  (_context: Context) -> Response =>
+    let result = handler()
+    to_response<R>(result)
+
+fn run_callback<R>(callback: fn() : (open) -> R): (open) -> R
+  callback()
+
+fn wrap_nested_handler<R: IntoResponse<R>>(
+  handler: fn() : (open) -> R
+) -> Handler
+  (context: Context) -> Response =>
+    run_callback<Response> do:
+      let result = handler()
+      let response = to_response<R>(result)
+      if context.marker == 1 then: response else: Response { value: "bad" }
+
+pub fn main(): Async -> i32
+  let direct_route = wrap_handler<String> do:
+    let _ = Async::await(5)
+    "ok"
+  let nested_route = wrap_nested_handler<String> do:
+    let _ = Async::await(6)
+    "ok"
+  let context = Context { marker: 1 }
+  let direct_result =
+    if direct_route(context).value.equals("ok") then: 1 else: 0
+  let nested_result =
+    if nested_route(context).value.equals("ok") then: 1 else: 0
+  direct_result + nested_result

--- a/packages/compiler/src/codegen/__tests__/effects-generic-escaped-closure-result.test.ts
+++ b/packages/compiler/src/codegen/__tests__/effects-generic-escaped-closure-result.test.ts
@@ -1,0 +1,34 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  compileEffectFixture,
+  parseEffectTable,
+  runEffectfulExport,
+} from "./support/effects-harness.js";
+
+const fixturePath = resolve(
+  import.meta.dirname,
+  "__fixtures__",
+  "effects-generic-escaped-closure-result.voyd",
+);
+
+describe("generic escaped closure continuation results", () => {
+  it("resumes through the generic wrapper after the callback performs", async () => {
+    const { module } = await compileEffectFixture({ entryPath: fixturePath });
+    const parsed = parseEffectTable(module);
+    const awaitOp = parsed.ops.find((op) => op.label.endsWith("Async.await"));
+    if (!awaitOp) {
+      throw new Error("missing Async.await op entry");
+    }
+
+    const result = await runEffectfulExport<number>({
+      wasm: module,
+      entryName: "main_effectful",
+      handlers: {
+        [`${awaitOp.opIndex}`]: (_request, value) => value,
+      },
+    });
+
+    expect(result.value).toBe(2);
+  });
+});

--- a/packages/compiler/src/codegen/effects/gc-trampoline/continuations.ts
+++ b/packages/compiler/src/codegen/effects/gc-trampoline/continuations.ts
@@ -27,7 +27,11 @@ import {
   allocateTempLocal,
   storeLocalValue,
 } from "../../locals.js";
-import { getRequiredExprType, wasmTypeFor } from "../../types.js";
+import {
+  getRequiredExprType,
+  getSymbolTypeId,
+  wasmTypeFor,
+} from "../../types.js";
 import { walkHirExpression, walkHirPattern } from "../../hir-walk.js";
 import { buildGroupContinuationCfg } from "../continuation-cfg.js";
 import { createGroupedContinuationExpressionCompiler } from "../continuation-compiler.js";
@@ -99,9 +103,15 @@ const collectIdentifierExprTypes = ({
         const setType = (symbol: SymbolId, typeId?: TypeId): void => {
           if (!shouldCaptureIdentifierSymbol(symbol, ctx)) return;
           if (types.has(symbol)) return;
+          let symbolTypeId: TypeId | undefined;
+          try {
+            symbolTypeId = getSymbolTypeId(symbol, ctx, typeInstanceId);
+          } catch {
+            symbolTypeId = undefined;
+          }
           types.set(
             symbol,
-            ctx.module.types.getValueType(symbol) ??
+            symbolTypeId ??
               typeId ??
               ctx.program.primitives.unknown,
           );

--- a/packages/compiler/src/codegen/effects/host-boundary/resume.ts
+++ b/packages/compiler/src/codegen/effects/host-boundary/resume.ts
@@ -334,7 +334,19 @@ export const createEndRequestRaw = ({
   stateFor(ctx, END_REQUEST_RAW_KEY, () => {
     const msgpack = ensureMsgPackFunctions(ctx);
     const msgPackType = wasmTypeFor(msgpack.msgPackTypeId, ctx);
-    const endSites = [...ctx.effectsState.contSiteByKey.values(), ...ctx.effectLowering.sites]
+    const specializedSites = [...ctx.effectsState.contSiteByKey.values()];
+    const specializedSiteIds = new Set(
+      specializedSites.map((site) => site.siteId),
+    );
+    // A specialized site replaces its generic template in emitted code. The
+    // template can still contain unresolved owner types, so it cannot safely
+    // participate in host-boundary payload decoding.
+    const endSites = [
+      ...specializedSites,
+      ...ctx.effectLowering.sites.filter(
+        (site) => !specializedSiteIds.has(site.siteId),
+      ),
+    ]
       .reduce((sites, variant) => {
         if (sites.some((site) => site.siteOrder === variant.siteOrder)) {
           return sites;

--- a/packages/compiler/src/semantics/effects/__tests__/__fixtures__/effects-lowering-info.voyd
+++ b/packages/compiler/src/semantics/effects/__tests__/__fixtures__/effects-lowering-info.voyd
@@ -17,3 +17,15 @@ fn call_mix(cb: fn() -> i32): Async -> i32
   pure_add(1, 2)
   cb()
   effectful()
+
+type GenericWrapper = fn(i32) : (open) -> i32
+
+fn generic_wrapper<T>(callback: fn() : (open) -> T) -> GenericWrapper
+  (_context: i32) -> i32 =>
+    let _ = callback()
+    1
+
+fn call_generic_wrapper(): Async -> i32
+  let wrapped = generic_wrapper<i32> do:
+    effectful()
+  wrapped(0)

--- a/packages/compiler/src/semantics/effects/__tests__/lowering-info.test.ts
+++ b/packages/compiler/src/semantics/effects/__tests__/lowering-info.test.ts
@@ -114,4 +114,21 @@ describe("EffectsLoweringInfo", () => {
     expect(effectfulCall?.effectful).toBe(true);
     expect(semantics.typing.effects.isEmpty(effectfulCall!.effectRow)).toBe(false);
   });
+
+  it("lowers a generic lambda whose body has an open effect row", () => {
+    const semantics = loadSemantics();
+    const info = buildEffectsLoweringInfo({
+      binding: semantics.binding,
+      symbolTable: getSymbolTable(semantics),
+      hir: semantics.hir,
+      typing: semantics.typing,
+    });
+
+    const escaped = Array.from(info.lambdas.values()).find((lambda) => {
+      const expr = semantics.hir.expressions.get(lambda.exprId);
+      return expr?.exprKind === "lambda" && expr.captures.length > 0;
+    });
+    expect(escaped?.abiEffectful).toBe(true);
+    expect(escaped?.shouldLower).toBe(true);
+  });
 });

--- a/packages/compiler/src/semantics/effects/analysis.ts
+++ b/packages/compiler/src/semantics/effects/analysis.ts
@@ -225,6 +225,11 @@ const lambdaEffectfulType = (expr: HirLambdaExpr, typing: TypingResult): boolean
   return typeof effectRow === "number" && !typing.effects.isEmpty(effectRow);
 };
 
+const lambdaBodyIsEffectful = (
+  expr: HirLambdaExpr,
+  typing: TypingResult,
+): boolean => !isPureEffectRow(exprEffectRow({ expr: expr.body, typing }), typing);
+
 export const buildEffectsLoweringInfo = ({
   binding,
   symbolTable,
@@ -346,7 +351,8 @@ export const buildEffectsLoweringInfo = ({
       visitLambdaBodies: false,
     });
     const effectfulType = lambdaEffectfulType(expr, typing);
-    const abiEffectful = effectfulType || hasHandlerInBody;
+    const abiEffectful =
+      effectfulType || lambdaBodyIsEffectful(expr, typing) || hasHandlerInBody;
     lambdas.set(expr.id, {
       exprId: expr.id,
       hasHandlerInBody,


### PR DESCRIPTION
## Summary

- lower generic lambdas when their inferred body carries an open effect row, even when the lambda's base expression type is unavailable before monomorphization
- restore continuation locals from instance-specialized symbol types so nested escaped closures capture the correct runtime representation
- omit superseded generic continuation templates from host-boundary payload decoding
- add semantic and runtime regressions for direct and nested generic wrapper callbacks

## Why

V-386 showed that an effectful generic callback could resume with its raw payload instead of continuing through the escaped wrapper. The generic wrapper lambda was not selected for lowering before monomorphization, so its effectful call returned without a wrapper continuation frame. Once lowered, nested captured values also needed their instance-specialized types restored when rebuilding continuation locals.

## Impact

Generic escaped closures now resume through all wrapper logic, including result conversion, and nested callbacks preserve nominal captured values without emitting invalid Wasm.

## Validation

- `npm run typecheck`
- `npm test` (14/14 workspace tasks)
- `npm run test:codegen` (48 files, 278 tests)
- `VOYD_USE_SRC=1 node ../../scripts/voyd test ./src --fail-empty-tests` in `packages/web` (62 tests)
