### PR TITLE
Enforce self return types for init methods

### DIFF
--- a/packages/compiler/src/semantics/__tests__/__fixtures__/constructor_init_explicit_return_mismatch.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/constructor_init_explicit_return_mismatch.voyd
@@ -1,0 +1,7 @@
+obj Widget {
+  value: i32
+}
+
+impl Widget
+  fn init() -> i32
+    1

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/constructor_init_generic_cross_module/dep.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/constructor_init_generic_cross_module/dep.voyd
@@ -1,0 +1,7 @@
+pub obj Box<T> {
+  value: T
+}
+
+impl Box<T>
+  pub fn init(value: T)
+    1

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/constructor_init_generic_cross_module/main.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/constructor_init_generic_cross_module/main.voyd
@@ -1,0 +1,4 @@
+use src::dep::Box
+
+pub fn main() -> i32
+  Box(1).value

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/constructor_init_generic_inferred_return.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/constructor_init_generic_inferred_return.voyd
@@ -1,0 +1,10 @@
+obj Box<T> {
+  value: T
+}
+
+impl Box<T>
+  fn init(value: T)
+    Box { value }
+
+pub fn main() -> i32
+  Box(1).value

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/constructor_init_inferred_return_mismatch.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/constructor_init_inferred_return_mismatch.voyd
@@ -1,0 +1,7 @@
+obj Widget {
+  value: i32
+}
+
+impl Widget
+  fn init()
+    1

--- a/packages/compiler/src/semantics/__tests__/pipeline.test.ts
+++ b/packages/compiler/src/semantics/__tests__/pipeline.test.ts
@@ -1102,6 +1102,17 @@ describe("semanticsPipeline", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("checks generic constructor bodies before exporting their signatures", () => {
+    expect(() =>
+      runMainWithSingleFixtureDependency({
+        depFixture: "constructor_init_generic_cross_module/dep.voyd",
+        mainFixture: "constructor_init_generic_cross_module/main.voyd",
+      }),
+    ).toThrow(
+      /TY0027: type mismatch: expected 'object Box.*received 'i32'/,
+    );
+  });
+
   it("resolves operator calls to impl overloads", () => {
     const ast = loadAst("operator_overload_eq.voyd");
     const result = semanticsPipeline(ast);

--- a/packages/compiler/src/semantics/__tests__/pipeline.test.ts
+++ b/packages/compiler/src/semantics/__tests__/pipeline.test.ts
@@ -1095,6 +1095,13 @@ describe("semanticsPipeline", () => {
     );
   });
 
+  it("derives generic constructor return types from the impl target", () => {
+    const result = semanticsPipeline(
+      loadAst("constructor_init_generic_inferred_return.voyd"),
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("resolves operator calls to impl overloads", () => {
     const ast = loadAst("operator_overload_eq.voyd");
     const result = semanticsPipeline(ast);

--- a/packages/compiler/src/semantics/__tests__/pipeline.test.ts
+++ b/packages/compiler/src/semantics/__tests__/pipeline.test.ts
@@ -1081,6 +1081,20 @@ describe("semanticsPipeline", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("requires explicit constructor return types to match the impl target", () => {
+    const ast = loadAst("constructor_init_explicit_return_mismatch.voyd");
+    expect(() => semanticsPipeline(ast)).toThrow(
+      /TY0027: type mismatch: expected 'object Widget.*received 'i32'/,
+    );
+  });
+
+  it("requires inferred constructor return types to match the impl target", () => {
+    const ast = loadAst("constructor_init_inferred_return_mismatch.voyd");
+    expect(() => semanticsPipeline(ast)).toThrow(
+      /TY0027: type mismatch: expected 'object Widget.*received 'i32'/,
+    );
+  });
+
   it("resolves operator calls to impl overloads", () => {
     const ast = loadAst("operator_overload_eq.voyd");
     const result = semanticsPipeline(ast);

--- a/packages/compiler/src/semantics/typing/expressions.ts
+++ b/packages/compiler/src/semantics/typing/expressions.ts
@@ -5,6 +5,7 @@ import {
   typeAssignExpr,
   typeBlockExpr,
   typeCallExpr,
+  validateGenericFunctionBody,
   typeMethodCallExpr,
   formatFunctionInstanceKey,
   typeFieldAccessExpr,
@@ -31,7 +32,7 @@ import {
 } from "../../diagnostics/index.js";
 import type { TypingContext, TypingState } from "./types.js";
 
-export { formatFunctionInstanceKey };
+export { formatFunctionInstanceKey, validateGenericFunctionBody };
 
 export type TypeExpressionOptions = {
   expectedType?: TypeId;

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -5145,12 +5145,14 @@ export const typeGenericFunctionBody = ({
   symbol,
   signature,
   substitution,
+  retainInstance = true,
   ctx,
   state,
 }: {
   symbol: SymbolId;
   signature: FunctionSignature;
   substitution: ReadonlyMap<TypeParamId, TypeId>;
+  retainInstance?: boolean;
   ctx: TypingContext;
   state: TypingState;
 }): void => {
@@ -5268,13 +5270,15 @@ export const typeGenericFunctionBody = ({
         );
       }
     }
-    ctx.functions.cacheInstanceValueTypes(key, ctx.valueTypes);
-    ctx.functions.cacheInstance(key, expectedReturn, ctx.resolvedExprTypes);
-    ctx.functions.recordInstantiation(
-      symbolRefKey(canonicalSymbolRefForTypingContext(symbol, ctx)),
-      key,
-      appliedTypeArgs,
-    );
+    if (retainInstance) {
+      ctx.functions.cacheInstanceValueTypes(key, ctx.valueTypes);
+      ctx.functions.cacheInstance(key, expectedReturn, ctx.resolvedExprTypes);
+      ctx.functions.recordInstantiation(
+        symbolRefKey(canonicalSymbolRefForTypingContext(symbol, ctx)),
+        key,
+        appliedTypeArgs,
+      );
+    }
   } finally {
     const updatedFunctionType = ctx.valueTypes.get(symbol);
     if (typeof updatedFunctionType === "number") {
@@ -5287,6 +5291,30 @@ export const typeGenericFunctionBody = ({
     ctx.functions.endInstantiation(key);
   }
 };
+
+export const validateGenericFunctionBody = ({
+  symbol,
+  signature,
+  substitution,
+  ctx,
+  state,
+}: {
+  symbol: SymbolId;
+  signature: FunctionSignature;
+  substitution: ReadonlyMap<TypeParamId, TypeId>;
+  ctx: TypingContext;
+  state: TypingState;
+}): void =>
+  withSpeculativeExprTyping(ctx, () =>
+    typeGenericFunctionBody({
+      symbol,
+      signature,
+      substitution,
+      retainInstance: false,
+      ctx,
+      state,
+    }),
+  );
 
 const refreshFunctionSignatureTypeForGenericBody = ({
   symbol,

--- a/packages/compiler/src/semantics/typing/expressions/index.ts
+++ b/packages/compiler/src/semantics/typing/expressions/index.ts
@@ -5,6 +5,7 @@ export {
   formatFunctionInstanceKey,
   mergeSubstitutions,
   typeCallExpr,
+  validateGenericFunctionBody,
   typeMethodCallExpr,
 } from "./call.js";
 export { typeFieldAccessExpr } from "./field-access.js";

--- a/packages/compiler/src/semantics/typing/inference.ts
+++ b/packages/compiler/src/semantics/typing/inference.ts
@@ -1,7 +1,11 @@
 import type { HirFunction, HirModuleLet } from "../hir/index.js";
 import { ensureTypeMatches } from "./type-system.js";
 import type { FunctionSignature, TypingContext, TypingState } from "./types.js";
-import { formatFunctionInstanceKey, typeExpression } from "./expressions.js";
+import {
+  formatFunctionInstanceKey,
+  typeExpression,
+  validateGenericFunctionBody,
+} from "./expressions.js";
 import { getValueType } from "./expressions/identifier.js";
 import { mergeBranchType } from "./expressions/branching.js";
 import { composeEffectRows, ensureEffectCompatibility, getExprEffectRow } from "./effects.js";
@@ -38,6 +42,44 @@ export const runStrictTypeCheck = (
   ctx.resolvedExprTypes.clear();
   typeAllModuleLets(ctx, state, { collectChanges: false });
   typeAllFunctions(ctx, state, { collectChanges: false });
+  validateGenericConstructorBodies(ctx, state);
+};
+
+const validateGenericConstructorBodies = (
+  ctx: TypingContext,
+  state: TypingState,
+): void => {
+  for (const fn of ctx.hir.items.values()) {
+    if (fn.kind !== "function") {
+      continue;
+    }
+    const signature = ctx.functions.getSignature(fn.symbol);
+    if (!signature?.typeParams || signature.typeParams.length === 0) {
+      continue;
+    }
+    const record = ctx.symbolTable.getSymbol(fn.symbol);
+    const metadata = (record.metadata ?? {}) as {
+      implTarget?: unknown;
+      static?: unknown;
+    };
+    if (
+      record.name !== "init" ||
+      metadata.static !== true ||
+      typeof metadata.implTarget !== "number"
+    ) {
+      continue;
+    }
+    const substitution = new Map(
+      signature.typeParams.map((param) => [param.typeParam, param.typeRef]),
+    );
+    validateGenericFunctionBody({
+      symbol: fn.symbol,
+      signature,
+      substitution,
+      ctx,
+      state,
+    });
+  }
 };
 
 export const requireInferredReturnTypes = (

--- a/packages/compiler/src/semantics/typing/registry.ts
+++ b/packages/compiler/src/semantics/typing/registry.ts
@@ -373,8 +373,24 @@ export const registerFunctionSignatures = (
         state,
       });
     const signatureTypeParams = typeParams.length > 0 ? typeParams : undefined;
+    const constructorReturn =
+      symbolRecord.name === "init" &&
+      symbolMetadata.static === true &&
+      implItem
+        ? resolveTypeExpr(
+            implItem.target,
+            ctx,
+            state,
+            ctx.primitives.unknown,
+            paramMap,
+          )
+        : undefined;
 
-    if (signatureTypeParams && !item.returnType) {
+    if (
+      signatureTypeParams &&
+      !item.returnType &&
+      typeof constructorReturn !== "number"
+    ) {
       ctx.diagnostics.report(
         diagnosticFromCode({
           code: "TY0034",
@@ -504,18 +520,6 @@ export const registerFunctionSignatures = (
         ctx.primitives.unknown,
         paramMap
       ) ?? ctx.primitives.unknown;
-    const constructorReturn =
-      symbolRecord.name === "init" &&
-      symbolMetadata.static === true &&
-      implItem
-        ? resolveTypeExpr(
-            implItem.target,
-            ctx,
-            state,
-            ctx.primitives.unknown,
-            paramMap,
-          )
-        : undefined;
 
     if (typeof constructorReturn === "number" && item.returnType) {
       ensureTypeMatches(

--- a/packages/compiler/src/semantics/typing/registry.ts
+++ b/packages/compiler/src/semantics/typing/registry.ts
@@ -4,6 +4,7 @@ import {
   resolveTypeExpr,
   getSymbolName,
   getNominalComponent,
+  ensureTypeMatches,
   unifyWithBudget,
 } from "./type-system.js";
 import type { SymbolId, TypeId } from "../ids.js";
@@ -304,6 +305,7 @@ export const registerFunctionSignatures = (
     const symbolMetadata = (symbolRecord.metadata ?? {}) as {
       intrinsic?: unknown;
       intrinsicName?: unknown;
+      static?: unknown;
     };
     const intrinsicName =
       typeof symbolMetadata.intrinsicName === "string"
@@ -494,8 +496,7 @@ export const registerFunctionSignatures = (
     const initialEffectRow = effectAnnotation ?? ctx.primitives.defaultEffectRow;
     const annotatedEffects = effectAnnotation !== undefined;
 
-    const hasExplicitReturn = Boolean(item.returnType);
-    const declaredReturn =
+    const annotatedReturn =
       resolveTypeExpr(
         item.returnType,
         ctx,
@@ -503,6 +504,33 @@ export const registerFunctionSignatures = (
         ctx.primitives.unknown,
         paramMap
       ) ?? ctx.primitives.unknown;
+    const constructorReturn =
+      symbolRecord.name === "init" &&
+      symbolMetadata.static === true &&
+      implItem
+        ? resolveTypeExpr(
+            implItem.target,
+            ctx,
+            state,
+            ctx.primitives.unknown,
+            paramMap,
+          )
+        : undefined;
+
+    if (typeof constructorReturn === "number" && item.returnType) {
+      ensureTypeMatches(
+        annotatedReturn,
+        constructorReturn,
+        ctx,
+        state,
+        "constructor return type",
+        item.returnType.span,
+      );
+    }
+
+    const declaredReturn = constructorReturn ?? annotatedReturn;
+    const hasExplicitReturn =
+      Boolean(item.returnType) || typeof constructorReturn === "number";
 
     const functionType = ctx.arena.internFunction({
       parameters: parameters.map(({ type, label, optional }) => ({

--- a/packages/voyd_semver/src/version.test.voyd
+++ b/packages/voyd_semver/src/version.test.voyd
@@ -1,8 +1,8 @@
 use std::test::assertions::all
 use std::string::type::new_string
 
-test "string init parses strict versions":
-  match(Version("1.2.3"))
+test "parse accepts strict versions":
+  match(parse("1.2.3"))
     Some { value: version }:
       assert(version.major, eq: 1)
       assert(version.minor, eq: 2)

--- a/packages/voyd_semver/src/version.voyd
+++ b/packages/voyd_semver/src/version.voyd
@@ -12,9 +12,6 @@ impl Version
   api fn init(major: i32, minor: i32, patch: i32)
     Version { major, minor, patch }
 
-  api fn init(version_text: String): () -> Optional<Version>
-    parse(version_text)
-
   api fn bump_major(self) -> Version
     Version(self.major + 1, 0, 0)
 


### PR DESCRIPTION
## Summary

- make each static `init` method's impl target its authoritative return contract
- reject both explicit return annotations and inferred bodies that do not satisfy that contract
- remove the semver example's fallible `init(String)` overload and use its existing `parse` API
- add compiler semantics regressions for explicit and inferred mismatches

## Root cause

Constructor methods were registered through the ordinary function-signature path. Their declared or inferred return type therefore became the constructor's public return type, even when it was unrelated to the impl target.

## Impact

Invalid constructors now fail during typing, while valid annotated and unannotated constructors continue to work. Fallible construction should use a named factory such as `parse` instead of `init`.

## Validation

- `npm test` — 14/14 package test tasks passed
- `npm run typecheck` — 13/13 affected package tasks passed
- `npx vitest packages/compiler/src/semantics/__tests__/pipeline.test.ts --run` — 78/78 passed
- `npm test --workspace voyd_semver` — 5/5 passed

Fixes V-301
