### PR TITLE
Fix free operator resolution in impl methods

### DIFF
--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_below_impl_method.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_below_impl_method.voyd
@@ -21,5 +21,11 @@ pub fn '*'(scalar: f64, vec: Vec) -> Vec
 pub fn '*'(vec: Vec, scalar: f64) -> Vec
   Vec { x: vec.x * scalar }
 
+fn intrinsic_forward_product() -> f64
+  1.0 * later()
+
+fn later()
+  2.0
+
 pub fn main() -> f64
-  Vec(3.0).scaled_from_left().x + Vec(3.0).scaled_from_right().x
+  Vec(3.0).scaled_from_left().x + Vec(3.0).scaled_from_right().x + intrinsic_forward_product()

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_below_impl_method.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_below_impl_method.voyd
@@ -6,14 +6,20 @@ impl Vec
   fn init(x: f64) -> Vec
     Vec { x }
 
-  fn '*'(self, scalar: f64) -> Vec
-    Vec { x: self.x * scalar }
+  fn '*'(self, other: Vec) -> Vec
+    Vec { x: self.x * other.x }
 
   fn scaled_from_left(self) -> Vec
     2.0 * self
 
+  fn scaled_from_right(self) -> Vec
+    self * 2.0
+
 pub fn '*'(scalar: f64, vec: Vec) -> Vec
   Vec { x: scalar * vec.x }
 
+pub fn '*'(vec: Vec, scalar: f64) -> Vec
+  Vec { x: vec.x * scalar }
+
 pub fn main() -> f64
-  Vec(3.0).scaled_from_left().x
+  Vec(3.0).scaled_from_left().x + Vec(3.0).scaled_from_right().x

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/function_below_impl_method.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/function_below_impl_method.voyd
@@ -1,0 +1,19 @@
+pub obj Vec {
+  x: f64
+}
+
+impl Vec
+  fn init(x: f64) -> Vec
+    Vec { x }
+
+  fn '*'(self, scalar: f64) -> Vec
+    Vec { x: self.x * scalar }
+
+  fn scaled_from_left(self) -> Vec
+    2.0 * self
+
+pub fn '*'(scalar: f64, vec: Vec) -> Vec
+  Vec { x: scalar * vec.x }
+
+pub fn main() -> f64
+  Vec(3.0).scaled_from_left().x

--- a/packages/compiler/src/semantics/__tests__/pipeline.test.ts
+++ b/packages/compiler/src/semantics/__tests__/pipeline.test.ts
@@ -1544,8 +1544,18 @@ describe("semanticsPipeline", () => {
     expect(result.diagnostics).toHaveLength(0);
     const symbolTable = getSymbolTable(result);
     const mainSymbol = symbolTable.resolve("main", symbolTable.rootScope);
+    const forwardProductSymbol = symbolTable.resolve(
+      "intrinsic_forward_product",
+      symbolTable.rootScope,
+    );
     expect(mainSymbol).toBeDefined();
+    expect(forwardProductSymbol).toBeDefined();
     expectFunctionReturnPrimitive(result.typing, mainSymbol!, "f64");
+    expectFunctionReturnPrimitive(
+      result.typing,
+      forwardProductSymbol!,
+      "f64",
+    );
   });
 
   it("infers forward-referenced helpers used by overloaded operators across modules", () => {

--- a/packages/compiler/src/semantics/__tests__/pipeline.test.ts
+++ b/packages/compiler/src/semantics/__tests__/pipeline.test.ts
@@ -1537,6 +1537,17 @@ describe("semanticsPipeline", () => {
     ).toBe(true);
   });
 
+  it("resolves functions declared below impl methods", () => {
+    const ast = loadAst("function_below_impl_method.voyd");
+    const result = semanticsPipeline(ast);
+
+    expect(result.diagnostics).toHaveLength(0);
+    const symbolTable = getSymbolTable(result);
+    const mainSymbol = symbolTable.resolve("main", symbolTable.rootScope);
+    expect(mainSymbol).toBeDefined();
+    expectFunctionReturnPrimitive(result.typing, mainSymbol!, "f64");
+  });
+
   it("infers forward-referenced helpers used by overloaded operators across modules", () => {
     const result = runMainWithSingleFixtureDependency({
       depFixture: "forward_inference_overloaded_operator_cross_module/dep.voyd",

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -3893,6 +3893,16 @@ const typeOperatorOverloadCall = ({
     return undefined;
   }
 
+  const hasUnresolvedOperand = args.some(
+    (arg) => arg.type === ctx.primitives.unknown,
+  );
+  if (
+    hasUnresolvedOperand &&
+    resolution.includesMethodCandidates !== true
+  ) {
+    return undefined;
+  }
+
   const methodCandidates = filterCandidatesByExplicitTypeArguments({
     candidates: resolution.candidates,
     typeArguments,
@@ -3937,6 +3947,7 @@ const typeOperatorOverloadCall = ({
   if (
     !traitDispatch &&
     matches.length === 0 &&
+    !hasUnresolvedOperand &&
     resolution.includesMethodCandidates === true
   ) {
     const fallbackCandidates = resolveFreeFunctionFallbackCandidates({

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -3822,7 +3822,12 @@ const resolveOperatorOverloadCandidates = ({
       methodName: operatorName,
       ctx,
     });
-    return traitResolution.candidates.length > 0 ? traitResolution : undefined;
+    if (traitResolution.candidates.length > 0) {
+      return {
+        ...traitResolution,
+        includesMethodCandidates: true,
+      };
+    }
   }
 
   const nominalResolution = resolveNominalMethodCandidates({
@@ -3831,7 +3836,10 @@ const resolveOperatorOverloadCandidates = ({
     ctx,
   });
   if (nominalResolution && nominalResolution.candidates.length > 0) {
-    return nominalResolution;
+    return {
+      ...nominalResolution,
+      includesMethodCandidates: true,
+    };
   }
 
   const freeFunctionCandidates = resolveFreeFunctionCandidates({
@@ -3839,7 +3847,7 @@ const resolveOperatorOverloadCandidates = ({
     ctx,
   });
   return freeFunctionCandidates.length > 0
-    ? { candidates: freeFunctionCandidates }
+    ? { candidates: freeFunctionCandidates, includesMethodCandidates: false }
     : undefined;
 };
 
@@ -3885,10 +3893,12 @@ const typeOperatorOverloadCall = ({
     return undefined;
   }
 
-  const candidates = filterCandidatesByExplicitTypeArguments({
+  const methodCandidates = filterCandidatesByExplicitTypeArguments({
     candidates: resolution.candidates,
     typeArguments,
   });
+  let candidates = methodCandidates;
+  let noOverloadDiagnosticCandidates = methodCandidates;
   enforceOverloadCandidateBudget({
     name: operatorName,
     candidateCount: candidates.length,
@@ -3896,7 +3906,7 @@ const typeOperatorOverloadCall = ({
     span: call.span,
   });
 
-  const matches = findMatchingOverloadCandidates({
+  let matches = findMatchingOverloadCandidates({
     name: operatorName,
     candidates,
     args,
@@ -3923,6 +3933,57 @@ const typeOperatorOverloadCall = ({
           state,
         })
       : undefined;
+
+  if (
+    !traitDispatch &&
+    matches.length === 0 &&
+    resolution.includesMethodCandidates === true
+  ) {
+    const fallbackCandidates = resolveFreeFunctionFallbackCandidates({
+      methodName: operatorName,
+      existing: resolution.candidates,
+      ctx,
+    });
+    if (fallbackCandidates.length > 0) {
+      const filteredFallbackCandidates =
+        filterCandidatesByExplicitTypeArguments({
+          candidates: fallbackCandidates,
+          typeArguments,
+        });
+      candidates = filteredFallbackCandidates;
+      noOverloadDiagnosticCandidates =
+        mergeCandidatesForMethodNoOverloadDiagnostic({
+          methodCandidates,
+          fallbackCandidates: filteredFallbackCandidates,
+          ctx,
+        });
+      enforceOverloadCandidateBudget({
+        name: operatorName,
+        candidateCount: candidates.length,
+        ctx,
+        span: call.span,
+      });
+      matches = findMatchingOverloadCandidates({
+        name: operatorName,
+        candidates,
+        args,
+        span: call.span,
+        ctx,
+        state,
+        typeArguments,
+        scoreMatches: (rawMatches) =>
+          scoreOverloadMatchesByLambdaCompatibility({
+            matches: rawMatches,
+            args,
+            callArgs: call.args,
+            typeArguments,
+            ctx,
+            state,
+          }),
+      });
+    }
+  }
+
   let selected: MethodCallCandidate | undefined = traitDispatch;
 
   if (!selected) {
@@ -3943,7 +4004,7 @@ const typeOperatorOverloadCall = ({
 
       if (
         emitConsensusCallArgumentShapeDiagnostic({
-          candidates,
+          candidates: noOverloadDiagnosticCandidates,
           args,
           ctx,
           state,
@@ -3961,7 +4022,7 @@ const typeOperatorOverloadCall = ({
         code: "TY0008",
         params: noOverloadDiagnosticParams({
           name: operatorName,
-          candidates,
+          candidates: noOverloadDiagnosticCandidates,
           args,
           ctx,
           state,

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -3830,8 +3830,16 @@ const resolveOperatorOverloadCandidates = ({
     methodName: operatorName,
     ctx,
   });
-  return nominalResolution && nominalResolution.candidates.length > 0
-    ? nominalResolution
+  if (nominalResolution && nominalResolution.candidates.length > 0) {
+    return nominalResolution;
+  }
+
+  const freeFunctionCandidates = resolveFreeFunctionCandidates({
+    methodName: operatorName,
+    ctx,
+  });
+  return freeFunctionCandidates.length > 0
+    ? { candidates: freeFunctionCandidates }
     : undefined;
 };
 
@@ -3919,6 +3927,20 @@ const typeOperatorOverloadCall = ({
 
   if (!selected) {
     if (matches.length === 0) {
+      const intrinsicFallback = typeIntrinsicFallbackCall({
+        name: operatorName,
+        args,
+        typeArguments,
+        callId: call.id,
+        callSpan: call.span,
+        calleeExprId: callee.id,
+        ctx,
+        state,
+      });
+      if (intrinsicFallback) {
+        return intrinsicFallback;
+      }
+
       if (
         emitConsensusCallArgumentShapeDiagnostic({
           candidates,


### PR DESCRIPTION
## Summary

- resolve same-module free operator functions when a primitive receiver has no impl/trait operator candidates
- preserve intrinsic operator fallback while typing free operator bodies
- add a compiler regression for a free `*` overload declared below the impl method that uses it

## Why

[V-304](https://linear.app/voyd-lang/issue/V-304/cannot-use-functions-declared-below-impl-methods) failed because operator dispatch only searched impl and trait methods based on the left operand. For expressions such as `f64 * Vec3`, the primitive receiver has no nominal method candidates, so the free `*` overload was skipped and typing reported only intrinsic numeric candidates. Once the free overload was considered, arithmetic inside its own body also needed to retain intrinsic fallback.

## Impact

Impl methods can now use free operator overloads declared later in the module, including reverse scalar/vector operators, without source-order workarounds.

## Validation

- focused semantics and external operator-overload suites: 86 tests passed
- `npm run typecheck`: 13/13 tasks passed
- `npm test`: 14/14 tasks passed