### PR TITLE
Add std::fs remove support

### DIFF
--- a/apps/smoke/fixtures/std-fs.voyd
+++ b/apps/smoke/fixtures/std-fs.voyd
@@ -1,0 +1,21 @@
+use std::env::self as env
+use std::error::IoError
+use std::fs::{ Fs, remove }
+use std::optional::types::all
+use std::path::Path
+use std::result::types::all
+use std::string::type::String
+
+pub fn remove_path_from_env(): (Fs, env::Env) -> i32
+  match(env::get("VOYD_STD_FS_REMOVE_PATH".as_slice()))
+    Some<String> { value: path }:
+      remove_path(path)
+    None:
+      -1
+
+fn remove_path(path: String): Fs -> i32
+  match(remove(Path::new(path)))
+    Ok<Unit>:
+      1
+    Err<IoError> { error }:
+      -error.code

--- a/apps/smoke/src/std-fs.test.ts
+++ b/apps/smoke/src/std-fs.test.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createSdk, type CompileResult } from "@voyd-lang/sdk";
+import { createVoydHost } from "@voyd-lang/sdk/js-host";
+
+const fixtureEntryPath = path.join(
+  import.meta.dirname,
+  "..",
+  "fixtures",
+  "std-fs.voyd"
+);
+
+const expectCompileSuccess = (
+  result: CompileResult
+): Extract<CompileResult, { success: true }> => {
+  if (!result.success) {
+    throw new Error(result.diagnostics.map((diagnostic) => diagnostic.message).join("\n"));
+  }
+  expect(result.success).toBe(true);
+  return result;
+};
+
+describe("smoke: std fs", () => {
+  const tempRoots: string[] = [];
+  let compiled: Extract<CompileResult, { success: true }>;
+
+  beforeAll(async () => {
+    const sdk = createSdk();
+    compiled = expectCompileSuccess(await sdk.compile({ entryPath: fixtureEntryPath }));
+  });
+
+  afterEach(async () => {
+    delete process.env.VOYD_STD_FS_REMOVE_PATH;
+    await Promise.all(
+      tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true }))
+    );
+  });
+
+  it("removes supported paths and preserves directory targets", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "voyd-std-fs-smoke-"));
+    tempRoots.push(tempRoot);
+    const filePath = path.join(tempRoot, "old.txt");
+    const directoryPath = path.join(tempRoot, "empty");
+    const targetPath = path.join(tempRoot, "target");
+    const targetFilePath = path.join(targetPath, "keep.txt");
+    const symlinkPath = path.join(tempRoot, "target-link");
+    await fs.writeFile(filePath, "remove me");
+    await fs.mkdir(directoryPath);
+    await fs.mkdir(targetPath);
+    await fs.writeFile(targetFilePath, "keep me");
+    await fs.symlink(
+      targetPath,
+      symlinkPath,
+      process.platform === "win32" ? "junction" : "dir"
+    );
+
+    const host = await createVoydHost({
+      wasm: compiled.wasm,
+      defaultAdapters: { runtime: "node" },
+    });
+    const removePath = async (target: string): Promise<number> => {
+      process.env.VOYD_STD_FS_REMOVE_PATH = target;
+      return host.run<number>("remove_path_from_env");
+    };
+
+    await expect(removePath(filePath)).resolves.toBe(1);
+    await expect(removePath(directoryPath)).resolves.toBe(1);
+    await expect(removePath(symlinkPath)).resolves.toBe(1);
+    await expect(fs.access(filePath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.access(directoryPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.access(symlinkPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readFile(targetFilePath, "utf8")).resolves.toBe("keep me");
+
+    await expect(removePath(targetPath)).resolves.not.toBe(1);
+    await expect(removePath(filePath)).resolves.not.toBe(1);
+    await expect(fs.readFile(targetFilePath, "utf8")).resolves.toBe("keep me");
+  });
+});

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/effects-imported-std-fs-handler.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/effects-imported-std-fs-handler.voyd
@@ -15,5 +15,7 @@ pub fn handle_imported_std_fs_ops(): () -> i32
     tail(_payload)
   Fs::write_string(tail, _payload: MsgPack):
     tail(_payload)
+  Fs::remove(tail, _path: MsgPack):
+    tail(_path)
   Fs::list_dir(tail, _path: MsgPack):
     tail(_path)

--- a/packages/js-host/src/adapters/default.test.ts
+++ b/packages/js-host/src/adapters/default.test.ts
@@ -413,6 +413,7 @@ describe("registerDefaultHostAdapters", () => {
       writeFile: async () => {},
       writeTextFile: async () => {},
       stat: async () => ({}),
+      remove: async () => {},
       readDir: (path: string) => ({
         async *[Symbol.asyncIterator]() {
           if (path === "/") {
@@ -445,6 +446,52 @@ describe("registerDefaultHostAdapters", () => {
     });
   });
 
+  it("removes paths through the deno fs adapter", async () => {
+    const table = buildTable([
+      { effectId: "voyd.std.fs", opName: "remove", opId: 0 },
+    ]);
+    const removedPaths: string[] = [];
+    vi.stubGlobal("Deno", {
+      readFile: async () => new Uint8Array(),
+      readTextFile: async () => "",
+      writeFile: async () => {},
+      writeTextFile: async () => {},
+      stat: async () => ({}),
+      remove: async (path: string) => {
+        if (path === "/tmp/denied.log") {
+          throw Object.assign(new Error("permission denied"), { errno: 13 });
+        }
+        removedPaths.push(path);
+      },
+      readDir: () => ({
+        async *[Symbol.asyncIterator]() {},
+      }),
+    });
+    const { host, getHandler } = createFakeHost(table);
+
+    await registerDefaultHostAdapters({
+      host,
+      options: { runtime: "deno" },
+    });
+
+    const result = await getHandler("voyd.std.fs", "remove")(
+      tailContinuation,
+      "/tmp/old.log"
+    );
+
+    expect(result).toEqual({ kind: "tail", value: { ok: true } });
+    expect(removedPaths).toEqual(["/tmp/old.log"]);
+
+    const errorResult = await getHandler("voyd.std.fs", "remove")(
+      tailContinuation,
+      "/tmp/denied.log"
+    );
+    expect(errorResult).toEqual({
+      kind: "tail",
+      value: { ok: false, code: 13, message: "permission denied" },
+    });
+  });
+
   it("returns io errors when fs read/list payloads exceed transport buffer", async () => {
     const table = buildTable([
       { effectId: "voyd.std.fs", opName: "read_bytes", opId: 0 },
@@ -457,6 +504,7 @@ describe("registerDefaultHostAdapters", () => {
       writeFile: async () => {},
       writeTextFile: async () => {},
       stat: async () => ({}),
+      remove: async () => {},
       readDir: () => ({
         async *[Symbol.asyncIterator]() {
           for (let index = 0; index < 16; index += 1) {

--- a/packages/js-host/src/adapters/default/capabilities/fs.ts
+++ b/packages/js-host/src/adapters/default/capabilities/fs.ts
@@ -45,6 +45,7 @@ export const fsCapabilityDefinition: CapabilityDefinition = {
       | ((path: string, data: string) => Promise<void>)
       | undefined;
     const denoStat = deno?.stat as ((path: string) => Promise<unknown>) | undefined;
+    const denoRemove = deno?.remove as ((path: string) => Promise<void>) | undefined;
     const denoReadDir = deno?.readDir as
       | ((path: string) => AsyncIterable<{ name: string }>)
       | undefined;
@@ -56,6 +57,7 @@ export const fsCapabilityDefinition: CapabilityDefinition = {
       !!denoWriteFile &&
       !!denoWriteTextFile &&
       !!denoStat &&
+      !!denoRemove &&
       !!denoReadDir;
 
     if (!hasNodeFs && !hasDenoFs) {
@@ -197,6 +199,31 @@ export const fsCapabilityDefinition: CapabilityDefinition = {
       },
     });
     implementedOps.add("exists");
+
+    registered += registerOpHandler({
+      host,
+      effectId: FS_EFFECT_ID,
+      opName: "remove",
+      handler: async ({ tail }, path) => {
+        try {
+          const resolvedPath = toPath(path);
+          if (hasNodeFs) {
+            const metadata = await nodeFs!.lstat(resolvedPath);
+            if (metadata.isDirectory()) {
+              await nodeFs!.rmdir(resolvedPath);
+            } else {
+              await nodeFs!.unlink(resolvedPath);
+            }
+          } else {
+            await denoRemove!(resolvedPath);
+          }
+          return tail({ ok: true });
+        } catch (error) {
+          return tail(hostError(ioErrorMessage(error), ioErrorCode(error)));
+        }
+      },
+    });
+    implementedOps.add("remove");
 
     registered += registerOpHandler({
       host,

--- a/packages/js-host/src/adapters/default/types.ts
+++ b/packages/js-host/src/adapters/default/types.ts
@@ -172,6 +172,9 @@ export type NodeFsPromises = {
   readTextFile?: never;
   writeFile: (path: string, data: string | Uint8Array) => Promise<void>;
   access: (path: string) => Promise<void>;
+  lstat: (path: string) => Promise<{ isDirectory: () => boolean }>;
+  rmdir: (path: string) => Promise<void>;
+  unlink: (path: string) => Promise<void>;
   readdir: (path: string) => Promise<string[]>;
 };
 

--- a/packages/std/src/fs.test.voyd
+++ b/packages/std/src/fs.test.voyd
@@ -70,6 +70,25 @@ test "fs list_dir decodes path arrays":
     Err<IoError>:
       assert(false, eq: true)
 
+test "fs remove encodes path and decodes success":
+  let ~paths = Array<String>::init()
+  let result = remove_with_capture(paths)
+
+  match(result)
+    Ok<Unit>:
+      assert(optional_string_or(paths.get(0), "missing".as_slice()).equals("/tmp/old.log"), eq: true)
+    Err<IoError>:
+      assert(false, eq: true)
+
+test "fs remove decodes host errors":
+  let result = remove_with_payload(host_dto_test::host_error_payload(code: 13, message: "permission denied"))
+  match(result)
+    Ok<Unit>:
+      assert(false, eq: true)
+    Err<IoError> { error }:
+      assert(error.code, eq: 13)
+      assert(error.message.equals("permission denied"), eq: true)
+
 fn read_string_with_payload(payload: MsgPack): () -> Result<String, IoError>
   try
     read_string(Path::new("/tmp/app.log".as_slice().to_string()))
@@ -83,6 +102,8 @@ fn read_string_with_payload(payload: MsgPack): () -> Result<String, IoError>
     tail(host_dto_test::host_default_error_payload())
   Fs::exists(tail, _path):
     tail(false)
+  Fs::remove(tail, _path):
+    tail(host_dto_test::host_default_error_payload())
   Fs::list_dir(tail, _path):
     tail(host_dto_test::host_default_error_payload())
 
@@ -99,6 +120,8 @@ fn read_bytes_with_payload(payload: MsgPack): () -> Result<Bytes, IoError>
     tail(host_dto_test::host_default_error_payload())
   Fs::exists(tail, _path):
     tail(false)
+  Fs::remove(tail, _path):
+    tail(host_dto_test::host_default_error_payload())
   Fs::list_dir(tail, _path):
     tail(host_dto_test::host_default_error_payload())
 
@@ -115,6 +138,8 @@ fn list_dir_with_payload(payload: MsgPack): () -> Result<Array<Path>, IoError>
     tail(host_dto_test::host_default_error_payload())
   Fs::exists(tail, _path):
     tail(false)
+  Fs::remove(tail, _path):
+    tail(host_dto_test::host_default_error_payload())
   Fs::list_dir(tail, _path):
     tail(payload)
 
@@ -134,6 +159,8 @@ fn write_string_with_capture(~paths: Array<String>, ~values: Array<String>): () 
     tail(host_dto_test::host_ok_payload())
   Fs::exists(tail, _path):
     tail(false)
+  Fs::remove(tail, _path):
+    tail(host_dto_test::host_default_error_payload())
   Fs::list_dir(tail, _path):
     tail(host_dto_test::host_default_error_payload())
 
@@ -165,6 +192,45 @@ fn write_bytes_with_capture(~paths: Array<String>, ~values: Array<i32>): () -> R
     tail(host_dto_test::host_default_error_payload())
   Fs::exists(tail, _path):
     tail(false)
+  Fs::remove(tail, _path):
+    tail(host_dto_test::host_default_error_payload())
+  Fs::list_dir(tail, _path):
+    tail(host_dto_test::host_default_error_payload())
+
+fn remove_with_capture(~paths: Array<String>): () -> Result<Unit, IoError>
+  try
+    remove(Path::new("/tmp/old.log".as_slice()))
+  Fs::read_bytes(tail, _path):
+    tail(host_dto_test::host_default_error_payload())
+  Fs::read_string(tail, _path):
+    tail(host_dto_test::host_default_error_payload())
+  Fs::write_bytes(tail, _payload):
+    tail(host_dto_test::host_default_error_payload())
+  Fs::write_string(tail, _payload):
+    tail(host_dto_test::host_default_error_payload())
+  Fs::exists(tail, _path):
+    tail(false)
+  Fs::remove(tail, path):
+    paths.push(unpack_msgpack_string(path))
+    tail(host_dto_test::host_ok_payload())
+  Fs::list_dir(tail, _path):
+    tail(host_dto_test::host_default_error_payload())
+
+fn remove_with_payload(payload: MsgPack): () -> Result<Unit, IoError>
+  try
+    remove(Path::new("/tmp/old.log".as_slice()))
+  Fs::read_bytes(tail, _path):
+    tail(host_dto_test::host_default_error_payload())
+  Fs::read_string(tail, _path):
+    tail(host_dto_test::host_default_error_payload())
+  Fs::write_bytes(tail, _payload):
+    tail(host_dto_test::host_default_error_payload())
+  Fs::write_string(tail, _payload):
+    tail(host_dto_test::host_default_error_payload())
+  Fs::exists(tail, _path):
+    tail(false)
+  Fs::remove(tail, _path):
+    tail(payload)
   Fs::list_dir(tail, _path):
     tail(host_dto_test::host_default_error_payload())
 
@@ -234,3 +300,11 @@ fn unpack_msgpack_i32(payload: MsgPack): () -> i32
     Err<MsgPackError>:
       panic("invalid msgpack i32".as_slice())
       0
+
+fn unpack_msgpack_string(payload: MsgPack): () -> String
+  match(msgpack::unpack_string(payload))
+    Ok<String> { value }:
+      value
+    Err<MsgPackError>:
+      panic("invalid msgpack string".as_slice())
+      String::init()

--- a/packages/std/src/fs.voyd
+++ b/packages/std/src/fs.voyd
@@ -1,6 +1,6 @@
 //! File system APIs backed by host runtime operations.
 //!
-//! `std::fs` provides read/write/existence/listing helpers that operate on
+//! `std::fs` provides read/write/existence/removal/listing helpers that operate on
 //! `std::path::Path` and return typed `Result` values where host I/O can fail.
 //! All effect payloads are MessagePack-encoded DTOs.
 
@@ -38,6 +38,8 @@ pub eff Fs
   exists(tail, path: MsgPack) -> bool
   /// Lists child paths in the directory at `path`, or returns an I/O error DTO.
   list_dir(tail, path: MsgPack) -> MsgPack
+  /// Removes the file or empty directory at `path`, or returns an I/O error DTO.
+  remove(tail, path: MsgPack) -> MsgPack
 
 /// Reads a file as raw bytes.
 ///
@@ -58,7 +60,7 @@ pub fn read_string(path: Path): Fs -> Result<String, IoError>
 /// `let write_result = fs::write_bytes(file_path, payload)`
 pub fn write_bytes(path: Path, bytes: Bytes): Fs -> Result<Unit, IoError>
   let payload = encode_write_bytes_payload(path, bytes)
-  decode_write_result(Fs::write_bytes(payload))
+  decode_unit_result(Fs::write_bytes(payload))
 
 /// Writes text to a file.
 ///
@@ -66,16 +68,20 @@ pub fn write_bytes(path: Path, bytes: Bytes): Fs -> Result<Unit, IoError>
 /// `let write_result = fs::write_string(file_path, "hello".as_slice())`
 pub fn write_string(path: Path, value: String): Fs -> Result<Unit, IoError>
   let payload = encode_write_string_payload(path, value)
-  decode_write_result(Fs::write_string(payload))
+  decode_unit_result(Fs::write_string(payload))
 
 /// Writes text to a file.
 pub fn write_string(path: Path, value: StringSlice): Fs -> Result<Unit, IoError>
   let payload = encode_write_string_payload(path, value.to_string())
-  decode_write_result(Fs::write_string(payload))
+  decode_unit_result(Fs::write_string(payload))
 
 /// Returns true when the path exists in the file system.
 pub fn exists(path: Path): Fs -> bool
   Fs::exists(encode_path(path))
+
+/// Removes a file or empty directory.
+pub fn remove(path: Path): Fs -> Result<Unit, IoError>
+  decode_unit_result(Fs::remove(encode_path(path)))
 
 /// Lists child paths in a directory.
 ///
@@ -147,7 +153,7 @@ fn decode_read_string_result(payload: MsgPack): () -> Result<String, IoError>
               Ok<String> { value }:
                 Ok<String> { value: value }
 
-fn decode_write_result(payload: MsgPack): () -> Result<Unit, IoError>
+fn decode_unit_result(payload: MsgPack): () -> Result<Unit, IoError>
   match(HostDto::unpack(payload))
     Err<HostError> { error }:
       Err<IoError> { error: host_error_to_io_error(error) }

--- a/packages/web/src/web.test.voyd
+++ b/packages/web/src/web.test.voyd
@@ -136,6 +136,8 @@ fn handle_static_with_fs(
     tail(host_dto_test::host_default_error_payload())
   Fs::write_string(tail, _payload: MsgPack):
     tail(host_dto_test::host_default_error_payload())
+  Fs::remove(tail, _path: MsgPack):
+    tail(host_dto_test::host_default_error_payload())
   Fs::list_dir(tail, _path: MsgPack):
     tail(host_dto_test::host_default_error_payload())
 


### PR DESCRIPTION
## Summary

- add `std::fs::remove(Path) -> Result<Unit, IoError>` and append its effect operation without changing existing op IDs
- implement file and empty-directory removal in the default Node and Deno filesystem adapters
- add std, adapter, compiler-handler, web-handler, and end-to-end smoke coverage

## Impact

Voyd programs can now remove files and empty directories through the standard filesystem effect. Directory symlinks are removed without deleting their targets, while missing paths and non-empty directories return `IoError`.

## Validation

- `npm test` (14/14 package tasks)
- `npm run typecheck` (14/14 tasks)
- `npm run lint` (11/11 tasks)
- agentic review/fix/re-review loop completed with no remaining findings