### PR TITLE
V-411: Fix full EventOptions Wasm lowering

### DIFF
--- a/apps/smoke/fixtures/vx.voyd
+++ b/apps/smoke/fixtures/vx.voyd
@@ -5,6 +5,9 @@ use std::msgpack::self as msgpack
 use std::string::type::{ String, new_string }
 use std::vx::all
 
+enum VxMessage
+  Save
+
 fn App() -> MsgPack
   let features = feature_list()
   <Card>
@@ -50,3 +53,29 @@ pub fn main()
 
 pub fn event_message_button() -> MsgPack
   <button on_click={msgpack::make_string("save")}>Save</button>
+
+pub fn full_event_options_form() -> MsgPack
+  <form
+    on_submit={on_submit_with(
+      options: EventOptions {
+        prevent_default: true,
+        stop_propagation: false,
+        capture: false,
+        passive: false
+      },
+      message: VxMessage::Save {}
+    )}
+  >
+    Save
+  </form>
+
+pub fn full_event_options_descriptor() -> MsgPack
+  on_submit_with(
+    options: EventOptions {
+      prevent_default: true,
+      stop_propagation: false,
+      capture: false,
+      passive: false
+    },
+    handler_id: 42
+  )

--- a/apps/smoke/src/wasm-validation.test.ts
+++ b/apps/smoke/src/wasm-validation.test.ts
@@ -128,12 +128,17 @@ describe("smoke: wasm validation", { timeout: 120_000 }, () => {
     expect((exports.main as () => number)()).toBe(42);
   });
 
-  it("compiles MsgPack recursive unions used by vx.voyd", async () => {
-    const module = await compileToBinaryenModule(fixturePath("vx.voyd"));
-    const wasm = assertRunnableWasm(module);
-    expect(WebAssembly.validate(wasm as BufferSource)).toBe(true);
+  it("compiles valid VX wasm and preserves complete event options", async () => {
+    const modules = await Promise.all(
+      [false, true].map((optimize) =>
+        compileToBinaryenModule(fixturePath("vx.voyd"), { optimize }),
+      ),
+    );
+    const [unoptimizedWasm, optimizedWasm] = modules.map(assertRunnableWasm);
+    expect(WebAssembly.validate(unoptimizedWasm as BufferSource)).toBe(true);
+    expect(WebAssembly.validate(optimizedWasm as BufferSource)).toBe(true);
 
-    const host = await createVoydHost({ wasm });
+    const host = await createVoydHost({ wasm: unoptimizedWasm });
     const result = await host.runPure("main");
 
     const normalized = normalize(result) as Record<string, unknown>;
@@ -142,6 +147,18 @@ describe("smoke: wasm validation", { timeout: 120_000 }, () => {
     );
     expect(normalized.attrs).toBeTypeOf("object");
     expect(normalized.children).toBeInstanceOf(Array);
+
+    const descriptor = normalize(
+      await host.runPure("full_event_options_descriptor"),
+    ) as {
+      options: Record<string, boolean>;
+    };
+    expect(descriptor.options).toEqual({
+      preventDefault: true,
+      stopPropagation: false,
+      capture: false,
+      passive: false,
+    });
   });
 
   it("supports generic enum macro expansion across modules", async () => {

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/optional_syntax.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/optional_syntax.voyd
@@ -10,6 +10,13 @@ obj OptionalBox {
   v?: i32
 }
 
+obj BooleanOptions {
+  first?: bool,
+  second?: bool,
+  third?: bool,
+  fourth?: bool
+}
+
 fn default_num(v: Optional<i32>, d: i32) -> i32
   match(v)
     Some<i32>: v.value
@@ -71,6 +78,27 @@ pub fn test10_optional_spread_wraps_some() -> i32
     Some<i32>: v.value
     None: 0
 
+fn option_state(value: Optional<bool>) -> i32
+  match(value)
+    Some<bool>:
+      if value.value then: 2 else: 1
+    None:
+      0
+
+fn encode_boolean_options(options: BooleanOptions) -> i32
+  option_state(options.first) * 1000 +
+  option_state(options.second) * 100 +
+  option_state(options.third) * 10 +
+  option_state(options.fourth)
+
+pub fn test11_full_optional_object_conversion() -> i32
+  encode_boolean_options(BooleanOptions {
+    first: true,
+    second: false,
+    third: false,
+    fourth: false
+  })
+
 pub fn main() -> i32
   test1_optional_obj_field() +
   test2_passed_optional_param() +
@@ -81,4 +109,5 @@ pub fn main() -> i32
   test7_skip_optional_labeled() +
   test8_closure_with_arg() +
   test9_closure_without_arg() +
-  test10_optional_spread_wraps_some()
+  test10_optional_spread_wraps_some() +
+  test11_full_optional_object_conversion()

--- a/packages/compiler/src/codegen/__tests__/codegen.test.ts
+++ b/packages/compiler/src/codegen/__tests__/codegen.test.ts
@@ -608,6 +608,7 @@ describe("next codegen", () => {
       test8_closure_with_arg,
       test9_closure_without_arg,
       test10_optional_spread_wraps_some,
+      test11_full_optional_object_conversion,
       main,
     } = instance.exports as Record<string, unknown>;
 
@@ -621,7 +622,10 @@ describe("next codegen", () => {
     expect((test8_closure_with_arg as () => number)()).toBe(2);
     expect((test9_closure_without_arg as () => number)()).toBe(1);
     expect((test10_optional_spread_wraps_some as () => number)()).toBe(5);
-    expect((main as () => number)()).toBe(25);
+    expect((test11_full_optional_object_conversion as () => number)()).toBe(
+      2111,
+    );
+    expect((main as () => number)()).toBe(2136);
   });
 
   it("infers generic labeled params from function-valued structural objects", () => {

--- a/packages/compiler/src/codegen/structural.ts
+++ b/packages/compiler/src/codegen/structural.ts
@@ -2607,9 +2607,11 @@ export const emitStructuralConversion = ({
               fieldIndex: sourceField.runtimeIndex,
               exprRef: casted,
             });
-            return sourceField.wasmType === sourceField.heapWasmType
-              ? loaded
-              : ctx.mod.block(null, [loaded], sourceField.wasmType);
+            return liftHeapValueToInline({
+              value: loaded,
+              typeId: sourceField.typeId,
+              ctx,
+            });
           })()
         : loadStructuralField({
             structInfo: actual,


### PR DESCRIPTION
## Summary

- lift heap-stored structural fields back into their canonical inline ABI before conversion
- cover multi-field `Optional<bool>` conversion at the compiler layer
- validate full VX `EventOptions` through the public SDK path in optimized and unoptimized builds
- verify all four event options survive descriptor serialization

## Root cause

Direct structural conversion loaded heap fields using their boxed storage representation, then relabeled mismatched boxed values with the inline Wasm result type. For `Optional<bool>`, that produced blocks declared as two `i32` result lanes even though the body emitted a boxed reference, yielding structurally invalid Wasm.

The conversion now uses the existing heap-to-inline lifting path before type coercion and re-storage.

## Impact

Fully populated typed VX event options can now cross generic event helpers without emitting invalid multi-value Wasm. The fix applies to the underlying structural conversion contract rather than VX-specific call sites.

## Validation

- `npx vitest run --config vitest.config.ts packages/compiler/src/codegen/__tests__/codegen.test.ts -t "supports optional fields and parameters" --testTimeout 120000 --hookTimeout 120000`
- `npx vitest run --config vitest.config.ts apps/smoke/src/wasm-validation.test.ts --testTimeout 120000 --hookTimeout 120000`
- `npm run typecheck`
- `npm test` (14/14 package tasks successful)
- agentic Implementation Gap Review: clean
- agentic Correctness Review: clean

Linear: [V-411](https://linear.app/voyd-lang/issue/V-411/full-vx-eventoptions-literals-can-emit-invalid-multi-value)