### PR TITLE
Add Eq support for String and StringSlice

### DIFF
--- a/packages/std/src/string/type.test.voyd
+++ b/packages/std/src/string/type.test.voyd
@@ -40,6 +40,32 @@ test "string init and capacity constructors":
   assert(reserved.is_empty(), eq: true)
   assert(reserved.byte_len(), eq: 0)
 
+test "owned strings support equality operators and generic assertions":
+  let actual = "Voyd".to_string()
+  let equal = "Voyd".to_string()
+  let unequal = "voyd".to_string()
+
+  assert(actual.eq(other: equal), eq: true)
+  assert(actual.ne(other: unequal), eq: true)
+  assert(actual == equal, eq: true)
+  assert(actual != unequal, eq: true)
+  assert(actual != "Voyd!".to_string(), eq: true)
+  assert(actual, eq: equal)
+  assert(actual, neq: unequal)
+
+test "string slices support equality operators and generic assertions":
+  let actual = "aVoydz".slice(bytes: 1, len: 4)
+  let equal = "Voyd".as_slice()
+  let unequal = "voyd".as_slice()
+
+  assert(actual.eq(other: equal), eq: true)
+  assert(actual.ne(other: unequal), eq: true)
+  assert(actual == equal, eq: true)
+  assert(actual != unequal, eq: true)
+  assert(actual != "Voyd!".as_slice(), eq: true)
+  assert(actual, eq: equal)
+  assert(actual, neq: unequal)
+
 test "string utf8 decode and encode":
   let value = must_utf8([104, 105])
   assert(value.equals("hi"), eq: true)

--- a/packages/std/src/string/type.voyd
+++ b/packages/std/src/string/type.voyd
@@ -7,6 +7,7 @@
 use std::array::{ Array, new_array_unchecked }
 use std::fixed_array::fns::{ new_fixed_array }
 use std::string::index::{ make_string_index }
+use std::traits::eq::Eq
 use std::traits::sequence::all
 use std::optional::all
 use std::result::types::all
@@ -430,6 +431,18 @@ impl StringSlice
   api fn parse_i64(self, { radix?: i32 }): () -> Result<i64, ParseIntError>
     parse_i64_from_slice(self, radix: radix)
 
+impl Eq<StringSlice> for StringSlice
+  api fn eq(self, { other: StringSlice }) -> bool
+    if self.byte_count != other.byte_count:
+      return false
+    string_ranges_equal(
+      self.source,
+      from: self.start,
+      to: other.source,
+      at: other.start,
+      len: self.byte_count
+    )
+
 impl String
   /// Creates an empty string.
   api fn init() -> String
@@ -604,21 +617,7 @@ impl String
   api fn equals(self, other: String): () -> bool
     if self.byte_count != other.byte_count:
       return false
-    if self.byte_count == 0:
-      return true
-
-    let self_source = self.bytes.raw_storage()
-    let other_source = other.bytes.raw_storage()
-    var index = 0
-    while index < self.byte_count:
-      if __array_get(self_source, index) != __array_get(other_source, index):
-        return false
-      index = index + 1
-    true
-
-  /// Compares two values for equality.
-  api fn '=='(self, other: String) -> bool
-    self.equals(other)
+    string_ranges_equal(self, from: 0, to: other, at: 0, len: self.byte_count)
 
   /// Returns a 32-bit hash of the string contents.
   api fn hash_i32(self): () -> i32
@@ -1227,6 +1226,10 @@ impl String
   /// Returns a source-like escaped string representation.
   api fn to_repr(self) -> String
     build_escaped(self, true)
+
+impl Eq<String> for String
+  api fn eq(self, { other: String }) -> bool
+    self.equals(other)
 
 obj Utf8Read {
   /// Unicode scalar value for this grapheme.
@@ -1930,6 +1933,19 @@ fn bytes_match_slice_at(
     if __array_get(source, index + cursor) != __array_get(target_source, target_start + cursor):
       return false
     cursor = cursor + 1
+  true
+
+fn string_ranges_equal(
+  left: String,
+  { from left_start: i32, to right: String, at right_start: i32, len: i32 }
+) -> bool
+  let left_source = left.raw_bytes()
+  let right_source = right.raw_bytes()
+  var index = 0
+  while index < len:
+    if __array_get(left_source, left_start + index) != __array_get(right_source, right_start + index):
+      return false
+    index = index + 1
   true
 
 fn append_bytes(~out: Array<i32>, source: FixedArray<i32>, count: i32) -> void

--- a/packages/std/src/string/type.voyd
+++ b/packages/std/src/string/type.voyd
@@ -443,6 +443,17 @@ impl Eq<StringSlice> for StringSlice
       len: self.byte_count
     )
 
+  // Injected trait defaults are package-visible, so public conformances must
+  // expose the forwarding methods explicitly.
+  api fn ne(self, { other: StringSlice }) -> bool
+    not self.eq(other: other)
+
+  api fn '=='(self, other: StringSlice) -> bool
+    self.eq(other: other)
+
+  api fn '!='(self, other: StringSlice) -> bool
+    self.ne(other: other)
+
 impl String
   /// Creates an empty string.
   api fn init() -> String
@@ -1230,6 +1241,17 @@ impl String
 impl Eq<String> for String
   api fn eq(self, { other: String }) -> bool
     self.equals(other)
+
+  // Injected trait defaults are package-visible, so public conformances must
+  // expose the forwarding methods explicitly.
+  api fn ne(self, { other: String }) -> bool
+    not self.eq(other: other)
+
+  api fn '=='(self, other: String) -> bool
+    self.eq(other: other)
+
+  api fn '!='(self, other: String) -> bool
+    self.ne(other: other)
 
 obj Utf8Read {
   /// Unicode scalar value for this grapheme.


### PR DESCRIPTION
## Summary

- make `String` conform to the canonical `Eq<String>` trait
- add matching `Eq<StringSlice>` conformance for slice parity
- centralize allocation-free byte-range equality for owned strings and slices
- cover trait methods, `==`/`!=`, and generic `eq`/`neq` assertions

## Why

`String` previously exposed `.equals(String)` and a direct `==` overload, but lacked `!=` and the full `Eq<String>` contract. Generic equality consumers such as the standard assertion helpers resolve those operators at instantiation, so string assertions failed to compile.

The implementation now uses the canonical trait defaults for both operators while preserving `.equals(String)` as the existing compatibility surface. `StringSlice` receives equivalent same-type behavior.

## Impact

Owned strings and string slices now work directly with generic equality APIs, including `assert(actual, eq: expected)` and `assert(actual, neq: expected)`.

## Validation

- `npm run --workspace @voyd-lang/std test` — 238 passed
- `npm test` — 14/14 tasks passed
- `npm run typecheck` — 14/14 tasks passed
- agentic Implementation Gap Review — no findings
- agentic Correctness Review — no findings

Linear: [V-412](https://linear.app/voyd-lang/issue/V-412/string-lacks-inequality-support-required-by-generic-assertions)