### PR TITLE
Reject reference-bound default parameters

### DIFF
--- a/packages/compiler/src/diagnostics/registry.ts
+++ b/packages/compiler/src/diagnostics/registry.ts
@@ -326,6 +326,11 @@ type DiagnosticParamsMap = {
         subsumedSignature: string;
       }
     | { kind: "subsumed-labeled-overload" };
+  TY0048: {
+    kind: "reference-bound-default-parameter";
+    functionName: string;
+    parameterName: string;
+  };
   TY9999: { kind: "unexpected-error"; message: string };
 };
 
@@ -1010,6 +1015,19 @@ export const diagnosticsRegistry: {
       },
     ],
   } satisfies DiagnosticDefinition<DiagnosticParamsMap["TY0047"]>,
+  TY0048: {
+    code: "TY0048",
+    message: (params) =>
+      `reference-bound parameter ${params.parameterName} in function ${params.functionName} cannot declare a default value`,
+    severity: "error",
+    phase: "typing",
+    hints: [
+      {
+        message:
+          "Remove the default value or make the parameter value-bound. To provide a default while preserving reference semantics, use an overload that creates mutable local storage before calling the reference-bound function.",
+      },
+    ],
+  } satisfies DiagnosticDefinition<DiagnosticParamsMap["TY0048"]>,
   TY9999: {
     code: "TY9999",
     message: (params) => params.message,

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/default_param_reference_binding.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/default_param_reference_binding.voyd
@@ -1,0 +1,13 @@
+obj Some<T> {
+  value: T
+}
+
+obj None {}
+
+type Optional<T> = Some<T> | None
+
+fn mutate(~value: i32 = 1) -> i32
+  value
+
+pub fn main() -> i32
+  mutate()

--- a/packages/compiler/src/semantics/typing/__tests__/default-parameter-diagnostics.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/default-parameter-diagnostics.test.ts
@@ -57,4 +57,26 @@ describe("default parameter diagnostics", () => {
     expect(caught.diagnostic.message).toMatch(/default parameter a/i);
     expect(caught.diagnostic.message).toMatch(/parameter b/i);
   });
+
+  it("rejects defaults on reference-bound parameters", () => {
+    const ast = loadAst("default_param_reference_binding.voyd");
+
+    let caught: unknown;
+    try {
+      semanticsPipeline(ast);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught instanceof DiagnosticError).toBe(true);
+    if (!(caught instanceof DiagnosticError)) {
+      return;
+    }
+
+    expect(caught.diagnostic.code).toBe("TY0048");
+    expect(caught.diagnostic.message).toMatch(
+      /reference-bound parameter value/i,
+    );
+    expect(caught.diagnostic.message).toMatch(/function mutate/i);
+  });
 });

--- a/packages/compiler/src/semantics/typing/registry.ts
+++ b/packages/compiler/src/semantics/typing/registry.ts
@@ -439,6 +439,22 @@ export const registerFunctionSignatures = (
       const hasDefaultValue = typeof param.defaultValue === "number";
       if (
         hasDefaultValue &&
+        param.pattern.bindingKind !== undefined &&
+        param.pattern.bindingKind !== "value"
+      ) {
+        return emitDiagnostic({
+          ctx,
+          code: "TY0048",
+          params: {
+            kind: "reference-bound-default-parameter",
+            functionName,
+            parameterName,
+          },
+          span: normalizeSpan(param.span, item.span, ctx.hir.module.span),
+        });
+      }
+      if (
+        hasDefaultValue &&
         !param.type &&
         signatureTypeParams &&
         signatureTypeParams.length > 0

--- a/packages/reference/docs/functions.md
+++ b/packages/reference/docs/functions.md
@@ -136,6 +136,9 @@ Current restrictions:
 - In generic functions, a defaulted parameter must declare an explicit type.
 - A default expression cannot reference a parameter declared at the same
   position or later in the parameter list.
+- A reference-bound parameter (such as `~value`) cannot declare a default.
+  Defaults create value-bound callee storage, which cannot preserve the
+  caller-aliasing contract of a reference-bound parameter.
 - `?` and `=` cannot be combined on the same parameter.
 
 ## Lambdas


### PR DESCRIPTION
## Summary

- reject reference-bound parameters that declare default values during typing
- add TY0048 with an actionable overload/local-storage remediation
- document the value-bound default parameter contract
- add compiler regression coverage for the former codegen failure

## Why

Default arguments are represented with an Optional wrapper and resolved into callee-owned storage. Applying that lowering to a `~` parameter violates its caller-aliasing contract and previously reached mutable-ref ABI lowering without addressable storage, causing a codegen error. Rejecting the declaration makes the language contract explicit and reports the issue at the source declaration.

## Validation

- `npm test`
- `npm run typecheck`
- `npx vitest packages/compiler/src/semantics/typing/__tests__/default-parameter-diagnostics.test.ts`

Fixes V-414.