### PR TITLE
Fix parser diagnostics for missing commas and invalid module access

### DIFF
--- a/apps/smoke/src/vx-dom.test.ts
+++ b/apps/smoke/src/vx-dom.test.ts
@@ -247,9 +247,10 @@ describe("smoke: compiled VX DOM rendering", () => {
       .spyOn(globalThis, "fetch")
       .mockImplementation(async (input, init) => {
         const request = normalizeFetchRequest(input, init);
-        if (request.method === "POST" && request.url.endsWith("/wiki/home/body")) {
+        if (request.method === "PUT" && request.url.endsWith("/api/articles")) {
           if (saveStatus >= 200 && saveStatus < 300) {
-            savedBodies.set("home", request.body);
+            const article = JSON.parse(request.body) as { slug: string; body: string };
+            savedBodies.set(article.slug, article.body);
           }
           return new Response(saveStatus >= 200 && saveStatus < 300 ? "saved" : "failed", {
             status: saveStatus,
@@ -274,37 +275,34 @@ describe("smoke: compiled VX DOM rendering", () => {
       });
 
       const editedBody = "# Mini Voydpedia\n\nOne two three";
-      const textarea = firstContainer.querySelector<HTMLTextAreaElement>("textarea")!;
+      const textarea = firstContainer.querySelector<HTMLTextAreaElement>("textarea.body-input")!;
       textarea.value = editedBody;
       textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
       await nextTurn();
 
       expect(firstContainer.textContent).toContain("Unsaved changes");
-      expect(firstContainer.textContent).toContain("Words6");
-      expect(firstContainer.querySelector("pre")?.textContent).toBe(editedBody);
 
-      firstContainer.querySelector<HTMLButtonElement>('button[type="button"]:last-of-type')?.click();
+      firstContainer.querySelector<HTMLButtonElement>('button[data-testid="save-article"]')?.click();
 
-      await waitForTextContaining(firstContainer, "form", "Saving...");
-      expect(firstContainer.querySelector<HTMLButtonElement>('button[type="button"]:last-of-type')?.disabled).toBe(
-        true,
-      );
+      await waitForTextContaining(firstContainer, "main", "Saving…");
+      expect(firstContainer.querySelector<HTMLButtonElement>('button[data-testid="save-article"]')?.disabled).toBe(true);
 
-      await waitForTextContaining(firstContainer, "form", "Client saves1");
+      await waitForTextContaining(firstContainer, "main", "Article saved");
       expect(savedBodies.get("home")).toBe(editedBody);
-      expect(firstContainer.textContent).toContain("Client saves1");
 
       saveStatus = 500;
+      firstContainer.querySelector<HTMLButtonElement>('button[data-testid="edit-article"]')?.click();
+      await nextTurn();
+      const failedTextarea = firstContainer.querySelector<HTMLTextAreaElement>("textarea.body-input")!;
       const failedBody = "# Mini Voydpedia\n\nThis will not save";
-      textarea.value = failedBody;
-      textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
-      await waitForTextContaining(firstContainer, "form", "Unsaved changes");
+      failedTextarea.value = failedBody;
+      failedTextarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+      await waitForTextContaining(firstContainer, "main", "Unsaved changes");
 
-      firstContainer.querySelector<HTMLButtonElement>('button[type="button"]:last-of-type')?.click();
-      await waitForTextContaining(firstContainer, "form", "Save failed");
+      firstContainer.querySelector<HTMLButtonElement>('button[data-testid="save-article"]')?.click();
+      await waitForTextContaining(firstContainer, "main", "Could not save the article");
 
       expect(savedBodies.get("home")).toBe(editedBody);
-      expect(firstContainer.textContent).toContain("Save failed");
 
       firstMounted.dispose();
 
@@ -317,10 +315,10 @@ describe("smoke: compiled VX DOM rendering", () => {
         }),
       });
 
-      expect(reloadedContainer.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe(
+      expect(reloadedContainer.querySelector<HTMLTextAreaElement>("textarea.body-input")?.value).toBe(
         editedBody,
       );
-      expect(reloadedContainer.textContent).toContain("Saved");
+      expect(reloadedContainer.textContent).toContain("Editing");
 
       reloadedMounted.dispose();
       expect(firstContainer.innerHTML).toBe("");
@@ -705,26 +703,45 @@ function nextTurn(): Promise<void> {
 }
 
 type MiniWikipediaModel = {
-  slug: string;
-  title: string;
-  body: string;
-  saved_body: string;
-  state_kind: string;
-  state_message: string;
-  preview_open: boolean;
-  save_count: number;
+  articles: Array<{
+    slug: string;
+    title: string;
+    overview: string;
+    body: string;
+    related: string[];
+  }>;
+  current_slug: string;
+  search: string;
+  mode: string;
+  editor: {
+    slug: string;
+    title: string;
+    overview: string;
+    body: string;
+    related: string;
+  };
+  status: string;
+  status_kind: string;
+  delete_pending: boolean;
 };
 
 function miniWikipediaModel(body: string): MiniWikipediaModel {
-  return {
+  const article = {
     slug: "home",
     title: "Mini Voydpedia",
+    overview: "A tiny editable knowledge base.",
     body,
-    saved_body: body,
-    state_kind: "saved",
-    state_message: "Saved",
-    preview_open: true,
-    save_count: 0,
+    related: [],
+  };
+  return {
+    articles: [article],
+    current_slug: "home",
+    search: "",
+    mode: "edit",
+    editor: { ...article, related: "" },
+    status: "Editing",
+    status_kind: "neutral",
+    delete_pending: false,
   };
 }
 

--- a/packages/compiler/src/__tests__/call-shape-diagnostics.test.ts
+++ b/packages/compiler/src/__tests__/call-shape-diagnostics.test.ts
@@ -29,6 +29,51 @@ const expectCompileSuccess = (
 };
 
 describe("call shape diagnostics", () => {
+  it("reports a missing comma between object literal fields", async () => {
+    const root = resolve("/proj/src");
+    const entryPath = `${root}${sep}pkg.voyd`;
+    const host = createMemoryHost({
+      [entryPath]: `pub fn main() -> i32
+  let value = { first: 1 second: 2 }
+  value.first`,
+    });
+
+    const result = expectCompileFailure(
+      await compileProgram({
+        entryPath,
+        roots: { src: root },
+        host,
+      }),
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("MD0002");
+    expect(result.diagnostics[0]?.message).toContain(
+      "Expected ',' before 'second' in braces",
+    );
+  });
+
+  it("allows labeled calls as object literal field values", async () => {
+    const root = resolve("/proj/src");
+    const entryPath = `${root}${sep}pkg.voyd`;
+    const host = createMemoryHost({
+      [entryPath]: `fn make({ value: i32 }) -> i32
+  value
+
+pub fn main() -> i32
+  let result = { value: make(value: 2) }
+  result.value`,
+    });
+
+    expectCompileSuccess(
+      await compileProgram({
+        entryPath,
+        roots: { src: root },
+        host,
+      }),
+    );
+  });
+
   it("reports label mismatch argument index using the failing argument position", async () => {
     const root = resolve("/proj/src");
     const entryPath = `${root}${sep}pkg.voyd`;

--- a/packages/compiler/src/parser/__tests__/__snapshots__/parser.test.ts.snap
+++ b/packages/compiler/src/parser/__tests__/__snapshots__/parser.test.ts.snap
@@ -28,7 +28,7 @@ exports[`parser can parse a file into a syntax expanded ast 1`] = `
         "object_literal",
         "read",
         [
-          ":",
+          "as",
           "write",
           "io_write",
         ],

--- a/packages/compiler/src/parser/__tests__/fixtures/sink.voyd
+++ b/packages/compiler/src/parser/__tests__/fixtures/sink.voyd
@@ -1,5 +1,5 @@
 use std::macros::all
-use std::io::{ read, write: io_write }
+use std::io::{ read, write as io_write }
 
 fn fib(n: i32) -> i32
   if n <= 1 then:

--- a/packages/compiler/src/parser/__tests__/syntax-errors.test.ts
+++ b/packages/compiler/src/parser/__tests__/syntax-errors.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { ParserSyntaxError } from "../errors.js";
+import { parse } from "../parser.js";
+
+describe("parser syntax errors", () => {
+  it.each([
+    "let value = { first: source second: 2 }",
+    "let value = { first: make(1) second: 2 }",
+    "let value = { first: 1 + 2 second: 3 }",
+    "obj Value { first: i32 second: i32 }",
+    "type Value = { first: i32 second: i32 }",
+  ])("reports missing commas in brace fields: %s", (source) => {
+    const error = parseError(source, "/proj/src/fields.voyd");
+
+    expect(error.message).toBe("Expected ',' before 'second' in braces");
+    expect(error.location?.filePath).toBe("/proj/src/fields.voyd");
+  });
+
+  it("reports colon module access syntax in use declarations", () => {
+    const error = parseError("use std:all", "/proj/src/use.voyd");
+
+    expect(error.message).toBe(
+      "Invalid module access syntax; use '::' between module path segments",
+    );
+    expect(error.location?.filePath).toBe("/proj/src/use.voyd");
+    expect(error.location?.startLine).toBe(1);
+  });
+
+  it.each([
+    "pub std:all",
+    "use std::{ write: io_write }",
+    "use std::{ foo:bar:baz }",
+  ])("reports colon module access syntax in exports: %s", (source) => {
+    const error = parseError(source, "/proj/src/export.voyd");
+
+    expect(error.message).toBe(
+      "Invalid module access syntax; use '::' between module path segments",
+    );
+  });
+
+  it.each([
+    "use std::{ write as io_write }",
+    "pub std::{ write as io_write }",
+    "obj Value {\n  first: i32\n  second: i32\n}",
+    "let value = { result: if true then: 1 else: 2 }",
+    "let value = { result: match(source) Some: 1 }",
+  ])("preserves valid brace and module syntax: %s", (source) => {
+    expect(() => parse(source, "/proj/src/valid.voyd")).not.toThrow();
+  });
+});
+
+const parseError = (source: string, filePath: string): ParserSyntaxError => {
+  try {
+    parse(source, filePath);
+  } catch (error) {
+    expect(error).toBeInstanceOf(ParserSyntaxError);
+    if (error instanceof ParserSyntaxError) return error;
+  }
+
+  throw new Error("expected parsing to fail");
+};

--- a/packages/compiler/src/parser/__tests__/syntax-errors.test.ts
+++ b/packages/compiler/src/parser/__tests__/syntax-errors.test.ts
@@ -44,6 +44,7 @@ describe("parser syntax errors", () => {
     "obj Value {\n  first: i32\n  second: i32\n}",
     "let value = { result: if true then: 1 else: 2 }",
     "let value = { result: match(source) Some: 1 }",
+    "fn use({ first: i32, second: i32 }) -> i32\n  first + second",
   ])("preserves valid brace and module syntax: %s", (source) => {
     expect(() => parse(source, "/proj/src/valid.voyd")).not.toThrow();
   });

--- a/packages/compiler/src/parser/attributes.ts
+++ b/packages/compiler/src/parser/attributes.ts
@@ -1,5 +1,8 @@
 import type { Expr } from "./ast/index.js";
 
+export const POSSIBLE_MISSING_BRACE_ENTRY_COMMA_ATTRIBUTE =
+  "possibleMissingBraceEntryComma";
+
 export type IntrinsicAttribute = {
   name?: string;
   usesSignature?: boolean;

--- a/packages/compiler/src/parser/fixtures/benchmark-file.ts
+++ b/packages/compiler/src/parser/fixtures/benchmark-file.ts
@@ -1,6 +1,6 @@
 const benchmarkBaseFile = `
 use std::macros::all
-use std::io::{ read, write: io_write }
+use std::io::{ read, write as io_write }
 
 fn fib(n: i32) -> i32
   if n <= 1 then:

--- a/packages/compiler/src/parser/reader-macros/object-literal.ts
+++ b/packages/compiler/src/parser/reader-macros/object-literal.ts
@@ -1,9 +1,45 @@
+import {
+  isIdentifierAtom,
+  isWhitespaceAtom,
+  type Expr,
+  type Form,
+} from "../ast/index.js";
+import { POSSIBLE_MISSING_BRACE_ENTRY_COMMA_ATTRIBUTE } from "../attributes.js";
 import { ReaderMacro } from "./types.js";
 
 export const objectLiteralMacro: ReaderMacro = {
   match: (t) => t.value === "{",
   macro: (dream, { reader }) => {
     const items = reader(dream, "}");
+    markPossibleMissingCommas(items);
     return items.splitInto("object_literal");
   },
+};
+
+const markPossibleMissingCommas = (items: Form): void => {
+  let colonCount = 0;
+  let previous: Expr | undefined;
+
+  items.toArray().forEach((entry) => {
+    if (isWhitespaceAtom(entry) && entry.isNewline) {
+      colonCount = 0;
+      previous = undefined;
+      return;
+    }
+    if (isIdentifierAtom(entry) && entry.value === ",") {
+      colonCount = 0;
+      previous = undefined;
+      return;
+    }
+    if (isIdentifierAtom(entry) && entry.value === ":") {
+      colonCount += 1;
+      if (colonCount > 1 && isIdentifierAtom(previous)) {
+        previous.attributes = {
+          ...previous.attributes,
+          [POSSIBLE_MISSING_BRACE_ENTRY_COMMA_ATTRIBUTE]: true,
+        };
+      }
+    }
+    if (!isWhitespaceAtom(entry)) previous = entry;
+  });
 };

--- a/packages/compiler/src/parser/syntax-macros/index.ts
+++ b/packages/compiler/src/parser/syntax-macros/index.ts
@@ -12,6 +12,8 @@ import { constructorObjectLiteral } from "./constructor-object-literal.js";
 import { SyntaxMacro } from "./types.js";
 import { functionalMacroExpander } from "./functional-macro-expander/index.js";
 import { testBlockMacro } from "./test-block.js";
+import { validateBraceEntrySyntax } from "./validate-brace-entry-syntax.js";
+import { validateUseSyntax } from "./validate-use-syntax.js";
 
 /** Caution: Order matters */
 export const BASE_SYNTAX_MACROS: SyntaxMacro[] = [
@@ -19,6 +21,8 @@ export const BASE_SYNTAX_MACROS: SyntaxMacro[] = [
   primary,
   attachColonClauses,
   constructorObjectLiteral,
+  validateBraceEntrySyntax,
+  validateUseSyntax,
 ];
 
 export const POST_SYNTAX_MACROS: SyntaxMacro[] = [

--- a/packages/compiler/src/parser/syntax-macros/validate-brace-entry-syntax.ts
+++ b/packages/compiler/src/parser/syntax-macros/validate-brace-entry-syntax.ts
@@ -1,0 +1,79 @@
+import {
+  type Expr,
+  type Form,
+  isForm,
+  isIdentifierAtom,
+} from "../ast/index.js";
+import { POSSIBLE_MISSING_BRACE_ENTRY_COMMA_ATTRIBUTE } from "../attributes.js";
+import { ParserSyntaxError } from "../errors.js";
+
+export const validateBraceEntrySyntax = (ast: Form): Form => {
+  visit(ast);
+  return ast;
+};
+
+const visit = (expr: Expr): void => {
+  if (!isForm(expr)) return;
+  if (isUseDeclaration(expr)) return;
+
+  if (expr.callsInternal("object_literal")) {
+    const missingCommaField = findMarkedField(expr);
+    if (missingCommaField) {
+      throw new ParserSyntaxError(
+        `Expected ',' before '${missingCommaField.value}' in braces`,
+        missingCommaField.location,
+      );
+    }
+  }
+
+  expr.toArray().forEach(visit);
+};
+
+const isUseDeclaration = (form: Form): boolean =>
+  isIdentifierWithValue(form.at(0), "use") ||
+  (isIdentifierWithValue(form.at(0), "pub") &&
+    (isIdentifierWithValue(form.at(1), "use") || isModulePathForm(form.at(1))));
+
+const isModulePathForm = (expr: Expr | undefined): boolean =>
+  isForm(expr) && (expr.calls("::") || expr.calls(":"));
+
+const isIdentifierWithValue = (
+  expr: Expr | undefined,
+  value: string,
+): boolean => isIdentifierAtom(expr) && expr.value === value;
+
+const findMarkedField = (expr: Expr): ReturnType<typeof markedField> => {
+  if (isIdentifierAtom(expr)) return markedField(expr);
+  if (!isForm(expr)) return undefined;
+  if (callsControlFlowForm(expr)) {
+    return expr.rest
+      .map(findMarkedFieldInControlFlowChild)
+      .find((candidate) => candidate !== undefined);
+  }
+
+  return expr
+    .toArray()
+    .map(findMarkedField)
+    .find((candidate) => candidate !== undefined);
+};
+
+const findMarkedFieldInControlFlowChild = (
+  expr: Expr,
+): ReturnType<typeof markedField> => {
+  if (!isForm(expr) || !expr.calls(":")) return findMarkedField(expr);
+
+  return expr
+    .toArray()
+    .slice(2)
+    .map(findMarkedField)
+    .find((candidate) => candidate !== undefined);
+};
+
+const markedField = (expr: Expr) =>
+  isIdentifierAtom(expr) &&
+  expr.attributes?.[POSSIBLE_MISSING_BRACE_ENTRY_COMMA_ATTRIBUTE] === true
+    ? expr
+    : undefined;
+
+const callsControlFlowForm = (form: Form): boolean =>
+  form.calls("if") || form.calls("match") || form.calls("try");

--- a/packages/compiler/src/parser/syntax-macros/validate-use-syntax.ts
+++ b/packages/compiler/src/parser/syntax-macros/validate-use-syntax.ts
@@ -7,11 +7,14 @@ import {
 import { ParserSyntaxError } from "../errors.js";
 
 export const validateUseSyntax = (ast: Form): Form => {
-  visit(ast);
+  validateModuleEntries(ast.rest);
   return ast;
 };
 
-const visit = (expr: Expr): void => {
+const validateModuleEntries = (entries: readonly Expr[]): void =>
+  entries.forEach(validateModuleEntry);
+
+const validateModuleEntry = (expr: Expr): void => {
   if (!isForm(expr)) return;
 
   const path = modulePathExpression(expr);
@@ -25,8 +28,19 @@ const visit = (expr: Expr): void => {
     }
   }
 
-  expr.toArray().forEach(visit);
+  if (!isInlineModuleDeclaration(expr)) return;
+  const body = expr
+    .toArray()
+    .find(
+      (entry): entry is Form => isForm(entry) && entry.calls("block"),
+    );
+  if (body) validateModuleEntries(body.rest);
 };
+
+const isInlineModuleDeclaration = (form: Form): boolean =>
+  isIdentifierWithValue(form.at(0), "mod") ||
+  (isIdentifierWithValue(form.at(0), "pub") &&
+    isIdentifierWithValue(form.at(1), "mod"));
 
 const findInvalidModuleSeparator = (
   expr: Expr | undefined,

--- a/packages/compiler/src/parser/syntax-macros/validate-use-syntax.ts
+++ b/packages/compiler/src/parser/syntax-macros/validate-use-syntax.ts
@@ -1,0 +1,58 @@
+import {
+  type Expr,
+  type Form,
+  isForm,
+  isIdentifierAtom,
+} from "../ast/index.js";
+import { ParserSyntaxError } from "../errors.js";
+
+export const validateUseSyntax = (ast: Form): Form => {
+  visit(ast);
+  return ast;
+};
+
+const visit = (expr: Expr): void => {
+  if (!isForm(expr)) return;
+
+  const path = modulePathExpression(expr);
+  if (path) {
+    const invalidSeparator = findInvalidModuleSeparator(path);
+    if (invalidSeparator) {
+      throw new ParserSyntaxError(
+        "Invalid module access syntax; use '::' between module path segments",
+        invalidSeparator.location,
+      );
+    }
+  }
+
+  expr.toArray().forEach(visit);
+};
+
+const findInvalidModuleSeparator = (
+  expr: Expr | undefined,
+): Expr | undefined => {
+  if (!expr) return undefined;
+  if (isIdentifierWithValue(expr, ":")) return expr;
+  if (!isForm(expr)) return undefined;
+
+  return expr
+    .toArray()
+    .map(findInvalidModuleSeparator)
+    .find((candidate): candidate is Expr => candidate !== undefined);
+};
+
+const isIdentifierWithValue = (
+  expr: Expr | undefined,
+  value: string,
+): boolean => isIdentifierAtom(expr) && expr.value === value;
+
+const modulePathExpression = (form: Form): Expr | undefined => {
+  if (isIdentifierWithValue(form.at(0), "use")) return form.at(1);
+  if (!isIdentifierWithValue(form.at(0), "pub")) return undefined;
+  if (isIdentifierWithValue(form.at(1), "use")) return form.at(2);
+
+  const bareExport = form.at(1);
+  return isForm(bareExport) && (bareExport.calls("::") || bareExport.calls(":"))
+    ? bareExport
+    : undefined;
+};

--- a/packages/compiler/src/pipeline-shared.ts
+++ b/packages/compiler/src/pipeline-shared.ts
@@ -716,6 +716,10 @@ export const compileProgramWithLoader = async (
     );
   }
 
+  if (hasErrorDiagnostics(graph.diagnostics)) {
+    return complete(compileProgramFailure([...graph.diagnostics]));
+  }
+
   const analyzeStartedAt = startCompilerPerfPhase();
   const dependencySnapshotReuse = prepareDependencySnapshotReuse({
     cache: options.dependencySnapshotCache,


### PR DESCRIPTION
## Summary

- detect missing commas between same-line brace fields before malformed ASTs cascade into import or typing errors
- reject invalid single-colon module access in `use`, `pub use`, and bare `pub` exports while retaining canonical `as` aliases
- stop compilation after module-graph errors so parse failures do not produce unrelated semantic diagnostics
- add regression coverage for object literals, object/type fields, compound values, nested labeled calls, control-flow clauses, grouped imports, and public exports

## Why

V-303 allowed a missing object-field comma to be folded into the preceding field expression, producing misleading downstream errors. V-203 allowed invalid module access such as `use std:all` to parse without a useful error.

## Validation

- `npm test`
- `npm run typecheck`
- three fresh correctness-review passes; all actionable findings were addressed

Closes V-303
Closes V-203