### PR TITLE
Improve release optimization and scalar boundary exports

### DIFF
--- a/docs/architecture/compiler-optimization-pipeline.md
+++ b/docs/architecture/compiler-optimization-pipeline.md
@@ -662,6 +662,7 @@ The compiler supports two profiles:
 - `aggressive`
   - Binaryen optimize level 3
   - Binaryen shrink level 2
+  - closed-world GC and function-reference optimization
   - `module.optimize()`
   - extra validated passes
   - a second `module.optimize()`
@@ -683,6 +684,15 @@ the aggressive profile; `none` skips both the semantic optimizer and Binaryen.
 The legacy `optimize: true` switch maps to `release`, while direct compiler
 clients using `optimize: true` with `optimizationProfile: "standard"` continue
 to map to `balanced`. Explicit `optimizationLevel` takes precedence.
+
+Release enables Binaryen's closed-world reference analysis because Voyd's host
+boundary treats exported GC objects and closures as opaque handles. The host may
+retain those references and pass them back to Wasm, but it does not inspect GC
+fields, call embedded function references, construct compatible values, or
+reflect on their runtime types. Import and export signatures remain stable.
+The shared helper restores Binaryen's process-global closed-world setting after
+every run, including failed optimization, so balanced and unrelated modules do
+not inherit the release assumption.
 
 Raw pass selection is not public API. The scorecard can run guarded internal
 ablation workers that omit one aggressive pass or the final optimization cycle;

--- a/docs/testing/ci.md
+++ b/docs/testing/ci.md
@@ -33,6 +33,14 @@ Dedicated conformance and integration jobs each use two Vitest workers, so the
 unit lane's three-package concurrency cannot multiply into unbounded nested
 worker pools.
 
+The first broad upstream unit runs after the lane split varied from about 224
+to 342 seconds on hosted runners. The slowest unchanged file varied from about
+119 to 147 seconds, and the file exceeding the limit changed between attempts
+even though every test passed. The initial unit guardrail is therefore 420
+seconds for the lane and 180 seconds per file. This retains regression
+detection without making ordinary hosted-runner variance a required-check
+failure; tighten it once retained artifacts provide a credible p95 baseline.
+
 The first live hosted-runner integration baseline completed all 128 assertions
 in about 201 seconds, with the slowest file at about 132 seconds. Its initial
 budget is therefore 300 seconds for the lane and 180 seconds per file. This

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/boundary-export.voyd
@@ -11,6 +11,18 @@ enum LookupResult
   Found { value: String }
   Missing
 
+pub fn primitive() -> i32
+  42
+
+pub fn echo_bool(value: bool) -> bool
+  value
+
+pub fn echo_i64(value: i64) -> i64
+  value
+
+pub fn echo_f32(value: f32) -> f32
+  value
+
 pub fn translate(point: Point, dx: i32, dy: i32) -> Point
   Point {
     x: point.x + dx,

--- a/packages/compiler/src/codegen/__tests__/export-abi.test.ts
+++ b/packages/compiler/src/codegen/__tests__/export-abi.test.ts
@@ -254,10 +254,32 @@ describe("export abi metadata", { timeout: 60_000 }, () => {
 
     expect(exports).toContain("translate");
     expect(exports).toContain("__voyd_serialized_export_translate");
+    expect(exports).not.toContain("__voyd_serialized_export_primitive");
+    expect(exports).not.toContain("__voyd_serialized_export_echo_bool");
+    expect(exports).not.toContain("__voyd_serialized_export_echo_i64");
+    expect(exports).not.toContain("__voyd_serialized_export_echo_f32");
     expect(abi.exports).not.toContainEqual(
       expect.objectContaining({ name: "call_callback", abi: "serialized" }),
     );
     expect(abi.exports).toEqual([
+      {
+        name: "echo_bool",
+        abi: "direct",
+        params: [expect.objectContaining({ kind: "bool" })],
+        result: expect.objectContaining({ kind: "bool" }),
+      },
+      {
+        name: "echo_f32",
+        abi: "direct",
+        params: [expect.objectContaining({ kind: "f32" })],
+        result: expect.objectContaining({ kind: "f32" }),
+      },
+      {
+        name: "echo_i64",
+        abi: "direct",
+        params: [expect.objectContaining({ kind: "i64" })],
+        result: expect.objectContaining({ kind: "i64" }),
+      },
       expect.objectContaining({
         name: "get_point",
         abi: "serialized",
@@ -272,6 +294,12 @@ describe("export abi metadata", { timeout: 60_000 }, () => {
         params: [expect.objectContaining({ kind: "string" })],
         result: expect.objectContaining({ kind: "union" }),
       }),
+      {
+        name: "primitive",
+        abi: "direct",
+        params: [],
+        result: expect.objectContaining({ kind: "i32" }),
+      },
       expect.objectContaining({
         name: "sum_values",
         abi: "serialized",

--- a/packages/compiler/src/codegen/exports/export-abi.ts
+++ b/packages/compiler/src/codegen/exports/export-abi.ts
@@ -7,6 +7,8 @@ export type ExportAbiEntry =
   | {
       name: string;
       abi: "direct";
+      params?: readonly BoundarySchema[];
+      result?: BoundarySchema;
     }
   | {
       name: string;

--- a/packages/compiler/src/codegen/functions.ts
+++ b/packages/compiler/src/codegen/functions.ts
@@ -309,6 +309,59 @@ const boundarySchemasForExport = ({
   }),
 });
 
+const scalarBoundaryWasmType = (
+  schema: BoundarySchema,
+): binaryen.Type | undefined => {
+  switch (schema.kind) {
+    case "bool":
+    case "i32":
+      return binaryen.i32;
+    case "i64":
+      return binaryen.i64;
+    case "f32":
+      return binaryen.f32;
+    case "f64":
+      return binaryen.f64;
+    default:
+      return undefined;
+  }
+};
+
+const supportsDirectScalarBoundary = ({
+  meta,
+  schemas,
+}: {
+  meta: FunctionMetadata;
+  schemas: { params: readonly BoundarySchema[]; result: BoundarySchema };
+}): boolean => {
+  if (meta.userParamOffset !== 0 || meta.resultAbiKind !== "direct") {
+    return false;
+  }
+  const paramsSupported = schemas.params.every((schema, index) => {
+    const wasmType = scalarBoundaryWasmType(schema);
+    const abiTypes = meta.paramAbiTypes[index] ?? [];
+    return (
+      wasmType !== undefined &&
+      meta.paramAbiKinds[index] === "direct" &&
+      meta.parameters[index]?.defaulted !== true &&
+      abiTypes.length === 1 &&
+      abiTypes[0] === wasmType
+    );
+  });
+  if (!paramsSupported || schemas.params.length !== meta.paramAbiTypes.length) {
+    return false;
+  }
+  if (schemas.result.kind === "void") {
+    return meta.resultAbiTypes.length === 0;
+  }
+  const resultType = scalarBoundaryWasmType(schemas.result);
+  return (
+    resultType !== undefined &&
+    meta.resultAbiTypes.length === 1 &&
+    meta.resultAbiTypes[0] === resultType
+  );
+};
+
 const reportBoundaryExportUnsupported = ({
   ctx,
   entry,
@@ -1571,6 +1624,16 @@ export const emitModuleExports = (
             meta,
             exportName,
           });
+          if (supportsDirectScalarBoundary({ meta, schemas })) {
+            exportAbiEntries.push({
+              name: exportName,
+              abi: "direct",
+              params: schemas.params,
+              result: schemas.result,
+            });
+            emittedBoundaryExports.add(exportName);
+            return;
+          }
           const wrapperExportName = allocateBoundaryWrapperExportName({
             ctx: exportCtx,
             exportName,

--- a/packages/js-host/src/boundary-values.ts
+++ b/packages/js-host/src/boundary-values.ts
@@ -56,6 +56,62 @@ export const decodeBoundaryResult = ({
     registry: buildSchemaRegistry([schema]),
   });
 
+export const encodeDirectBoundaryArgs = ({
+  exportName,
+  schemas,
+  args,
+}: {
+  exportName: string;
+  schemas: readonly BoundarySchema[];
+  args: readonly unknown[];
+}): unknown[] =>
+  encodeBoundaryArgs({ exportName, schemas, args }).map((value, index) => {
+    const schema = schemas[index]!;
+    switch (schema.kind) {
+      case "bool":
+        return value ? 1 : 0;
+      case "i64":
+        return typeof value === "number" ? BigInt(value) : value;
+      case "i32":
+      case "f32":
+      case "f64":
+        return value;
+      default:
+        throw new Error(
+          `typed export ${exportName} has unsupported direct parameter schema ${schema.kind}`,
+        );
+    }
+  });
+
+export const decodeDirectBoundaryResult = ({
+  exportName,
+  schema,
+  value,
+}: {
+  exportName: string;
+  schema: BoundarySchema;
+  value: unknown;
+}): unknown => {
+  switch (schema.kind) {
+    case "bool":
+      return decodeBoundaryResult({
+        exportName,
+        schema,
+        value: value !== 0,
+      });
+    case "i32":
+    case "i64":
+    case "f32":
+    case "f64":
+    case "void":
+      return decodeBoundaryResult({ exportName, schema, value });
+    default:
+      throw new Error(
+        `typed export ${exportName} has unsupported direct result schema ${schema.kind}`,
+      );
+  }
+};
+
 const encodeBoundaryValue = ({
   exportName,
   schema,

--- a/packages/js-host/src/host.ts
+++ b/packages/js-host/src/host.ts
@@ -28,7 +28,9 @@ import { registerHandlersByLabelSuffix } from "./handlers.js";
 import { parseExportAbi } from "./protocol/export-abi.js";
 import {
   decodeBoundaryResult,
+  decodeDirectBoundaryResult,
   encodeBoundaryArgs,
+  encodeDirectBoundaryArgs,
 } from "./boundary-values.js";
 import type { ExportAbiEntry } from "./protocol/export-abi.js";
 import {
@@ -938,8 +940,16 @@ export const createVoydHost = async ({
       return runSerialized<T>(entryName, args, abi);
     }
     const entry = requireExportedFunction({ instance, name: entryName });
+    const directArgs = abi?.params
+      ? encodeDirectBoundaryArgs({
+          exportName: entryName,
+          schemas: abi.params,
+          args,
+        })
+      : args;
+    let result: unknown;
     try {
-      return (entry as (...params: unknown[]) => T)(...args);
+      result = (entry as (...params: unknown[]) => unknown)(...directArgs);
     } catch (error) {
       throw annotateTrap(error, {
         transition: {
@@ -949,6 +959,13 @@ export const createVoydHost = async ({
         fallbackFunctionName: entryName,
       });
     }
+    return (abi?.result
+      ? decodeDirectBoundaryResult({
+          exportName: entryName,
+          schema: abi.result,
+          value: result,
+        })
+      : result) as T;
   };
 
   const runEffectfulManaged = <T = unknown>(

--- a/packages/js-host/src/protocol/export-abi.ts
+++ b/packages/js-host/src/protocol/export-abi.ts
@@ -61,6 +61,8 @@ export type ExportAbiEntry =
   | {
       name: string;
       abi: "direct";
+      params?: readonly BoundarySchema[];
+      result?: BoundarySchema;
     }
   | {
       name: string;

--- a/packages/lib/src/lib/__tests__/binaryen-optimize.test.ts
+++ b/packages/lib/src/lib/__tests__/binaryen-optimize.test.ts
@@ -9,6 +9,7 @@ describe("binaryen aggressive optimization profile", () => {
   afterEach(() => {
     delete process.env.VOYD_INTERNAL_BINARYEN_ABLATION;
     delete process.env.VOYD_BINARYEN_EXPERIMENT;
+    vi.restoreAllMocks();
   });
 
   it("includes the heap allocation passes", () => {
@@ -69,31 +70,73 @@ describe("binaryen aggressive optimization profile", () => {
     mod.setFeatures(binaryen.Features.All);
     mod.addFunction("main", binaryen.none, binaryen.i32, [], mod.i32.const(42));
     mod.addFunctionExport("main", "main");
-
-    const report = optimizeBinaryenModule({
-      module: mod,
-      profile: "aggressive",
+    const previousClosedWorld = binaryen.getClosedWorld();
+    const observedClosedWorld: boolean[] = [];
+    const optimize = mod.optimize.bind(mod);
+    vi.spyOn(mod, "optimize").mockImplementation(() => {
+      observedClosedWorld.push(binaryen.getClosedWorld());
+      optimize();
     });
+    binaryen.setClosedWorld(false);
 
-    expect(Boolean(mod.validate())).toBe(true);
-    expect(report.profile).toBe("aggressive");
-    expect(report.extraPasses).toEqual(AGGRESSIVE_BINARYEN_EXTRA_PASSES);
-    expect(report.phasesMs.initialOptimize).toBeGreaterThanOrEqual(0);
-    expect(report.phasesMs.extraPasses).toBeGreaterThanOrEqual(0);
-    expect(report.phasesMs.finalOptimize).toBeGreaterThanOrEqual(0);
+    try {
+      const report = optimizeBinaryenModule({
+        module: mod,
+        profile: "aggressive",
+      });
+
+      expect(Boolean(mod.validate())).toBe(true);
+      expect(report.profile).toBe("aggressive");
+      expect(report.extraPasses).toEqual(AGGRESSIVE_BINARYEN_EXTRA_PASSES);
+      expect(report.phasesMs.initialOptimize).toBeGreaterThanOrEqual(0);
+      expect(report.phasesMs.extraPasses).toBeGreaterThanOrEqual(0);
+      expect(report.phasesMs.finalOptimize).toBeGreaterThanOrEqual(0);
+      expect(observedClosedWorld).toEqual([true, true]);
+      expect(binaryen.getClosedWorld()).toBe(false);
+    } finally {
+      binaryen.setClosedWorld(previousClosedWorld);
+    }
   });
 
   it("uses one optimize call and no extra passes for the standard profile", () => {
     const mod = createMinimalModule();
     const optimize = vi.spyOn(mod, "optimize");
     const runPasses = vi.spyOn(mod, "runPasses");
+    const previousClosedWorld = binaryen.getClosedWorld();
+    binaryen.setClosedWorld(true);
 
-    const report = optimizeBinaryenModule({ module: mod, profile: "standard" });
+    try {
+      const report = optimizeBinaryenModule({
+        module: mod,
+        profile: "standard",
+      });
 
-    expect(optimize).toHaveBeenCalledTimes(1);
-    expect(runPasses).not.toHaveBeenCalled();
-    expect(report.extraPasses).toEqual([]);
-    expect(Boolean(mod.validate())).toBe(true);
+      expect(optimize).toHaveBeenCalledTimes(1);
+      expect(runPasses).not.toHaveBeenCalled();
+      expect(report.extraPasses).toEqual([]);
+      expect(Boolean(mod.validate())).toBe(true);
+      expect(binaryen.getClosedWorld()).toBe(true);
+    } finally {
+      binaryen.setClosedWorld(previousClosedWorld);
+    }
+  });
+
+  it("restores Binaryen globals when aggressive optimization throws", () => {
+    const mod = createMinimalModule();
+    const previousOptimizeLevel = binaryen.getOptimizeLevel();
+    const previousShrinkLevel = binaryen.getShrinkLevel();
+    const previousClosedWorld = binaryen.getClosedWorld();
+    vi.spyOn(mod, "optimize").mockImplementation(() => {
+      expect(binaryen.getClosedWorld()).toBe(true);
+      throw new Error("optimization failed");
+    });
+
+    expect(() =>
+      optimizeBinaryenModule({ module: mod, profile: "aggressive" }),
+    ).toThrow("optimization failed");
+    expect(binaryen.getOptimizeLevel()).toBe(previousOptimizeLevel);
+    expect(binaryen.getShrinkLevel()).toBe(previousShrinkLevel);
+    expect(binaryen.getClosedWorld()).toBe(previousClosedWorld);
   });
 
   it("can ablate an aggressive extra pass and the final optimize call", () => {

--- a/packages/lib/src/lib/binaryen-optimize.ts
+++ b/packages/lib/src/lib/binaryen-optimize.ts
@@ -41,6 +41,7 @@ export const optimizeBinaryenModule = ({
 }): BinaryenOptimizationReport => {
   const previousOptimizeLevel = binaryen.getOptimizeLevel();
   const previousShrinkLevel = binaryen.getShrinkLevel();
+  const previousClosedWorld = binaryen.getClosedWorld();
   const optimizeLevel = profile === "aggressive" ? 3 : 2;
   const shrinkLevel = profile === "aggressive" ? 2 : 1;
 
@@ -68,6 +69,12 @@ export const optimizeBinaryenModule = ({
 
   binaryen.setOptimizeLevel(optimizeLevel);
   binaryen.setShrinkLevel(shrinkLevel);
+  // Voyd's exported GC and function references are opaque host handles: they
+  // may be retained and passed back, but their contents are not host-inspected.
+  // That contract lets release builds unlock Binaryen's closed-world GC passes.
+  if (profile === "aggressive") {
+    binaryen.setClosedWorld(true);
+  }
 
   try {
     let startedAt = performance.now();
@@ -88,6 +95,7 @@ export const optimizeBinaryenModule = ({
   } finally {
     binaryen.setOptimizeLevel(previousOptimizeLevel);
     binaryen.setShrinkLevel(previousShrinkLevel);
+    binaryen.setClosedWorld(previousClosedWorld);
   }
   return { profile, extraPasses, phasesMs };
 };

--- a/packages/reference/docs/sdk.md
+++ b/packages/reference/docs/sdk.md
@@ -148,6 +148,11 @@ Raw Wasm exports remain available through `host.instance.exports`. Existing
 raw MsgPack interop still works; MsgPack is an internal codec detail for typed
 boundary exports, not a stable WIT/component-model replacement.
 
+Raw Wasm GC objects and closures are opaque boundary handles. A host may retain
+them and pass the same reference back to Voyd exports, but inspecting their
+fields, invoking embedded function references, constructing compatible GC
+values, or reflecting on their runtime types is outside the supported ABI.
+
 ## Module roots and package resolution
 
 `createSdk().compile(...)` accepts `roots` when you need to override module

--- a/packages/reference/docs/sdk.md
+++ b/packages/reference/docs/sdk.md
@@ -60,6 +60,9 @@ Raw Binaryen pass configuration is intentionally not public SDK API.
 SDK builds automatically expose boundary-compatible public Voyd functions
 through the existing host and compiled-result run APIs. JavaScript callers pass
 plain JS values; the host validates and encodes them at the Wasm boundary.
+Primitive-only signatures use a validated direct Wasm call and do not pull in
+the serialized boundary runtime. Strings, arrays, records, and unions continue
+to use the serialized boundary ABI.
 
 ```ts
 const result = await sdk.compile({
@@ -135,7 +138,8 @@ pub fn call_callback(callback: fn() -> i32) -> i32
 });
 ```
 
-Disable automatic wrappers when Wasm size or compile-time overhead matters.
+Disable automatic boundary generation when raw Wasm calling conventions are
+preferred over JavaScript validation and DTO conversion.
 
 ```ts
 const result = await sdk.compile({

--- a/packages/sdk/src/__tests__/sdk-node.test.ts
+++ b/packages/sdk/src/__tests__/sdk-node.test.ts
@@ -52,6 +52,15 @@ enum NestedResult
 pub fn primitive() -> i32
   42
 
+pub fn echo_bool(value: bool) -> bool
+  value
+
+pub fn echo_i64(value: i64) -> i64
+  value
+
+pub fn echo_f32(value: f32) -> f32
+  value
+
 pub fn translate(point: Point, dx: i32, dy: i32) -> Point
   Point {
     x: point.x + dx,
@@ -573,8 +582,32 @@ pub fn main() -> i32
       await sdk.compile({ source: BOUNDARY_EXPORTS_SOURCE }),
     );
     const host = await createVoydHost({ wasm: result.wasm });
+    const module = new WebAssembly.Module(wasmBufferSource(result.wasm));
+    const abi = parseExportAbi(module);
+    const exports = WebAssembly.Module.exports(module).map(
+      (entry) => entry.name,
+    );
 
     await expect(host.run("primitive")).resolves.toBe(42);
+    await expect(host.run("echo_bool", [true])).resolves.toBe(true);
+    await expect(host.run("echo_i64", [42])).resolves.toBe(42n);
+    await expect(host.run("echo_f32", [1.5])).resolves.toBe(1.5);
+    await expect(host.run("echo_bool", [1])).rejects.toThrow(
+      "typed export echo_bool arg0 expected bool, got number",
+    );
+    await expect(host.run("primitive", [1])).rejects.toThrow(
+      "typed export primitive expected 0 args, got 1",
+    );
+    await expect(
+      host.run("echo_i64", [Number.MAX_SAFE_INTEGER + 1]),
+    ).rejects.toThrow("typed export echo_i64 arg0 expected i64, got number");
+    expect(exports).not.toContain("__voyd_serialized_export_primitive");
+    expect(abi.exports).toContainEqual({
+      name: "primitive",
+      abi: "direct",
+      params: [],
+      result: expect.objectContaining({ kind: "i32" }),
+    });
     await expect(
       host.run("translate", [{ x: 1, y: 2 }, 10, 20]),
     ).resolves.toEqual({ x: 11, y: 22 });
@@ -671,6 +704,37 @@ pub fn main() -> i32
     ).rejects.toThrow("increase createVoydHost({ bufferSize })");
     await expect(tinyBufferHost.run("long_text")).rejects.toThrow(
       "increase createVoydHost({ bufferSize })",
+    );
+  });
+
+  it("keeps scalar-only typed release exports independent of serialization", async () => {
+    const sdk = createSdk();
+    const result = expectCompileSuccess(
+      await sdk.compile({
+        source: `pub fn increment(value: i32) -> i32
+  value + 1
+`,
+        optimizationLevel: "release",
+      }),
+    );
+    const module = new WebAssembly.Module(wasmBufferSource(result.wasm));
+    const exports = WebAssembly.Module.exports(module).map(
+      (entry) => entry.name,
+    );
+    const abi = parseExportAbi(module);
+    const host = await createVoydHost({ wasm: result.wasm });
+
+    expect(result.wasm.byteLength).toBeLessThan(2_000);
+    expect(exports).not.toContain("__voyd_serialized_export_increment");
+    expect(abi.exports).toContainEqual({
+      name: "increment",
+      abi: "direct",
+      params: [expect.objectContaining({ kind: "i32" })],
+      result: expect.objectContaining({ kind: "i32" }),
+    });
+    await expect(host.run("increment", [41])).resolves.toBe(42);
+    await expect(host.run("increment", ["41"])).rejects.toThrow(
+      "typed export increment arg0 expected i32, got string",
     );
   });
 

--- a/scripts/testing/timing-budgets.json
+++ b/scripts/testing/timing-budgets.json
@@ -1,7 +1,7 @@
 {
   "unit": {
-    "maxWallMs": 300000,
-    "maxFileMs": 120000
+    "maxWallMs": 420000,
+    "maxFileMs": 180000
   },
   "conformance": {
     "maxWallMs": 120000,

--- a/tests/integration/fixtures/optimization-differential.voyd
+++ b/tests/integration/fixtures/optimization-differential.voyd
@@ -59,3 +59,12 @@ fn zero() -> i32
 
 pub fn deliberate_trap() -> i32
   10 / zero()
+
+fn make_incrementer(delta: i32) -> (fn(i32) -> i32)
+  (value) => value + delta
+
+pub fn make_incrementer_export(delta: i32) -> (fn(i32) -> i32)
+  make_incrementer(delta)
+
+pub fn apply_incrementer(transform: fn(i32) -> i32, value: i32) -> i32
+  transform(value)

--- a/tests/integration/src/optimization-differential.test.ts
+++ b/tests/integration/src/optimization-differential.test.ts
@@ -72,6 +72,26 @@ describe("integration: optimization-level differential behavior", () => {
     });
   });
 
+  it("preserves opaque raw closure references across the host boundary", async () => {
+    await Promise.all(
+      LEVELS.map(async (level) => {
+        const module = new WebAssembly.Module(
+          compiledByLevel.get(level)!.wasm as BufferSource,
+        );
+        expect(WebAssembly.Module.imports(module)).toEqual([]);
+        const instance = await WebAssembly.instantiate(module, {});
+        const exports = instance.exports as {
+          make_incrementer_export(delta: number): unknown;
+          apply_incrementer(transform: unknown, value: number): number;
+        };
+        const incrementer = exports.make_incrementer_export(5);
+
+        expect(typeof incrementer).toBe("object");
+        expect(exports.apply_incrementer(incrementer, 7)).toBe(12);
+      }),
+    );
+  });
+
   it.each([
     ["folded_branch", 42],
     ["trait_dispatch", 9],

--- a/tests/performance/src/vtrace-compute-benchmark.test.ts
+++ b/tests/performance/src/vtrace-compute-benchmark.test.ts
@@ -101,14 +101,14 @@ benchmarkDescribe("performance: vtrace compute-only benchmark", () => {
     async () => {
       const host = await createVoydHost({ wasm: compiled.wasm });
 
-      await expect(host.run<number>("benchmark")).resolves.toBe(
+      await expect(host.runPure<number>("benchmark")).resolves.toBe(
         benchmarkChecksum,
       );
 
       const durationsMs: number[] = [];
       for (let iteration = 0; iteration < perfIterations; iteration += 1) {
         const startedAt = performance.now();
-        await expect(host.run<number>("benchmark")).resolves.toBe(
+        await expect(host.runPure<number>("benchmark")).resolves.toBe(
           benchmarkChecksum,
         );
         durationsMs.push(performance.now() - startedAt);


### PR DESCRIPTION
## Summary

- Enables Binaryen closed-world reference optimization for the aggressive/release profile.
- Restores Binaryen's process-global optimization, shrink, and closed-world settings on both success and failure; balanced builds remain unchanged.
- Calibrates the new unit timing guard to 420s per lane / 180s per file after three identical hosted runs showed 224–342s lane and 119–147s unchanged-file variance.
- Documents and tests the host ABI assumption that raw Wasm GC objects and closures are opaque handles that may be retained and passed back, but not inspected or invoked by the host.
- Adds a validated direct boundary ABI for pure scalar signatures (`bool`, `i32`, `i64`, `f32`, `f64`, and `void` results), avoiding MessagePack wrappers and runtime reachability when the physical Wasm signature matches.
- Preserves JavaScript boundary validation and coercion, including `bool ↔ i32` and safe numeric `i64 → bigint` conversion; DTO signatures remain serialized.

Binaryen's closed-world mode is valid under that ABI contract and unlocks materially stronger GC dead-code and type optimization while preserving import/export signatures.

## Performance

### Closed-world optimization

Measured with the repository's full six-scenario optimizer scorecard, using identical corpus hashes, 1 compile warmup, 3 compile samples, and 15 runtime samples:

| Scenario | Raw Wasm | gzip |
| --- | ---: | ---: |
| Tier 1 kernels | -2.05% | +0.98% (+70 B) |
| Scalar kernels | -4.08% | -1.05% |
| Call-shape kernels | -4.13% | -0.90% |
| Math kernels | -3.28% | -0.73% |
| vtrace workload | **-11.23%** | **-6.21%** |
| Effects workload | -5.89% | -3.68% |
| **Aggregate** | **162,288 → 151,474 B (-6.66%)** | **56,469 → 54,824 B (-2.91%)** |

The representative vtrace workload also improved from 175.059 ms to 163.316 ms median runtime (**-6.71%**). Its 15-sample ranges did not overlap (baseline 173.890–178.040 ms; optimized 162.415–164.747 ms). Structural counts moved in the expected direction: functions 418→384, `struct.new` 763→650, `array.new` 197→140, and `ref.cast` 904→614.

Every raw Wasm artifact decreased. The repository's optimizer regression gate passed; the isolated +70-byte gzip result on the smallest tier-1 corpus is disclosed above rather than hidden by the aggregate improvement.

Benchmark commands:

```sh
npm run bench:optimizer -- --preset full --modes release --compile-warmups 1 --compile-samples 3 --runtime-samples 15 --output /tmp/voyd-optimizer-{baseline,closed-world}.json
node scripts/ci/check-optimizer-bench-regression.mjs --base-json /tmp/voyd-optimizer-baseline.json --head-json /tmp/voyd-optimizer-closed-world.json
```

### Typed scalar boundary fast path

For the original minimal release case (`pub fn main() -> i32`) with automatic typed exports:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Raw Wasm | 17,111 B | **783 B** | **-95.42%** |
| gzip | 6,348 B | **462 B** | **-92.72%** |
| Warm `runPure` | 0.901 µs/call | **0.146 µs/call** | **6.17× faster** |

The untyped `boundaryExports: false` reference was 736 B raw / 429 B gzip / 0.063 µs per call. The small remaining direct-path overhead is the retained schema validation and JavaScript/Wasm scalar conversion. The permanent regression uses a generous <2 KB ceiling rather than pinning exact output bytes.

### Vtrace `runPure` validation

The compute-only vtrace benchmark now calls `host.runPure("benchmark")` explicitly. It is a pure export that handles RNG effects internally.

- Heavy renderer, 15 samples: `run` **7,267.70 ms** median (7,111.11–7,371.83 ms); `runPure` **7,359.59 ms** (7,287.11–7,394.93 ms). The overlapping ranges and +1.26% ordered-run difference show no meaningful end-to-end change; roughly seven seconds of rendering dominates dispatch.
- Paired handled-effect probe, 7 × 20,000 calls: `run` **0.3647 µs/call**; `runPure` **0.1603 µs/call**—**2.28× faster / 56.0% lower dispatch overhead**.
- Wasm size is unchanged because this follow-up changes only the benchmark host invocation.

## Testing

- `npm test` (16/16 tasks; run outside the sandbox because the std HTTP tests bind local ports)
- `npm run typecheck` (15/15 tasks)
- `npm run test:audit`
- `npm run test:codegen` (50 files, 297 tests)
- Focused optimizer/integration/effects Vitest suite (3 files, 26 tests)
- Focused compiler/SDK boundary suite (2 files, 52 tests), plus the scalar-only release-size regression
- `npm run lint`
- Prettier and `git diff --check`
- Revalidated the worst hosted timing artifact (342.102s lane / 142.650s file) against the calibrated guard
- Agentic review loop: Implementation Gap Review and Correctness Review both clean, with no production-impacting findings

If this PR adds or expands tests:

- Canonical owning layer: `packages/lib` for Binaryen profile/state behavior; `tests/integration` for the raw Wasm host boundary.
- Capability or regression protected: aggressive mode enables closed-world analysis only while optimizing and restores all global state; opaque closure references survive a host retain/pass-back round trip at every optimization level.
- Evidence the test fails without the change: the aggressive optimizer spy observes closed-world mode as disabled without this implementation; the state-restoration coverage exercises the new failure path.
- Runtime impact: expands an existing integration fixture/test with three small compile-and-instantiate cases; no new test file or fixture.
- Boundary rationale for any duplicated behavior: the unit test protects Binaryen global configuration, while the integration test protects the distinct user-visible host ABI contract that makes the optimization sound.

## Follow-up

A more invasive residual-effect ABI specialization showed a large synthetic recursive speedup but no improvement on the canonical vtrace scorecard, so it was rejected from this high-bar change. The opportunity and required production evidence are tracked in [V-418](https://linear.app/voyd-lang/issue/V-418/eliminate-residual-effect-abi-for-statically-handled-recursive-call).

Effect-aware scalar replacement is tracked in [V-419](https://linear.app/voyd-lang/issue/V-419/enable-stack-switching-compatible-scalar-replacement-in-effectful). Voyd expects to adopt WebAssembly stack switching soon, so that ticket targets a backend-neutral scalarization contract for the stack-switching backend and explicitly avoids a broad GC-trampoline-specific SROA subsystem.

Binaryen contract reference: [GC Optimization Guidebook](https://github.com/WebAssembly/binaryen/wiki/GC-Optimization-Guidebook).