### PR TITLE
Enable safe effectful scalar replacement

### DIFF
--- a/docs/architecture/compiler-optimization-pipeline.md
+++ b/docs/architecture/compiler-optimization-pipeline.md
@@ -588,7 +588,7 @@ The complexity added by this path is:
 - localized field load/store/rematerialization helpers
 - a private direct-call specialization path for selected small heap-object
   parameters and fresh heap-object results
-- additional local rechecks for mutable method receivers, effectful functions,
+- additional local rechecks for mutable method receivers, suspension liveness,
   effect-handler captures, aliasing, and storage-ref capture boundaries
 
 It avoids a separate optimizer rewrite pass and keeps the public function ABI
@@ -598,8 +598,54 @@ mutation/capture boundaries and accidentally specializing alias-returning heap
 objects. The implementation pays a compile-time cost in the affected scenarios
 for extra fact checks and specialization metadata, but the hot aggregate cases
 below show runtime and code-size wins where Binaryen alone did not remove the
-semantic allocation pattern. Effectful functions deliberately fall back to
-materialized values until storage/capture semantics can be proven more tightly.
+semantic allocation pattern.
+
+Effectful functions use the continuation lowering's backend-neutral
+`symbolsLiveAcrossSuspension` fact set. The GC-trampoline backend allows scalar
+lanes only when the initializer itself does not suspend and the binding is not
+live across a later suspension. A future stack-switching backend can set its
+scalar-aggregate policy to preserve lanes across suspension because suspended
+Wasm frames retain their locals. Escape, identity, aliasing, and mutation checks
+remain independent of that backend choice.
+
+This policy assumes Voyd's existing one-shot continuation contract. One-shot
+semantics prevent multiple resumed frames from observing divergent copies of a
+mutable scalar lane. They do not relax object identity or aliasing rules: any
+candidate requiring stable identity still materializes before scalarization is
+considered.
+
+### Effectful scalar replacement measurement (V-419)
+
+The original trace reported 293 categorical effectful initializer bailouts and
+47 categorical effectful parameter bailouts, with 26 initializer and 8
+parameter applications. Re-running the representative
+`vtrace-compute-benchmark.voyd` workload after classifying candidates with the
+ordinary safety checks first produced:
+
+| Decision                                                         | Count |
+| ---------------------------------------------------------------- | ----: |
+| initializer applied                                              |    38 |
+| initializer evaluation suspends                                  |    45 |
+| initializer value live across suspension                         |    11 |
+| parameter applied                                                |     8 |
+| parameter live across suspension after independent safety checks |     0 |
+
+The current GC-safe slice therefore adds 12 initializer applications (a 46%
+increase) in the effect-heavy representative workload. The old parameter
+bailouts were all rejected by independent escape, layout, or ABI checks, so the
+workload gains no parameter applications yet.
+
+The focused effectful codegen regression removes aggregate `struct.new` and
+field traffic for values consumed between suspension points, while paired tests
+confirm materialization for live-across-suspension and suspending-initializer
+cases. On the fully optimized representative vtrace module, Binaryen already
+eliminates the newly scalarized allocation shapes: base and head both emit
+61,474 Wasm bytes, 890,130 WAT bytes, and 771 `struct.new` operations. Median
+fresh-instance runtime was 170.47 ms at base and 170.73 ms at head (+0.2%,
+noise). This is a verified pre-Binaryen structural improvement rather than a
+measurable end-to-end win on that workload; the explicit contract remains
+valuable for shapes Binaryen cannot recover and for the future stack-switching
+backend.
 
 Rejected simpler alternatives:
 

--- a/packages/compiler/src/codegen/__tests__/codegen.test.ts
+++ b/packages/compiler/src/codegen/__tests__/codegen.test.ts
@@ -223,6 +223,7 @@ const buildCodegenProgram = (
     effectLowering: {
       sitesByExpr: new Map(),
       sites: [],
+      symbolsLiveAcrossSuspension: new Set(),
       callArgTemps: new Map(),
       tempTypeIds: new Map(),
       defaultParamTemps: new Map(),
@@ -322,6 +323,7 @@ describe("next codegen", () => {
       effectLowering: {
         sitesByExpr: new Map(),
         sites: [],
+        symbolsLiveAcrossSuspension: new Set(),
         callArgTemps: new Map(),
         tempTypeIds: new Map(),
         defaultParamTemps: new Map(),

--- a/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
+++ b/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
@@ -235,6 +235,7 @@ const buildLoweringSnapshot = () => {
     effectLowering: {
       sitesByExpr: new Map(),
       sites: [],
+      symbolsLiveAcrossSuspension: new Set(),
       callArgTemps: new Map(),
       tempTypeIds: new Map(),
       defaultParamTemps: new Map(),

--- a/packages/compiler/src/codegen/__tests__/program-helper-registry.test.ts
+++ b/packages/compiler/src/codegen/__tests__/program-helper-registry.test.ts
@@ -22,6 +22,7 @@ describe("program helper registry", () => {
       effectLowering: {
         sitesByExpr: new Map(),
         sites: [],
+        symbolsLiveAcrossSuspension: new Set<number>(),
         callArgTemps: new Map(),
         tempTypeIds: new Map(),
         defaultParamTemps: new Map(),

--- a/packages/compiler/src/codegen/__tests__/scalar-aggregate-replacement.test.ts
+++ b/packages/compiler/src/codegen/__tests__/scalar-aggregate-replacement.test.ts
@@ -833,6 +833,179 @@ pub fn main(): () -> i32
     );
   });
 
+  it("scalarizes effectful aggregate locals that are not live across suspension", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+eff Local
+  next(tail) -> i32
+
+fn compute(): Local -> i32
+  let before = Vec2 { x: 1, y: 2 }
+  let subtotal = before.x + before.y
+  let value = Local::next()
+  let after = Vec2 { x: value, y: 4 }
+  subtotal + after.x + after.y
+
+pub fn main(): () -> i32
+  try
+    compute()
+  Local::next(tail):
+    tail(10)
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(17);
+    const aggregateAllocations = (text: string): number =>
+      text.match(/\(struct\.new \$voyd_struct_shape_/g)?.length ?? 0;
+    expect(
+      aggregateAllocations(baselineCodegen.module.emitText()),
+    ).toBeGreaterThan(aggregateAllocations(optimizedCodegen.module.emitText()));
+  });
+
+  it("materializes effectful aggregate locals that are live across suspension", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+eff Local
+  next(tail) -> i32
+
+fn compute(): Local -> i32
+  let vec = Vec2 { x: 3, y: 4 }
+  let value = Local::next()
+  vec.x + vec.y + value
+
+pub fn main(): () -> i32
+  try
+    compute()
+  Local::next(tail):
+    tail(5)
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(12);
+    expect(optimizedCodegen.module.emitText()).toMatch(
+      /\(struct\.new \$voyd_struct_shape_/,
+    );
+  });
+
+  it("materializes aggregate initializers whose evaluation suspends", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Vec2 {
+  x: i32,
+  y: i32
+}
+
+eff Local
+  next(tail) -> i32
+
+fn compute(): Local -> i32
+  let vec = Vec2 { x: Local::next(), y: 2 }
+  vec.x + vec.y
+
+pub fn main(): () -> i32
+  try
+    compute()
+  Local::next(tail):
+    tail(5)
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(7);
+    expect(optimizedCodegen.module.emitText()).toMatch(
+      /\(struct\.new \$voyd_struct_shape_/,
+    );
+  });
+
+  it("scalarizes effectful value parameters dead before suspension", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+val Vec2 {
+  x: i32,
+  y: i32
+}
+
+eff Local
+  next(tail) -> i32
+
+fn compute(vec: Vec2): Local -> i32
+  let subtotal = vec.x + vec.y
+  subtotal + Local::next()
+
+pub fn main(): () -> i32
+  try
+    compute(Vec2 { x: 3, y: 4 })
+  Local::next(tail):
+    tail(5)
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(12);
+    const aggregateAllocations = (text: string): number =>
+      text.match(
+        /\(struct\.new \$std__scalar_aggregate_replacement__struct_nominal_/g,
+      )?.length ?? 0;
+    expect(
+      aggregateAllocations(baselineCodegen.module.emitText()),
+    ).toBeGreaterThan(aggregateAllocations(optimizedCodegen.module.emitText()));
+  });
+
+  it("keeps live effectful value parameters materialized across suspension", () => {
+    const { optimizedCodegen } = compileOptimized(`
+val Vec2 {
+  x: i32,
+  y: i32
+}
+
+eff Local
+  next(tail) -> i32
+
+fn compute(vec: Vec2): Local -> i32
+  let value = Local::next()
+  vec.x + vec.y + value
+
+pub fn main(): () -> i32
+  try
+    compute(Vec2 { x: 3, y: 4 })
+  Local::next(tail):
+    tail(5)
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(12);
+    expect(optimizedCodegen.module.emitText()).toMatch(
+      /\(struct\.new \$std__scalar_aggregate_replacement__struct_nominal_/,
+    );
+  });
+
+  it("preserves identity and mutation guards in effectful functions", () => {
+    const { optimizedCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+eff Local
+  next(tail) -> i32
+
+fn compute(): Local -> i32
+  let ~box = Box { value: 1 }
+  let ~alias = box
+  alias.value = 7
+  box.value + Local::next()
+
+pub fn main(): () -> i32
+  try
+    compute()
+  Local::next(tail):
+    tail(5)
+`);
+
+    expect(runMain(optimizedCodegen.module)()).toBe(12);
+    expect(optimizedCodegen.module.emitText()).toMatch(
+      /\(struct\.set \$voyd_struct_shape_/,
+    );
+  });
+
   it("restores bindings after failed scalar heap-result probing", () => {
     const { optimizedCodegen } = compileOptimized(`
 obj Box {

--- a/packages/compiler/src/codegen/__tests__/support/test-codegen-context.ts
+++ b/packages/compiler/src/codegen/__tests__/support/test-codegen-context.ts
@@ -210,6 +210,7 @@ export const createTestCodegenContext = (): {
     effectLowering: {
       sitesByExpr: new Map(),
       sites: [],
+      symbolsLiveAcrossSuspension: new Set(),
       callArgTemps: new Map(),
       tempTypeIds: new Map(),
       defaultParamTemps: new Map(),

--- a/packages/compiler/src/codegen/codegen.ts
+++ b/packages/compiler/src/codegen/codegen.ts
@@ -175,6 +175,7 @@ export const codegenProgram = ({
     effectLowering: {
       sitesByExpr: new Map(),
       sites: [],
+      symbolsLiveAcrossSuspension: new Set(),
       callArgTemps: new Map(),
       tempTypeIds: new Map(),
       defaultParamTemps: new Map(),

--- a/packages/compiler/src/codegen/effects/codegen-backend.ts
+++ b/packages/compiler/src/codegen/effects/codegen-backend.ts
@@ -52,6 +52,14 @@ export interface EffectsBackend {
   requestedKind: EffectsBackendKind;
   stackSwitchRequested: boolean;
   stackSwitchUnavailableReason?: string;
+  scalarAggregates: {
+    /**
+     * Stack switching preserves Wasm locals while a frame is suspended. The
+     * GC trampoline does not: live source bindings must be captured in a
+     * materialized continuation environment.
+     */
+    keepLanesAcrossSuspension: boolean;
+  };
   abi: EffectsAbiStrategy;
   buildLowering: (params: {
     ctx: CodegenContext;

--- a/packages/compiler/src/codegen/effects/effect-lowering/build.ts
+++ b/packages/compiler/src/codegen/effects/effect-lowering/build.ts
@@ -540,9 +540,19 @@ export const buildEffectLoweringEir = ({
     callArgTemps.set(key, sorted);
   });
 
+  const symbolsLiveAcrossSuspension = new Set<SymbolId>();
+  sites.forEach((site) =>
+    site.captureFields.forEach((field) => {
+      if (typeof field.symbol === "number") {
+        symbolsLiveAcrossSuspension.add(field.symbol);
+      }
+    }),
+  );
+
   return {
     sitesByExpr,
     sites,
+    symbolsLiveAcrossSuspension,
     callArgTemps,
     tempTypeIds,
     defaultParamTemps,

--- a/packages/compiler/src/codegen/effects/effect-lowering/gc-trampoline-materialize.ts
+++ b/packages/compiler/src/codegen/effects/effect-lowering/gc-trampoline-materialize.ts
@@ -194,6 +194,7 @@ export const materializeGcTrampolineEffectLowering = ({
   return {
     sitesByExpr,
     sites,
+    symbolsLiveAcrossSuspension: eir.symbolsLiveAcrossSuspension,
     callArgTemps: eir.callArgTemps,
     tempTypeIds: eir.tempTypeIds,
     defaultParamTemps: eir.defaultParamTemps,

--- a/packages/compiler/src/codegen/effects/effect-lowering/types.ts
+++ b/packages/compiler/src/codegen/effects/effect-lowering/types.ts
@@ -86,6 +86,7 @@ export type ContinuationSiteEir =
 export interface EffectLoweringResult {
   sitesByExpr: Map<HirExprId, ContinuationSite>;
   sites: readonly ContinuationSite[];
+  symbolsLiveAcrossSuspension: ReadonlySet<SymbolId>;
   callArgTemps: Map<
     HirExprId,
     readonly { argIndex: number; tempId: number; typeId: TypeId }[]
@@ -106,6 +107,7 @@ export interface EffectLoweringResult {
 export interface EffectLoweringEirResult {
   sitesByExpr: Map<HirExprId, ContinuationSiteEir>;
   sites: readonly ContinuationSiteEir[];
+  symbolsLiveAcrossSuspension: ReadonlySet<SymbolId>;
   callArgTemps: Map<
     HirExprId,
     readonly { argIndex: number; tempId: number; typeId: TypeId }[]

--- a/packages/compiler/src/codegen/effects/gc-trampoline-backend.ts
+++ b/packages/compiler/src/codegen/effects/gc-trampoline-backend.ts
@@ -22,6 +22,9 @@ export const createGcTrampolineBackend = ({
   requestedKind,
   stackSwitchRequested,
   stackSwitchUnavailableReason,
+  scalarAggregates: {
+    keepLanesAcrossSuspension: false,
+  },
   abi: gcTrampolineAbiStrategy,
   buildLowering: ({ ctx, siteCounter }) =>
     materializeGcTrampolineEffectLowering({
@@ -45,6 +48,6 @@ export const createGcTrampolineBackend = ({
       fnCtx,
       compileExpr,
       tailPosition,
-      expectedResultTypeId
+      expectedResultTypeId,
     ),
 });

--- a/packages/compiler/src/codegen/optimization/scalar-aggregates.ts
+++ b/packages/compiler/src/codegen/optimization/scalar-aggregates.ts
@@ -43,6 +43,38 @@ const recordScalarAggregateDecision = (
 ): void =>
   incrementCompilerPerfCounter(`codegen.scalar_aggregate.${kind}.${decision}`);
 
+type ScalarAggregateSuspensionBailout =
+  | "initializer_suspends"
+  | "live_across_suspension";
+
+const scalarAggregateSuspensionBailout = ({
+  symbol,
+  initializer,
+  ctx,
+  fnCtx,
+}: {
+  symbol: SymbolId;
+  initializer?: HirExprId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): ScalarAggregateSuspensionBailout | undefined => {
+  if (
+    !fnCtx.effectful ||
+    ctx.effectsBackend.scalarAggregates.keepLanesAcrossSuspension
+  ) {
+    return undefined;
+  }
+  if (
+    typeof initializer === "number" &&
+    (fnCtx.continuation?.cfg.sitesByExpr.get(initializer)?.size ?? 0) > 0
+  ) {
+    return "initializer_suspends";
+  }
+  return ctx.effectLowering.symbolsLiveAcrossSuspension.has(symbol)
+    ? "live_across_suspension"
+    : undefined;
+};
+
 export type ScalarAggregateStatementCompiler = (
   stmtId: number,
 ) => binaryen.ExpressionRef;
@@ -870,10 +902,6 @@ export const tryScalarizeAggregateInitializer = ({
   compileStatement?: ScalarAggregateStatementCompiler;
   compileBlockInitializer?: ScalarAggregateBlockInitializerCompiler;
 }): binaryen.ExpressionRef[] | undefined => {
-  if (fnCtx.effectful) {
-    recordScalarAggregateDecision("initializer", "bailout.effectful");
-    return undefined;
-  }
   const structInfo = getStructuralTypeInfo(targetTypeId, ctx);
   if (!structInfo) {
     recordScalarAggregateDecision("initializer", "bailout.no_layout");
@@ -921,6 +949,20 @@ export const tryScalarizeAggregateInitializer = ({
     })
   ) {
     recordScalarAggregateDecision("initializer", "bailout.escape_or_shape");
+    return undefined;
+  }
+
+  const suspensionBailout = scalarAggregateSuspensionBailout({
+    symbol,
+    initializer,
+    ctx,
+    fnCtx,
+  });
+  if (suspensionBailout) {
+    recordScalarAggregateDecision(
+      "initializer",
+      `bailout.${suspensionBailout}`,
+    );
     return undefined;
   }
 
@@ -1109,10 +1151,6 @@ export const tryBindScalarAggregateParameter = ({
   ctx: CodegenContext;
   fnCtx: FunctionContext;
 }): binaryen.ExpressionRef[] | undefined => {
-  if (fnCtx.effectful) {
-    recordScalarAggregateDecision("parameter", "bailout.effectful");
-    return undefined;
-  }
   if (mutable) {
     recordScalarAggregateDecision("parameter", "bailout.mutable");
     return undefined;
@@ -1136,6 +1174,16 @@ export const tryBindScalarAggregateParameter = ({
   }
   if (abiValues.length !== aggregateLaneCount(structInfo)) {
     recordScalarAggregateDecision("parameter", "bailout.lane_mismatch");
+    return undefined;
+  }
+
+  const suspensionBailout = scalarAggregateSuspensionBailout({
+    symbol,
+    ctx,
+    fnCtx,
+  });
+  if (suspensionBailout) {
+    recordScalarAggregateDecision("parameter", `bailout.${suspensionBailout}`);
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

- replace the categorical effectful-function scalar aggregate bailout with backend-neutral suspension-liveness facts
- let the GC-trampoline backend scalarize safe initializer and value-parameter candidates that neither suspend during construction nor remain live across suspension
- retain materialization for live-across-suspension values and preserve escape, identity, aliasing, mutation, layout, and ABI guards
- add focused effectful coverage and document the measurement, one-shot continuation assumption, and future stack-switching policy

## Why

V-419 originally deferred the optimization to a future stack-switching backend. The GC trampoline can safely benefit today for aggregates consumed entirely between suspension points, without building a continuation-aware SROA subsystem. Publishing the liveness/policy boundary also gives a future stack-switch backend one explicit switch to relax when suspended Wasm locals are preserved.

## Measurement

On the representative effect-heavy vtrace workload:

- initializer applications: 26 → 38 (+46%)
- otherwise-eligible initializer evaluations that suspend: 45
- otherwise-eligible initializer values live across suspension: 11
- parameter applications: unchanged at 8; the old 47 categorical parameter bailouts are rejected by independent escape/layout/ABI checks

Focused generated-Wasm tests verify fewer aggregate allocations/field operations between suspension points. The fully Binaryen-optimized vtrace artifact is unchanged (61,474 Wasm bytes, 890,130 WAT bytes, 771 `struct.new` operations), and runtime is noise-level (+0.2%), because Binaryen already recovers those particular shapes. This limitation is documented rather than presented as an end-to-end speedup.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run test:audit`
- focused compiler tests: 55 passed
- agentic Implementation Gap Review: clean
- agentic Correctness Review: clean

Linear: V-419