### PR TITLE
Add external package adapters and Markdown integration

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@voyd-lang/sdk": "^0.2.0",
     "@voyd-lang/lib": "^0.2.0",
+    "@voyd-lang/package-adapter": "^0.2.0",
     "@voyd-lang/std": "^0.2.0",
     "binaryen": "^125.0.0",
     "commander": "^14.0.0"

--- a/apps/cli/src/__tests__/arg-parser.test.ts
+++ b/apps/cli/src/__tests__/arg-parser.test.ts
@@ -132,6 +132,30 @@ describe("getConfigFromCli", () => {
     expect(config.bootstrapForce).toBe(true);
   });
 
+  it("parses package adapter and application registry generation", () => {
+    const adapter = runWithArgv([
+      "node",
+      "voyd",
+      "generate",
+      "adapter",
+      "./src",
+      "--out",
+      "./generated/adapter",
+    ]);
+    expect(adapter.generateAdapter).toBe(true);
+    expect(adapter.index).toBe("./src");
+    expect(adapter.generateOut).toBe("./generated/adapter");
+
+    const registry = runWithArgv([
+      "node",
+      "voyd",
+      "generate",
+      "registry",
+      "./src/main.voyd",
+    ]);
+    expect(registry.generateAdapterRegistry).toBe(true);
+  });
+
   it("parses `voyd test` when global options come first", () => {
     const config = runWithArgv([
       "node",

--- a/apps/cli/src/__tests__/generate-adapter.test.ts
+++ b/apps/cli/src/__tests__/generate-adapter.test.ts
@@ -1,0 +1,175 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  generateAdapterRegistry,
+  generatePackageAdapter,
+} from "../generate-adapter.js";
+
+const temporaryDirectories: string[] = [];
+const repoRoot = path.resolve(import.meta.dirname, "../../../..");
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((dir) =>
+      rm(dir, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe("adapter generation", () => {
+  it("generates a typed package helper and WIT", async () => {
+    const outDir = await temporaryDirectory();
+    await generatePackageAdapter({
+      index: path.join(repoRoot, "packages/markdown/src"),
+      outDir,
+    });
+
+    const helper = await readFile(path.join(outDir, "voyd-adapter.ts"), "utf8");
+    const wit = await readFile(path.join(outDir, "interface.wit"), "utf8");
+    expect(helper).not.toContain("typeId");
+    expect(helper).toContain('readonly "render_static": (this: VoydPackageAdapterInvocationContext, arg0: string) => {');
+    expect(wit).toContain("package voyd:markdown@1.0.0;");
+    expect(wit).toMatch(/record type-[0-9a-f]{16}/);
+    expect(wit).toMatch(/render-static: func\(arg0: string\) -> type-[0-9a-f]{16}/);
+  });
+
+  it("generates static imports for reachable application adapters", async () => {
+    const outDir = await temporaryDirectory();
+    const outPath = path.join(outDir, "adapters.ts");
+    await generateAdapterRegistry({
+      index: path.join(repoRoot, "examples/markdown.voyd"),
+      outPath,
+    });
+
+    await expect(readFile(outPath, "utf8")).resolves.toContain(
+      'import adapter0 from "@voyd-lang/markdown/adapter"',
+    );
+  });
+
+  it("generates Promise-aware bindings for external effects", async () => {
+    const sourceDir = await temporaryDirectory();
+    const outDir = path.join(sourceDir, "generated");
+    await writeFile(path.join(sourceDir, "remote.voyd"), `@external(id: "example:remote/data@1")
+pub eff Remote
+  load(tail, id: i32) -> i32
+`, "utf8");
+
+    await generatePackageAdapter({ index: sourceDir, outDir });
+
+    const helper = await readFile(path.join(outDir, "voyd-adapter.ts"), "utf8");
+    const contract = await readFile(path.join(outDir, "contract.json"), "utf8");
+    expect(helper).toContain("Promise<number> | number");
+    expect(contract).toContain('"kind": "async"');
+    expect(contract).not.toContain('"effect"');
+  });
+
+  it("emits structural contracts without compiler-local schema IDs", async () => {
+    const sourceDir = await temporaryDirectory();
+    const outDir = path.join(sourceDir, "generated");
+    await writeFile(path.join(sourceDir, "left.voyd"), `
+pub type Left = { value: i32 }
+
+@external(id: "example:shapes/values@1")
+pub fn left() -> Left
+  left()
+`, "utf8");
+    await writeFile(path.join(sourceDir, "right.voyd"), `use std::string::type::String
+pub type Right = { label: String }
+
+@external(id: "example:shapes/values@1")
+pub fn right() -> Right
+  right()
+`, "utf8");
+
+    await generatePackageAdapter({ index: sourceDir, outDir });
+    const contract = JSON.parse(
+      await readFile(path.join(outDir, "contract.json"), "utf8"),
+    ) as { functions: Array<{ result: { fields?: unknown[] } }> };
+    expect(contract.functions.map((fn) => fn.result.fields)).toEqual([
+      [expect.objectContaining({ name: "value" })],
+      [expect.objectContaining({ name: "label" })],
+    ]);
+    expect(JSON.stringify(contract)).not.toContain("typeId");
+  });
+
+  it("rejects recursive DTOs that cannot become Component Model values", async () => {
+    const sourceDir = await temporaryDirectory();
+    const outDir = path.join(sourceDir, "generated");
+    await writeFile(path.join(sourceDir, "tree.voyd"), `pub obj Node {
+  api value: i32,
+  api next?: Node
+}
+
+@external(id: "example:tree/model@1")
+pub fn root() -> Node
+  root()
+`, "utf8");
+
+    await expect(generatePackageAdapter({ index: sourceDir, outDir }))
+      .rejects.toMatchObject({
+        diagnostics: [expect.objectContaining({
+          message: expect.stringMatching(/recursive.*Component Model/),
+        })],
+      });
+  });
+
+  it("preserves variant discriminators and payload field names", async () => {
+    const sourceDir = await temporaryDirectory();
+    const outDir = path.join(sourceDir, "generated");
+    await writeFile(path.join(sourceDir, "variants.voyd"), `use std::optional::all
+
+@external(id: "example:variants/options@1")
+pub fn read(value: Option<i32>) -> Option<i32>
+  read(value)
+
+@external(id: "example:variants/options@1")
+pub fn read_some(value: Some<i32>) -> Some<i32>
+  read_some(value)
+`, "utf8");
+
+    await generatePackageAdapter({ index: sourceDir, outDir });
+    const helper = await readFile(path.join(outDir, "voyd-adapter.ts"), "utf8");
+    const wit = await readFile(path.join(outDir, "interface.wit"), "utf8");
+    expect(helper).toContain('tag: "Some"');
+    expect(wit).toMatch(/record type-[0-9a-f]{16}-some-payload \{\n\s+value: s32,/);
+    expect(wit).toMatch(/record type-[0-9a-f]{16} \{\n\s+tag: string,/);
+  });
+
+  it("escapes WIT reserved field identifiers", async () => {
+    const sourceDir = await temporaryDirectory();
+    const outDir = path.join(sourceDir, "generated");
+    await writeFile(path.join(sourceDir, "keywords.voyd"), `pub type Keyword = { type: i32 }
+
+@external(id: "example:keywords/fields@1")
+pub fn read(value: Keyword) -> i32
+  read(value)
+`, "utf8");
+
+    await generatePackageAdapter({ index: sourceDir, outDir });
+    const wit = await readFile(path.join(outDir, "interface.wit"), "utf8");
+    expect(wit).toContain("%type: s32");
+  });
+
+  it("rejects distinct API names that normalize to the same WIT name", async () => {
+    const sourceDir = await temporaryDirectory();
+    const outDir = path.join(sourceDir, "generated");
+    await writeFile(path.join(sourceDir, "collisions.voyd"), `@external(id: "example:names/functions@1")
+pub fn Read() -> i32
+  Read()
+
+@external(id: "example:names/functions@1")
+pub fn read() -> i32
+  read()
+`, "utf8");
+
+    await expect(generatePackageAdapter({ index: sourceDir, outDir }))
+      .rejects.toThrow(/WIT name collision.*Read.*read/);
+  });
+});
+
+const temporaryDirectory = async (): Promise<string> => {
+  const dir = await mkdtemp(path.join(repoRoot, ".tmp-adapter-generation-"));
+  temporaryDirectories.push(dir);
+  return dir;
+};

--- a/apps/cli/src/__tests__/generate-adapter.test.ts
+++ b/apps/cli/src/__tests__/generate-adapter.test.ts
@@ -136,6 +136,29 @@ pub fn read_some(value: Some<i32>) -> Some<i32>
     expect(wit).toMatch(/record type-[0-9a-f]{16} \{\n\s+tag: string,/);
   });
 
+  it("rejects variant payload fields named tag", async () => {
+    const sourceDir = await temporaryDirectory();
+    const outDir = path.join(sourceDir, "generated");
+    await writeFile(path.join(sourceDir, "tag-collision.voyd"), `use std::enums::{ enum }
+use std::string::type::String
+
+enum TaggedResult
+  Tagged { tag: String }
+  Other {}
+
+@external(id: "example:variants/tagged@1")
+pub fn read(value: TaggedResult) -> TaggedResult
+  read(value)
+`, "utf8");
+
+    await expect(generatePackageAdapter({ index: sourceDir, outDir }))
+      .rejects.toMatchObject({
+        diagnostics: [expect.objectContaining({
+          message: expect.stringMatching(/payload fields named "tag".*discriminator/i),
+        })],
+      });
+  });
+
   it("escapes WIT reserved field identifiers", async () => {
     const sourceDir = await temporaryDirectory();
     const outDir = path.join(sourceDir, "generated");

--- a/apps/cli/src/__tests__/generate-adapter.test.ts
+++ b/apps/cli/src/__tests__/generate-adapter.test.ts
@@ -174,6 +174,26 @@ pub fn read(value: Keyword) -> i32
     expect(wit).toContain("%type: s32");
   });
 
+  it("uses unescaped keyword fragments in generated WIT payload names", async () => {
+    const sourceDir = await temporaryDirectory();
+    const outDir = path.join(sourceDir, "generated");
+    await writeFile(path.join(sourceDir, "keyword-variant.voyd"), `use std::enums::{ enum }
+
+enum KeywordVariant
+  Type { value: i32 }
+  Other {}
+
+@external(id: "example:keywords/variants@1")
+pub fn read(value: KeywordVariant) -> KeywordVariant
+  read(value)
+`, "utf8");
+
+    await generatePackageAdapter({ index: sourceDir, outDir });
+    const wit = await readFile(path.join(outDir, "interface.wit"), "utf8");
+    expect(wit).toMatch(/record type-[0-9a-f]{16}-type-payload/);
+    expect(wit).not.toContain("-%type-payload");
+  });
+
   it("rejects distinct API names that normalize to the same WIT name", async () => {
     const sourceDir = await temporaryDirectory();
     const outDir = path.join(sourceDir, "generated");

--- a/apps/cli/src/bootstrap/loaders/vx-spa.ts
+++ b/apps/cli/src/bootstrap/loaders/vx-spa.ts
@@ -146,11 +146,13 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const rootDir = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const entryPath = resolve(rootDir, "src/main.voyd");
 const outPath = resolve(rootDir, "src/generated/main.wasm");
+const adaptersPath = resolve(rootDir, "src/generated/voyd-adapters.ts");
 
 export async function compileVoyd({ verbose = true } = {}) {
   await mkdir(dirname(outPath), { recursive: true });
   const wasm = await runVoyd(["--emit-wasm", "--opt", entryPath]);
   await writeFile(outPath, wasm);
+  await runVoyd(["generate", "registry", entryPath, "--out", adaptersPath]);
   if (verbose) {
     console.log(\`compiled \${entryPath} -> \${outPath}\`);
   }
@@ -196,6 +198,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 const mainTs = `import { createVoydHost } from "@voyd-lang/sdk/js-host";
 import { createVoydVxAppRuntime, mountVxApp } from "@voyd-lang/vx-dom/browser";
 import wasmUrl from "./generated/main.wasm?url";
+import { adapters } from "./generated/voyd-adapters";
 import "./style.css";
 
 const root = document.getElementById("root");
@@ -208,6 +211,7 @@ const start = async () => {
   const host = await createVoydHost({
     wasm,
     bufferSize: 256 * 1024,
+    adapters,
   });
   const app = createVoydVxAppRuntime({ host });
   const mounted = await mountVxApp({ container: root, app });

--- a/apps/cli/src/config/arg-parser.ts
+++ b/apps/cli/src/config/arg-parser.ts
@@ -143,6 +143,7 @@ const parseMainConfig = (argv: readonly string[]): VoydConfig => {
         "  doc [index]          generate API documentation",
         "  docs [index]         alias for `doc`",
         "  bootstrap [dir]      scaffold a new Voyd project",
+        "  generate adapter     generate host adapter bindings",
       ].join("\n"),
     );
 
@@ -280,6 +281,45 @@ const parseDocConfig = (argv: readonly string[]): VoydConfig => {
   };
 };
 
+const parseGenerateConfig = (argv: readonly string[]): VoydConfig => {
+  const program = createBaseCommand({
+    name: "voyd generate adapter",
+    description: "Generate package adapter bindings or an application registry",
+  });
+
+  program
+    .argument("<kind>", "artifact kind (adapter|registry)")
+    .argument("[index]", "package entry (default: ./src)")
+    .option(
+      "--out <path>",
+      "output path (adapter default: ./generated/voyd-adapter; registry default: ./generated/voyd-adapters.ts)",
+    )
+    .option(
+      "--pkg-dir <path>",
+      "additional package directory (repeatable)",
+      appendOptionValue,
+      [],
+    );
+
+  program.parse(["node", "voyd generate", ...argv]);
+  const opts = program.opts();
+  const [kind, indexArg] = program.args as [string, string?];
+  if (kind !== "adapter" && kind !== "registry") {
+    throw new InvalidArgumentError(
+      `invalid generation kind "${kind}" (allowed: adapter, registry)`,
+    );
+  }
+  return {
+    index: indexArg ?? "./src",
+    pkgDirs: opts.pkgDir,
+    generateAdapter: kind === "adapter",
+    generateAdapterRegistry: kind === "registry",
+    generateOut: opts.out,
+    doc: false,
+    docFormat: "html",
+  };
+};
+
 const findSubcommandIndex = (args: readonly string[]): number => {
   const optionsWithValues: ReadonlySet<string> = new Set(
     MAIN_OPTIONS_WITH_VALUES,
@@ -292,7 +332,8 @@ const findSubcommandIndex = (args: readonly string[]): number => {
       arg === "test" ||
       arg === "doc" ||
       arg === "docs" ||
-      arg === "bootstrap"
+      arg === "bootstrap" ||
+      arg === "generate"
     ) {
       return index;
     }
@@ -338,6 +379,9 @@ export const getConfigFromCli = (): VoydConfig => {
   }
   if (command === "bootstrap") {
     return parseBootstrapConfig(rest);
+  }
+  if (command === "generate") {
+    return parseGenerateConfig(rest);
   }
   return parseMainConfig(args);
 };

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -48,4 +48,10 @@ export type VoydConfig = {
   bootstrapDryRun?: boolean;
   /** Allow bootstrap to write into a non-empty directory */
   bootstrapForce?: boolean;
+  /** Generate package-adapter bindings. */
+  generateAdapter?: boolean;
+  /** Generate an application adapter registry. */
+  generateAdapterRegistry?: boolean;
+  /** Generated adapter output directory. */
+  generateOut?: string;
 };

--- a/apps/cli/src/exec.ts
+++ b/apps/cli/src/exec.ts
@@ -1,7 +1,7 @@
 import { stdout } from "process";
 import { readFileSync, statSync, existsSync } from "fs";
 import { writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import type { CompileResult, OptimizationLevel } from "@voyd-lang/sdk";
 import type {
   Diagnostic,
@@ -27,6 +27,22 @@ type TestFailurePhase = "discovery" | "typing" | "execution";
 
 async function main() {
   const config = getConfig();
+  if (config.generateAdapter) {
+    const { generatePackageAdapter } = await import("./generate-adapter.js");
+    return generatePackageAdapter({
+      index: config.index,
+      outDir: config.generateOut,
+      pkgDirs: config.pkgDirs,
+    });
+  }
+  if (config.generateAdapterRegistry) {
+    const { generateAdapterRegistry } = await import("./generate-adapter.js");
+    return generateAdapterRegistry({
+      index: config.index,
+      outPath: config.generateOut,
+      pkgDirs: config.pkgDirs,
+    });
+  }
   if (config.bootstrap) {
     const { printBootstrapResult, runBootstrap } =
       await import("./bootstrap/index.js");
@@ -282,8 +298,16 @@ async function runVoyd({
   const compiled = requireCompileSuccess(
     await sdk.compile({ entryPath, roots, optimizationLevel }),
   );
-
-  const result = await sdk.run({ wasm: compiled.wasm, entryName });
+  const { loadVoydPackageAdapters } = await import("@voyd-lang/sdk");
+  const adapters = await loadVoydPackageAdapters({
+    wasm: compiled.wasm,
+    startDir: dirname(entryPath),
+  });
+  const result = await sdk.run({
+    wasm: compiled.wasm,
+    entryName,
+    adapters,
+  });
   printRunResult(result);
 }
 

--- a/apps/cli/src/generate-adapter.ts
+++ b/apps/cli/src/generate-adapter.ts
@@ -1,0 +1,565 @@
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { existsSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import type {
+  ExternalFunctionRequirement,
+} from "@voyd-lang/sdk/js-host";
+import type {
+  VoydDtoSchema,
+  VoydExternalFunctionContract,
+} from "@voyd-lang/package-adapter";
+import { voydInterfaceFingerprint } from "@voyd-lang/package-adapter";
+
+type PortableRequirement = VoydExternalFunctionContract;
+type VoydBoundarySchema = ExternalFunctionRequirement["params"][number];
+
+export const generatePackageAdapter = async ({
+  index,
+  outDir = "./generated/voyd-adapter",
+  pkgDirs = [],
+}: {
+  index: string;
+  outDir?: string;
+  pkgDirs?: readonly string[];
+}): Promise<void> => {
+  const entryPaths = await resolvePackageEntries(index);
+  const entryPath = entryPaths[0]!;
+  const [{ createSdk }, { parseExternalRequirements }] = await Promise.all([
+    import("@voyd-lang/sdk"),
+    import("@voyd-lang/sdk/js-host"),
+  ]);
+  const compiledRequirements = await Promise.all(
+    entryPaths.map(async (candidate) => {
+      const roots = await adapterModuleRoots({ entryPath: candidate, pkgDirs });
+      const result = await createSdk().compile({
+        entryPath: candidate,
+        roots,
+        boundaryExports: "auto",
+        externalDeclarations: true,
+      });
+      if (!result.success) throw { diagnostics: result.diagnostics };
+      return parseExternalRequirements(
+        new WebAssembly.Module(result.wasm as Uint8Array<ArrayBuffer>),
+      ).functions;
+    }),
+  );
+  const functions = compiledRequirements.flat();
+  if (functions.length === 0) {
+    throw new Error(
+      `No reachable @external functions found from ${entryPath}. Re-export external functions from the package root.`,
+    );
+  }
+  const packageName = await readPackageName(entryPath);
+  const target = resolve(outDir);
+  await mkdir(target, { recursive: true });
+  const portableFunctions = dedupeRequirements(
+    compiledRequirements.flatMap(toPortableRequirements),
+  );
+  const contract = {
+    abiVersion: 1 as const,
+    packageName,
+    interfaces: [...groupBy(portableFunctions, (fn) => fn.interfaceId)].map(
+      ([interfaceId, interfaceFunctions]) => ({
+        interfaceId,
+        fingerprint: voydInterfaceFingerprint(interfaceFunctions),
+      }),
+    ),
+    functions: portableFunctions,
+  };
+  const witDocuments = renderWitDocuments(contract.functions);
+  await Promise.all([
+    writeFile(
+      join(target, "contract.json"),
+      `${JSON.stringify(contract, null, 2)}\n`,
+      "utf8",
+    ),
+    writeFile(join(target, "contract.ts"), renderContractTs(contract), "utf8"),
+    writeFile(
+      join(target, "voyd-adapter.ts"),
+      renderAdapterTs(contract.functions),
+      "utf8",
+    ),
+    ...witDocuments.map((document) =>
+      writeFile(join(target, document.fileName), document.content, "utf8"),
+    ),
+  ]);
+  console.log(target);
+};
+
+export const generateAdapterRegistry = async ({
+  index,
+  outPath = "./generated/voyd-adapters.ts",
+  pkgDirs = [],
+}: {
+  index: string;
+  outPath?: string;
+  pkgDirs?: readonly string[];
+}): Promise<void> => {
+  const entryPath = resolveApplicationEntry(index);
+  const [{ createSdk, findVoydPackageAdapterSpecifiers }, { parseExternalRequirements }] =
+    await Promise.all([
+      import("@voyd-lang/sdk"),
+      import("@voyd-lang/sdk/js-host"),
+    ]);
+  const roots = await adapterModuleRoots({ entryPath, pkgDirs });
+  const result = await createSdk().compile({ entryPath, roots });
+  if (!result.success) throw { diagnostics: result.diagnostics };
+  const interfaces = Array.from(
+    new Set(
+      parseExternalRequirements(
+        new WebAssembly.Module(result.wasm as Uint8Array<ArrayBuffer>),
+      ).functions.map((fn) => fn.interfaceId),
+    ),
+  );
+  const specifiers = await findVoydPackageAdapterSpecifiers({
+    interfaceIds: interfaces,
+    startDir: dirname(entryPath),
+  });
+  const target = resolve(outPath);
+  await mkdir(dirname(target), { recursive: true });
+  const imports = specifiers
+    .map((specifier, index) => `import adapter${index} from ${JSON.stringify(specifier)};`)
+    .join("\n");
+  const values = specifiers.map((_, index) => `adapter${index}`).join(", ");
+  await writeFile(
+    target,
+    `${imports}${imports ? "\n\n" : ""}export const adapters = [${values}] as const;\n`,
+    "utf8",
+  );
+  console.log(target);
+};
+
+const resolvePackageEntries = async (index: string): Promise<string[]> => {
+  const resolved = resolve(index);
+  if (!existsSync(resolved)) return [resolved];
+  if (!statSync(resolved).isDirectory()) return [resolved];
+  const packageEntry = join(resolved, "pkg.voyd");
+  if (existsSync(packageEntry)) return [packageEntry];
+  const nestedPackageEntry = join(resolved, "src", "pkg.voyd");
+  if (existsSync(nestedPackageEntry)) return [nestedPackageEntry];
+  const externalFiles = await findExternalSourceFiles(resolved);
+  if (externalFiles.length > 0) return externalFiles;
+  throw new Error(`No pkg.voyd found under ${resolved}`);
+};
+
+const resolveApplicationEntry = (index: string): string => {
+  const resolved = resolve(index);
+  if (!existsSync(resolved) || !statSync(resolved).isDirectory()) return resolved;
+  const main = join(resolved, "main.voyd");
+  if (existsSync(main)) return main;
+  const nestedMain = join(resolved, "src", "main.voyd");
+  if (existsSync(nestedMain)) return nestedMain;
+  throw new Error(`No main.voyd found under ${resolved}`);
+};
+
+const findExternalSourceFiles = async (root: string): Promise<string[]> => {
+  const entries = await readdir(root, { withFileTypes: true });
+  const nested = await Promise.all(
+    entries
+      .filter((entry) => entry.name !== "node_modules" && entry.name !== "dist")
+      .map(async (entry) => {
+        const path = join(root, entry.name);
+        if (entry.isDirectory()) return findExternalSourceFiles(path);
+        if (!entry.isFile() || !entry.name.endsWith(".voyd")) return [];
+        return (await readFile(path, "utf8")).includes("@external") ? [path] : [];
+      }),
+  );
+  return nested.flat().sort();
+};
+
+const dedupeRequirements = (
+  functions: readonly PortableRequirement[],
+): PortableRequirement[] => {
+  const byKey = new Map<string, PortableRequirement>();
+  functions.forEach((fn) => {
+    const key = `${fn.interfaceId}::${fn.functionName}`;
+    const existing = byKey.get(key);
+    if (existing && canonicalRequirement(existing) !== canonicalRequirement(fn)) {
+      throw new Error(`Conflicting external function declarations for ${key}`);
+    }
+    byKey.set(key, fn);
+  });
+  return [...byKey.values()].sort((left, right) =>
+    `${left.interfaceId}::${left.functionName}`.localeCompare(
+      `${right.interfaceId}::${right.functionName}`,
+    ),
+  );
+};
+
+const canonicalRequirement = (
+  requirement: PortableRequirement,
+): string => JSON.stringify(requirement);
+
+const toPortableRequirements = (
+  functions: readonly ExternalFunctionRequirement[],
+): PortableRequirement[] => {
+  const schemas = new Map<number, VoydBoundarySchema>();
+  const register = (schema: VoydBoundarySchema): void => {
+    if (schema.kind === "ref") return;
+    if (schema.typeId !== undefined) {
+      schemas.set(schema.typeId, schema);
+      if (schema.kind === "array" || schema.kind === "record" || schema.kind === "union") {
+        schema.aliases?.forEach((alias) => schemas.set(alias, schema));
+      }
+    }
+    if (schema.kind === "array") register(schema.element);
+    if (schema.kind === "record") schema.fields.forEach((field) => register(field.schema));
+    if (schema.kind === "union") {
+      schema.variants.forEach((variant) => variant.fields.forEach((field) => register(field.schema)));
+    }
+  };
+  functions.forEach((fn) => [...fn.params, fn.result].forEach(register));
+
+  const portable = (schema: VoydBoundarySchema, active = new Set<number>()): VoydDtoSchema => {
+    if (schema.kind === "ref") {
+      const target = schemas.get(schema.typeId);
+      if (!target) throw new Error(`External DTO references unknown compiler type ${schema.typeId}`);
+      if (active.has(schema.typeId)) {
+        throw new Error("Recursive external DTOs are not supported");
+      }
+      return portable(target, new Set(active).add(schema.typeId));
+    }
+    if (schema.kind === "array") return { kind: "array", element: portable(schema.element, active) };
+    if (schema.kind === "record") return {
+      kind: "record",
+      ...(schema.tag ? { tag: schema.tag } : {}),
+      fields: schema.fields.map((field) => ({
+        name: field.name,
+        ...(field.optional ? { optional: true } : {}),
+        schema: portable(field.schema, active),
+      })),
+    };
+    if (schema.kind === "union") return {
+      kind: "union",
+      variants: schema.variants.map((variant) => ({
+        name: variant.name,
+        fields: variant.fields.map((field) => ({
+          name: field.name,
+          ...(field.optional ? { optional: true } : {}),
+          schema: portable(field.schema, active),
+        })),
+      })),
+    };
+    return { kind: schema.kind };
+  };
+  return functions.map((fn) => ({
+    kind: fn.kind,
+    interfaceId: fn.interfaceId,
+    functionName: fn.functionName,
+    params: fn.params.map((schema) => portable(schema)),
+    result: portable(fn.result),
+  }));
+};
+
+const adapterModuleRoots = async ({
+  entryPath,
+  pkgDirs,
+}: {
+  entryPath: string;
+  pkgDirs: readonly string[];
+}) => {
+  const [{ detectSrcRootForPath }, { resolveStdRoot }, { resolvePackageDirs }] =
+    await Promise.all([
+      import("@voyd-lang/sdk"),
+      import("@voyd-lang/lib/resolve-std.js"),
+      import("./package-dirs.js"),
+    ]);
+  const srcRoot = detectSrcRootForPath(entryPath);
+  return {
+    src: srcRoot,
+    std: resolveStdRoot(),
+    pkgDirs: resolvePackageDirs({
+      srcRoot,
+      additionalPkgDirs: pkgDirs,
+    }),
+  };
+};
+
+const readPackageName = async (entryPath: string): Promise<string> => {
+  let current = dirname(entryPath);
+  while (true) {
+    const candidate = join(current, "package.json");
+    if (existsSync(candidate)) {
+      const parsed = JSON.parse(await readFile(candidate, "utf8")) as {
+        name?: unknown;
+      };
+      if (typeof parsed.name === "string" && parsed.name.trim()) {
+        return parsed.name;
+      }
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error(`Unable to find package.json for ${entryPath}`);
+};
+
+const renderContractTs = (contract: {
+  abiVersion: 1;
+  packageName: string;
+  interfaces: readonly { interfaceId: string; fingerprint: string }[];
+  functions: readonly PortableRequirement[];
+}): string => `import type { VoydPackageAdapterContract } from "@voyd-lang/package-adapter";
+
+export const contract = ${JSON.stringify(contract, null, 2)} as const satisfies VoydPackageAdapterContract;
+`;
+
+const renderAdapterTs = (
+  functions: readonly PortableRequirement[],
+): string => {
+  const interfaces = groupBy(functions, (fn) => fn.interfaceId);
+  const implementation = [...interfaces.entries()]
+    .map(([interfaceId, entries]) => {
+      const members = entries
+        .map((fn) => {
+          const params = fn.params
+            .map((schema, index) => `arg${index}: ${typescriptType(schema)}`)
+            .join(", ");
+          const result = typescriptType(fn.result);
+          return `    readonly ${JSON.stringify(fn.functionName)}: (this: VoydPackageAdapterInvocationContext${params ? `, ${params}` : ""}) => ${fn.kind === "async" ? `Promise<${result}> | ${result}` : result};`;
+        })
+        .join("\n");
+      return `  readonly ${JSON.stringify(interfaceId)}: {\n${members}\n  };`;
+    })
+    .join("\n");
+  return `import { defineVoydPackageAdapter } from "@voyd-lang/package-adapter";
+import type { VoydPackageAdapterInvocationContext } from "@voyd-lang/package-adapter";
+import { contract } from "./contract.js";
+
+export type AdapterImplementation = {
+${implementation}
+};
+
+export const defineAdapter = (implementation: AdapterImplementation) =>
+  defineVoydPackageAdapter(contract, implementation);
+`;
+};
+
+const typescriptType = (
+  schema: VoydDtoSchema,
+): string => {
+  switch (schema.kind) {
+    case "bool": return "boolean";
+    case "i32": case "f32": case "f64": return "number";
+    case "i64": return "bigint | number";
+    case "void": return "void";
+    case "string": return "string";
+    case "array": return `readonly ${typescriptType(schema.element)}[]`;
+    case "record":
+      return `{ ${schema.tag ? `tag: ${JSON.stringify(schema.tag)}; ` : ""}${schema.fields.map((field) => `${JSON.stringify(field.name)}${field.optional ? "?" : ""}: ${typescriptType(field.schema)}`).join("; ")} }`;
+    case "union":
+      return schema.variants.map((variant) => `{ tag: ${JSON.stringify(variant.name)}; ${variant.fields.map((field) => `${JSON.stringify(field.name)}${field.optional ? "?" : ""}: ${typescriptType(field.schema)}`).join("; ")} }`).join(" | ");
+  }
+};
+
+const renderWitDocuments = (
+  functions: readonly PortableRequirement[],
+): Array<{ fileName: string; content: string }> => {
+  assertUniqueWitNames(
+    [...new Set(functions.map(({ interfaceId }) => interfaceId))].map((interfaceId) => {
+      const parsed = parseWitInterfaceId(interfaceId);
+      return { source: interfaceId, normalized: `${parsed.packageId}/${parsed.interfaceName}` };
+    }),
+    "external interfaces",
+  );
+  const interfaces = groupBy(functions, (fn) => fn.interfaceId);
+  const byPackage = groupBy(
+    [...interfaces.entries()],
+    ([interfaceId]) => parseWitInterfaceId(interfaceId).packageId,
+  );
+  return [...byPackage.entries()].map(([packageId, packageInterfaces], packageIndex) => {
+    const body = packageInterfaces
+    .map(([interfaceId, entries]) => {
+      const name = parseWitInterfaceId(interfaceId).interfaceName;
+      assertUniqueWitNames(
+        entries.map(({ functionName }) => ({
+          source: functionName,
+          normalized: witIdentifier(functionName),
+        })),
+        `functions in ${interfaceId}`,
+      );
+      const renderer = createWitRenderer(entries);
+      const methods = entries.map((fn) => {
+        const params = fn.params.map((schema, index) => `arg${index}: ${renderer.type(schema)}`).join(", ");
+        const result = fn.result.kind === "void" ? "" : ` -> ${renderer.type(fn.result)}`;
+        return `  ${witIdentifier(fn.functionName)}: func(${params})${result};`;
+      }).join("\n");
+      const declarations = renderer.declarations();
+      return `interface ${name} {\n${declarations}${declarations ? "\n\n" : ""}${methods}\n}`;
+    })
+    .join("\n\n");
+    return {
+      fileName: packageIndex === 0
+        ? "interface.wit"
+        : `interface-${witIdentifier(packageId)}.wit`,
+      content: `package ${packageId};\n\n${body}\n`,
+    };
+  });
+};
+
+const parseWitInterfaceId = (
+  interfaceId: string,
+): { packageId: string; interfaceName: string } => {
+  const match = /^([a-zA-Z][a-zA-Z0-9-]*):([a-zA-Z][a-zA-Z0-9-]*)\/([a-zA-Z][a-zA-Z0-9-]*)@(\d+(?:\.\d+){0,2})$/.exec(interfaceId);
+  if (!match) {
+    throw new Error(
+      `External interface ID ${interfaceId} must use namespace:package/interface@version for WIT generation`,
+    );
+  }
+  const versionParts = match[4]!.split(".");
+  while (versionParts.length < 3) versionParts.push("0");
+  return {
+    packageId: `${witIdentifier(match[1]!)}:${witIdentifier(match[2]!)}@${versionParts.join(".")}`,
+    interfaceName: witIdentifier(match[3]!),
+  };
+};
+
+const createWitRenderer = (functions: readonly PortableRequirement[]) => {
+  const schemas = new Map<string, VoydDtoSchema>();
+  const schemaKey = (schema: VoydDtoSchema): string => JSON.stringify(schema);
+  const nameFor = (schema: VoydDtoSchema): string => {
+    const key = schemaKey(schema);
+    const hash = stableHash(key);
+    const name = `type-${hash}`;
+    const existing = schemas.get(name);
+    if (existing && schemaKey(existing) !== key) {
+      throw new Error(`WIT structural type hash collision for ${name}`);
+    }
+    schemas.set(name, schema);
+    return name;
+  };
+  const register = (schema: VoydDtoSchema): void => {
+    if (schema.kind === "array" || schema.kind === "record" || schema.kind === "union") nameFor(schema);
+    if (schema.kind === "array") register(schema.element);
+    if (schema.kind === "record") schema.fields.forEach((field) => register(field.schema));
+    if (schema.kind === "union") schema.variants.forEach((variant) => variant.fields.forEach((field) => register(field.schema)));
+  };
+  functions.forEach((fn) => [...fn.params, fn.result].forEach(register));
+  const inlineType = (schema: VoydDtoSchema, declaration = false): string => {
+    if (!declaration && (schema.kind === "array" || schema.kind === "record" || schema.kind === "union")) {
+      return nameFor(schema);
+    }
+    switch (schema.kind) {
+      case "bool": return "bool";
+      case "i32": return "s32";
+      case "i64": return "s64";
+      case "f32": return "float32";
+      case "f64": return "float64";
+      case "string": return "string";
+      case "void": return "tuple<>";
+      case "array": return `list<${inlineType(schema.element)}>`;
+      case "record": return nameFor(schema);
+      case "union": return nameFor(schema);
+    }
+  };
+  const declarations = (): string => [...schemas.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .flatMap(([name, schema]) => {
+      if (schema.kind === "array") return [`  type ${name} = ${inlineType(schema, true)};`];
+      if (schema.kind === "record") {
+        assertUniqueWitNames(
+          [
+            ...(schema.tag ? [{ source: "generated tag", normalized: witIdentifier("tag") }] : []),
+            ...schema.fields.map((field) => ({
+              source: field.name,
+              normalized: witIdentifier(field.name),
+            })),
+          ],
+          `fields in WIT record ${name}`,
+        );
+        const fields = [
+          ...(schema.tag ? ["    tag: string,"] : []),
+          ...schema.fields.map((field) =>
+          `    ${witIdentifier(field.name)}: ${field.optional ? `option<${inlineType(field.schema)}>` : inlineType(field.schema)},`
+          ),
+        ].join("\n");
+        return [`  record ${name} {\n${fields}\n  }`];
+      }
+      if (schema.kind === "union") {
+        assertUniqueWitNames(
+          schema.variants.map((variant) => ({
+            source: variant.name,
+            normalized: witIdentifier(variant.name),
+          })),
+          `variants in WIT type ${name}`,
+        );
+        const payloadRecords: string[] = [];
+        const variants = schema.variants.map((variant) => {
+          if (variant.fields.length === 0) return `    ${witIdentifier(variant.name)},`;
+          const payloadName = `${name}-${witIdentifier(variant.name)}-payload`;
+          assertUniqueWitNames(
+            variant.fields.map((field) => ({
+              source: field.name,
+              normalized: witIdentifier(field.name),
+            })),
+            `fields in WIT variant ${variant.name}`,
+          );
+          const fields = variant.fields.map((field) =>
+            `    ${witIdentifier(field.name)}: ${field.optional ? `option<${inlineType(field.schema)}>` : inlineType(field.schema)},`
+          ).join("\n");
+          payloadRecords.push(`  record ${payloadName} {\n${fields}\n  }`);
+          return `    ${witIdentifier(variant.name)}(${payloadName}),`;
+        }).join("\n");
+        return [...payloadRecords, `  variant ${name} {\n${variants}\n  }`];
+      }
+      return [];
+    })
+    .join("\n");
+  return { type: (schema: VoydDtoSchema) => inlineType(schema), declarations };
+};
+
+const stableHash = (value: string): string => {
+  let left = 0x811c9dc5;
+  let right = 0x9e3779b9;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    left = Math.imul(left ^ code, 0x01000193);
+    right = Math.imul(right ^ code, 0x85ebca6b);
+  }
+  return `${(left >>> 0).toString(16).padStart(8, "0")}${(right >>> 0).toString(16).padStart(8, "0")}`;
+};
+
+const witIdentifier = (value: string): string =>
+  escapeWitKeyword(
+    value.replace(/_/g, "-").replace(/[^a-zA-Z0-9-]/g, "-").toLowerCase(),
+  );
+
+const assertUniqueWitNames = (
+  names: readonly { source: string; normalized: string }[],
+  scope: string,
+): void => {
+  const byNormalized = new Map<string, string>();
+  names.forEach(({ source, normalized }) => {
+    const existing = byNormalized.get(normalized);
+    if (existing !== undefined) {
+      throw new Error(
+        `WIT name collision in ${scope}: ${JSON.stringify(existing)} and ${JSON.stringify(source)} both normalize to ${JSON.stringify(normalized)}`,
+      );
+    }
+    byNormalized.set(normalized, source);
+  });
+};
+
+const WIT_KEYWORDS = new Set([
+  "as", "borrow", "constructor", "enum", "export", "flags", "func",
+  "future", "import", "include", "interface", "list", "option", "own",
+  "package", "record", "resource", "result", "static", "stream", "tuple",
+  "type", "union", "use", "variant", "with", "world",
+]);
+
+const escapeWitKeyword = (value: string): string =>
+  WIT_KEYWORDS.has(value) ? `%${value}` : value;
+
+const groupBy = <T, K>(
+  values: Iterable<T>,
+  keyFor: (value: T) => K,
+): Map<K, T[]> => {
+  const groups = new Map<K, T[]>();
+  for (const value of values) {
+    const key = keyFor(value);
+    const group = groups.get(key);
+    if (group) group.push(value);
+    else groups.set(key, [value]);
+  }
+  return groups;
+};

--- a/apps/cli/src/generate-adapter.ts
+++ b/apps/cli/src/generate-adapter.ts
@@ -516,7 +516,9 @@ const createWitRenderer = (functions: readonly PortableRequirement[]) => {
         const payloadRecords: string[] = [];
         const variants = schema.variants.map((variant) => {
           if (variant.fields.length === 0) return `    ${witIdentifier(variant.name)},`;
-          const payloadName = `${name}-${witIdentifier(variant.name)}-payload`;
+          const payloadName = witIdentifier(
+            `${name}-${normalizeWitIdentifier(variant.name)}-payload`,
+          );
           assertUniqueWitNames(
             variant.fields.map((field) => ({
               source: field.name,
@@ -550,9 +552,10 @@ const stableHash = (value: string): string => {
 };
 
 const witIdentifier = (value: string): string =>
-  escapeWitKeyword(
-    value.replace(/_/g, "-").replace(/[^a-zA-Z0-9-]/g, "-").toLowerCase(),
-  );
+  escapeWitKeyword(normalizeWitIdentifier(value));
+
+const normalizeWitIdentifier = (value: string): string =>
+  value.replace(/_/g, "-").replace(/[^a-zA-Z0-9-]/g, "-").toLowerCase();
 
 const assertUniqueWitNames = (
   names: readonly { source: string; normalized: string }[],

--- a/apps/cli/src/generate-adapter.ts
+++ b/apps/cli/src/generate-adapter.ts
@@ -55,6 +55,10 @@ export const generatePackageAdapter = async ({
   const portableFunctions = dedupeRequirements(
     compiledRequirements.flatMap(toPortableRequirements),
   );
+  portableFunctions.forEach((fn) => {
+    fn.params.forEach(assertNoTagDiscriminatorCollision);
+    assertNoTagDiscriminatorCollision(fn.result);
+  });
   const contract = {
     abiVersion: 1 as const,
     packageName,
@@ -189,6 +193,32 @@ const dedupeRequirements = (
 const canonicalRequirement = (
   requirement: PortableRequirement,
 ): string => JSON.stringify(requirement);
+
+const assertNoTagDiscriminatorCollision = (schema: VoydDtoSchema): void => {
+  if (schema.kind === "array") {
+    assertNoTagDiscriminatorCollision(schema.element);
+    return;
+  }
+  if (schema.kind === "record") {
+    if (schema.tag && schema.fields.some((field) => field.name === "tag")) {
+      throw new Error(
+        'Variant payload fields named "tag" conflict with the adapter discriminator',
+      );
+    }
+    schema.fields.forEach((field) => assertNoTagDiscriminatorCollision(field.schema));
+    return;
+  }
+  if (schema.kind === "union") {
+    schema.variants.forEach((variant) => {
+      if (variant.fields.some((field) => field.name === "tag")) {
+        throw new Error(
+          `Variant ${JSON.stringify(variant.name)} payload field "tag" conflicts with the adapter discriminator`,
+        );
+      }
+      variant.fields.forEach((field) => assertNoTagDiscriminatorCollision(field.schema));
+    });
+  }
+};
 
 const toPortableRequirements = (
   functions: readonly ExternalFunctionRequirement[],

--- a/docs/architecture/external-package-adapters.md
+++ b/docs/architecture/external-package-adapters.md
@@ -1,0 +1,72 @@
+# External Package Adapter Boundary
+
+Status: implemented fallback ABI
+
+## Contract
+
+`@external(id: "...")` declares either a synchronous function or an effectful
+asynchronous interface implemented by a host-language package adapter. The Voyd
+declaration, interface ID, function name, execution kind, and boundary-compatible
+parameter/result shapes are the stable contract.
+
+Generated contracts expand those shapes into a transport-neutral structural
+DTO schema and fingerprint the complete set of functions in each versioned
+interface. Compiler-local reference IDs never cross into the package contract.
+
+The core-Wasm fallback records only reachable function requirements. It
+validates those shapes, validates a provider's complete fingerprint against its
+own immutable contract, and forbids splitting one interface across providers;
+it cannot independently reconstruct an unused declaration's shape. The
+versioned interface ID is therefore the nominal compatibility promise in the
+fallback. Component Model linking later enforces the generated WIT interface as
+a whole without changing package or adapter source.
+
+The compiler lowers reachable calls to imports in the `voyd.external` core-Wasm
+module and records normalized requirements in `voyd.external_requirements`.
+Synchronous arguments and results currently use the existing boundary schema plus MsgPack
+transport. Transport pointers, buffer sizing, compiler type IDs, and MsgPack
+are not public package API.
+
+External effects lower through the normal Voyd effect runtime. The requirements
+section records their operation ID, signature hash, resume kind, and DTO schema;
+the host registers adapter functions as typed effect handlers.
+
+`@voyd-lang/package-adapter` owns the host-language descriptor and
+`defineVoydPackageAdapter`. It deliberately has no compiler, SDK, JS-host, or VX
+dependency. `@voyd-lang/js-host` validates requirements and supplies the import
+trampolines during instantiation. Node discovery and build-time registry
+generation live in the SDK and CLI respectively.
+
+## Boundary rules
+
+- Adapter descriptors contain sync and async functions and, in a future revision, resources.
+- UI frameworks are consumers of functions, not adapter categories.
+- Recoverable errors belong in explicit Voyd result types. A thrown host error
+  is a runtime failure annotated with external function identity.
+- A synchronous external function returning a Promise is an error; an async
+  external effect may return either a value or Promise.
+- The host invokes functions with a host-owned `this` context. It reserves
+  optional cancellation and resource-table capabilities so they can be wired
+  without changing generated function signatures.
+- External schemas must stay within the Component Model-compatible DTO subset.
+- Recursive value graphs are rejected; callers must use explicit indexed DTOs
+  or future resource handles.
+- Installed packages are not loaded merely because they exist; only reachable
+  interface requirements select providers.
+
+## Component Model migration
+
+The Component Model backend replaces core imports and MsgPack lowering with
+component imports and Canonical ABI lowering. Generated WIT already describes
+the stable `namespace:package/interface@version` identity and supported DTO
+subset. Voyd package APIs and generated adapter
+implementation shapes remain stable; packages may require rebuilding.
+
+The Component Model host keeps a generated adapter-value façade between
+canonical bindings and package implementations. It normalizes i64 and variant
+payload representations, so WIT binding conventions do not leak into the
+transport-neutral JavaScript adapter API.
+
+Resources should extend the same interface model. External integrations must
+not be implemented as special VX hooks or arbitrary JavaScript object escape
+hatches.

--- a/docs/testing/test-inventory.json
+++ b/docs/testing/test-inventory.json
@@ -48,6 +48,12 @@
     "rationale": "Keep co-located: protects CLI parsing, command wiring, packaged behavior, or process UX."
   },
   {
+    "file": "apps/cli/src/__tests__/generate-adapter.test.ts",
+    "owner": "cli-contract",
+    "disposition": "cli-local",
+    "rationale": "Keep co-located: protects adapter and registry generation command output without duplicating compiler or runtime semantics."
+  },
+  {
     "file": "apps/cli/src/__tests__/output.test.ts",
     "owner": "cli-contract",
     "disposition": "cli-local",
@@ -1868,6 +1874,12 @@
     "rationale": "Asserts internal continuation-use min/max/escape analysis; portable rejection behavior should be extracted from effects-inference.test.ts."
   },
   {
+    "file": "packages/js-host/src/__tests__/boundary-values.test.ts",
+    "owner": "package-unit",
+    "disposition": "package-local",
+    "rationale": "Keep co-located: protects JS-host conversion between the fallback wire schema and the stable adapter DTO contract at the cheapest precise boundary."
+  },
+  {
     "file": "packages/js-host/src/__tests__/effect-op.test.ts",
     "owner": "package-unit",
     "disposition": "package-local",
@@ -2010,6 +2022,18 @@
     "owner": "package-unit",
     "disposition": "package-local",
     "rationale": "Keep co-located: protects one package or app implementation contract at the cheapest precise boundary."
+  },
+  {
+    "file": "packages/markdown/host/adapter.test.ts",
+    "owner": "package-unit",
+    "disposition": "package-local",
+    "rationale": "Keep co-located: protects Markdown rendering and sanitization owned by the adapter package."
+  },
+  {
+    "file": "packages/package-adapter/src/index.test.ts",
+    "owner": "package-unit",
+    "disposition": "package-local",
+    "rationale": "Keep co-located: protects package-adapter descriptor validation at its cheapest boundary."
   },
   {
     "file": "packages/sdk/src/__tests__/browser-exports.test.ts",

--- a/examples/markdown.voyd
+++ b/examples/markdown.voyd
@@ -1,0 +1,7 @@
+use pkg::markdown::Markdown
+use std::vx::all
+
+pub fn main() -> Html<i32>
+  <article class="markdown-example">
+    <Markdown source="# Voyd Markdown\n\nRendered by an installed JavaScript package." />
+  </article>

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@voyd-lang/lib": "^0.2.0",
+        "@voyd-lang/package-adapter": "^0.2.0",
         "@voyd-lang/sdk": "^0.2.0",
         "@voyd-lang/std": "^0.2.0",
         "binaryen": "^125.0.0",
@@ -3918,6 +3919,14 @@
       "resolved": "packages/lib",
       "link": true
     },
+    "node_modules/@voyd-lang/markdown": {
+      "resolved": "packages/markdown",
+      "link": true
+    },
+    "node_modules/@voyd-lang/package-adapter": {
+      "resolved": "packages/package-adapter",
+      "link": true
+    },
     "node_modules/@voyd-lang/performance-tests": {
       "resolved": "tests/performance",
       "link": true
@@ -5480,7 +5489,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -7490,7 +7498,6 @@
     "node_modules/marked": {
       "version": "14.0.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -12539,7 +12546,8 @@
       "name": "@voyd-lang/js-host",
       "version": "0.2.0",
       "dependencies": {
-        "@msgpack/msgpack": "^3.1.2"
+        "@msgpack/msgpack": "^3.1.2",
+        "@voyd-lang/package-adapter": "^0.2.0"
       }
     },
     "packages/language-server": {
@@ -12565,6 +12573,20 @@
         "binaryen": "^125.0.0"
       }
     },
+    "packages/markdown": {
+      "name": "@voyd-lang/markdown",
+      "version": "0.2.0",
+      "dependencies": {
+        "@voyd-lang/package-adapter": "^0.2.0",
+        "@voyd-lang/std": "^0.2.0",
+        "entities": "^4.5.0",
+        "marked": "^14.0.0"
+      }
+    },
+    "packages/package-adapter": {
+      "name": "@voyd-lang/package-adapter",
+      "version": "0.2.0"
+    },
     "packages/reference": {
       "name": "@voyd-lang/reference",
       "version": "0.2.0"
@@ -12576,6 +12598,7 @@
         "@voyd-lang/compiler": "^0.2.0",
         "@voyd-lang/js-host": "^0.2.0",
         "@voyd-lang/lib": "^0.2.0",
+        "@voyd-lang/package-adapter": "^0.2.0",
         "@voyd-lang/std": "^0.2.0",
         "binaryen": "^125.0.0"
       }
@@ -12615,6 +12638,7 @@
       "name": "@voyd-lang/integration-tests",
       "version": "0.0.0",
       "dependencies": {
+        "@voyd-lang/markdown": "^0.2.0",
         "@voyd-lang/sdk": "^0.2.0",
         "@voyd-lang/vx-dom": "^0.2.0",
         "voyd_semver": "0.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6687,6 +6687,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "dev": true,
@@ -12600,7 +12610,8 @@
         "@voyd-lang/lib": "^0.2.0",
         "@voyd-lang/package-adapter": "^0.2.0",
         "@voyd-lang/std": "^0.2.0",
-        "binaryen": "^125.0.0"
+        "binaryen": "^125.0.0",
+        "import-meta-resolve": "^4.2.0"
       }
     },
     "packages/std": {

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/external-generic-effect-unused.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/external-generic-effect-unused.voyd
@@ -1,0 +1,6 @@
+@external(id: "example:unused/generic@1")
+eff GenericExternal<T>
+  load(tail, value: T) -> T
+
+pub fn main() -> i32
+  42

--- a/packages/compiler/src/codegen/__tests__/codegen.test.ts
+++ b/packages/compiler/src/codegen/__tests__/codegen.test.ts
@@ -149,6 +149,7 @@ const DEFAULT_OPTIONS = {
   linearMemoryExport: "always",
   effectsMemoryExport: "auto",
   boundaryExports: false,
+  externalDeclarations: false,
   testScope: "all",
 } as const;
 

--- a/packages/compiler/src/codegen/__tests__/effects-export.test.ts
+++ b/packages/compiler/src/codegen/__tests__/effects-export.test.ts
@@ -24,6 +24,11 @@ const openRowNoPerformFixturePath = resolve(
   "__fixtures__",
   "effects-export-open-row-no-perform.voyd"
 );
+const unusedGenericExternalFixturePath = resolve(
+  import.meta.dirname,
+  "__fixtures__",
+  "external-generic-effect-unused.voyd",
+);
 
 const compileFixture = async (fixture: string) => {
   const result = await compileEffectFixture({ entryPath: fixture });
@@ -37,6 +42,22 @@ const buildModule = () => compileFixture(fixturePath);
 const buildMsgpackModule = () => compileFixture(msgpackFixturePath);
 
 describe("effectful exports & host boundary", () => {
+  it("allows unused generic external effect declarations in ordinary builds", async () => {
+    const result = await compileProgram({
+      entryPath: unusedGenericExternalFixturePath,
+      roots: {
+        src: dirname(unusedGenericExternalFixturePath),
+        std: resolve(import.meta.dirname, "../../../../std/src"),
+      },
+      host: createFsModuleHost(),
+    });
+
+    if (!result.success) {
+      throw new Error(JSON.stringify(result.diagnostics, null, 2));
+    }
+    expect(result.wasm).toBeInstanceOf(Uint8Array);
+  });
+
   it("retains MsgPack host-boundary contracts in optimized builds without typed boundary exports", async () => {
     const result = await compileProgram({
       entryPath: fixturePath,

--- a/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
+++ b/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
@@ -207,6 +207,7 @@ const buildLoweringSnapshot = () => {
       linearMemoryExport: "always",
       effectsMemoryExport: "auto",
       boundaryExports: false,
+      externalDeclarations: false,
       testScope: "all",
     },
     programHelpers,

--- a/packages/compiler/src/codegen/__tests__/support/test-codegen-context.ts
+++ b/packages/compiler/src/codegen/__tests__/support/test-codegen-context.ts
@@ -179,6 +179,7 @@ export const createTestCodegenContext = (): {
       linearMemoryExport: "always",
       effectsMemoryExport: "auto",
       boundaryExports: false,
+      externalDeclarations: false,
       testScope: "all",
     },
     programHelpers,

--- a/packages/compiler/src/codegen/codegen.ts
+++ b/packages/compiler/src/codegen/codegen.ts
@@ -211,7 +211,11 @@ export const codegenProgram = ({
     ctx.effectLowering = ctx.effectsBackend.buildLowering({ ctx, siteCounter });
   });
   contexts.forEach(registerFunctionMetadata);
-  const effectRegistry = buildEffectRegistry(contexts, reachableFunctionSymbols);
+  const effectRegistry = buildEffectRegistry(
+    contexts,
+    reachableFunctionSymbols,
+    mergedOptions.externalDeclarations,
+  );
   contexts.forEach((ctx) => {
     ctx.effectsState.effectRegistry = effectRegistry;
   });

--- a/packages/compiler/src/codegen/codegen.ts
+++ b/packages/compiler/src/codegen/codegen.ts
@@ -64,6 +64,7 @@ import {
   specializationPolicyForOptimizationLevel,
 } from "../optimization-policy.js";
 import { createSpecializationReservations } from "../optimize/codegen-plan.js";
+import { emitExternalRequirementsSection } from "./external/imports.js";
 
 const DEFAULT_OPTIONS: Required<CodegenOptions> = {
   optimizationLevel: "none",
@@ -76,6 +77,7 @@ const DEFAULT_OPTIONS: Required<CodegenOptions> = {
   linearMemoryExport: "always",
   effectsMemoryExport: "auto",
   boundaryExports: false,
+  externalDeclarations: false,
   continuationBackend: {},
   testMode: false,
   testScope: "all",
@@ -197,7 +199,10 @@ export const codegenProgram = ({
   const siteCounter = { current: 0 };
   const entryCtx =
     contexts.find((ctx) => ctx.moduleId === entryModuleId) ?? contexts[0];
-  prepareReachableFunctionSymbols({ contexts, entryModuleId });
+  const reachableFunctionSymbols = prepareReachableFunctionSymbols({
+    contexts,
+    entryModuleId,
+  });
   applyConfiguredMemoryExports(entryCtx);
   contexts.forEach((ctx) => {
     ctx.effectsBackend = selectEffectsBackend(ctx);
@@ -206,7 +211,7 @@ export const codegenProgram = ({
     ctx.effectLowering = ctx.effectsBackend.buildLowering({ ctx, siteCounter });
   });
   contexts.forEach(registerFunctionMetadata);
-  const effectRegistry = buildEffectRegistry(contexts);
+  const effectRegistry = buildEffectRegistry(contexts, reachableFunctionSymbols);
   contexts.forEach((ctx) => {
     ctx.effectsState.effectRegistry = effectRegistry;
   });
@@ -233,6 +238,12 @@ export const codegenProgram = ({
     entryModuleId,
     mod,
     exportName: EFFECT_TABLE_EXPORT,
+  });
+  emitExternalRequirementsSection({
+    mod,
+    programHelpers,
+    effectRegistry,
+    includeDeclarations: mergedOptions.externalDeclarations,
   });
   if (mergedOptions.runtimeDiagnostics) {
     emitRuntimeDiagnosticsSection({
@@ -386,6 +397,8 @@ const normalizeCodegenOptions = (
     effectsMemoryExport:
       options.effectsMemoryExport ?? DEFAULT_OPTIONS.effectsMemoryExport,
     boundaryExports: options.boundaryExports ?? DEFAULT_OPTIONS.boundaryExports,
+    externalDeclarations:
+      options.externalDeclarations ?? DEFAULT_OPTIONS.externalDeclarations,
     continuationBackend: {
       ...DEFAULT_OPTIONS.continuationBackend,
       ...(options.continuationBackend ?? {}),

--- a/packages/compiler/src/codegen/context.ts
+++ b/packages/compiler/src/codegen/context.ts
@@ -69,6 +69,8 @@ export interface CodegenOptions {
   linearMemoryExport?: "always" | "auto" | "off";
   effectsMemoryExport?: "auto" | "always" | "off";
   boundaryExports?: BoundaryExportsOption;
+  /** Include external interface declarations even when they have no reachable call. */
+  externalDeclarations?: boolean;
   continuationBackend?: ContinuationBackendOptions;
   testMode?: boolean;
   testScope?: "all" | "entry";

--- a/packages/compiler/src/codegen/effects/effect-registry.ts
+++ b/packages/compiler/src/codegen/effects/effect-registry.ts
@@ -3,6 +3,7 @@ import type { CodegenContext } from "../context.js";
 import type {
   HirExprId,
   ProgramFunctionInstanceId,
+  ProgramSymbolId,
   SymbolId,
   TypeId,
   TypeParamId,
@@ -19,6 +20,7 @@ import {
   findSerializerForType,
   serializerKeyFor,
 } from "../serializer.js";
+import { deriveBoundarySchema, type BoundarySchema } from "../boundary/schema.js";
 
 const encoder = new TextEncoder();
 const FNV_OFFSET = 14695981039346656037n;
@@ -45,6 +47,11 @@ export type EffectOpEntry = {
   label: string;
   effectName: string;
   opName: string;
+  external?: {
+    params: readonly BoundarySchema[];
+    result: BoundarySchema;
+    declaredOnly?: boolean;
+  };
 };
 
 export type EffectRegistry = {
@@ -456,6 +463,7 @@ const fallbackEffectAndOpNames = (
 
 export const buildEffectRegistry = (
   contexts: readonly CodegenContext[],
+  reachableFunctionSymbols?: ReadonlySet<ProgramSymbolId>,
 ): EffectRegistry => {
   const entriesByKey = new Map<EffectOpKey, EffectOpEntry>();
   const effectIdsByModule = new Map<string, EffectIdInfo[]>();
@@ -476,6 +484,13 @@ export const buildEffectRegistry = (
 
     ctx.effectLowering.sites.forEach((site) => {
       if (site.kind !== "perform") return;
+      const owner = ownerByExpr.get(site.exprId);
+      const siteReachable =
+        owner === undefined ||
+        !reachableFunctionSymbols ||
+        reachableFunctionSymbols.has(
+          ctx.program.symbols.canonicalIdOf(ctx.moduleId, owner) as ProgramSymbolId,
+        );
       const info = ctx.module.effectsInfo.operations.get(site.effectSymbol);
       if (!info) {
         throw new Error(`missing effect info for op ${site.effectSymbol}`);
@@ -503,8 +518,7 @@ export const buildEffectRegistry = (
       const label = `${sourceModuleId}::${effectName}.${opName}`;
       const resumeKind =
         info.resumable === "tail" ? RESUME_KIND.tail : RESUME_KIND.resume;
-      const owners = ownerByExpr.get(site.exprId);
-      const instances = owners ? (instancesBySymbol.get(owners) ?? []) : [];
+      const instances = owner !== undefined ? (instancesBySymbol.get(owner) ?? []) : [];
       const instanceList = instances.length > 0 ? instances : [undefined];
 
       instanceList.forEach((instanceId) => {
@@ -521,18 +535,103 @@ export const buildEffectRegistry = (
           returnSerializerOverride: signature.returnSerializerOverride,
         });
         const key = toEffectOpKey(effectId.hash, info.opIndex, signatureHash);
-        if (!entriesByKey.has(key)) {
-          entriesByKey.set(key, {
-            opIndex: -1,
-            effectId,
-            opId: info.opIndex,
-            resumeKind,
-            signatureHash,
-            label,
-            effectName,
-            opName,
-          });
+        const external = effectMeta?.external && siteReachable
+            ? {
+                params: signature.params.map((typeId, index) =>
+                  deriveBoundarySchema({
+                    typeId,
+                    ctx,
+                    label: `${effectId.id}::${opName} arg${index}`,
+                    options: { tagStandaloneVariants: true },
+                  }),
+                ),
+                result: deriveBoundarySchema({
+                  typeId: signature.returnType,
+                  ctx,
+                  label: `${effectId.id}::${opName} result`,
+                  options: { tagStandaloneVariants: true },
+                }),
+              }
+            : undefined;
+        const existing = entriesByKey.get(key);
+        if (existing) {
+          if (external) existing.external = external;
+          return;
         }
+        entriesByKey.set(key, {
+          opIndex: -1,
+          effectId,
+          opId: info.opIndex,
+          resumeKind,
+          signatureHash,
+          label,
+          effectName,
+          opName,
+          ...(external ? { external } : {}),
+        });
+      });
+    });
+  });
+
+  // External effect declarations are interface definitions, so adapter binding
+  // generation must see their operations even when the declaring package does
+  // not perform them itself.
+  contexts.forEach((ctx) => {
+    const effectIds = effectIdsByModule.get(ctx.moduleId) ?? [];
+    ctx.module.meta.effects.forEach((effect, localEffectIndex) => {
+      if (!effect.external) return;
+      const effectId = effectIds[localEffectIndex];
+      if (!effectId) throw new Error(`missing external effect id for ${effect.name}`);
+      effect.operations.forEach((op, opId) => {
+        const signature = ctx.program.functions.getSignature(ctx.moduleId, op.symbol);
+        if (!signature) throw new Error(`missing external effect signature for ${effect.name}.${op.name}`);
+        if (signature.typeParams.length > 0) {
+          throw new Error(`generic external effect operations are not supported: ${effect.name}.${op.name}`);
+        }
+        const params = signature.parameters.map((param) => param.typeId);
+        const signatureHash = signatureHashFor({
+          params,
+          returnType: signature.returnType,
+          ctx,
+          paramSerializerOverrides: signature.parameters.map((param) =>
+            param.declaredSerializer ?? findSerializerForDeclaredType(param.declaredType, ctx),
+          ),
+          returnSerializerOverride:
+            signature.declaredReturnSerializer ??
+            findSerializerForDeclaredType(signature.declaredReturnType, ctx),
+        });
+        const key = toEffectOpKey(effectId.hash, opId, signatureHash);
+        const external = {
+          params: params.map((typeId, index) => deriveBoundarySchema({
+            typeId,
+            ctx,
+            label: `${effectId.id}::${op.name} arg${index}`,
+            options: { tagStandaloneVariants: true },
+          })),
+          result: deriveBoundarySchema({
+            typeId: signature.returnType,
+            ctx,
+            label: `${effectId.id}::${op.name} result`,
+            options: { tagStandaloneVariants: true },
+          }),
+          declaredOnly: true,
+        };
+        const existing = entriesByKey.get(key);
+        if (existing) {
+          existing.external ??= external;
+          return;
+        }
+        entriesByKey.set(key, {
+          opIndex: -1,
+          effectId,
+          opId,
+          resumeKind: op.resumable === "tail" ? RESUME_KIND.tail : RESUME_KIND.resume,
+          signatureHash,
+          label: `${ctx.moduleId}::${effect.name}.${op.name}`,
+          effectName: effect.name,
+          opName: op.name,
+          external,
+        });
       });
     });
   });

--- a/packages/compiler/src/codegen/effects/effect-registry.ts
+++ b/packages/compiler/src/codegen/effects/effect-registry.ts
@@ -464,6 +464,7 @@ const fallbackEffectAndOpNames = (
 export const buildEffectRegistry = (
   contexts: readonly CodegenContext[],
   reachableFunctionSymbols?: ReadonlySet<ProgramSymbolId>,
+  includeExternalDeclarations = false,
 ): EffectRegistry => {
   const entriesByKey = new Map<EffectOpKey, EffectOpEntry>();
   const effectIdsByModule = new Map<string, EffectIdInfo[]>();
@@ -576,65 +577,67 @@ export const buildEffectRegistry = (
   // External effect declarations are interface definitions, so adapter binding
   // generation must see their operations even when the declaring package does
   // not perform them itself.
-  contexts.forEach((ctx) => {
-    const effectIds = effectIdsByModule.get(ctx.moduleId) ?? [];
-    ctx.module.meta.effects.forEach((effect, localEffectIndex) => {
-      if (!effect.external) return;
-      const effectId = effectIds[localEffectIndex];
-      if (!effectId) throw new Error(`missing external effect id for ${effect.name}`);
-      effect.operations.forEach((op, opId) => {
-        const signature = ctx.program.functions.getSignature(ctx.moduleId, op.symbol);
-        if (!signature) throw new Error(`missing external effect signature for ${effect.name}.${op.name}`);
-        if (signature.typeParams.length > 0) {
-          throw new Error(`generic external effect operations are not supported: ${effect.name}.${op.name}`);
-        }
-        const params = signature.parameters.map((param) => param.typeId);
-        const signatureHash = signatureHashFor({
-          params,
-          returnType: signature.returnType,
-          ctx,
-          paramSerializerOverrides: signature.parameters.map((param) =>
-            param.declaredSerializer ?? findSerializerForDeclaredType(param.declaredType, ctx),
-          ),
-          returnSerializerOverride:
-            signature.declaredReturnSerializer ??
-            findSerializerForDeclaredType(signature.declaredReturnType, ctx),
-        });
-        const key = toEffectOpKey(effectId.hash, opId, signatureHash);
-        const external = {
-          params: params.map((typeId, index) => deriveBoundarySchema({
-            typeId,
+  if (includeExternalDeclarations) {
+    contexts.forEach((ctx) => {
+      const effectIds = effectIdsByModule.get(ctx.moduleId) ?? [];
+      ctx.module.meta.effects.forEach((effect, localEffectIndex) => {
+        if (!effect.external) return;
+        const effectId = effectIds[localEffectIndex];
+        if (!effectId) throw new Error(`missing external effect id for ${effect.name}`);
+        effect.operations.forEach((op, opId) => {
+          const signature = ctx.program.functions.getSignature(ctx.moduleId, op.symbol);
+          if (!signature) throw new Error(`missing external effect signature for ${effect.name}.${op.name}`);
+          if (signature.typeParams.length > 0) {
+            throw new Error(`generic external effect operations are not supported: ${effect.name}.${op.name}`);
+          }
+          const params = signature.parameters.map((param) => param.typeId);
+          const signatureHash = signatureHashFor({
+            params,
+            returnType: signature.returnType,
             ctx,
-            label: `${effectId.id}::${op.name} arg${index}`,
-            options: { tagStandaloneVariants: true },
-          })),
-          result: deriveBoundarySchema({
-            typeId: signature.returnType,
-            ctx,
-            label: `${effectId.id}::${op.name} result`,
-            options: { tagStandaloneVariants: true },
-          }),
-          declaredOnly: true,
-        };
-        const existing = entriesByKey.get(key);
-        if (existing) {
-          existing.external ??= external;
-          return;
-        }
-        entriesByKey.set(key, {
-          opIndex: -1,
-          effectId,
-          opId,
-          resumeKind: op.resumable === "tail" ? RESUME_KIND.tail : RESUME_KIND.resume,
-          signatureHash,
-          label: `${ctx.moduleId}::${effect.name}.${op.name}`,
-          effectName: effect.name,
-          opName: op.name,
-          external,
+            paramSerializerOverrides: signature.parameters.map((param) =>
+              param.declaredSerializer ?? findSerializerForDeclaredType(param.declaredType, ctx),
+            ),
+            returnSerializerOverride:
+              signature.declaredReturnSerializer ??
+              findSerializerForDeclaredType(signature.declaredReturnType, ctx),
+          });
+          const key = toEffectOpKey(effectId.hash, opId, signatureHash);
+          const external = {
+            params: params.map((typeId, index) => deriveBoundarySchema({
+              typeId,
+              ctx,
+              label: `${effectId.id}::${op.name} arg${index}`,
+              options: { tagStandaloneVariants: true },
+            })),
+            result: deriveBoundarySchema({
+              typeId: signature.returnType,
+              ctx,
+              label: `${effectId.id}::${op.name} result`,
+              options: { tagStandaloneVariants: true },
+            }),
+            declaredOnly: true,
+          };
+          const existing = entriesByKey.get(key);
+          if (existing) {
+            existing.external ??= external;
+            return;
+          }
+          entriesByKey.set(key, {
+            opIndex: -1,
+            effectId,
+            opId,
+            resumeKind: op.resumable === "tail" ? RESUME_KIND.tail : RESUME_KIND.resume,
+            signatureHash,
+            label: `${ctx.moduleId}::${effect.name}.${op.name}`,
+            effectName: effect.name,
+            opName: op.name,
+            external,
+          });
         });
       });
     });
-  });
+  }
 
   const entries = Array.from(entriesByKey.values()).sort((a, b) => {
     if (a.effectId.hash.high !== b.effectId.hash.high) {

--- a/packages/compiler/src/codegen/effects/host-boundary/effect-request-msgpack.ts
+++ b/packages/compiler/src/codegen/effects/host-boundary/effect-request-msgpack.ts
@@ -2,6 +2,8 @@ import binaryen from "binaryen";
 import { refCast, structGetFieldValue } from "@voyd-lang/lib/binaryen-gc/index.js";
 import { emitStringLiteral } from "../../expressions/primitives.js";
 import type { CodegenContext } from "../../context.js";
+import type { FunctionContext } from "../../context.js";
+import { packBoundaryValueAsMsgPack } from "../../boundary/msgpack-codec.js";
 import type { EffectRuntime } from "../runtime-abi.js";
 import { EFFECT_REQUEST_MSGPACK_KEYS } from "./constants.js";
 import { ensureMsgPackFunctions } from "./msgpack.js";
@@ -16,6 +18,7 @@ const buildArgsArray = ({
   arrayLocal,
   ctx,
   runtime,
+  fnCtx,
 }: {
   sig: EffectOpSignature;
   request: () => binaryen.ExpressionRef;
@@ -24,6 +27,7 @@ const buildArgsArray = ({
   arrayLocal: number;
   ctx: CodegenContext;
   runtime: EffectRuntime;
+  fnCtx: FunctionContext;
 }): binaryen.ExpressionRef => {
   const arrayType = msgpack.arrayWithCapacity.resultType;
   const argsCount = sig.paramTypeIds.length;
@@ -45,7 +49,10 @@ const buildArgsArray = ({
       fieldType: sig.params[index]!,
       exprRef: typedArgs,
     });
-    const msgpackValue = packMsgPackValueForType({
+    const boundarySchema = sig.externalBoundary?.params[index];
+    const msgpackValue = boundarySchema
+      ? packBoundaryValueAsMsgPack({ value: argValue, schema: boundarySchema, ctx, fnCtx })
+      : packMsgPackValueForType({
       value: argValue,
       typeId: paramTypeId,
       msgPackType,
@@ -54,7 +61,7 @@ const buildArgsArray = ({
       label: `${sig.label} arg${index}`,
       serializerOverride: sig.paramSerializerOverrides?.[index],
       onUnsupported: "trap",
-    });
+        });
     ops.push(
       ctx.mod.local.set(
         arrayLocal,
@@ -206,6 +213,7 @@ export const buildEffectRequestMsgPack = ({
   mapLocal,
   ctx,
   runtime,
+  fnCtx,
 }: {
   sig: EffectOpSignature;
   request: () => binaryen.ExpressionRef;
@@ -215,6 +223,7 @@ export const buildEffectRequestMsgPack = ({
   mapLocal: number;
   ctx: CodegenContext;
   runtime: EffectRuntime;
+  fnCtx: FunctionContext;
 }): binaryen.ExpressionRef => {
   const argsArray = buildArgsArray({
     sig,
@@ -224,6 +233,7 @@ export const buildEffectRequestMsgPack = ({
     arrayLocal,
     ctx,
     runtime,
+    fnCtx,
   });
   return buildEffectRequestMap({
     request,

--- a/packages/compiler/src/codegen/effects/host-boundary/handle-outcome.ts
+++ b/packages/compiler/src/codegen/effects/host-boundary/handle-outcome.ts
@@ -355,6 +355,7 @@ export const createHandleOutcomeDynamic = ({
         mapLocal,
         ctx,
         runtime,
+        fnCtx,
       });
 
       const effectOps = ctx.mod.block(null, [

--- a/packages/compiler/src/codegen/effects/host-boundary/payload-compatibility.ts
+++ b/packages/compiler/src/codegen/effects/host-boundary/payload-compatibility.ts
@@ -251,6 +251,7 @@ export const collectHostBoundaryPayloadViolations = ({
 }): HostBoundaryPayloadViolation[] => {
   const violations: HostBoundaryPayloadViolation[] = [];
   signatures.forEach((signature) => {
+    if (signature.externalBoundary) return;
     signature.paramTypeIds.forEach((typeId, index) => {
       collectViolation({
         signature,

--- a/packages/compiler/src/codegen/effects/host-boundary/resume.ts
+++ b/packages/compiler/src/codegen/effects/host-boundary/resume.ts
@@ -2,11 +2,12 @@ import binaryen from "binaryen";
 import { callRef, refCast } from "@voyd-lang/lib/binaryen-gc/index.js";
 import { getFunctionRefType, getRequiredExprType, wasmTypeFor } from "../../types.js";
 import { boxOutcomeValue } from "../outcome-values.js";
-import type { CodegenContext } from "../../context.js";
+import type { CodegenContext, FunctionContext } from "../../context.js";
 import type { EffectRuntime } from "../runtime-abi.js";
 import { ensureDispatcher } from "../dispatcher.js";
 import { ensureMsgPackFunctions } from "./msgpack.js";
 import { unpackMsgPackValueForType } from "./msgpack-values.js";
+import { unpackBoundaryValueFromMsgPack } from "../../boundary/msgpack-codec.js";
 import { hostBoundaryPayloadSupportForType } from "./payload-compatibility.js";
 import { stateFor } from "./state.js";
 import type { EffectOpSignature } from "./types.js";
@@ -100,9 +101,13 @@ export const createResumeContinuation = ({
       runtime.continuationType,
       msgPackType,
     ];
-    const scratch = {
+    const scratch: FunctionContext = {
+      bindings: new Map(),
+      tempLocals: new Map(),
       locals,
       nextLocalIndex: binaryen.expandType(params).length + locals.length,
+      returnTypeId: ctx.program.primitives.void,
+      effectful: false,
     };
     const requestLocal = 0;
     const bufPtrLocal = 1;
@@ -152,6 +157,13 @@ export const createResumeContinuation = ({
       const resumeValue =
         sig.returnType === binaryen.none
           ? ctx.mod.nop()
+          : sig.externalBoundary
+          ? unpackBoundaryValueFromMsgPack({
+              value: ctx.mod.local.get(decodedLocal, msgPackType),
+              schema: sig.externalBoundary.result,
+              ctx,
+              fnCtx: scratch,
+            })
           : unpackMsgPackValueForType({
               value: ctx.mod.local.get(decodedLocal, msgPackType),
               typeId: sig.returnTypeId,
@@ -376,9 +388,13 @@ export const createEndRequestRaw = ({
       binaryen.i32,
     ]);
     const locals: binaryen.Type[] = [msgPackType];
-    const scratch = {
+    const scratch: FunctionContext = {
+      bindings: new Map(),
+      tempLocals: new Map(),
       locals,
       nextLocalIndex: binaryen.expandType(params).length + locals.length,
+      returnTypeId: ctx.program.primitives.void,
+      effectful: false,
     };
     const requestLocal = 0;
     const bufPtrLocal = 1;
@@ -436,14 +452,21 @@ export const createEndRequestRaw = ({
         sig.returnType === binaryen.none
           ? ctx.mod.ref.null(binaryen.eqref)
           : boxOutcomeValue({
-              value: unpackMsgPackValueForType({
-                value: decodedValue(),
-                typeId: sig.returnTypeId,
-                msgpack,
-                ctx,
-                label: sig.label,
-                serializerOverride: sig.returnSerializerOverride,
-              }),
+              value: sig.externalBoundary
+                ? unpackBoundaryValueFromMsgPack({
+                    value: decodedValue(),
+                    schema: sig.externalBoundary.result,
+                    ctx,
+                    fnCtx: scratch,
+                  })
+                : unpackMsgPackValueForType({
+                    value: decodedValue(),
+                    typeId: sig.returnTypeId,
+                    msgpack,
+                    ctx,
+                    label: sig.label,
+                    serializerOverride: sig.returnSerializerOverride,
+                  }),
               valueType: sig.returnType,
               typeId: sig.returnTypeId,
               serializer: sig.returnSerializerOverride,

--- a/packages/compiler/src/codegen/effects/host-boundary/signatures.ts
+++ b/packages/compiler/src/codegen/effects/host-boundary/signatures.ts
@@ -103,6 +103,13 @@ export const collectEffectOperationSignatures = (
             opIndex: opInfo.opIndex,
             paramTypes: signature.params,
           });
+          const external = registry.getEntry(
+            registry.keyFor(
+              opInfo.effectId.hash,
+              opInfo.opId,
+              opInfo.signatureHash,
+            ),
+          )?.external;
 
           const existing = signaturesByIndex.get(opInfo.opIndex);
           if (!existing) {
@@ -123,6 +130,14 @@ export const collectEffectOperationSignatures = (
               span:
                 siteCtx.module.hir.expressions.get(site.exprId)?.span ??
                 siteCtx.module.hir.module.span,
+              ...(external
+                ? {
+                    externalBoundary: {
+                      params: external.params,
+                      result: external.result,
+                    },
+                  }
+                : {}),
             });
             return;
           }

--- a/packages/compiler/src/codegen/effects/host-boundary/types.ts
+++ b/packages/compiler/src/codegen/effects/host-boundary/types.ts
@@ -2,6 +2,7 @@ import type binaryen from "binaryen";
 import type { TypeId } from "../../../semantics/ids.js";
 import type { SourceSpan } from "../../../diagnostics/types.js";
 import type { SerializerMetadata } from "../../../semantics/symbol-index.js";
+import type { BoundarySchema } from "../../boundary/schema.js";
 
 export type EffectOpSignature = {
   opIndex: number;
@@ -18,4 +19,8 @@ export type EffectOpSignature = {
   argsType?: binaryen.Type;
   label: string;
   span: SourceSpan;
+  externalBoundary?: {
+    params: readonly BoundarySchema[];
+    result: BoundarySchema;
+  };
 };

--- a/packages/compiler/src/codegen/expressions/call/entrypoints.ts
+++ b/packages/compiler/src/codegen/expressions/call/entrypoints.ts
@@ -165,25 +165,46 @@ export const compileCallExpr = (
       shouldCompileIntrinsicCall({
         intrinsicName,
         usesSignature: intrinsicMetadata.intrinsicUsesSignature,
+        external: intrinsicMetadata.external !== undefined,
       });
 
     if (shouldCompileIntrinsic) {
-      const args = compileCallArgExpressionsWithTemps({
-        callId: expr.id,
-        args: expr.args,
-        expectedTypeIdAt: () => undefined,
-        ctx,
-        fnCtx,
-        compileExpr,
-      });
+      const externalMeta = intrinsicMetadata.external
+        ? getFunctionMetadataForCall({
+            symbol: callee.symbol,
+            callId: expr.id,
+            ctx,
+            typeInstanceId,
+          })
+        : undefined;
+      if (externalMeta?.parameters.some((parameter) => parameter.defaulted)) {
+        throw new Error(`external function ${intrinsicName} cannot declare default parameters`);
+      }
+      const planned = externalMeta
+        ? compileCallArgumentsWithMetadata({ call: expr, meta: externalMeta, ctx, fnCtx, compileExpr })
+        : undefined;
+      const args = planned?.args ?? compileCallArgExpressionsWithTemps({
+          callId: expr.id,
+          args: expr.args,
+          expectedTypeIdAt: () => undefined,
+          ctx,
+          fnCtx,
+          compileExpr,
+        });
       return {
         expr: compileIntrinsicCall({
           name: intrinsicName,
+          externalIdentity: intrinsicMetadata.external,
           call: expr,
           args,
           ctx,
           fnCtx,
           instanceId: typeInstanceId,
+          paramTypeIds: planned
+            ? ctx.program.functions
+                .getSignature(ctx.moduleId, callee.symbol)
+                ?.parameters.map((parameter) => parameter.typeId)
+            : undefined,
         }),
         usedReturnCall: false,
       };
@@ -479,24 +500,46 @@ const compileResolvedSymbolCall = ({
     shouldCompileIntrinsicCall({
       intrinsicName,
       usesSignature: intrinsicMetadata.intrinsicUsesSignature,
+      external: intrinsicMetadata.external !== undefined,
     });
   if (shouldCompileIntrinsic) {
-    const args = compileCallArgExpressionsWithTemps({
-      callId: expr.id,
-      args: expr.args,
-      expectedTypeIdAt: () => undefined,
-      ctx,
-      fnCtx,
-      compileExpr,
-    });
+    const externalMeta = intrinsicMetadata.external
+      ? getFunctionMetadataForCall({
+          symbol,
+          callId: expr.id,
+          ctx,
+          moduleId,
+          typeInstanceId,
+        })
+      : undefined;
+    if (externalMeta?.parameters.some((parameter) => parameter.defaulted)) {
+      throw new Error(`external function ${intrinsicName} cannot declare default parameters`);
+    }
+    const planned = externalMeta
+      ? compileCallArgumentsWithMetadata({ call: expr, meta: externalMeta, ctx, fnCtx, compileExpr })
+      : undefined;
+    const args = planned?.args ?? compileCallArgExpressionsWithTemps({
+        callId: expr.id,
+        args: expr.args,
+        expectedTypeIdAt: () => undefined,
+        ctx,
+        fnCtx,
+        compileExpr,
+      });
     return {
       expr: compileIntrinsicCall({
         name: intrinsicName,
+        externalIdentity: intrinsicMetadata.external,
         call: expr,
       args,
       ctx,
       fnCtx,
       instanceId: typeInstanceId,
+      paramTypeIds: planned
+        ? ctx.program.functions
+            .getSignature(moduleId, symbol)
+            ?.parameters.map((parameter) => parameter.typeId)
+        : undefined,
     }),
     usedReturnCall: false,
   };
@@ -591,11 +634,14 @@ const getCalleeTypeId = ({
 const shouldCompileIntrinsicCall = ({
   intrinsicName,
   usesSignature,
+  external,
 }: {
   intrinsicName: string;
   usesSignature: boolean;
+  external: boolean;
 }): boolean =>
   usesSignature !== true ||
+  external ||
   intrinsicName === "__retain_callback" ||
   intrinsicName === "__boundary_retain_callback";
 

--- a/packages/compiler/src/codegen/external/imports.ts
+++ b/packages/compiler/src/codegen/external/imports.ts
@@ -1,0 +1,497 @@
+import binaryen from "binaryen";
+import type {
+  CodegenContext,
+  FunctionContext,
+  HirCallExpr,
+} from "../context.js";
+import type { ProgramFunctionInstanceId, TypeId } from "../../semantics/ids.js";
+import { allocateTempLocal } from "../locals.js";
+import { ensureLinearMemoryExport } from "../memory-exports.js";
+import { ensureMsgPackFunctions } from "../effects/host-boundary/msgpack.js";
+import {
+  wasmTypeFor,
+  getStructuralTypeInfo,
+  getRequiredExprType,
+} from "../types.js";
+import { deriveBoundarySchema, type BoundarySchema } from "../boundary/schema.js";
+import {
+  packBoundaryValueAsMsgPack,
+  unpackBoundaryValueFromMsgPack,
+} from "../boundary/msgpack-codec.js";
+import { findSerializerForType } from "../serializer.js";
+import {
+  boundaryMsgPackPayloadField,
+  isBoundaryMsgPackValue,
+} from "../boundary-metadata.js";
+import { coerceValueToType, loadStructuralField } from "../structural.js";
+import type { EffectRegistry } from "../effects/effect-registry.js";
+import { murmurHash3 } from "@voyd-lang/lib/murmur-hash.js";
+
+export const EXTERNAL_IMPORT_MODULE = "voyd.external";
+export const EXTERNAL_REQUIREMENTS_SECTION = "voyd.external_requirements";
+export const EXTERNAL_BUFFER_SIZE_IMPORT = "buffer_size";
+export const EXTERNAL_BUFFER_ERROR_IMPORT = "buffer_error";
+
+export type ExternalFunctionRequirement = {
+  kind: "sync" | "async";
+  interfaceId: string;
+  functionName: string;
+  params: readonly BoundarySchema[];
+  result: BoundarySchema;
+  effect?: {
+    opId: number;
+    signatureHash: string;
+    resumeKind: "resume" | "tail";
+  };
+};
+
+const EXTERNAL_IMPORTS_KEY = Symbol("voyd.external.imports");
+const EXTERNAL_REQUIREMENTS_KEY = Symbol("voyd.external.requirements");
+
+export const compileExternalCall = ({
+  identity,
+  call,
+  args,
+  ctx,
+  fnCtx,
+  instanceId,
+  paramTypeIds: plannedParamTypeIds,
+}: {
+  identity: { interfaceId: string; functionName: string };
+  call: HirCallExpr;
+  args: readonly binaryen.ExpressionRef[];
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  instanceId?: ProgramFunctionInstanceId;
+  paramTypeIds?: readonly TypeId[];
+}): binaryen.ExpressionRef => {
+  const paramTypeIds = plannedParamTypeIds ?? call.args.map((arg) =>
+    getRequiredExprType(arg.expr, ctx, instanceId),
+  );
+  if (paramTypeIds.length !== args.length) {
+    throw new Error(`external call argument plan mismatch for ${identity.interfaceId}::${identity.functionName}`);
+  }
+  const resultTypeId = getRequiredExprType(call.id, ctx, instanceId);
+  const params = paramTypeIds.map((typeId, index) =>
+    deriveBoundarySchema({
+      typeId,
+      ctx,
+      label: `${identity.interfaceId}::${identity.functionName} arg${index}`,
+      options: { tagStandaloneVariants: true },
+    }),
+  );
+  const result = deriveBoundarySchema({
+    typeId: resultTypeId,
+    ctx,
+    label: `${identity.interfaceId}::${identity.functionName} result`,
+    options: { tagStandaloneVariants: true },
+  });
+
+  recordExternalRequirement({
+    ctx,
+    requirement: {
+      kind: "sync",
+      ...identity,
+      params,
+      result,
+    },
+  });
+  ensureLinearMemoryExport(ctx);
+  const importName = ensureExternalFunctionImport({ ctx, ...identity });
+  const bufferSizeImport = ensureExternalBufferSizeImport(ctx);
+  const bufferErrorImport = ensureExternalBufferErrorImport(ctx);
+  const msgpack = ensureMsgPackFunctions(ctx);
+  const msgPackType = wasmTypeFor(msgpack.msgPackTypeId, ctx);
+  const arrayType = msgpack.arrayWithCapacity.resultType;
+  const arrayLocal = allocateTempLocal(arrayType, fnCtx);
+  const capacityLocal = allocateTempLocal(binaryen.i32, fnCtx);
+  const encodedLengthLocal = allocateTempLocal(binaryen.i32, fnCtx);
+  const writtenLocal = allocateTempLocal(binaryen.i32, fnCtx);
+  const arrayRef = () => ctx.mod.local.get(arrayLocal.index, arrayType);
+  const capacityRef = () =>
+    ctx.mod.local.get(capacityLocal.index, binaryen.i32);
+  const encodedLengthRef = () =>
+    ctx.mod.local.get(encodedLengthLocal.index, binaryen.i32);
+  const writtenRef = () =>
+    ctx.mod.local.get(writtenLocal.index, binaryen.i32);
+
+  const setup: binaryen.ExpressionRef[] = [
+    ctx.mod.local.set(
+      capacityLocal.index,
+      ctx.mod.call(bufferSizeImport, [], binaryen.i32),
+    ),
+    ctx.mod.local.set(
+      arrayLocal.index,
+      ctx.mod.call(
+        msgpack.arrayWithCapacity.wasmName,
+        [ctx.mod.i32.const(args.length)],
+        arrayType,
+      ),
+    ),
+    ...args.map((arg, index) =>
+      ctx.mod.local.set(
+        arrayLocal.index,
+        ctx.mod.call(
+          msgpack.arrayPush.wasmName,
+          [
+            arrayRef(),
+            packExternalValue({
+              value: arg,
+              typeId: paramTypeIds[index]!,
+              schema: params[index]!,
+              ctx,
+              fnCtx,
+              label: `${identity.interfaceId}::${identity.functionName} arg${index}`,
+            }),
+          ],
+          arrayType,
+        ),
+      ),
+    ),
+    ctx.mod.local.set(
+      encodedLengthLocal.index,
+      ctx.mod.call(
+        msgpack.encodeValue.wasmName,
+        [
+          ctx.mod.call(msgpack.makeArray.wasmName, [arrayRef()], msgPackType),
+          ctx.mod.i32.const(0),
+          capacityRef(),
+        ],
+        binaryen.i32,
+      ),
+    ),
+    ctx.mod.if(
+      ctx.mod.i32.lt_s(encodedLengthRef(), ctx.mod.i32.const(0)),
+      ctx.mod.block(null, [
+        ctx.mod.call(
+          bufferErrorImport,
+          [ctx.mod.i32.sub(ctx.mod.i32.const(0), encodedLengthRef()), ctx.mod.i32.const(0)],
+          binaryen.none,
+        ),
+        ctx.mod.unreachable(),
+      ]),
+    ),
+    ctx.mod.local.set(
+      writtenLocal.index,
+      ctx.mod.call(
+        importName,
+        [
+          ctx.mod.i32.const(0),
+          encodedLengthRef(),
+          capacityRef(),
+          capacityRef(),
+        ],
+        binaryen.i32,
+      ),
+    ),
+    trapIfNegative(writtenRef(), ctx),
+  ];
+
+  const decoded = ctx.mod.call(
+    msgpack.decodeValue.wasmName,
+    [capacityRef(), writtenRef()],
+    msgPackType,
+  );
+  const value = unpackExternalValue({
+    value: decoded,
+    typeId: resultTypeId,
+    schema: result,
+    ctx,
+    fnCtx,
+  });
+  const resultType = wasmTypeFor(resultTypeId, ctx);
+  return ctx.mod.block(null, [...setup, value], resultType);
+};
+
+export const emitExternalRequirementsSection = ({
+  mod,
+  programHelpers,
+  effectRegistry,
+  includeDeclarations = false,
+}: {
+  mod: binaryen.Module;
+  programHelpers: CodegenContext["programHelpers"];
+  effectRegistry: EffectRegistry;
+  includeDeclarations?: boolean;
+}): void => {
+  const requirements = programHelpers.getHelperState(
+    EXTERNAL_REQUIREMENTS_KEY,
+    () => new Map<string, ExternalFunctionRequirement>(),
+  );
+  effectRegistry.entries.forEach((entry) => {
+    if (!entry.external || (entry.external.declaredOnly && !includeDeclarations)) return;
+    const requirement: ExternalFunctionRequirement = {
+      kind: "async",
+      interfaceId: entry.effectId.id,
+      functionName: entry.opName,
+      params: entry.external.params,
+      result: entry.external.result,
+      effect: {
+        opId: entry.opId,
+        signatureHash: `0x${entry.signatureHash.toString(16).padStart(8, "0")}`,
+        resumeKind: entry.resumeKind === 1 ? "tail" : "resume",
+      },
+    };
+    const key = externalRequirementKey(requirement);
+    const existing = requirements.get(key);
+    if (existing && JSON.stringify(existing) !== JSON.stringify(requirement)) {
+      throw new Error(`external function contract mismatch for ${key}`);
+    }
+    requirements.set(key, requirement);
+  });
+  if (requirements.size === 0) return;
+  const functions = [...requirements.values()].sort((left, right) =>
+    externalRequirementKey(left).localeCompare(externalRequirementKey(right)),
+  );
+  assertComponentCompatibleSchemas(functions);
+  mod.addCustomSection(
+    EXTERNAL_REQUIREMENTS_SECTION,
+    new TextEncoder().encode(JSON.stringify({ version: 1, functions })),
+  );
+};
+
+const assertComponentCompatibleSchemas = (
+  functions: readonly ExternalFunctionRequirement[],
+): void => {
+  const declarations = new Map<number, BoundarySchema>();
+  const register = (schema: BoundarySchema): void => {
+    if (schema.kind === "ref") return;
+    if (
+      (schema.kind === "array" || schema.kind === "record" || schema.kind === "union") &&
+      schema.typeId !== undefined
+    ) {
+      declarations.set(schema.typeId, schema);
+      schema.aliases?.forEach((alias) => declarations.set(alias, schema));
+    }
+    if (schema.kind === "array") register(schema.element);
+    if (schema.kind === "record") schema.fields.forEach((field) => register(field.schema));
+    if (schema.kind === "union") {
+      schema.variants.forEach((variant) => variant.fields.forEach((field) => register(field.schema)));
+    }
+  };
+  const roots = functions.flatMap((fn) => [...fn.params, fn.result]);
+  roots.forEach(register);
+
+  const complete = new Set<number>();
+  const active = new Set<number>();
+  const visit = (schema: BoundarySchema, label: string): void => {
+    if (schema.kind === "ref") {
+      const target = declarations.get(schema.typeId);
+      if (!target) {
+        throw new Error(`external DTO ${label} references unknown type ${schema.typeId}`);
+      }
+      visit(target, label);
+      return;
+    }
+    const typeId =
+      schema.kind === "array" || schema.kind === "record" || schema.kind === "union"
+        ? schema.typeId
+        : undefined;
+    if (typeId !== undefined) {
+      if (active.has(typeId)) {
+        throw new Error(
+          `external DTO ${label} is recursive; Component Model values require an acyclic DTO (use an indexed or handle-based representation)`,
+        );
+      }
+      if (complete.has(typeId)) return;
+      active.add(typeId);
+    }
+    if (schema.kind === "array") visit(schema.element, label);
+    if (schema.kind === "record") schema.fields.forEach((field) => visit(field.schema, label));
+    if (schema.kind === "union") {
+      schema.variants.forEach((variant) => variant.fields.forEach((field) => visit(field.schema, label)));
+    }
+    if (typeId !== undefined) {
+      active.delete(typeId);
+      complete.add(typeId);
+    }
+  };
+  functions.forEach((fn) =>
+    [...fn.params, fn.result].forEach((schema) =>
+      visit(schema, `${fn.interfaceId}::${fn.functionName}`),
+    ),
+  );
+};
+
+const ensureExternalFunctionImport = ({
+  ctx,
+  interfaceId,
+  functionName,
+}: {
+  ctx: CodegenContext;
+  interfaceId: string;
+  functionName: string;
+}): string => {
+  const imports = ctx.programHelpers.getHelperState(
+    EXTERNAL_IMPORTS_KEY,
+    () => new Map<string, string>(),
+  );
+  const base = `${interfaceId}::${functionName}`;
+  const existing = imports.get(base);
+  if (existing) return existing;
+  const hash = (murmurHash3(base) >>> 0).toString(16).padStart(8, "0");
+  const internal = `__voyd_external_import_${sanitizeIdentifier(base)}_${hash}`;
+  ctx.mod.addFunctionImport(
+    internal,
+    EXTERNAL_IMPORT_MODULE,
+    base,
+    binaryen.createType([
+      binaryen.i32,
+      binaryen.i32,
+      binaryen.i32,
+      binaryen.i32,
+    ]),
+    binaryen.i32,
+  );
+  imports.set(base, internal);
+  return internal;
+};
+
+const ensureExternalBufferSizeImport = (ctx: CodegenContext): string => {
+  const imports = ctx.programHelpers.getHelperState(
+    EXTERNAL_IMPORTS_KEY,
+    () => new Map<string, string>(),
+  );
+  const existing = imports.get(EXTERNAL_BUFFER_SIZE_IMPORT);
+  if (existing) return existing;
+  const internal = "__voyd_external_buffer_size";
+  ctx.mod.addFunctionImport(
+    internal,
+    EXTERNAL_IMPORT_MODULE,
+    EXTERNAL_BUFFER_SIZE_IMPORT,
+    binaryen.none,
+    binaryen.i32,
+  );
+  imports.set(EXTERNAL_BUFFER_SIZE_IMPORT, internal);
+  return internal;
+};
+
+const ensureExternalBufferErrorImport = (ctx: CodegenContext): string => {
+  const imports = ctx.programHelpers.getHelperState(
+    EXTERNAL_IMPORTS_KEY,
+    () => new Map<string, string>(),
+  );
+  const existing = imports.get(EXTERNAL_BUFFER_ERROR_IMPORT);
+  if (existing) return existing;
+  const internal = "__voyd_external_buffer_error";
+  ctx.mod.addFunctionImport(
+    internal,
+    EXTERNAL_IMPORT_MODULE,
+    EXTERNAL_BUFFER_ERROR_IMPORT,
+    binaryen.createType([binaryen.i32, binaryen.i32]),
+    binaryen.none,
+  );
+  imports.set(EXTERNAL_BUFFER_ERROR_IMPORT, internal);
+  return internal;
+};
+
+const recordExternalRequirement = ({
+  ctx,
+  requirement,
+}: {
+  ctx: CodegenContext;
+  requirement: ExternalFunctionRequirement;
+}): void => {
+  const requirements = ctx.programHelpers.getHelperState(
+    EXTERNAL_REQUIREMENTS_KEY,
+    () => new Map<string, ExternalFunctionRequirement>(),
+  );
+  const key = externalRequirementKey(requirement);
+  const existing = requirements.get(key);
+  if (existing && JSON.stringify(existing) !== JSON.stringify(requirement)) {
+    throw new Error(`external function contract mismatch for ${key}`);
+  }
+  requirements.set(key, requirement);
+};
+
+const externalRequirementKey = (
+  requirement: Pick<ExternalFunctionRequirement, "interfaceId" | "functionName">,
+): string => `${requirement.interfaceId}::${requirement.functionName}`;
+
+const packExternalValue = ({
+  value,
+  typeId,
+  schema,
+  ctx,
+  fnCtx,
+  label,
+}: {
+  value: binaryen.ExpressionRef;
+  typeId: TypeId;
+  schema: BoundarySchema;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  label: string;
+}): binaryen.ExpressionRef => {
+  const msgpack = ensureMsgPackFunctions(ctx);
+  const serializer = findSerializerForType(typeId, ctx);
+  if (serializer) {
+    if (serializer.formatId !== "msgpack") {
+      throw new Error(`unsupported external serializer for ${label}`);
+    }
+    return coerceValueToType({
+      value,
+      actualType: typeId,
+      targetType: msgpack.msgPackTypeId,
+      ctx,
+      fnCtx,
+    });
+  }
+  if (isBoundaryMsgPackValue(typeId, ctx)) return value;
+  const payloadField = boundaryMsgPackPayloadField(typeId, ctx);
+  if (payloadField) {
+    const info = getStructuralTypeInfo(typeId, ctx);
+    if (!info) throw new Error(`external payload ${label} is missing structural info`);
+    return loadStructuralField({
+      structInfo: info,
+      field: payloadField,
+      pointer: () => value,
+      ctx,
+    });
+  }
+  return packBoundaryValueAsMsgPack({ value, schema, ctx, fnCtx });
+};
+
+const unpackExternalValue = ({
+  value,
+  typeId,
+  schema,
+  ctx,
+  fnCtx,
+}: {
+  value: binaryen.ExpressionRef;
+  typeId: TypeId;
+  schema: BoundarySchema;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  const msgpack = ensureMsgPackFunctions(ctx);
+  const serializer = findSerializerForType(typeId, ctx);
+  if (serializer) {
+    if (serializer.formatId !== "msgpack") {
+      throw new Error("unsupported external result serializer");
+    }
+    return coerceValueToType({
+      value,
+      actualType: msgpack.msgPackTypeId,
+      targetType: typeId,
+      ctx,
+      fnCtx,
+    });
+  }
+  if (isBoundaryMsgPackValue(typeId, ctx)) return value;
+  return unpackBoundaryValueFromMsgPack({ value, schema, ctx, fnCtx });
+};
+
+const trapIfNegative = (
+  value: binaryen.ExpressionRef,
+  ctx: CodegenContext,
+): binaryen.ExpressionRef =>
+  ctx.mod.if(
+    ctx.mod.i32.lt_s(value, ctx.mod.i32.const(0)),
+    ctx.mod.unreachable(),
+    ctx.mod.nop(),
+  );
+
+const sanitizeIdentifier = (value: string): string =>
+  value.replace(/[^a-zA-Z0-9_]/g, "_");

--- a/packages/compiler/src/codegen/intrinsics.ts
+++ b/packages/compiler/src/codegen/intrinsics.ts
@@ -58,6 +58,9 @@ import {
   isBoundaryMsgPackValue,
 } from "./boundary-metadata.js";
 import { currentHandlerValue } from "./expressions/call/shared.js";
+import {
+  compileExternalCall,
+} from "./external/imports.js";
 
 type NumericKind = "i32" | "i64" | "f32" | "f64";
 type EqualityKind = NumericKind | "bool";
@@ -78,6 +81,8 @@ interface CompileIntrinsicCallParams {
   ctx: CodegenContext;
   fnCtx: FunctionContext;
   instanceId?: ProgramFunctionInstanceId;
+  paramTypeIds?: readonly TypeId[];
+  externalIdentity?: { interfaceId: string; functionName: string };
 }
 
 interface EmitNumericIntrinsicParams {
@@ -638,7 +643,12 @@ export const compileIntrinsicCall = ({
   ctx,
   fnCtx,
   instanceId,
+  paramTypeIds,
+  externalIdentity,
 }: CompileIntrinsicCallParams): binaryen.ExpressionRef => {
+  if (externalIdentity) {
+    return compileExternalCall({ identity: externalIdentity, call, args, ctx, fnCtx, instanceId, paramTypeIds });
+  }
   switch (name) {
     case "~": {
       assertArgCount(name, args, 1);

--- a/packages/compiler/src/parser/__tests__/intrinsic-attribute.test.ts
+++ b/packages/compiler/src/parser/__tests__/intrinsic-attribute.test.ts
@@ -56,3 +56,33 @@ fn bad() -> i32
   0`)
   ).toThrow(/must be labeled with ':'/);
 });
+
+test("@external attaches a signature-aware external intrinsic", (t) => {
+  const fn = parseFunction(`@external(id: "example:math/ops@1")
+fn double(value: i32) -> i32
+  double(value)`);
+
+  t.expect(fn.attributes?.external).toEqual({ id: "example:math/ops@1" });
+  t.expect(fn.attributes?.intrinsic as IntrinsicAttribute | undefined).toEqual({
+    name: "voyd_external",
+    usesSignature: true,
+  });
+});
+
+test("@external requires a stable id", (t) => {
+  t.expect(() =>
+    parse(`@external
+fn missing(value: i32) -> i32
+  missing(value)`),
+  ).toThrow(/requires an 'id:' argument/);
+});
+
+test("@external turns an effect declaration into an async adapter interface", (t) => {
+  const ast = parse(`@external(id: "example:remote/data@1")
+eff Remote
+  load(tail, id: i32) -> i32`);
+  const effect = ast.rest[0];
+  if (!isForm(effect)) throw new Error("expected an effect declaration");
+  t.expect(effect.attributes?.external).toEqual({ id: "example:remote/data@1" });
+  t.expect(effect.attributes?.effect).toEqual({ id: "example:remote/data@1" });
+});

--- a/packages/compiler/src/parser/attributes.ts
+++ b/packages/compiler/src/parser/attributes.ts
@@ -32,3 +32,7 @@ export type TestAttribute = {
 export type EffectAttribute = {
   id?: string;
 };
+
+export type ExternalAttribute = {
+  id: string;
+};

--- a/packages/compiler/src/parser/surface/declarations.ts
+++ b/packages/compiler/src/parser/surface/declarations.ts
@@ -1,7 +1,7 @@
 import {
   type Expr,
   Form,
-  type IdentifierAtom,
+  IdentifierAtom,
   type Syntax,
   formCallsInternal,
   isForm,
@@ -188,15 +188,27 @@ export const parseFunctionDecl = (form: Form): ParsedFunctionDecl | null => {
     throw new ParserSyntaxError("fn missing signature", form.location);
   }
 
-  if (!bodyExpr) {
-    throw new ParserSyntaxError("fn missing body expression", form.location);
-  }
-
   const signatureForm = ensureForm(
     signatureExpr,
     "fn signature must be a form",
   );
   const signature = parseFunctionSignature(signatureForm);
+  if (!bodyExpr && form.attributes?.external) {
+    const args = signature.params.map((param) => {
+      const value = new IdentifierAtom(param.name);
+      return param.label
+        ? new Form([
+            new IdentifierAtom(":"),
+            new IdentifierAtom(param.label),
+            value,
+          ]).toCall()
+        : value;
+    });
+    bodyExpr = new Form([new IdentifierAtom(signature.name.value), ...args]).toCall();
+  }
+  if (!bodyExpr) {
+    throw new ParserSyntaxError("fn missing body expression", form.location);
+  }
 
   return {
     form,

--- a/packages/compiler/src/parser/syntax-macros/external-attribute.ts
+++ b/packages/compiler/src/parser/syntax-macros/external-attribute.ts
@@ -1,0 +1,158 @@
+import type { Expr, Form } from "../ast/index.js";
+import { isForm, isIdentifierAtom } from "../ast/index.js";
+import { cloneAttributes } from "../ast/syntax.js";
+import type { ExternalAttribute } from "../attributes.js";
+import type { SyntaxMacro } from "./types.js";
+import { parseStringValue } from "../string-value.js";
+import { transformFormSequence } from "./sequence-transform.js";
+
+export const EXTERNAL_INTRINSIC_NAME = "voyd_external";
+
+type PendingExternalAttribute = ExternalAttribute & { source: Form };
+
+export const externalAttributeMacro: SyntaxMacro = (form) =>
+  attachExternalAttributes(form);
+
+const attachExternalAttributes = (form: Form): Form =>
+  transformFormSequence({ form, transform: processSequence });
+
+const processSequence = (
+  elements: readonly Expr[],
+  allowAttributes: boolean,
+): { elements: Expr[]; changed: boolean } => {
+  const result: Expr[] = [];
+  let pending: PendingExternalAttribute | null = null;
+  let changed = false;
+
+  for (const element of elements) {
+    const processed = isForm(element)
+      ? attachExternalAttributes(element)
+      : element;
+    if (processed !== element) changed = true;
+
+    if (allowAttributes && isExternalAttributeForm(processed)) {
+      if (pending) throw new Error("duplicate @external attribute");
+      pending = parseExternalAttribute(processed);
+      changed = true;
+      continue;
+    }
+
+    if (pending && allowAttributes) {
+      if (!isForm(processed) || (!isFunctionDeclForm(processed) && !isEffectDeclForm(processed))) {
+        throw new Error("@external attribute must precede a function or effect declaration");
+      }
+      attachExternalAttribute(processed, pending);
+      pending = null;
+      changed = true;
+    }
+
+    result.push(processed);
+  }
+
+  if (pending && allowAttributes) {
+    throw new Error("@external attribute missing a function or effect declaration");
+  }
+
+  return { elements: result, changed };
+};
+
+const isFunctionDeclForm = (form: Form): boolean => {
+  const head = form.at(0);
+  if (!isIdentifierAtom(head)) return false;
+  if (head.value !== "pub") return head.value === "fn";
+  const keyword = form.at(1);
+  return isIdentifierAtom(keyword) && keyword.value === "fn";
+};
+
+const isEffectDeclForm = (form: Form): boolean => {
+  const head = form.at(0);
+  if (!isIdentifierAtom(head)) return false;
+  if (head.value !== "pub") return head.value === "eff";
+  const keyword = form.at(1);
+  return isIdentifierAtom(keyword) && keyword.value === "eff";
+};
+
+const isExternalAttributeForm = (expr: Expr): expr is Form =>
+  isForm(expr) && expr.calls("@") && isExternalHead(expr.at(1));
+
+const isExternalHead = (expr?: Expr): boolean => {
+  if (isIdentifierAtom(expr)) return expr.value === "external";
+  if (!isForm(expr)) return false;
+  const head = expr.at(0);
+  return isIdentifierAtom(head) && head.value === "external";
+};
+
+const parseExternalAttribute = (form: Form): PendingExternalAttribute => {
+  const target = form.at(1);
+  const args = isForm(target) ? target.rest : [];
+  let id: string | undefined;
+
+  args.forEach((arg) => {
+    if (!isForm(arg) || !arg.calls(":")) {
+      throw new Error("@external arguments must be labeled with ':'");
+    }
+    const label = arg.at(1);
+    if (!isIdentifierAtom(label)) {
+      throw new Error("@external argument labels must be identifiers");
+    }
+    if (label.value !== "id") {
+      throw new Error(`unknown @external argument '${label.value}'`);
+    }
+    const parsed = parseStringValue(arg.at(2));
+    if (parsed === null) throw new Error("@external id must be a string");
+    id = parsed;
+  });
+
+  if (!id) throw new Error("@external requires an 'id:' argument");
+  return { id, source: form };
+};
+
+const attachExternalAttribute = (
+  form: Form,
+  attr: PendingExternalAttribute,
+): void => {
+  const attributes = cloneAttributes(form.attributes) ?? {};
+  if ((attributes as { external?: unknown }).external) {
+    throw new Error("duplicate @external attribute");
+  }
+  if ((attributes as { intrinsic?: unknown }).intrinsic) {
+    throw new Error("@external cannot be combined with @intrinsic");
+  }
+
+  attributes.external = { id: attr.id };
+  if (isEffectDeclForm(form)) {
+    if ((attributes as { effect?: unknown }).effect) {
+      throw new Error("@external effect cannot also use @effect");
+    }
+    attributes.effect = { id: attr.id };
+    form.attributes = attributes;
+    return;
+  }
+
+  const name = inferFunctionName(form);
+  if (!name) throw new Error("@external function is missing a name");
+  attributes.intrinsic = {
+    name: EXTERNAL_INTRINSIC_NAME,
+    usesSignature: true,
+  };
+  form.attributes = attributes;
+};
+
+const inferFunctionName = (form: Form): string | undefined => {
+  let index = 0;
+  const first = form.at(0);
+  if (isIdentifierAtom(first) && first.value === "pub") index += 1;
+  const keyword = form.at(index);
+  if (!isIdentifierAtom(keyword) || keyword.value !== "fn") return undefined;
+  return inferFunctionNameFromSignature(form.at(index + 1));
+};
+
+const inferFunctionNameFromSignature = (expr?: Expr): string | undefined => {
+  if (!expr) return undefined;
+  if (isIdentifierAtom(expr)) return expr.value;
+  if (!isForm(expr)) return undefined;
+  if (expr.calls("=")) return inferFunctionNameFromSignature(expr.at(1));
+  if (expr.calls("->")) return inferFunctionNameFromSignature(expr.at(1));
+  const head = expr.at(0);
+  return isIdentifierAtom(head) ? head.value : undefined;
+};

--- a/packages/compiler/src/parser/syntax-macros/index.ts
+++ b/packages/compiler/src/parser/syntax-macros/index.ts
@@ -4,6 +4,7 @@ import { intrinsicAttributeMacro } from "./intrinsic-attribute.js";
 import { compilerContractAttributeMacro } from "./compiler-contract-attribute.js";
 import { intrinsicTypeAttributeMacro } from "./intrinsic-type-attribute.js";
 import { effectAttributeMacro } from "./effect-attribute.js";
+import { externalAttributeMacro } from "./external-attribute.js";
 import { serializerAttributeMacro } from "./serializer-attribute.js";
 import { boundaryAttributeMacro } from "./boundary-attribute.js";
 import { primary } from "./primary.js";
@@ -29,6 +30,7 @@ export const POST_SYNTAX_MACROS: SyntaxMacro[] = [
   intrinsicTypeAttributeMacro,
   boundaryAttributeMacro,
   serializerAttributeMacro,
+  externalAttributeMacro,
   effectAttributeMacro,
   testBlockMacro,
 ];

--- a/packages/compiler/src/semantics/binding/binders/function.ts
+++ b/packages/compiler/src/semantics/binding/binders/function.ts
@@ -62,6 +62,13 @@ export const bindFunctionDecl = (
     symbolMetadata.intrinsicUsesSignature =
       intrinsicMetadata.usesSignature ?? false;
   }
+  const external = decl.form.attributes?.external as { id: string } | undefined;
+  if (external) {
+    symbolMetadata.externalFunction = {
+      interfaceId: external.id,
+      functionName: decl.signature.name.value,
+    };
+  }
 
   const fnSymbol = ctx.symbolTable.declare(
     {

--- a/packages/compiler/src/semantics/codegen-view/index.ts
+++ b/packages/compiler/src/semantics/codegen-view/index.ts
@@ -315,6 +315,7 @@ export type ModuleCodegenMetadata = {
   effects: readonly {
     name: string;
     effectId?: string;
+    external: boolean;
     visibility: HirVisibility;
     symbol: SymbolId;
     operations: readonly {
@@ -1150,6 +1151,9 @@ export const buildProgramCodegenView = (
       effects: mod.binding.effects.map((effect) => ({
         name: effect.name,
         effectId: effect.effectId,
+        external: Boolean(
+          (effect.form?.attributes as { external?: unknown } | undefined)?.external,
+        ),
         visibility: effect.visibility,
         symbol: effect.symbol,
         operations: effect.operations.map((op) => ({

--- a/packages/compiler/src/semantics/imports/metadata.ts
+++ b/packages/compiler/src/semantics/imports/metadata.ts
@@ -6,6 +6,7 @@ const IMPORTABLE_KEYS = [
   "intrinsic",
   "intrinsicName",
   "intrinsicUsesSignature",
+  "externalFunction",
   "intrinsicType",
   "serializer",
   "boundary",

--- a/packages/compiler/src/semantics/symbol-index.ts
+++ b/packages/compiler/src/semantics/symbol-index.ts
@@ -12,6 +12,7 @@ import {
 export type IntrinsicFunctionFlags = {
   intrinsic: boolean;
   intrinsicUsesSignature: boolean;
+  external?: { interfaceId: string; functionName: string };
 };
 
 export type SerializerMetadata = {
@@ -102,6 +103,7 @@ export const buildModuleSymbolIndex = ({
       intrinsicName?: unknown;
       intrinsic?: unknown;
       intrinsicUsesSignature?: unknown;
+      externalFunction?: unknown;
       compilerFunctionContract?: unknown;
       import?: unknown;
       serializer?: unknown;
@@ -132,6 +134,9 @@ export const buildModuleSymbolIndex = ({
       intrinsicFlagsBySymbol.set(symbol, {
         intrinsic: metadata.intrinsic === true,
         intrinsicUsesSignature: metadata.intrinsicUsesSignature === true,
+        ...(isExternalFunctionMetadata(metadata.externalFunction)
+          ? { external: metadata.externalFunction }
+          : {}),
       });
     }
     const compilerFunctionContract = metadata.import
@@ -199,6 +204,14 @@ export const buildModuleSymbolIndex = ({
     getBoundary: (symbol) => boundaryBySymbol.get(symbol),
   };
 };
+
+const isExternalFunctionMetadata = (
+  value: unknown,
+): value is { interfaceId: string; functionName: string } =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as { interfaceId?: unknown }).interfaceId === "string" &&
+  typeof (value as { functionName?: unknown }).functionName === "string";
 
 const readStdIntrinsicTypeContract = ({
   metadata,

--- a/packages/js-host/package.json
+++ b/packages/js-host/package.json
@@ -41,6 +41,7 @@
     "prepublishOnly": "node ../../scripts/release/enforce-workspace-release.mjs"
   },
   "dependencies": {
-    "@msgpack/msgpack": "^3.1.2"
+    "@msgpack/msgpack": "^3.1.2",
+    "@voyd-lang/package-adapter": "^0.2.0"
   }
 }

--- a/packages/js-host/src/__tests__/boundary-values.test.ts
+++ b/packages/js-host/src/__tests__/boundary-values.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { decodeBoundaryArgs } from "../boundary-values.js";
+
+describe("boundary DTO decoding", () => {
+  it("restores adapter-facing tags for unions and standalone variants", () => {
+    const [union, variant] = decodeBoundaryArgs({
+      exportName: "external variants",
+      schemas: [
+        {
+          kind: "union",
+          variants: [
+            { name: "None", fields: [] },
+            { name: "Some", fields: [{ name: "value", schema: { kind: "i32" } }] },
+          ],
+        },
+        {
+          kind: "record",
+          tag: "Some",
+          fields: [{ name: "value", schema: { kind: "i32" } }],
+        },
+      ],
+      args: [{ $variant: "Some", value: 3 }, { value: 4 }],
+    });
+
+    expect(union).toEqual({ tag: "Some", value: 3 });
+    expect(variant).toEqual({ tag: "Some", value: 4 });
+  });
+});

--- a/packages/js-host/src/boundary-values.ts
+++ b/packages/js-host/src/boundary-values.ts
@@ -56,6 +56,32 @@ export const decodeBoundaryResult = ({
     registry: buildSchemaRegistry([schema]),
   });
 
+export const decodeBoundaryArgs = ({
+  exportName,
+  schemas,
+  args,
+}: {
+  exportName: string;
+  schemas: readonly BoundarySchema[];
+  args: readonly unknown[];
+}): unknown[] => {
+  if (args.length !== schemas.length) {
+    throw new Error(
+      `typed export ${exportName} expected ${schemas.length} args, got ${args.length}`,
+    );
+  }
+  const registry = buildSchemaRegistry(schemas);
+  return schemas.map((schema, index) =>
+    decodeBoundaryValue({
+      exportName,
+      schema,
+      value: args[index],
+      path: `arg${index}`,
+      registry,
+    }),
+  );
+};
+
 export const encodeDirectBoundaryArgs = ({
   exportName,
   schemas,

--- a/packages/js-host/src/host.ts
+++ b/packages/js-host/src/host.ts
@@ -54,6 +54,12 @@ import {
   createRetainedEventHandlerRegistry,
   type RetainedEventHandlerRegistry,
 } from "./retained-callbacks.js";
+import type { VoydPackageAdapter } from "@voyd-lang/package-adapter";
+import {
+  buildExternalImportModule,
+  parseExternalRequirements,
+  registerExternalAdapterHandlers,
+} from "./protocol/external.js";
 
 export type HostInitOptions = {
   wasm: Uint8Array | WebAssembly.Module;
@@ -62,6 +68,7 @@ export type HostInitOptions = {
   scheduler?: RuntimeSchedulerOptions;
   defaultAdapters?: boolean | DefaultAdapterOptions;
   retainedCallbacks?: RetainedEventHandlerRegistry;
+  adapters?: readonly VoydPackageAdapter[];
 };
 
 export type VoydHost = {
@@ -698,6 +705,7 @@ export const createVoydHost = async ({
   scheduler,
   defaultAdapters = true,
   retainedCallbacks,
+  adapters = [],
 }: HostInitOptions): Promise<VoydHost> => {
   const module = toModule(wasm);
   const trapDiagnostics = createVoydTrapDiagnostics({ module });
@@ -722,6 +730,7 @@ export const createVoydHost = async ({
   const parsedTable = parseEffectTable(module, EFFECT_TABLE_EXPORT);
   const table = toHostProtocolTable(parsedTable);
   const exportAbi = parseExportAbi(module);
+  const externalRequirements = parseExternalRequirements(module);
   const exportAbiByName = new Map(
     exportAbi.exports.map((entry) => [entry.name, entry] as const)
   );
@@ -776,6 +785,17 @@ export const createVoydHost = async ({
     runEffectfulRetainedCallback: (params) => runEffectfulRetainedCallback(params),
     decorateResult: (value) => attachTaskObserver(value, observeStandaloneTask),
   });
+  const externalImports = buildExternalImportModule({
+    requirements: externalRequirements,
+    adapters,
+    bufferSize,
+    getInstance: () => {
+      if (!instanceRef) {
+        throw new Error("external import called before host instance initialization");
+      }
+      return instanceRef;
+    },
+  });
   instanceRef = new WebAssembly.Instance(
     module,
     mergeDefaultImports(
@@ -783,11 +803,19 @@ export const createVoydHost = async ({
         ...defaultImports(),
         ...(taskRuntimeImports as Record<string, unknown>),
         ...(retainedCallbackImports as Record<string, unknown>),
+        ...(externalImports as Record<string, unknown>),
       } as WebAssembly.Imports,
       imports
     )
   );
   const instance = instanceRef;
+  if (externalRequirements.functions.length > 0) {
+    ensureMemoryCapacity({
+      memory: requireExportedMemory({ instance, name: LINEAR_MEMORY_EXPORT }),
+      requiredBytes: bufferSize * 2,
+      label: LINEAR_MEMORY_EXPORT,
+    });
+  }
 
   const handlersByKey = new Map<string, EffectHandler>();
   const opByKey = buildParsedEffectOpMap({ ops: parsedTable.ops });
@@ -840,6 +868,13 @@ export const createVoydHost = async ({
       handlersByOpIndex[opEntry.opIndex] = handler;
     }
   };
+
+  registerExternalAdapterHandlers({
+    requirements: externalRequirements,
+    adapters,
+    table,
+    registerHandler,
+  });
 
   const initEffects = (): void => {
     if (initialized) {

--- a/packages/js-host/src/index.ts
+++ b/packages/js-host/src/index.ts
@@ -48,6 +48,11 @@ export {
   resumeKindName,
 } from "./effect-op.js";
 export { EXPORT_ABI_SECTION, parseExportAbi } from "./protocol/export-abi.js";
+export {
+  EXTERNAL_IMPORT_MODULE,
+  EXTERNAL_REQUIREMENTS_SECTION,
+  parseExternalRequirements,
+} from "./protocol/external.js";
 export type {
   EffectOpKey,
   EffectOpKeyInput,
@@ -59,6 +64,11 @@ export type {
   ResumeKindCode,
 } from "./protocol/table.js";
 export type { ExportAbiEntry, ParsedExportAbi } from "./protocol/export-abi.js";
+export type {
+  ExternalFunctionRequirement,
+  ParsedExternalRequirements,
+} from "./protocol/external.js";
+export type { VoydPackageAdapter } from "@voyd-lang/package-adapter";
 export type {
   EffectContinuation,
   EffectContinuationCall,

--- a/packages/js-host/src/protocol/external.ts
+++ b/packages/js-host/src/protocol/external.ts
@@ -1,0 +1,438 @@
+import { decode, encode } from "@msgpack/msgpack";
+import {
+  externalFunctionKey,
+  isVoydPackageAdapter,
+  type VoydDtoSchema,
+  type VoydPackageAdapter,
+  type VoydPackageAdapterInvocationContext,
+} from "@voyd-lang/package-adapter";
+import { decodeBoundaryArgs, encodeBoundaryArgs } from "../boundary-values.js";
+import type { EffectContinuation, EffectHandler, HostProtocolTable } from "./types.js";
+
+export const EXTERNAL_IMPORT_MODULE = "voyd.external";
+export const EXTERNAL_REQUIREMENTS_SECTION = "voyd.external_requirements";
+export const EXTERNAL_BUFFER_SIZE_IMPORT = "buffer_size";
+export const EXTERNAL_BUFFER_ERROR_IMPORT = "buffer_error";
+
+/** Internal schema emitted by the core-Wasm fallback compiler ABI. */
+export type VoydBoundarySchema =
+  | { kind: "bool" | "i32" | "i64" | "f32" | "f64" | "void" | "string"; typeId?: number }
+  | { kind: "array"; typeId?: number; aliases?: readonly number[]; elementTypeId?: number; element: VoydBoundarySchema }
+  | { kind: "record"; typeId?: number; aliases?: readonly number[]; name?: string; tag?: string; fields: readonly VoydBoundaryFieldSchema[] }
+  | { kind: "union"; typeId?: number; aliases?: readonly number[]; name?: string; variants: readonly VoydBoundaryVariantSchema[] }
+  | { kind: "ref"; typeId: number };
+
+type VoydBoundaryFieldSchema = {
+  name: string;
+  typeId?: number;
+  schema: VoydBoundarySchema;
+  optional?: boolean;
+};
+
+type VoydBoundaryVariantSchema = {
+  name: string;
+  typeId?: number;
+  fields: readonly VoydBoundaryFieldSchema[];
+};
+
+export type ExternalFunctionRequirement = {
+  kind: "sync" | "async";
+  interfaceId: string;
+  functionName: string;
+  params: readonly VoydBoundarySchema[];
+  result: VoydBoundarySchema;
+  effect?: {
+    opId: number;
+    signatureHash: string;
+    resumeKind: "resume" | "tail";
+  };
+};
+
+export type ParsedExternalRequirements = {
+  version: number;
+  functions: readonly ExternalFunctionRequirement[];
+};
+
+const MSGPACK_OPTIONS = { useBigInt64: true } as const;
+const INVOCATION_CONTEXT: VoydPackageAdapterInvocationContext = Object.freeze({});
+
+export const parseExternalRequirements = (
+  module: WebAssembly.Module,
+): ParsedExternalRequirements => {
+  const sections = WebAssembly.Module.customSections(
+    module,
+    EXTERNAL_REQUIREMENTS_SECTION,
+  );
+  if (sections.length === 0) return { version: 0, functions: [] };
+  const parsed = JSON.parse(
+    new TextDecoder().decode(new Uint8Array(sections[0]!)),
+  ) as Partial<ParsedExternalRequirements>;
+  return {
+    version: typeof parsed.version === "number" ? parsed.version : 0,
+    functions: Array.isArray(parsed.functions) ? parsed.functions : [],
+  };
+};
+
+export const buildExternalImportModule = ({
+  requirements,
+  adapters,
+  bufferSize,
+  getInstance,
+}: {
+  requirements: ParsedExternalRequirements;
+  adapters: readonly VoydPackageAdapter[];
+  bufferSize: number;
+  getInstance: () => WebAssembly.Instance;
+}): WebAssembly.Imports => {
+  if (requirements.functions.length === 0) return {};
+  if (requirements.version !== 1) {
+    throw new Error(
+      `Unsupported Voyd external requirements version ${requirements.version}`,
+    );
+  }
+
+  const providers = buildProviderMap(
+    adapters,
+    new Set(requirements.functions.map((requirement) =>
+      externalFunctionKey(requirement.interfaceId, requirement.functionName),
+    )),
+  );
+  const imports: Record<string, CallableFunction | (() => number)> = {
+    [EXTERNAL_BUFFER_SIZE_IMPORT]: () => bufferSize,
+    [EXTERNAL_BUFFER_ERROR_IMPORT]: (() => {
+      throw new Error(
+        `Voyd external argument payload exceeds bufferSize ${bufferSize}; increase createVoydHost({ bufferSize })`,
+      );
+    }) as CallableFunction,
+  };
+  requirements.functions.filter((requirement) => requirement.kind !== "async").forEach((requirement) => {
+    const key = externalFunctionKey(
+      requirement.interfaceId,
+      requirement.functionName,
+    );
+    const provider = providers.get(key);
+    if (!provider) {
+      throw new Error(
+        `Missing Voyd package adapter for external function ${key}`,
+      );
+    }
+    assertCompatibleContract({ requirement, provider });
+    imports[key] = (inPtr: number, inLen: number, outPtr: number, outCap: number) => {
+      const memory = requireMemory(getInstance());
+      const argsValue = decode(
+        new Uint8Array(memory.buffer, inPtr, inLen),
+        MSGPACK_OPTIONS,
+      );
+      if (!Array.isArray(argsValue)) {
+        throw externalCallError(key, "arguments payload was not an array");
+      }
+      const args = decodeBoundaryArgs({
+        exportName: `external function ${key}`,
+        schemas: requirement.params,
+        args: argsValue,
+      });
+      let result: unknown;
+      try {
+        result = provider.fn.call(INVOCATION_CONTEXT, ...args);
+      } catch (cause) {
+        throw externalCallError(key, "adapter threw", cause);
+      }
+      if (isPromiseLike(result)) {
+        throw externalCallError(
+          key,
+          "returned a Promise from a synchronous external function",
+        );
+      }
+      const boundaryResult = encodeBoundaryArgs({
+        exportName: `external function ${key}`,
+        schemas: [requirement.result],
+        args: [result],
+      })[0];
+      const encoded = encode(boundaryResult, MSGPACK_OPTIONS) as Uint8Array;
+      if (encoded.length > outCap) {
+        throw externalCallError(
+          key,
+          `result requires ${encoded.length} bytes but bufferSize is ${bufferSize}; increase createVoydHost({ bufferSize })`,
+        );
+      }
+      new Uint8Array(memory.buffer, outPtr, encoded.length).set(encoded);
+      return encoded.length;
+    };
+  });
+  return { [EXTERNAL_IMPORT_MODULE]: imports };
+};
+
+export const registerExternalAdapterHandlers = ({
+  requirements,
+  adapters,
+  table,
+  registerHandler,
+}: {
+  requirements: ParsedExternalRequirements;
+  adapters: readonly VoydPackageAdapter[];
+  table: HostProtocolTable;
+  registerHandler: (
+    effectId: string,
+    opId: number,
+    signatureHash: string,
+    handler: EffectHandler,
+  ) => void;
+}): void => {
+  const asyncRequirements = requirements.functions.filter(
+    (requirement) => requirement.kind === "async",
+  );
+  if (asyncRequirements.length === 0) return;
+  const providers = buildProviderMap(
+    adapters,
+    new Set(requirements.functions.map((requirement) =>
+      externalFunctionKey(requirement.interfaceId, requirement.functionName),
+    )),
+  );
+  asyncRequirements.forEach((requirement) => {
+    const key = externalFunctionKey(requirement.interfaceId, requirement.functionName);
+    const effect = requirement.effect;
+    if (!effect) throw new Error(`External async function ${key} is missing effect metadata`);
+    const provider = providers.get(key);
+    if (!provider) throw new Error(`Missing Voyd package adapter for external function ${key}`);
+    assertCompatibleContract({ requirement, provider });
+    const descriptor = table.ops.find(
+      (op) =>
+        op.effectId === requirement.interfaceId &&
+        op.opId === effect.opId &&
+        op.signatureHash === effect.signatureHash,
+    );
+    if (!descriptor) throw new Error(`External async function ${key} has no matching effect operation`);
+    const handler: EffectHandler = async (
+      continuation: EffectContinuation,
+      ...rawArgs: unknown[]
+    ) => {
+      const args = decodeBoundaryArgs({
+        exportName: `external function ${key}`,
+        schemas: requirement.params,
+        args: rawArgs,
+      });
+      let value: unknown;
+      try {
+        value = await provider.fn.call(INVOCATION_CONTEXT, ...args);
+      } catch (cause) {
+        throw externalCallError(key, "adapter rejected", cause);
+      }
+      const result = encodeBoundaryArgs({
+        exportName: `external function ${key}`,
+        schemas: [requirement.result],
+        args: [value],
+      })[0];
+      return continuation[effect.resumeKind](result);
+    };
+    registerHandler(
+      requirement.interfaceId,
+      effect.opId,
+      effect.signatureHash,
+      handler,
+    );
+  });
+};
+
+const buildProviderMap = (
+  adapters: readonly VoydPackageAdapter[],
+  requiredKeys: ReadonlySet<string>,
+): Map<
+  string,
+  {
+    packageName: string;
+    contract: VoydPackageAdapter["contract"]["functions"][number];
+    fn: (this: VoydPackageAdapterInvocationContext, ...args: readonly unknown[]) => unknown;
+  }
+> => {
+  const providers = new Map<
+    string,
+    {
+      packageName: string;
+      contract: VoydPackageAdapter["contract"]["functions"][number];
+      fn: (this: VoydPackageAdapterInvocationContext, ...args: readonly unknown[]) => unknown;
+    }
+  >();
+  const interfaceProviders = new Map<string, string>();
+  adapters.forEach((adapter) => {
+    if (!isVoydPackageAdapter(adapter)) {
+      throw new Error("Unsupported or malformed Voyd package adapter ABI");
+    }
+    const requiredInterfaces = new Set(
+      adapter.contract.functions
+        .filter((contract) => requiredKeys.has(externalFunctionKey(contract.interfaceId, contract.functionName)))
+        .map(({ interfaceId }) => interfaceId),
+    );
+    requiredInterfaces.forEach((interfaceId) => {
+      const existing = interfaceProviders.get(interfaceId);
+      if (existing) {
+        throw new Error(
+          `Multiple Voyd package adapters provide interface ${interfaceId}: ${existing}, ${adapter.contract.packageName}`,
+        );
+      }
+      interfaceProviders.set(interfaceId, adapter.contract.packageName);
+    });
+    adapter.contract.functions.forEach((contract) => {
+      const key = externalFunctionKey(contract.interfaceId, contract.functionName);
+      if (!requiredKeys.has(key)) return;
+      if (providers.has(key)) {
+        throw new Error(`Multiple Voyd package adapters provide ${key}`);
+      }
+      const implementation = adapter.implementation[contract.interfaceId]?.[contract.functionName];
+      const fn = implementation as
+        | ((this: VoydPackageAdapterInvocationContext, ...args: readonly unknown[]) => unknown)
+        | undefined;
+      if (!fn) {
+        throw new Error(
+          `Voyd package adapter ${adapter.contract.packageName} is missing ${key}`,
+        );
+      }
+      providers.set(key, {
+        packageName: adapter.contract.packageName,
+        contract,
+        fn,
+      });
+    });
+  });
+  return providers;
+};
+
+const assertCompatibleContract = ({
+  requirement,
+  provider,
+}: {
+  requirement: ExternalFunctionRequirement;
+  provider: {
+    packageName: string;
+    contract: VoydPackageAdapter["contract"]["functions"][number];
+  };
+}): void => {
+  const expected = canonicalContract({
+    kind: requirement.kind,
+    params: requirement.params,
+    result: requirement.result,
+  });
+  const actual = canonicalContract(provider.contract);
+  if (expected !== actual) {
+    const key = externalFunctionKey(
+      requirement.interfaceId,
+      requirement.functionName,
+    );
+    throw new Error(
+      `Voyd package adapter ${provider.packageName} has an incompatible contract for ${key}`,
+    );
+  }
+};
+
+const canonicalContract = ({
+  kind,
+  params,
+  result,
+}: {
+  kind: "sync" | "async";
+  params: readonly (VoydBoundarySchema | VoydDtoSchema)[];
+  result: VoydBoundarySchema | VoydDtoSchema;
+}): string => {
+  const normalizedIds = new Map<number, number>();
+  let nextId = 1;
+  const normalizeId = (typeId: number): number => {
+    const existing = normalizedIds.get(typeId);
+    if (existing !== undefined) return existing;
+    const created = nextId++;
+    normalizedIds.set(typeId, created);
+    return created;
+  };
+  const runtimeSchemas = new Map<number, VoydBoundarySchema>();
+  const register = (schema: VoydBoundarySchema | VoydDtoSchema): void => {
+    if (schema.kind === "ref") {
+      normalizeId(schema.typeId);
+      return;
+    }
+    if (
+      (schema.kind === "array" || schema.kind === "record" || schema.kind === "union") &&
+      "typeId" in schema &&
+      schema.typeId !== undefined
+    ) {
+      const canonical = normalizeId(schema.typeId);
+      runtimeSchemas.set(schema.typeId, schema);
+      schema.aliases?.forEach((alias) => {
+        normalizedIds.set(alias, canonical);
+        runtimeSchemas.set(alias, schema);
+      });
+    }
+    if (schema.kind === "array") register(schema.element);
+    if (schema.kind === "record") schema.fields.forEach((field) => register(field.schema));
+    if (schema.kind === "union") {
+      schema.variants.forEach((variant) => variant.fields.forEach((field) => register(field.schema)));
+    }
+  };
+  [...params, result].forEach(register);
+  return JSON.stringify({
+    kind,
+    params: params.map((schema) => canonicalSchema(schema, normalizeId, runtimeSchemas)),
+    result: canonicalSchema(result, normalizeId, runtimeSchemas),
+  });
+};
+
+const canonicalSchema = (
+  schema: VoydBoundarySchema | VoydDtoSchema,
+  normalizeId: (typeId: number) => number,
+  runtimeSchemas?: ReadonlyMap<number, VoydBoundarySchema>,
+): unknown => {
+  switch (schema.kind) {
+    case "array":
+      return { kind: schema.kind, element: canonicalSchema(schema.element, normalizeId, runtimeSchemas) };
+    case "record":
+      return {
+        kind: schema.kind,
+        tag: schema.tag,
+        fields: schema.fields.map((field) => ({
+          name: field.name,
+          optional: field.optional === true,
+          schema: canonicalSchema(field.schema, normalizeId, runtimeSchemas),
+        })),
+      };
+    case "union":
+      return {
+        kind: schema.kind,
+        variants: schema.variants.map((variant) => ({
+          name: variant.name,
+          fields: variant.fields.map((field) => ({
+            name: field.name,
+            optional: field.optional === true,
+            schema: canonicalSchema(field.schema, normalizeId, runtimeSchemas),
+          })),
+        })),
+      };
+    case "ref": {
+      const target = runtimeSchemas?.get(schema.typeId);
+      return target
+        ? canonicalSchema(target, normalizeId, runtimeSchemas)
+        : { kind: schema.kind, typeId: normalizeId(schema.typeId) };
+    }
+    default:
+      return { kind: schema.kind };
+  }
+};
+
+const requireMemory = (instance: WebAssembly.Instance): WebAssembly.Memory => {
+  const memory = instance.exports.memory;
+  if (!(memory instanceof WebAssembly.Memory)) {
+    throw new Error("Voyd external function requires exported memory");
+  }
+  return memory;
+};
+
+const isPromiseLike = (value: unknown): value is PromiseLike<unknown> =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as { then?: unknown }).then === "function";
+
+const externalCallError = (
+  key: string,
+  message: string,
+  cause?: unknown,
+): Error => {
+  const error = new Error(`Voyd external function ${key} ${message}`);
+  if (cause !== undefined) (error as Error & { cause?: unknown }).cause = cause;
+  return error;
+};

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -1,0 +1,45 @@
+# `@voyd-lang/markdown`
+
+JS-backed Markdown rendering for Voyd. The package uses `marked` to produce a
+restricted static-node DTO. Raw HTML becomes text and active link and image URL
+schemes are rejected. No HTML string or DOM object crosses the adapter boundary.
+
+```bash
+npm install @voyd-lang/markdown
+```
+
+Use the renderer without VX:
+
+```voyd
+use pkg::markdown::{ StaticHtml, to_static }
+
+pub fn main() -> StaticHtml
+  to_static("# Hello")
+```
+
+Or use its ordinary Voyd VX component:
+
+```voyd
+use pkg::markdown::Markdown
+use std::vx::all
+
+fn Article({ source: String }) -> Html<AppMsg>
+  <article class="wiki-article">
+    <Markdown source={source} />
+  </article>
+```
+
+For custom browser embedding, import the adapter and pass it to the host:
+
+```ts
+import markdownAdapter from "@voyd-lang/markdown/adapter";
+
+const host = await createVoydHost({ wasm, adapters: [markdownAdapter] });
+```
+
+The CLI and generated application registry can discover this adapter from the
+package metadata automatically.
+
+The VX wrapper converts the static DTO into ordinary VX text, fragment, element,
+and attribute nodes. VX validates and diffs the result normally; there is no
+`innerHTML` escape hatch.

--- a/packages/markdown/generated/contract.json
+++ b/packages/markdown/generated/contract.json
@@ -1,0 +1,94 @@
+{
+  "abiVersion": 1,
+  "packageName": "@voyd-lang/markdown",
+  "interfaces": [
+    {
+      "interfaceId": "voyd:markdown/renderer@1",
+      "fingerprint": "b2e5a88fd08cff73"
+    }
+  ],
+  "functions": [
+    {
+      "kind": "sync",
+      "interfaceId": "voyd:markdown/renderer@1",
+      "functionName": "render_static",
+      "params": [
+        {
+          "kind": "string"
+        }
+      ],
+      "result": {
+        "kind": "record",
+        "fields": [
+          {
+            "name": "nodes",
+            "schema": {
+              "kind": "array",
+              "element": {
+                "kind": "record",
+                "fields": [
+                  {
+                    "name": "attrs",
+                    "schema": {
+                      "kind": "array",
+                      "element": {
+                        "kind": "record",
+                        "fields": [
+                          {
+                            "name": "name",
+                            "schema": {
+                              "kind": "string"
+                            }
+                          },
+                          {
+                            "name": "value",
+                            "schema": {
+                              "kind": "string"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "name": "children",
+                    "schema": {
+                      "kind": "array",
+                      "element": {
+                        "kind": "i32"
+                      }
+                    }
+                  },
+                  {
+                    "name": "kind",
+                    "schema": {
+                      "kind": "string"
+                    }
+                  },
+                  {
+                    "name": "tag",
+                    "schema": {
+                      "kind": "string"
+                    }
+                  },
+                  {
+                    "name": "value",
+                    "schema": {
+                      "kind": "string"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "root",
+            "schema": {
+              "kind": "i32"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/markdown/generated/contract.ts
+++ b/packages/markdown/generated/contract.ts
@@ -1,0 +1,96 @@
+import type { VoydPackageAdapterContract } from "@voyd-lang/package-adapter";
+
+export const contract = {
+  "abiVersion": 1,
+  "packageName": "@voyd-lang/markdown",
+  "interfaces": [
+    {
+      "interfaceId": "voyd:markdown/renderer@1",
+      "fingerprint": "b2e5a88fd08cff73"
+    }
+  ],
+  "functions": [
+    {
+      "kind": "sync",
+      "interfaceId": "voyd:markdown/renderer@1",
+      "functionName": "render_static",
+      "params": [
+        {
+          "kind": "string"
+        }
+      ],
+      "result": {
+        "kind": "record",
+        "fields": [
+          {
+            "name": "nodes",
+            "schema": {
+              "kind": "array",
+              "element": {
+                "kind": "record",
+                "fields": [
+                  {
+                    "name": "attrs",
+                    "schema": {
+                      "kind": "array",
+                      "element": {
+                        "kind": "record",
+                        "fields": [
+                          {
+                            "name": "name",
+                            "schema": {
+                              "kind": "string"
+                            }
+                          },
+                          {
+                            "name": "value",
+                            "schema": {
+                              "kind": "string"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "name": "children",
+                    "schema": {
+                      "kind": "array",
+                      "element": {
+                        "kind": "i32"
+                      }
+                    }
+                  },
+                  {
+                    "name": "kind",
+                    "schema": {
+                      "kind": "string"
+                    }
+                  },
+                  {
+                    "name": "tag",
+                    "schema": {
+                      "kind": "string"
+                    }
+                  },
+                  {
+                    "name": "value",
+                    "schema": {
+                      "kind": "string"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "root",
+            "schema": {
+              "kind": "i32"
+            }
+          }
+        ]
+      }
+    }
+  ]
+} as const satisfies VoydPackageAdapterContract;

--- a/packages/markdown/generated/interface.wit
+++ b/packages/markdown/generated/interface.wit
@@ -1,0 +1,24 @@
+package voyd:markdown@1.0.0;
+
+interface renderer {
+  record type-205dd88c1c3a4170 {
+    attrs: type-f6707c0e97695e72,
+    children: type-3761ea7248d03056,
+    kind: string,
+    tag: string,
+    value: string,
+  }
+  type type-3761ea7248d03056 = list<s32>;
+  record type-4a5ccd431996f5e7 {
+    name: string,
+    value: string,
+  }
+  record type-880476ac6a208990 {
+    nodes: type-cdce12171121a6f3,
+    root: s32,
+  }
+  type type-cdce12171121a6f3 = list<type-205dd88c1c3a4170>;
+  type type-f6707c0e97695e72 = list<type-4a5ccd431996f5e7>;
+
+  render-static: func(arg0: string) -> type-880476ac6a208990;
+}

--- a/packages/markdown/generated/voyd-adapter.ts
+++ b/packages/markdown/generated/voyd-adapter.ts
@@ -1,0 +1,12 @@
+import { defineVoydPackageAdapter } from "@voyd-lang/package-adapter";
+import type { VoydPackageAdapterInvocationContext } from "@voyd-lang/package-adapter";
+import { contract } from "./contract.js";
+
+export type AdapterImplementation = {
+  readonly "voyd:markdown/renderer@1": {
+    readonly "render_static": (this: VoydPackageAdapterInvocationContext, arg0: string) => { "nodes": readonly { "attrs": readonly { "name": string; "value": string }[]; "children": readonly number[]; "kind": string; "tag": string; "value": string }[]; "root": number };
+  };
+};
+
+export const defineAdapter = (implementation: AdapterImplementation) =>
+  defineVoydPackageAdapter(contract, implementation);

--- a/packages/markdown/host/adapter.test.ts
+++ b/packages/markdown/host/adapter.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import adapter, { renderMarkdown } from "./adapter.js";
+
+describe("markdown package adapter", () => {
+  it("renders common Markdown through the package contract", () => {
+    const rendered = renderMarkdown("# Wiki\n\n**Voyd**");
+    expect(rendered.nodes.some((node) => node.tag === "h1")).toBe(true);
+    expect(rendered.nodes.some((node) => node.tag === "strong")).toBe(true);
+    expect(rendered.nodes.some((node) => node.value === "Voyd")).toBe(true);
+    expect(adapter.contract.packageName).toBe("@voyd-lang/markdown");
+  });
+
+  it("escapes raw HTML and blocks active URL schemes", () => {
+    const rendered = renderMarkdown(
+      '<script>alert(1)</script>\n\n[bad](javascript:alert(1)) ![bad](data:text/html,x)',
+    );
+
+    expect(rendered.nodes.some((node) => node.tag === "script")).toBe(false);
+    expect(rendered.nodes.some((node) => node.value.includes("<script>"))).toBe(true);
+    const attrs = rendered.nodes.flatMap((node) => node.attrs);
+    expect(attrs.some((attr) => attr.value.startsWith("javascript:"))).toBe(false);
+    expect(attrs.some((attr) => attr.value.startsWith("data:"))).toBe(false);
+    expect(attrs.filter((attr) => attr.name === "href" || attr.name === "src").map((attr) => attr.value)).toEqual(["#", "#"]);
+  });
+
+  it("renders GFM tables into static table nodes", () => {
+    const rendered = renderMarkdown("| A | B |\n|:---|---:|\n| 1 | 2 |");
+    expect(rendered.nodes.some((node) => node.tag === "table")).toBe(true);
+    expect(rendered.nodes.filter((node) => node.tag === "th")).toHaveLength(2);
+    expect(rendered.nodes.filter((node) => node.tag === "td")).toHaveLength(2);
+    expect(rendered.nodes.find((node) => node.tag === "th")?.attrs).toContainEqual({ name: "align", value: "left" });
+  });
+
+  it("preserves fenced-code language metadata", () => {
+    const rendered = renderMarkdown("```js\nconst answer = 42;\n```");
+    expect(rendered.nodes.find((node) => node.tag === "code")?.attrs)
+      .toContainEqual({ name: "class", value: "language-js" });
+  });
+
+  it("preserves GFM task-list checked state", () => {
+    const rendered = renderMarkdown("- [x] done\n- [ ] todo");
+    const inputs = rendered.nodes.filter((node) => node.tag === "input");
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0]?.attrs.some((attr) => attr.name === "checked")).toBe(true);
+    expect(inputs[1]?.attrs.some((attr) => attr.name === "checked")).toBe(false);
+  });
+
+  it("preserves paragraph structure in loose lists", () => {
+    const rendered = renderMarkdown("- first\n\n- second");
+    const paragraphs = rendered.nodes.filter((node) => node.tag === "p");
+    expect(paragraphs).toHaveLength(2);
+  });
+
+  it("decodes Marked entities before creating inert text and URL attributes", () => {
+    const rendered = renderMarkdown("2 < 3 &amp; 4 &copy; &nbsp; &#0; [link &amp; label](https://example.test/?a=1&amp;b=2)");
+    expect(rendered.nodes.some((node) => node.value.includes("2 < 3 & 4"))).toBe(true);
+    expect(rendered.nodes.some((node) => node.value.includes("link & label"))).toBe(true);
+    expect(rendered.nodes.some((node) => node.value.includes("© \u00a0 �"))).toBe(true);
+    expect(rendered.nodes.flatMap((node) => node.attrs)).toContainEqual({
+      name: "href",
+      value: "https://example.test/?a=1&b=2",
+    });
+  });
+
+  it("rejects hostile nesting with a controlled error", () => {
+    expect(() => renderMarkdown(`${"> ".repeat(5000)}x`))
+      .toThrow(/Markdown nesting exceeds/);
+  });
+});

--- a/packages/markdown/host/adapter.ts
+++ b/packages/markdown/host/adapter.ts
@@ -1,0 +1,258 @@
+import { marked } from "marked";
+import { decodeHTML } from "entities";
+import { defineAdapter } from "../generated/voyd-adapter.js";
+
+export type StaticHtmlAttr = { name: string; value: string };
+export type StaticHtmlNode = {
+  kind: "text" | "element" | "fragment";
+  tag: string;
+  value: string;
+  attrs: StaticHtmlAttr[];
+  children: number[];
+};
+export type StaticHtml = { root: number; nodes: StaticHtmlNode[] };
+
+type MarkdownToken = {
+  type: string;
+  raw?: string;
+  text?: string;
+  depth?: number;
+  href?: string;
+  title?: string | null;
+  ordered?: boolean;
+  start?: number | "";
+  tokens?: MarkdownToken[];
+  items?: MarkdownToken[];
+  header?: MarkdownToken[];
+  rows?: MarkdownToken[][];
+  task?: boolean;
+  checked?: boolean;
+  lang?: string;
+  align?: Array<"left" | "center" | "right" | null>;
+  loose?: boolean;
+};
+
+type TreeNode = {
+  kind: StaticHtmlNode["kind"];
+  tag?: string;
+  value?: string;
+  attrs?: StaticHtmlAttr[];
+  children?: TreeNode[];
+};
+
+const MAX_SOURCE_LENGTH = 2_000_000;
+const MAX_TOKEN_DEPTH = 64;
+const MAX_TOKEN_COUNT = 50_000;
+
+export const renderMarkdown = (source: string): StaticHtml => {
+  if (source.length > MAX_SOURCE_LENGTH) {
+    throw new Error(`Markdown source exceeds ${MAX_SOURCE_LENGTH} characters`);
+  }
+  const tokens = marked.lexer(source, { gfm: true }) as unknown as MarkdownToken[];
+  assertTokenBudget(tokens);
+  return flattenTree({ kind: "fragment", children: renderBlocks(tokens) });
+};
+
+export default defineAdapter({
+  "voyd:markdown/renderer@1": {
+    render_static: renderMarkdown,
+  },
+});
+
+const renderBlocks = (tokens: readonly MarkdownToken[]): TreeNode[] =>
+  tokens.flatMap((token) => renderBlock(token));
+
+const assertTokenBudget = (tokens: readonly MarkdownToken[]): void => {
+  const pending = tokens.map((token) => ({ token, depth: 1 }));
+  let count = 0;
+  while (pending.length > 0) {
+    const { token, depth } = pending.pop()!;
+    count += 1;
+    if (depth > MAX_TOKEN_DEPTH) {
+      throw new Error(`Markdown nesting exceeds ${MAX_TOKEN_DEPTH} levels`);
+    }
+    if (count > MAX_TOKEN_COUNT) {
+      throw new Error(`Markdown document exceeds ${MAX_TOKEN_COUNT} tokens`);
+    }
+    const nested = [
+      ...(Array.isArray(token.tokens) ? token.tokens : []),
+      ...(Array.isArray(token.items) ? token.items : []),
+      ...(Array.isArray(token.header) ? token.header : []),
+      ...(Array.isArray(token.rows) ? token.rows.flat() : []),
+    ];
+    nested.forEach((child) => pending.push({ token: child, depth: depth + 1 }));
+  }
+};
+
+const renderBlock = (token: MarkdownToken): TreeNode[] => {
+  switch (token.type) {
+    case "space":
+      return [];
+    case "heading":
+      return [element(`h${clampHeading(token.depth)}`, renderInline(token))];
+    case "paragraph":
+      return [element("p", renderInline(token))];
+    case "text":
+      return token.tokens ? renderInline(token) : [text(decodeHtmlEntities(token.text ?? ""))];
+    case "code":
+      return [element("pre", [element(
+        "code",
+        [text(token.text ?? "")],
+        token.lang ? [{ name: "class", value: `language-${token.lang.split(/\s+/)[0]}` }] : [],
+      )])];
+    case "blockquote":
+      return [element("blockquote", renderBlocks(token.tokens ?? []))];
+    case "list": {
+      const tag = token.ordered ? "ol" : "ul";
+      const attrs = token.ordered && typeof token.start === "number" && token.start !== 1
+        ? [{ name: "start", value: String(token.start) }]
+        : [];
+      const items = token.items ?? [];
+      const listAttrs = items.some((item) => item.task)
+        ? [...attrs, { name: "class", value: "contains-task-list" }]
+        : attrs;
+      return [element(tag, items.map(renderListItem), listAttrs)];
+    }
+    case "hr":
+      return [element("hr")];
+    case "table":
+      return [renderTable(token)];
+    case "html":
+      return [text(token.raw ?? token.text ?? "")];
+    default:
+      return token.tokens ? renderBlocks(token.tokens) : [text(token.text ?? "")];
+  }
+};
+
+const renderListItem = (token: MarkdownToken): TreeNode =>
+  element(
+    "li",
+    [
+      ...(token.task
+        ? [element("input", [], [
+            { name: "type", value: "checkbox" },
+            { name: "disabled", value: "" },
+            ...(token.checked ? [{ name: "checked", value: "" }] : []),
+          ])]
+        : []),
+      ...(token.tokens ?? []).flatMap((child) =>
+        token.loose && child.type === "text"
+          ? [element("p", renderInline(child))]
+          : renderBlock(child),
+      ),
+    ],
+    token.task ? [{ name: "class", value: "task-list-item" }] : [],
+  );
+
+const renderInline = (token: MarkdownToken): TreeNode[] =>
+  (token.tokens ?? [{ type: "text", text: token.text ?? "" }]).flatMap(renderInlineToken);
+
+const renderInlineToken = (token: MarkdownToken): TreeNode[] => {
+  switch (token.type) {
+    case "text":
+    case "escape":
+      return [text(decodeHtmlEntities(token.text ?? ""))];
+    case "strong":
+      return [element("strong", renderInline(token))];
+    case "em":
+      return [element("em", renderInline(token))];
+    case "del":
+      return [element("del", renderInline(token))];
+    case "codespan":
+      return [element("code", [text(token.text ?? "")])];
+    case "br":
+      return [element("br")];
+    case "link":
+      return [element("a", renderInline(token), linkAttrs(token, "href"))];
+    case "image":
+      return [element("img", [], [
+        { name: "src", value: safeUrl(decodeHtmlEntities(token.href ?? "")) },
+        { name: "alt", value: decodeHtmlEntities(token.text ?? "") },
+        ...titleAttr(token.title),
+      ])];
+    case "html":
+      return [text(token.raw ?? token.text ?? "")];
+    default:
+      return token.tokens ? renderInline(token) : [text(token.text ?? "")];
+  }
+};
+
+const renderTable = (token: MarkdownToken): TreeNode => {
+  const cellAttrs = (index: number): StaticHtmlAttr[] => {
+    const alignment = token.align?.[index];
+    return alignment ? [{ name: "align", value: alignment }] : [];
+  };
+  const header = element(
+    "thead",
+    [element("tr", (token.header ?? []).map((cell, index) =>
+      element("th", renderInline(cell), cellAttrs(index)),
+    ))],
+  );
+  const body = element(
+    "tbody",
+    (token.rows ?? []).map((row) =>
+      element("tr", row.map((cell, index) =>
+        element("td", renderInline(cell), cellAttrs(index)),
+      )),
+    ),
+  );
+  return element("table", [header, body]);
+};
+
+const element = (
+  tag: string,
+  children: TreeNode[] = [],
+  attrs: StaticHtmlAttr[] = [],
+): TreeNode => ({ kind: "element", tag, attrs, children });
+
+const text = (value: string): TreeNode => ({ kind: "text", value });
+
+const linkAttrs = (token: MarkdownToken, name: string): StaticHtmlAttr[] => [
+  { name, value: safeUrl(decodeHtmlEntities(token.href ?? "")) },
+  ...titleAttr(token.title),
+];
+
+const titleAttr = (title: string | null | undefined): StaticHtmlAttr[] =>
+  title ? [{ name: "title", value: decodeHtmlEntities(title) }] : [];
+
+const clampHeading = (value: number | undefined): number =>
+  Math.max(1, Math.min(6, value ?? 1));
+
+const flattenTree = (root: TreeNode): StaticHtml => {
+  const nodes: StaticHtmlNode[] = [];
+  const visit = (node: TreeNode): number => {
+    const index = nodes.length;
+    nodes.push({ kind: "text", tag: "", value: "", attrs: [], children: [] });
+    const children = (node.children ?? []).map(visit);
+    nodes[index] = {
+      kind: node.kind,
+      tag: node.tag ?? "",
+      value: node.value ?? "",
+      attrs: node.attrs ?? [],
+      children,
+    };
+    return index;
+  };
+  return { root: visit(root), nodes };
+};
+
+const safeUrl = (value: string): string => {
+  const normalized = decodeUrlForSchemeCheck(value)
+    .replace(/[\u0000-\u0020\u007f]/g, "")
+    .toLowerCase();
+  return normalized.startsWith("javascript:") ||
+    normalized.startsWith("vbscript:") ||
+    normalized.startsWith("data:")
+    ? "#"
+    : value;
+};
+
+const decodeUrlForSchemeCheck = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+const decodeHtmlEntities = (value: string): string => decodeHTML(value);

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@voyd-lang/markdown",
+  "version": "0.2.0",
+  "description": "JS-backed Markdown rendering for Voyd and VX",
+  "type": "module",
+  "main": "./dist/host/adapter.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyd-lang/voyd"
+  },
+  "files": [
+    "src",
+    "dist",
+    "generated"
+  ],
+  "exports": {
+    "./adapter": {
+      "types": "./dist/host/adapter.d.ts",
+      "development": "./host/adapter.ts",
+      "import": "./dist/host/adapter.js",
+      "default": "./dist/host/adapter.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "voyd": {
+    "source": "./src/pkg.voyd",
+    "adapter": {
+      "abi": 1,
+      "interfaces": [
+        "voyd:markdown/renderer@1"
+      ],
+      "browser": "./adapter",
+      "node": "./adapter",
+      "default": "./adapter"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist",
+    "generate": "voyd generate adapter ./src --out ./generated",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run --config ../../vitest.config.ts host --passWithNoTests",
+    "lint": "echo 'no lint configured'",
+    "prepack": "npm run generate && npm run clean && npm run build",
+    "prepublishOnly": "node ../../scripts/release/enforce-workspace-release.mjs"
+  },
+  "dependencies": {
+    "@voyd-lang/package-adapter": "^0.2.0",
+    "@voyd-lang/std": "^0.2.0",
+    "entities": "^4.5.0",
+    "marked": "^14.0.0"
+  }
+}

--- a/packages/markdown/src/external.voyd
+++ b/packages/markdown/src/external.voyd
@@ -1,0 +1,24 @@
+use std::string::type::String
+use std::array::Array
+
+pub type StaticHtmlAttr = {
+  name: String,
+  value: String
+}
+
+pub type StaticHtmlNode = {
+  kind: String,
+  tag: String,
+  value: String,
+  attrs: Array<StaticHtmlAttr>,
+  children: Array<i32>
+}
+
+pub type StaticHtml = {
+  root: i32,
+  nodes: Array<StaticHtmlNode>
+}
+
+// Parses Markdown into a restricted, inert static HTML tree.
+@external(id: "voyd:markdown/renderer@1")
+pub fn render_static(source: String) -> StaticHtml

--- a/packages/markdown/src/markdown.voyd
+++ b/packages/markdown/src/markdown.voyd
@@ -1,0 +1,47 @@
+use std::string::type::{ String, StringSlice }
+use std::array::Array
+use std::vx::{ HtmlNode, attr, element, fragment, text }
+use super::external::{ StaticHtml, StaticHtmlNode, render_static }
+
+/// Renders Markdown as a VX component.
+pub fn Markdown({ source: String }) -> HtmlNode
+  from_static(render_static(source))
+
+/// Renders Markdown from a string slice as a VX component.
+pub fn Markdown({ source: StringSlice }) -> HtmlNode
+  Markdown(source: source.to_string())
+
+/// Parses Markdown without coupling the caller to VX.
+pub fn to_static(source: String) -> StaticHtml
+  render_static(source)
+
+/// Renders a Markdown string slice to sanitized HTML.
+pub fn to_static(source: StringSlice) -> StaticHtml
+  to_static(source.to_string())
+
+fn from_static(value: StaticHtml): () -> HtmlNode
+  render_node(value.nodes, value.root)
+
+fn render_node(nodes: Array<StaticHtmlNode>, index: i32): () -> HtmlNode
+  if index < 0 || index >= nodes.len():
+    return text("")
+  let node = nodes.at(index)
+  if node.kind == "text":
+    return text(node.value)
+
+  let ~children = Array<HtmlNode>::with_capacity(node.children.len())
+  var child_index = 0
+  while child_index < node.children.len():
+    children.push(render_node(nodes, node.children.at(child_index)))
+    child_index = child_index + 1
+
+  if node.kind == "fragment":
+    return fragment(children)
+
+  let ~attrs = Array<HtmlNode>::with_capacity(node.attrs.len())
+  var attr_index = 0
+  while attr_index < node.attrs.len():
+    let item = node.attrs.at(attr_index)
+    attrs.push(attr(name: item.name, value: item.value))
+    attr_index = attr_index + 1
+  element(tag: node.tag, attrs: attrs, children: children)

--- a/packages/markdown/src/pkg.voyd
+++ b/packages/markdown/src/pkg.voyd
@@ -1,0 +1,7 @@
+//! JS-backed Markdown rendering and optional VX integration.
+
+pub self::external
+pub self::markdown
+
+pub use self::external::{ StaticHtml, StaticHtmlAttr, StaticHtmlNode, render_static }
+pub use self::markdown::{ Markdown, to_static }

--- a/packages/markdown/tsconfig.build.json
+++ b/packages/markdown/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["host/**/*", "generated/**/*"],
+  "exclude": ["host/**/*.test.ts"]
+}

--- a/packages/markdown/tsconfig.json
+++ b/packages/markdown/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.dev.json",
+  "include": ["host/**/*", "generated/**/*"]
+}

--- a/packages/package-adapter/README.md
+++ b/packages/package-adapter/README.md
@@ -1,0 +1,28 @@
+# `@voyd-lang/package-adapter`
+
+Defines the host-language descriptor used to implement Voyd external package
+interfaces. It is deliberately independent of VX, the compiler, and the host
+runtime.
+
+Package authors normally generate a typed `defineAdapter` helper:
+
+```bash
+voyd generate adapter ./src --out ./generated
+```
+
+```ts
+import { defineAdapter } from "./generated/voyd-adapter.js";
+
+export default defineAdapter({
+  "example:text/format@1": {
+    format(value) {
+      return value.trim();
+    },
+  },
+});
+```
+
+The lower-level `defineVoydPackageAdapter(contract, implementation)` API checks
+the ABI version and requires an exact implementation for every declared sync or
+async function. It returns a deeply frozen descriptor and performs no global
+registration or Wasm instantiation.

--- a/packages/package-adapter/package.json
+++ b/packages/package-adapter/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@voyd-lang/package-adapter",
+  "version": "0.2.0",
+  "description": "Host-language adapter contracts for Voyd packages",
+  "type": "module",
+  "main": "./dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyd-lang/voyd"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "development": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run --config ../../vitest.config.ts src --passWithNoTests",
+    "lint": "echo 'no lint configured'",
+    "prepack": "npm run clean && npm run build",
+    "prepublishOnly": "node ../../scripts/release/enforce-workspace-release.mjs"
+  }
+}

--- a/packages/package-adapter/src/index.test.ts
+++ b/packages/package-adapter/src/index.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { defineVoydPackageAdapter } from "./index.js";
+
+const contract = {
+  abiVersion: 1 as const,
+  packageName: "example",
+  functions: [
+    {
+      kind: "sync" as const,
+      interfaceId: "example:math/ops@1",
+      functionName: "double",
+      params: [{ kind: "i32" as const }],
+      result: { kind: "i32" as const },
+    },
+  ],
+};
+
+describe("defineVoydPackageAdapter", () => {
+  it("defines an immutable descriptor for a complete implementation", () => {
+    const adapter = defineVoydPackageAdapter(contract, {
+      "example:math/ops@1": { double: (value: number) => value * 2 },
+    });
+
+    expect(adapter.kind).toBe("voyd-package-adapter");
+    expect(adapter.contract).toMatchObject(contract);
+    expect(adapter.contract.interfaces).toHaveLength(1);
+    expect(Object.isFrozen(adapter)).toBe(true);
+  });
+
+  it("rejects missing and unknown functions", () => {
+    expect(() => defineVoydPackageAdapter(contract, {})).toThrow(/missing external functions/);
+    expect(() =>
+      defineVoydPackageAdapter(contract, {
+        "example:math/ops@1": {
+          double: (value: number) => value * 2,
+          triple: (value: number) => value * 3,
+        },
+      }),
+    ).toThrow(/unknown external function/);
+  });
+});

--- a/packages/package-adapter/src/index.ts
+++ b/packages/package-adapter/src/index.ts
@@ -1,0 +1,223 @@
+export const VOYD_PACKAGE_ADAPTER_ABI = 1 as const;
+
+/** Stable, transport-neutral schema written to generated adapter contracts. */
+export type VoydDtoSchema =
+  | { kind: "bool" | "i32" | "i64" | "f32" | "f64" | "void" | "string" }
+  | { kind: "array"; element: VoydDtoSchema }
+  | {
+      kind: "record";
+      tag?: string;
+      fields: readonly VoydDtoFieldSchema[];
+    }
+  | {
+      kind: "union";
+      variants: readonly VoydDtoVariantSchema[];
+    };
+
+export type VoydDtoFieldSchema = {
+  name: string;
+  schema: VoydDtoSchema;
+  optional?: boolean;
+};
+
+export type VoydDtoVariantSchema = {
+  name: string;
+  fields: readonly VoydDtoFieldSchema[];
+};
+
+export type VoydExternalFunctionContract = {
+  kind: "sync" | "async";
+  interfaceId: string;
+  functionName: string;
+  params: readonly VoydDtoSchema[];
+  result: VoydDtoSchema;
+};
+
+export type VoydPackageAdapterContract = {
+  abiVersion: typeof VOYD_PACKAGE_ADAPTER_ABI;
+  packageName: string;
+  interfaces: readonly VoydExternalInterfaceContract[];
+  functions: readonly VoydExternalFunctionContract[];
+};
+
+export type VoydPackageAdapterContractInput = Omit<
+  VoydPackageAdapterContract,
+  "interfaces"
+> & { interfaces?: readonly VoydExternalInterfaceContract[] };
+
+export type VoydExternalInterfaceContract = {
+  interfaceId: string;
+  /** Fingerprint of every function in this versioned interface. */
+  fingerprint: string;
+};
+
+/** Host-owned capabilities available to adapter calls without coupling adapters to VX. */
+export type VoydPackageAdapterInvocationContext = Readonly<{
+  signal?: AbortSignal;
+  resources?: VoydPackageAdapterResourceStore;
+}>;
+
+/** Opaque resource table reserved for resource handles in future component-model adapters. */
+export type VoydPackageAdapterResourceStore = Readonly<{
+  get(handle: number): unknown;
+}>;
+
+export type VoydExternalFunction = (
+  this: VoydPackageAdapterInvocationContext,
+  ...args: never[]
+) => unknown;
+
+export type VoydPackageAdapterImplementation = Readonly<
+  Record<string, Readonly<Record<string, VoydExternalFunction>>>
+>;
+
+export type VoydPackageAdapter = Readonly<{
+  kind: "voyd-package-adapter";
+  contract: VoydPackageAdapterContract;
+  implementation: VoydPackageAdapterImplementation;
+}>;
+
+export const defineVoydPackageAdapter = (
+  input: VoydPackageAdapterContractInput,
+  implementation: VoydPackageAdapterImplementation,
+): VoydPackageAdapter => {
+  const contract: VoydPackageAdapterContract = {
+    ...input,
+    interfaces: input.interfaces ?? interfaceContractsFor(input.functions),
+  };
+  validateContract(contract);
+  const expected = new Set(
+    contract.functions.map(({ interfaceId, functionName }) =>
+      functionKey(interfaceId, functionName),
+    ),
+  );
+  const actual = new Set<string>();
+  Object.entries(implementation).forEach(([interfaceId, functions]) => {
+    Object.entries(functions).forEach(([functionName, fn]) => {
+      if (typeof fn !== "function") {
+        throw new TypeError(
+          `Voyd package adapter ${contract.packageName} ${functionKey(interfaceId, functionName)} must be a function`,
+        );
+      }
+      const key = functionKey(interfaceId, functionName);
+      if (!expected.has(key)) {
+        throw new Error(
+          `Voyd package adapter ${contract.packageName} implements unknown external function ${key}`,
+        );
+      }
+      actual.add(key);
+    });
+  });
+  const missing = [...expected].filter((key) => !actual.has(key));
+  if (missing.length > 0) {
+    throw new Error(
+      `Voyd package adapter ${contract.packageName} is missing external functions: ${missing.join(", ")}`,
+    );
+  }
+  return Object.freeze({
+    kind: "voyd-package-adapter" as const,
+    contract: deepFreeze(contract),
+    implementation: deepFreeze(implementation),
+  });
+};
+
+export const voydInterfaceFingerprint = (
+  functions: readonly VoydExternalFunctionContract[],
+): string => {
+  const canonical = [...functions]
+    .sort((left, right) => left.functionName.localeCompare(right.functionName))
+    .map(({ kind, functionName, params, result }) => ({ kind, functionName, params, result }));
+  return stableHash(JSON.stringify(canonical));
+};
+
+const interfaceContractsFor = (
+  functions: readonly VoydExternalFunctionContract[],
+): VoydExternalInterfaceContract[] => {
+  const ids = [...new Set(functions.map(({ interfaceId }) => interfaceId))].sort();
+  return ids.map((interfaceId) => ({
+    interfaceId,
+    fingerprint: voydInterfaceFingerprint(
+      functions.filter((fn) => fn.interfaceId === interfaceId),
+    ),
+  }));
+};
+
+export const isVoydPackageAdapter = (
+  value: unknown,
+): value is VoydPackageAdapter =>
+  typeof value === "object" &&
+  value !== null &&
+  (value as { kind?: unknown }).kind === "voyd-package-adapter" &&
+  (value as { contract?: { abiVersion?: unknown } }).contract?.abiVersion ===
+    VOYD_PACKAGE_ADAPTER_ABI;
+
+const validateContract = (contract: VoydPackageAdapterContract): void => {
+  if (contract.abiVersion !== VOYD_PACKAGE_ADAPTER_ABI) {
+    throw new Error(
+      `Unsupported Voyd package adapter ABI ${String(contract.abiVersion)}; expected ${VOYD_PACKAGE_ADAPTER_ABI}`,
+    );
+  }
+  if (!contract.packageName.trim()) {
+    throw new Error("Voyd package adapter contract requires a packageName");
+  }
+  {
+    const interfaceIds = new Set(contract.functions.map(({ interfaceId }) => interfaceId));
+    const fingerprintIds = contract.interfaces.map(({ interfaceId }) => interfaceId);
+    if (
+      contract.interfaces.length !== interfaceIds.size ||
+      new Set(fingerprintIds).size !== fingerprintIds.length
+    ) {
+      throw new Error(`Voyd package adapter ${contract.packageName} requires one unique fingerprint per interface`);
+    }
+    contract.interfaces.forEach(({ interfaceId, fingerprint }) => {
+      const functions = contract.functions.filter((fn) => fn.interfaceId === interfaceId);
+      if (functions.length === 0 || !interfaceIds.has(interfaceId)) {
+        throw new Error(`Voyd package adapter ${contract.packageName} fingerprints unknown interface ${interfaceId}`);
+      }
+      if (voydInterfaceFingerprint(functions) !== fingerprint) {
+        throw new Error(`Voyd package adapter ${contract.packageName} has an invalid fingerprint for ${interfaceId}`);
+      }
+    });
+  }
+  const keys = contract.functions.map(({ kind, interfaceId, functionName }) => {
+    if (!interfaceId.trim() || !functionName.trim()) {
+      throw new Error("Voyd external functions require interfaceId and functionName");
+    }
+    if (kind !== "sync" && kind !== "async") {
+      throw new Error(`Voyd external function ${functionKey(interfaceId, functionName)} requires a sync or async kind`);
+    }
+    return functionKey(interfaceId, functionName);
+  });
+  if (new Set(keys).size !== keys.length) {
+    throw new Error(`Voyd package adapter ${contract.packageName} contains duplicate external functions`);
+  }
+};
+
+export function externalFunctionKey(
+  interfaceId: string,
+  functionName: string,
+): string {
+  return `${interfaceId}::${functionName}`;
+}
+
+const functionKey = externalFunctionKey;
+
+const deepFreeze = <T>(value: T, seen = new WeakSet<object>()): T => {
+  if (typeof value !== "object" || value === null || seen.has(value)) {
+    return value;
+  }
+  seen.add(value);
+  Object.values(value).forEach((child) => deepFreeze(child, seen));
+  return Object.freeze(value);
+};
+
+const stableHash = (value: string): string => {
+  let left = 0x811c9dc5;
+  let right = 0x9e3779b9;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    left = Math.imul(left ^ code, 0x01000193);
+    right = Math.imul(right ^ code, 0x85ebca6b);
+  }
+  return `${(left >>> 0).toString(16).padStart(8, "0")}${(right >>> 0).toString(16).padStart(8, "0")}`;
+};

--- a/packages/package-adapter/tsconfig.build.json
+++ b/packages/package-adapter/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/__tests__", "src/**/*.test.ts"]
+}

--- a/packages/package-adapter/tsconfig.json
+++ b/packages/package-adapter/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.dev.json",
+  "include": ["src/**/*"]
+}

--- a/packages/reference/docs/README.md
+++ b/packages/reference/docs/README.md
@@ -46,6 +46,7 @@ The installed command is `voyd`.
 - [VX](./vx.md)
 - [Web](./web.md)
 - [Modules](./modules.md)
+- [External Packages](./external-packages.md)
 - [Types Overview](./types/overview.md)
 
 ## Feature map

--- a/packages/reference/docs/cli.md
+++ b/packages/reference/docs/cli.md
@@ -94,11 +94,37 @@ voyd docs ./demo --out docs.html
 - `docs` is an alias for `doc`.
 - The default output file is `docs.html` for HTML and `docs.json` for JSON.
 
+## Generate package adapters
+
+Generate the TypeScript contract and WIT interface for a package containing
+`@external` functions and effects:
+
+```bash
+voyd generate adapter ./src --out ./generated
+```
+
+Generate the static adapter imports needed by a browser application:
+
+```bash
+voyd generate registry ./src/main.voyd \
+  --out ./src/generated/voyd-adapters.ts
+```
+
+The adapter generator compiles the package's canonical `pkg.voyd` graph and
+emits every re-exported `@external` declaration. Legacy source folders without
+a package root fall back to individual declaration files. The registry
+generator compiles the application, selects only reachable external
+interfaces, and resolves their installed npm providers.
+
+See [External Packages](./external-packages.md) for the package format and
+authoring workflow.
+
 ## Help and version
 
 ```bash
 voyd --help
 voyd doc --help
+voyd generate adapter --help
 voyd --version
 ```
 

--- a/packages/reference/docs/external-packages.md
+++ b/packages/reference/docs/external-packages.md
@@ -1,0 +1,244 @@
+---
+order: 18
+---
+
+# External packages
+
+Voyd packages can expose functions implemented by JavaScript or another host
+language. The public API remains ordinary typed Voyd code; a package adapter
+provides the external implementation when the Wasm module is instantiated.
+
+External package support is independent of VX. A renderer, parser, database
+client, or cryptography library uses the same function boundary.
+
+## Installing and using a package
+
+Install a mixed Voyd/JavaScript package through npm:
+
+```bash
+npm install @voyd-lang/markdown
+```
+
+Voyd resolves its source through the normal `pkg::` namespace:
+
+```voyd
+use pkg::markdown::{ StaticHtml, to_static }
+
+pub fn main() -> StaticHtml
+  to_static("# Hello")
+```
+
+The Node CLI discovers installed adapters automatically when running source:
+
+```bash
+voyd --run ./src/main.voyd
+```
+
+Browser builds use a generated static registry so bundlers can see the required
+JavaScript imports:
+
+```bash
+voyd generate registry ./src/main.voyd \
+  --out ./src/generated/voyd-adapters.ts
+```
+
+```ts
+import { adapters } from "./generated/voyd-adapters.js";
+
+const host = await createVoydHost({ wasm, adapters });
+```
+
+The VX starter performs this generation automatically.
+
+## Declaring an external function
+
+`@external` marks either a synchronous function or an asynchronous effect whose
+implementation is supplied by an adapter:
+
+```voyd
+use std::string::type::String
+
+@external(id: "example:markdown/renderer@1")
+pub fn render_html(source: String) -> String
+```
+
+External functions are bodyless declarations and must have explicit parameter
+and result types. Labeled arguments are supported; default parameters are
+rejected in the fallback ABI so adapters always receive a fixed argument list.
+
+The ID is a stable interface identity, not an npm package name. Use the WIT-shaped
+`namespace:package/interface@version` form and change its major version for an
+incompatible contract.
+
+External values are restricted to boundary-compatible values:
+
+- booleans and numeric primitives;
+- strings;
+- arrays;
+- public records and structural records;
+- options, results, and named variants.
+
+DTO graphs must be acyclic because Component Model values cannot be recursive.
+Represent trees and graphs with flat node arrays plus integer indices, or use a
+future resource/handle interface when identity is required.
+
+Closures, DOM nodes, arbitrary JavaScript objects, cyclic graphs, and values
+whose meaning depends on JavaScript object identity cannot cross this boundary.
+
+External functions are synchronous in the current fallback ABI. Returning a
+Promise from one is a runtime error. Use an external effect when the host may
+suspend:
+
+```voyd
+@external(id: "example:data/client@1")
+pub eff DataClient
+  load(tail, url: String) -> String
+```
+
+External effects use Voyd's existing effect runtime, so their suspension and
+effect requirements remain visible in Voyd types. The generated adapter accepts
+either a result or `Promise<result>` for these operations.
+
+## Generating adapter bindings
+
+Re-export external functions from the package root, then run:
+
+```bash
+voyd generate adapter ./src --out ./generated
+```
+
+The generator compiles the canonical `pkg.voyd` package graph once (falling
+back to individual external declaration files for legacy source folders) and
+produces:
+
+- `contract.json`: portable interface metadata;
+- `contract.ts`: the runtime contract;
+- `voyd-adapter.ts`: a typed package-specific `defineAdapter` helper;
+- `interface.wit`: the corresponding Component Model package and interface,
+  including records, lists, optional fields, variants, and shared acyclic references.
+  If one adapter spans multiple WIT packages, additional `interface-*.wit`
+  documents are emitted.
+
+The generated contract expands compiler references into structural DTO schemas
+and strips compiler-local type IDs. It also records a deterministic fingerprint
+of every function in each versioned interface.
+
+## Implementing the adapter
+
+Package authors implement the generated interface:
+
+```ts
+import { defineAdapter } from "../generated/voyd-adapter.js";
+
+export default defineAdapter({
+  "example:markdown/renderer@1": {
+    render_html(source) {
+      return renderMarkdown(source);
+    },
+  },
+});
+```
+
+`defineAdapter` delegates to the lower-level
+`defineVoydPackageAdapter(contract, implementation)` API. The generated helper
+is preferred because it fixes the correct IDs, functions, and TypeScript types.
+
+Generated functions receive a typed host invocation context as their
+JavaScript `this` value. The fallback host currently supplies an empty context;
+`signal` and `resources` are reserved optional capabilities for a later runtime
+revision and must be feature-detected before use. Arrow functions remain valid
+when the context is not needed. These capabilities are framework agnostic and
+do not introduce a VX dependency.
+
+`defineVoydPackageAdapter` validates that every required function is present,
+unknown functions are rejected, and the adapter ABI is supported. It only
+creates an immutable descriptor; it does not inspect packages, instantiate
+Wasm, or register global state.
+
+## Package metadata
+
+The npm package advertises its source, adapter entrypoints, and provided
+interfaces:
+
+```json
+{
+  "name": "@example/markdown",
+  "voyd": {
+    "source": "./src/pkg.voyd",
+    "adapter": {
+      "abi": 1,
+      "interfaces": ["example:markdown/renderer@1"],
+      "browser": "./adapter",
+      "node": "./adapter",
+      "default": "./adapter"
+    }
+  }
+}
+```
+
+Only adapters required by reachable external functions are loaded. Missing,
+duplicate, and structurally incompatible providers fail before the external
+function executes.
+
+The fallback linker checks every reachable function and requires one provider
+per versioned interface. Its whole-interface fingerprint proves that the
+adapter descriptor is internally complete and unmodified; because core-Wasm
+requirements intentionally omit unreachable declarations, the versioned
+interface ID remains the nominal promise for those unused members. Component
+Model linking replaces that limitation with whole-WIT-interface validation.
+
+## Runtime API
+
+Custom embedders can pass adapters explicitly:
+
+```ts
+import markdownAdapter from "@voyd-lang/markdown/adapter";
+
+const host = await createVoydHost({
+  wasm,
+  adapters: [markdownAdapter],
+});
+```
+
+The fallback synchronous transport uses the host `bufferSize` for each encoded
+argument/result payload. If a payload is larger, the host throws an actionable
+capacity error without invoking the adapter twice. Increase `bufferSize` for
+applications that intentionally exchange large DTOs; this limit disappears
+when the transport is replaced by the Component Model canonical ABI.
+
+Node applications can discover them using the SDK:
+
+```ts
+const adapters = await loadVoydPackageAdapters({
+  wasm,
+  startDir: process.cwd(),
+});
+```
+
+On Node, `compileResult.run(...)` performs this discovery automatically when
+the caller does not supply `adapters`. Passing an explicit adapter list disables
+discovery for that run. Browser builds use the generated static registry.
+
+The compiler records reachable imports in the versioned
+`voyd.external_requirements` custom section. MsgPack is used by the current
+fallback transport but is not part of the package contract.
+
+## Component Model migration
+
+The durable contract consists of the Voyd API, external interface ID, function
+names, execution semantics, and DTO shapes. The current MsgPack buffer,
+core-Wasm import trampolines, custom section, and generated JavaScript registry
+are replaceable transport details.
+
+When Voyd adopts the Component Model, synchronous functions become component
+imports and async effect operations map to async component calls as that support
+lands. Generated WIT becomes the linking interface. Packages may need to be
+rebuilt, but conforming Voyd application source and adapter implementation
+source should not need to change.
+
+Canonical Component Model bindings are not themselves the JavaScript adapter
+API: the future host backend owns a generated façade that converts canonical
+values to the stable adapter DTO representation. In particular it normalizes
+64-bit integers accepted as JavaScript numbers or bigints and maps WIT variant
+payload records to the existing flat `{ tag, ...fields }` objects. This shim is
+what preserves adapter implementation source across the transport migration.

--- a/packages/reference/docs/sdk.md
+++ b/packages/reference/docs/sdk.md
@@ -199,6 +199,39 @@ if (result.success) {
 }
 ```
 
+## External package adapters
+
+Pass adapters explicitly when embedding a mixed Voyd/host-language package:
+
+```ts
+import markdownAdapter from "@voyd-lang/markdown/adapter";
+
+if (result.success) {
+  const html = await result.run({
+    entryName: "main",
+    adapters: [markdownAdapter],
+  });
+}
+```
+
+Node applications can discover the providers declared by installed packages:
+
+```ts
+import { loadVoydPackageAdapters } from "@voyd-lang/sdk";
+
+const adapters = await loadVoydPackageAdapters({
+  wasm: result.wasm,
+  startDir: process.cwd(),
+});
+```
+
+The Node SDK does this automatically when `result.run(...)` is called without
+an `adapters` option. Pass an explicit list to control linking yourself.
+
+`createVoydHost({ wasm, adapters })` accepts the same descriptors. Browser
+bundlers should use `voyd generate registry` so adapter imports remain static
+and tree-shakeable. See [External Packages](./external-packages.md).
+
 ## Discovering and running tests
 
 Set `includeTests: true` to collect tests.

--- a/packages/reference/docs/vx.md
+++ b/packages/reference/docs/vx.md
@@ -2014,3 +2014,29 @@ The same structure scales beyond todos. Add features by giving each feature its
 own model, messages, view, commands, and subscriptions. Let parents compose those
 pieces with the VX mapping helpers. Keep outside work behind commands and
 subscriptions, and keep durable behavior visible in `step`.
+
+## Markdown
+
+The optional `@voyd-lang/markdown` package demonstrates the intended external
+package integration:
+
+```bash
+npm install @voyd-lang/markdown
+```
+
+```voyd
+use pkg::markdown::Markdown
+use std::vx::all
+
+fn Article({ source: String }) -> Html<AppMsg>
+  <article class="wiki-article">
+    <Markdown source={source} />
+  </article>
+```
+
+`Markdown` is an ordinary Voyd component function. Its underlying
+`render_static` function is implemented by a generic package adapter; neither
+the adapter contract nor `defineVoydPackageAdapter` depends on VX. The adapter
+returns a restricted static-node DTO, turns raw HTML into text, and blocks active
+link and image schemes. The Voyd wrapper converts that DTO into ordinary VX
+nodes, which are validated, rendered, and diffed like any other component tree.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -63,9 +63,10 @@
   "dependencies": {
     "@voyd-lang/compiler": "^0.2.0",
     "@voyd-lang/js-host": "^0.2.0",
+    "@voyd-lang/lib": "^0.2.0",
     "@voyd-lang/package-adapter": "^0.2.0",
     "@voyd-lang/std": "^0.2.0",
-    "@voyd-lang/lib": "^0.2.0",
-    "binaryen": "^125.0.0"
+    "binaryen": "^125.0.0",
+    "import-meta-resolve": "^4.2.0"
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -54,7 +54,7 @@
     "build": "tsc -p tsconfig.build.json && vite build -c ../../vite.config.ts",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test": "vitest run --config ../../vitest.config.ts --testTimeout 30000 src",
+    "test": "vitest run --config ../../vitest.config.ts --testTimeout 30000 src --testNamePattern='^(?!.*\\[external-[ab]\\])' && vitest run --config ../../vitest.config.ts --testTimeout 30000 src/__tests__/sdk-node.test.ts --testNamePattern='\\[external-a\\]' && vitest run --config ../../vitest.config.ts --testTimeout 30000 src/__tests__/sdk-node.test.ts --testNamePattern='\\[external-b\\]'",
     "test:w": "vitest --config ../../vitest.config.ts src",
     "lint": "echo 'no lint configured'",
     "prepack": "npm run clean && npm run build",
@@ -63,6 +63,7 @@
   "dependencies": {
     "@voyd-lang/compiler": "^0.2.0",
     "@voyd-lang/js-host": "^0.2.0",
+    "@voyd-lang/package-adapter": "^0.2.0",
     "@voyd-lang/std": "^0.2.0",
     "@voyd-lang/lib": "^0.2.0",
     "binaryen": "^125.0.0"

--- a/packages/sdk/src/__tests__/sdk-node.test.ts
+++ b/packages/sdk/src/__tests__/sdk-node.test.ts
@@ -1495,6 +1495,34 @@ pub fn main() -> i32
     }
   });
 
+  it("[external-a] ignores unsupported adapter ABIs unless their interface is required", async () => {
+    const projectRoot = await fs.mkdtemp(path.join(repoRoot, ".tmp-adapter-abi-"));
+    const packageRoot = path.join(projectRoot, "node_modules", "future-provider");
+    await fs.mkdir(packageRoot, { recursive: true });
+    await fs.writeFile(path.join(packageRoot, "package.json"), JSON.stringify({
+      name: "future-provider",
+      voyd: {
+        adapter: {
+          abi: 2,
+          interfaces: ["example:future/service@1"],
+          browser: "./adapter.js",
+        },
+      },
+    }));
+    try {
+      await expect(findVoydPackageAdapterSpecifiers({
+        interfaceIds: [],
+        startDir: projectRoot,
+      })).resolves.toEqual([]);
+      await expect(findVoydPackageAdapterSpecifiers({
+        interfaceIds: ["example:future/service@1"],
+        startDir: projectRoot,
+      })).rejects.toThrow(/unsupported ABI 2/);
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   it("[external-a] does not mix metadata from a shadowed outer package version", async () => {
     const projectRoot = await fs.mkdtemp(path.join(repoRoot, ".tmp-adapter-shadow-"));
     const nested = path.join(projectRoot, "packages", "app");

--- a/packages/sdk/src/__tests__/sdk-node.test.ts
+++ b/packages/sdk/src/__tests__/sdk-node.test.ts
@@ -8,12 +8,14 @@ import {
   collectNodeModulesDirs,
   createSdk,
   detectSrcRootForPath,
+  findVoydPackageAdapterSpecifiers,
   type CompileResult,
   type EffectContinuation,
   type EffectHandler,
 } from "@voyd-lang/sdk";
 import { createVoydHost } from "@voyd-lang/sdk/js-host";
 import { parseExportAbi } from "@voyd-lang/js-host";
+import { defineVoydPackageAdapter } from "@voyd-lang/package-adapter";
 
 const EFFECT_SOURCE = `use std::msgpack::self as __std_msgpack
 use std::string::self as __std_string
@@ -24,6 +26,13 @@ eff Async
 
 pub fn main(): Async -> i32
   Async::await(2) + 1
+`;
+const EXTERNAL_SOURCE = `@external(id: "example:math/ops@1")
+fn double(value: i32) -> i32
+  double(value)
+
+pub fn main() -> i32
+  double(21)
 `;
 const BOUNDARY_EXPORTS_SOURCE = `use std::array::Array
 use std::enums::{ enum }
@@ -1371,5 +1380,338 @@ pub fn second(): Async -> i32
 
     await expect(left.outcome).resolves.toEqual({ kind: "value", value: 11 });
     await expect(right.outcome).resolves.toEqual({ kind: "value", value: 22 });
+  });
+
+  it("[external-a] runs typed synchronous external functions through package adapters", async () => {
+    const sdk = createSdk();
+    const result = expectCompileSuccess(await sdk.compile({
+      source: EXTERNAL_SOURCE,
+    }));
+    expect(result.external.functions).toMatchObject([
+      {
+        interfaceId: "example:math/ops@1",
+        functionName: "double",
+      },
+    ]);
+    const adapter = defineVoydPackageAdapter(
+      {
+        abiVersion: 1,
+        packageName: "example-math",
+        functions: [
+          {
+            kind: "sync",
+            interfaceId: "example:math/ops@1",
+            functionName: "double",
+            params: [{ kind: "i32" }],
+            result: { kind: "i32" },
+          },
+        ],
+      },
+      {
+        "example:math/ops@1": {
+          double: (value: number) => value * 2,
+        },
+      },
+    );
+
+    await expect(result.run<number>({
+      entryName: "main",
+      adapters: [adapter],
+    })).resolves.toBe(42);
+    await expect(result.run<number>({ entryName: "main" })).rejects.toThrow(
+      /Missing installed Voyd package adapters.*example:math\/ops@1/,
+    );
+  });
+
+  it("[external-a] ignores duplicate providers for functions the module does not require", async () => {
+    const result = expectCompileSuccess(await createSdk().compile({ source: `@external(id: "example:required/a@1")
+fn a() -> i32
+  a()
+
+@external(id: "example:required/b@1")
+fn b() -> i32
+  b()
+
+pub fn main() -> i32
+  a() + b()
+` }));
+    const scalar = { params: [], result: { kind: "i32" as const } };
+    const shared = { kind: "sync" as const, interfaceId: "example:unused/c@1", functionName: "c", ...scalar };
+    const adapterA = defineVoydPackageAdapter({
+      abiVersion: 1,
+      packageName: "provider-a",
+      functions: [
+        { kind: "sync", interfaceId: "example:required/a@1", functionName: "a", ...scalar },
+        shared,
+      ],
+    }, {
+      "example:required/a@1": { a: () => 1 },
+      "example:unused/c@1": { c: () => 30 },
+    });
+    const adapterB = defineVoydPackageAdapter({
+      abiVersion: 1,
+      packageName: "provider-b",
+      functions: [
+        { kind: "sync", interfaceId: "example:required/b@1", functionName: "b", ...scalar },
+        shared,
+      ],
+    }, {
+      "example:required/b@1": { b: () => 2 },
+      "example:unused/c@1": { c: () => 40 },
+    });
+
+    await expect(result.run<number>({ entryName: "main", adapters: [adapterA, adapterB] }))
+      .resolves.toBe(3);
+  });
+
+  it("[external-a] detects duplicate required providers across nested node_modules", async () => {
+    const projectRoot = await fs.mkdtemp(path.join(repoRoot, ".tmp-adapter-discovery-"));
+    const nested = path.join(projectRoot, "packages", "app");
+    const writeProvider = async (root: string, name: string) => {
+      const packageRoot = path.join(root, "node_modules", name);
+      await fs.mkdir(packageRoot, { recursive: true });
+      await fs.writeFile(path.join(packageRoot, "package.json"), JSON.stringify({
+        name,
+        voyd: {
+          adapter: {
+            abi: 1,
+            interfaces: ["example:duplicate/service@1"],
+            browser: "./adapter.js",
+          },
+        },
+      }));
+    };
+    try {
+      await Promise.all([
+        writeProvider(projectRoot, "provider-parent"),
+        writeProvider(nested, "provider-child"),
+      ]);
+      await expect(findVoydPackageAdapterSpecifiers({
+        interfaceIds: ["example:duplicate/service@1"],
+        startDir: nested,
+      })).rejects.toThrow(/Multiple installed Voyd package adapters/);
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("[external-a] does not mix metadata from a shadowed outer package version", async () => {
+    const projectRoot = await fs.mkdtemp(path.join(repoRoot, ".tmp-adapter-shadow-"));
+    const nested = path.join(projectRoot, "packages", "app");
+    const writePackage = async (
+      root: string,
+      adapter: { abi: number; interfaces: string[]; browser?: string },
+    ) => {
+      const packageRoot = path.join(root, "node_modules", "same-provider");
+      await fs.mkdir(packageRoot, { recursive: true });
+      await fs.writeFile(path.join(packageRoot, "package.json"), JSON.stringify({
+        name: "same-provider",
+        voyd: { adapter },
+      }));
+    };
+    try {
+      await Promise.all([
+        writePackage(projectRoot, {
+          abi: 1,
+          interfaces: ["example:shadowed/service@1"],
+          browser: "./outer.js",
+        }),
+        writePackage(nested, { abi: 1, interfaces: [] }),
+      ]);
+      await expect(findVoydPackageAdapterSpecifiers({
+        interfaceIds: ["example:shadowed/service@1"],
+        startDir: nested,
+      })).rejects.toThrow(/Missing installed Voyd package adapters/);
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("[external-a] passes package adapters to compiled Voyd tests", async () => {
+    const result = expectCompileSuccess(await createSdk().compile({
+      includeTests: true,
+      source: `use std::test::assertions::all
+
+@external(id: "example:test/math@1")
+fn double(value: i32) -> i32
+  double(value)
+
+test "external adapter":
+  assert(double(2), eq: 4)
+`,
+    }));
+    const adapter = defineVoydPackageAdapter({
+      abiVersion: 1,
+      packageName: "test-math",
+      functions: [{
+        kind: "sync",
+        interfaceId: "example:test/math@1",
+        functionName: "double",
+        params: [{ kind: "i32" }],
+        result: { kind: "i32" },
+      }],
+    }, {
+      "example:test/math@1": { double: (value: number) => value * 2 },
+    });
+
+    expect(result.tests).toBeDefined();
+    const summary = await result.tests!.run({ adapters: [adapter] });
+    expect(summary.failed).toBe(0);
+    expect(summary.passed).toBe(1);
+  });
+
+  it("[external-b] auto-discovers adapters required only by the test Wasm", async () => {
+    const result = expectCompileSuccess(await createSdk().compile({
+      includeTests: true,
+      source: `use pkg::markdown::to_static
+use std::test::assertions::all
+
+pub fn main() -> i32
+  0
+
+test "markdown adapter":
+  assert(to_static("# Test").root, eq: 0)
+`,
+    }));
+    expect(result.tests).toBeDefined();
+
+    const summary = await result.tests!.run({});
+    expect(summary.failed).toBe(0);
+    expect(summary.passed).toBe(1);
+  });
+
+  it("[external-b] runs asynchronous external functions as Voyd effects", async () => {
+    const result = expectCompileSuccess(await createSdk().compile({
+      source: `use std::msgpack::self as __std_msgpack
+
+@external(id: "example:async/ops@1")
+eff Remote
+  double(tail, value: i32) -> i32
+
+pub fn main(): Remote -> i32
+  Remote::double(21)
+`,
+    }));
+    expect(result.external.functions).toMatchObject([{
+      kind: "async",
+      interfaceId: "example:async/ops@1",
+      functionName: "double",
+    }]);
+    const adapter = defineVoydPackageAdapter({
+      abiVersion: 1,
+      packageName: "example-async",
+      functions: [{
+        kind: "async",
+        interfaceId: "example:async/ops@1",
+        functionName: "double",
+        params: [{ kind: "i32" }],
+        result: { kind: "i32" },
+      }],
+    }, {
+      "example:async/ops@1": {
+        double: async (value: number) => {
+          await Promise.resolve();
+          return value * 2;
+        },
+      },
+    });
+
+    await expect(result.run<number>({ entryName: "main", adapters: [adapter] }))
+      .resolves.toBe(42);
+  });
+
+  it("[external-b] runs async external effects with structured and string DTOs regardless of source order", async () => {
+    const result = expectCompileSuccess(await createSdk().compile({ source: `use std::msgpack::self as __std_msgpack
+use std::string::type::String
+use std::string::self as __std_string
+
+pub type Request = { url: String }
+pub type Response = { status: i32, body: String }
+
+@external(id: "example:http/client@1")
+eff Http
+  request(tail, input: Request) -> Response
+
+fn unused(input: Request): Http -> Response
+  Http::request(input)
+
+pub fn main(): Http -> i32
+  Http::request({ url: "https://example.test" }).status
+` }));
+    const requirement = result.external.functions[0]!;
+    expect(requirement).toMatchObject({
+      kind: "async",
+      interfaceId: "example:http/client@1",
+      functionName: "request",
+    });
+    const adapter = defineVoydPackageAdapter({
+      abiVersion: 1,
+      packageName: "example-http",
+      functions: [{
+        kind: "async",
+        interfaceId: requirement.interfaceId,
+        functionName: requirement.functionName,
+        params: [{
+          kind: "record",
+          fields: [{ name: "url", schema: { kind: "string" } }],
+        }],
+        result: {
+          kind: "record",
+          fields: [
+            { name: "body", schema: { kind: "string" } },
+            { name: "status", schema: { kind: "i32" } },
+          ],
+        },
+      }],
+    }, {
+      "example:http/client@1": {
+        request: async (input: { url: string }) => ({
+          status: 200,
+          body: `loaded ${input.url}`,
+        }),
+      },
+    });
+
+    await expect(result.run<number>({ entryName: "main", adapters: [adapter] }))
+      .resolves.toBe(200);
+  });
+
+  it("[external-b] does not require adapters used only by unreachable private functions", async () => {
+    const result = expectCompileSuccess(await createSdk().compile({ source: `use std::msgpack::self as __std_msgpack
+
+@external(id: "example:optional/remote@1")
+eff Remote
+  load(tail, value: i32) -> i32
+
+fn unused(): Remote -> i32
+  Remote::load(1)
+
+pub fn main() -> i32
+  7
+` }));
+
+    expect(result.external.functions).toEqual([]);
+    await expect(result.run<number>({ entryName: "main" })).resolves.toBe(7);
+  });
+
+  it("[external-b] rejects recursive external DTOs before runtime linking", async () => {
+    const result = await createSdk().compile({ source: `use std::optional::all
+
+pub obj Node {
+  api value: i32,
+  api next?: Node
+}
+
+@external(id: "example:tree/model@1")
+pub fn root() -> Node
+  root()
+
+pub fn main() -> i32
+  root().value
+` });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.diagnostics.map((diagnostic) => diagnostic.message).join("\n"))
+      .toMatch(/recursive.*Component Model/);
   });
 });

--- a/packages/sdk/src/__tests__/sdk-node.test.ts
+++ b/packages/sdk/src/__tests__/sdk-node.test.ts
@@ -1426,7 +1426,12 @@ pub fn second(): Async -> i32
     await fs.writeFile(path.join(packageRoot, "package.json"), JSON.stringify({
       name: "esm-only-math",
       type: "module",
-      exports: { "./adapter": { import: "./adapter.js" } },
+      exports: {
+        "./adapter": {
+          development: "./adapter.js",
+          import: "./dist/adapter.js",
+        },
+      },
       voyd: {
         adapter: {
           abi: 1,

--- a/packages/sdk/src/__tests__/sdk-node.test.ts
+++ b/packages/sdk/src/__tests__/sdk-node.test.ts
@@ -9,6 +9,7 @@ import {
   createSdk,
   detectSrcRootForPath,
   findVoydPackageAdapterSpecifiers,
+  loadVoydPackageAdapters,
   type CompileResult,
   type EffectContinuation,
   type EffectHandler,
@@ -1418,6 +1419,53 @@ pub fn second(): Async -> i32
       entryName: "main",
       adapters: [adapter],
     })).resolves.toBe(42);
+
+    const projectRoot = await fs.mkdtemp(path.join(repoRoot, ".tmp-esm-adapter-"));
+    const packageRoot = path.join(projectRoot, "node_modules", "esm-only-math");
+    await fs.mkdir(packageRoot, { recursive: true });
+    await fs.writeFile(path.join(packageRoot, "package.json"), JSON.stringify({
+      name: "esm-only-math",
+      type: "module",
+      exports: { "./adapter": { import: "./adapter.js" } },
+      voyd: {
+        adapter: {
+          abi: 1,
+          interfaces: ["example:math/ops@1"],
+          node: "./adapter",
+        },
+      },
+    }));
+    await fs.writeFile(path.join(packageRoot, "adapter.js"), `export default {
+  kind: "voyd-package-adapter",
+  contract: {
+    abiVersion: 1,
+    packageName: "esm-only-math",
+    functions: [{
+      kind: "sync",
+      interfaceId: "example:math/ops@1",
+      functionName: "double",
+      params: [{ kind: "i32" }],
+      result: { kind: "i32" }
+    }]
+  },
+  implementation: {
+    "example:math/ops@1": { double: (value) => value * 2 }
+  }
+};
+`);
+    try {
+      const discovered = await loadVoydPackageAdapters({
+        wasm: result.wasm,
+        startDir: projectRoot,
+      });
+      await expect(result.run<number>({
+        entryName: "main",
+        adapters: discovered,
+      })).resolves.toBe(42);
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+
     await expect(result.run<number>({ entryName: "main" })).rejects.toThrow(
       /Missing installed Voyd package adapters.*example:math\/ops@1/,
     );

--- a/packages/sdk/src/__tests__/sdk-node.test.ts
+++ b/packages/sdk/src/__tests__/sdk-node.test.ts
@@ -258,7 +258,37 @@ const httpGet = (
     });
   });
 
+const restoreTestEnv = (key: string, value: string | undefined): void => {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+};
+
 describe("node sdk", () => {
+  it("restores web environment variables when adapter discovery fails", async () => {
+    const previousPort = process.env.VOYD_WEB_PORT;
+    const previousHost = process.env.VOYD_WEB_HOST;
+    process.env.VOYD_WEB_PORT = "previous-port";
+    process.env.VOYD_WEB_HOST = "previous-host";
+
+    try {
+      await expect(createSdk().serveWebApp({
+        port: await findFreePort(),
+        host: "127.0.0.2",
+        source: EXTERNAL_SOURCE,
+      })).rejects.toThrow(
+        /Missing installed Voyd package adapters.*example:math\/ops@1/,
+      );
+      expect(process.env.VOYD_WEB_PORT).toBe("previous-port");
+      expect(process.env.VOYD_WEB_HOST).toBe("previous-host");
+    } finally {
+      restoreTestEnv("VOYD_WEB_PORT", previousPort);
+      restoreTestEnv("VOYD_WEB_HOST", previousHost);
+    }
+  }, 120_000);
+
   it("closes a long-running web app entry through the SDK helper", async () => {
     const sdk = createSdk();
     const port = await findFreePort();
@@ -1428,8 +1458,8 @@ pub fn second(): Async -> i32
       type: "module",
       exports: {
         "./adapter": {
-          development: "./adapter.js",
           import: "./dist/adapter.js",
+          development: "./adapter.js",
         },
       },
       voyd: {

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -147,6 +147,7 @@ const compileSdk = async (
       optimize: options.optimize,
       loadModuleGraph,
       boundaryExports: options.boundaryExports,
+      externalDeclarations: options.externalDeclarations,
       cache: compilerCache,
       setupPhasesMs,
     });

--- a/packages/sdk/src/js-host.ts
+++ b/packages/sdk/src/js-host.ts
@@ -1,4 +1,10 @@
 export { createVoydHost } from "@voyd-lang/js-host";
+export { defineVoydPackageAdapter } from "@voyd-lang/package-adapter";
+export { parseExternalRequirements } from "@voyd-lang/js-host";
+export type {
+  ExternalFunctionRequirement,
+  ParsedExternalRequirements,
+} from "@voyd-lang/js-host";
 export { CancelledRunError } from "@voyd-lang/js-host";
 export { detectHostRuntime, registerDefaultHostAdapters, scheduleTaskForRuntime } from "@voyd-lang/js-host";
 export { createDeterministicRuntime } from "@voyd-lang/js-host";

--- a/packages/sdk/src/node.ts
+++ b/packages/sdk/src/node.ts
@@ -20,6 +20,7 @@ import {
   runWithHandlers,
 } from "./shared/host.js";
 import { createCompileResult } from "./shared/result.js";
+import { loadVoydPackageAdapters } from "./package-adapters.js";
 import type { CompileArtifactsSuccess } from "./shared/compile.js";
 import {
   createUnexpectedDiagnostic,
@@ -36,6 +37,10 @@ import type {
 } from "./shared/types.js";
 
 export { detectSrcRootForPath } from "./shared/source-root.js";
+export {
+  findVoydPackageAdapterSpecifiers,
+  loadVoydPackageAdapters,
+} from "./package-adapters.js";
 
 const DEFAULT_ENTRY = "index.voyd";
 const DEFAULT_VIRTUAL_ROOT = ".voyd";
@@ -74,6 +79,15 @@ export const serveWebApp = async (
     imports: run.imports,
     bufferSize: run.bufferSize,
     defaultAdapters: webAppDefaultAdapters(run.defaultAdapters),
+    adapters:
+      run.adapters ??
+      (await loadVoydPackageAdapters({
+        wasm: result.wasm,
+        startDir:
+          options.entryPath && options.source === undefined
+            ? path.dirname(path.resolve(options.entryPath))
+            : process.cwd(),
+      })),
   });
   if (run.handlersByLabelSuffix) {
     registerHandlersByLabelSuffix({
@@ -298,6 +312,7 @@ const compileSdk = async (
       runtimeDiagnostics,
       loadModuleGraph,
       boundaryExports: options.boundaryExports,
+      externalDeclarations: options.externalDeclarations,
       cache: compilerCache,
       setupPhasesMs,
       finalizeSuccess: (result) => finalizeCompile({ options, result }),
@@ -307,7 +322,22 @@ const compileSdk = async (
       return result;
     }
 
-    return createCompileResult(result);
+    const discoveredAdapters = new Map<
+      Uint8Array,
+      ReturnType<typeof loadVoydPackageAdapters>
+    >();
+    return createCompileResult(result, {
+      resolveAdapters: (wasm) => {
+        const existing = discoveredAdapters.get(wasm);
+        if (existing) return existing;
+        const loading = loadVoydPackageAdapters({
+          wasm,
+          startDir: path.dirname(entryPath),
+        });
+        discoveredAdapters.set(wasm, loading);
+        return loading;
+      },
+    });
   } catch (error) {
     return {
       success: false,

--- a/packages/sdk/src/node.ts
+++ b/packages/sdk/src/node.ts
@@ -74,32 +74,48 @@ export const serveWebApp = async (
   const previousHost = process.env.VOYD_WEB_HOST;
   process.env.VOYD_WEB_PORT = String(port);
   process.env.VOYD_WEB_HOST = host;
-  const hostRuntime = await createHost({
-    wasm: result.wasm,
-    imports: run.imports,
-    bufferSize: run.bufferSize,
-    defaultAdapters: webAppDefaultAdapters(run.defaultAdapters),
-    adapters:
-      run.adapters ??
-      (await loadVoydPackageAdapters({
-        wasm: result.wasm,
-        startDir:
-          options.entryPath && options.source === undefined
-            ? path.dirname(path.resolve(options.entryPath))
-            : process.cwd(),
-      })),
-  });
-  if (run.handlersByLabelSuffix) {
-    registerHandlersByLabelSuffix({
-      host: hostRuntime,
-      handlersByLabelSuffix: run.handlersByLabelSuffix,
+  const restoreWebEnvironment = (): void => {
+    restoreEnv("VOYD_WEB_PORT", previousPort);
+    restoreEnv("VOYD_WEB_HOST", previousHost);
+  };
+  let hostRuntime: Awaited<ReturnType<typeof createHost>>;
+  try {
+    hostRuntime = await createHost({
+      wasm: result.wasm,
+      imports: run.imports,
+      bufferSize: run.bufferSize,
+      defaultAdapters: webAppDefaultAdapters(run.defaultAdapters),
+      adapters:
+        run.adapters ??
+        (await loadVoydPackageAdapters({
+          wasm: result.wasm,
+          startDir:
+            options.entryPath && options.source === undefined
+              ? path.dirname(path.resolve(options.entryPath))
+              : process.cwd(),
+        })),
     });
-  }
-  if (run.handlers) {
-    registerHandlers({ host: hostRuntime, handlers: run.handlers });
+    if (run.handlersByLabelSuffix) {
+      registerHandlersByLabelSuffix({
+        host: hostRuntime,
+        handlersByLabelSuffix: run.handlersByLabelSuffix,
+      });
+    }
+    if (run.handlers) {
+      registerHandlers({ host: hostRuntime, handlers: run.handlers });
+    }
+  } catch (error) {
+    restoreWebEnvironment();
+    throw error;
   }
 
-  const started = hostRuntime.runManaged(entryName, run.args);
+  let started: ReturnType<typeof hostRuntime.runManaged>;
+  try {
+    started = hostRuntime.runManaged(entryName, run.args);
+  } catch (error) {
+    restoreWebEnvironment();
+    throw error;
+  }
   const closed = started.outcome
     .then((outcome) => {
       if (outcome.kind === "value") {
@@ -110,10 +126,7 @@ export const serveWebApp = async (
       }
       return undefined;
     })
-    .finally(() => {
-      restoreEnv("VOYD_WEB_PORT", previousPort);
-      restoreEnv("VOYD_WEB_HOST", previousHost);
-    });
+    .finally(restoreWebEnvironment);
   const ready = waitForTcpPort({ host, port, timeoutMs: readinessTimeoutMs });
   const close = (reason: unknown = "serveWebApp closed"): Promise<unknown> => {
     started.cancel(reason);

--- a/packages/sdk/src/package-adapters.ts
+++ b/packages/sdk/src/package-adapters.ts
@@ -1,0 +1,200 @@
+import { createRequire } from "node:module";
+import { readdir, readFile } from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  isVoydPackageAdapter,
+  VOYD_PACKAGE_ADAPTER_ABI,
+  type VoydPackageAdapter,
+} from "@voyd-lang/package-adapter";
+import { parseExternalRequirements } from "@voyd-lang/js-host";
+
+type AdapterMetadata = {
+  abi?: number;
+  interfaces?: readonly string[];
+  browser?: string;
+  node?: string;
+  default?: string;
+};
+
+type VoydPackageJson = {
+  name?: string;
+  voyd?: {
+    adapter?: AdapterMetadata;
+  };
+};
+
+export const loadVoydPackageAdapters = async ({
+  wasm,
+  startDir = process.cwd(),
+}: {
+  wasm: Uint8Array | WebAssembly.Module;
+  startDir?: string;
+}): Promise<VoydPackageAdapter[]> => {
+  const module =
+    wasm instanceof WebAssembly.Module
+      ? wasm
+      : new WebAssembly.Module(wasm as Uint8Array<ArrayBuffer>);
+  const requiredInterfaces = new Set(
+    parseExternalRequirements(module).functions.map((fn) => fn.interfaceId),
+  );
+  if (requiredInterfaces.size === 0) return [];
+  const providers = await findAdapterProviders({ requiredInterfaces, startDir });
+  const missing = [...requiredInterfaces].filter(
+    (interfaceId) => !providers.has(interfaceId),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing installed Voyd package adapters for interfaces: ${missing.join(", ")}`,
+    );
+  }
+  const unique = new Map<string, AdapterProvider>();
+  providers.forEach((provider) => unique.set(provider.packageName, provider));
+  return Promise.all(
+    [...unique.values()].map((provider) => loadAdapter(provider, startDir)),
+  );
+};
+
+export const findVoydPackageAdapterSpecifiers = async ({
+  interfaceIds,
+  startDir = process.cwd(),
+}: {
+  interfaceIds: readonly string[];
+  startDir?: string;
+}): Promise<string[]> => {
+  const requiredInterfaces = new Set(interfaceIds);
+  const providers = await findAdapterProviders({ requiredInterfaces, startDir });
+  const missing = [...requiredInterfaces].filter(
+    (interfaceId) => !providers.has(interfaceId),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing installed Voyd package adapters for interfaces: ${missing.join(", ")}`,
+    );
+  }
+  return [...new Map(
+    [...providers.values()].map((provider) => [
+      provider.packageName,
+      adapterSpecifier(provider, "browser"),
+    ]),
+  ).values()].sort();
+};
+
+type AdapterProvider = {
+  packageName: string;
+  packageRoot: string;
+  metadata: AdapterMetadata;
+};
+
+const findAdapterProviders = async ({
+  requiredInterfaces,
+  startDir,
+}: {
+  requiredInterfaces: ReadonlySet<string>;
+  startDir: string;
+}): Promise<Map<string, AdapterProvider>> => {
+  const providers = new Map<string, AdapterProvider>();
+  const shadowedPackageNames = new Set<string>();
+  for (const nodeModulesDir of collectNodeModulesDirs(startDir)) {
+    const packageRoots = await listPackageRoots(nodeModulesDir);
+    for (const packageRoot of packageRoots) {
+      const parsed = await readPackageJson(packageRoot);
+      if (!parsed?.name || shadowedPackageNames.has(parsed.name)) continue;
+      shadowedPackageNames.add(parsed.name);
+      const metadata = parsed?.voyd?.adapter;
+      if (!metadata?.interfaces) continue;
+      if (metadata.abi !== VOYD_PACKAGE_ADAPTER_ABI) {
+        throw new Error(
+          `Voyd package adapter ${parsed.name} declares unsupported ABI ${String(metadata.abi)}; expected ${VOYD_PACKAGE_ADAPTER_ABI}`,
+        );
+      }
+      metadata.interfaces.forEach((interfaceId) => {
+        if (!requiredInterfaces.has(interfaceId)) return;
+        const existing = providers.get(interfaceId);
+        if (existing && existing.packageName !== parsed.name) {
+          throw new Error(
+            `Multiple installed Voyd package adapters provide ${interfaceId}: ${existing.packageName}, ${parsed.name}`,
+          );
+        }
+        providers.set(interfaceId, {
+          packageName: parsed.name!,
+          packageRoot,
+          metadata,
+        });
+      });
+    }
+  }
+  return providers;
+};
+
+const loadAdapter = async (
+  provider: AdapterProvider,
+  startDir: string,
+): Promise<VoydPackageAdapter> => {
+  const require = createRequire(path.join(path.resolve(startDir), "package.json"));
+  const specifier = adapterSpecifier(provider, "node");
+  const resolved = require.resolve(specifier);
+  const loaded = (await import(pathToFileURL(resolved).href)) as {
+    default?: unknown;
+  };
+  if (!isVoydPackageAdapter(loaded.default)) {
+    throw new Error(
+      `Voyd package adapter ${provider.packageName} entry ${specifier} does not default-export a VoydPackageAdapter`,
+    );
+  }
+  return loaded.default;
+};
+
+const adapterSpecifier = (
+  provider: AdapterProvider,
+  runtime: "browser" | "node",
+): string => {
+  const entry = provider.metadata[runtime] ?? provider.metadata.default;
+  if (!entry) {
+    throw new Error(
+      `Voyd package adapter ${provider.packageName} has no ${runtime} or default entry`,
+    );
+  }
+  if (entry.startsWith("./")) return `${provider.packageName}/${entry.slice(2)}`;
+  return entry;
+};
+
+const collectNodeModulesDirs = (startDir: string): string[] => {
+  const dirs: string[] = [];
+  let current = path.resolve(startDir);
+  while (true) {
+    dirs.push(path.join(current, "node_modules"));
+    const parent = path.dirname(current);
+    if (parent === current) return dirs;
+    current = parent;
+  }
+};
+
+const listPackageRoots = async (nodeModulesDir: string): Promise<string[]> => {
+  const entries: Dirent[] = await readdir(nodeModulesDir, {
+    withFileTypes: true,
+  }).catch(() => [] as Dirent[]);
+  const roots = await Promise.all(
+    entries.map(async (entry): Promise<string[]> => {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) return [];
+      const candidate = path.join(nodeModulesDir, entry.name);
+      if (!entry.name.startsWith("@")) return [candidate];
+      return readdir(candidate, { withFileTypes: true })
+        .then((scoped) =>
+          scoped
+            .filter((child) => child.isDirectory() || child.isSymbolicLink())
+            .map((child) => path.join(candidate, child.name)),
+        )
+        .catch(() => []);
+    }),
+  );
+  return roots.flat();
+};
+
+const readPackageJson = async (
+  packageRoot: string,
+): Promise<VoydPackageJson | undefined> =>
+  readFile(path.join(packageRoot, "package.json"), "utf8")
+    .then((source) => JSON.parse(source) as VoydPackageJson)
+    .catch(() => undefined);

--- a/packages/sdk/src/package-adapters.ts
+++ b/packages/sdk/src/package-adapters.ts
@@ -1,8 +1,8 @@
-import { createRequire } from "node:module";
 import { readdir, readFile } from "node:fs/promises";
 import type { Dirent } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { resolve as resolveImport } from "import-meta-resolve";
 import {
   isVoydPackageAdapter,
   VOYD_PACKAGE_ADAPTER_ABI,
@@ -135,10 +135,12 @@ const loadAdapter = async (
   provider: AdapterProvider,
   startDir: string,
 ): Promise<VoydPackageAdapter> => {
-  const require = createRequire(path.join(path.resolve(startDir), "package.json"));
   const specifier = adapterSpecifier(provider, "node");
-  const resolved = require.resolve(specifier);
-  const loaded = (await import(pathToFileURL(resolved).href)) as {
+  const parentUrl = pathToFileURL(
+    path.join(path.resolve(startDir), "__voyd_adapter_resolver.mjs"),
+  ).href;
+  const resolved = resolveImport(specifier, parentUrl);
+  const loaded = (await import(resolved)) as {
     default?: unknown;
   };
   if (!isVoydPackageAdapter(loaded.default)) {

--- a/packages/sdk/src/package-adapters.ts
+++ b/packages/sdk/src/package-adapters.ts
@@ -104,13 +104,16 @@ const findAdapterProviders = async ({
       shadowedPackageNames.add(parsed.name);
       const metadata = parsed?.voyd?.adapter;
       if (!metadata?.interfaces) continue;
+      const matchingInterfaces = metadata.interfaces.filter((interfaceId) =>
+        requiredInterfaces.has(interfaceId),
+      );
+      if (matchingInterfaces.length === 0) continue;
       if (metadata.abi !== VOYD_PACKAGE_ADAPTER_ABI) {
         throw new Error(
           `Voyd package adapter ${parsed.name} declares unsupported ABI ${String(metadata.abi)}; expected ${VOYD_PACKAGE_ADAPTER_ABI}`,
         );
       }
-      metadata.interfaces.forEach((interfaceId) => {
-        if (!requiredInterfaces.has(interfaceId)) return;
+      matchingInterfaces.forEach((interfaceId) => {
         const existing = providers.get(interfaceId);
         if (existing && existing.packageName !== parsed.name) {
           throw new Error(

--- a/packages/sdk/src/package-adapters.ts
+++ b/packages/sdk/src/package-adapters.ts
@@ -166,7 +166,7 @@ const resolveAdapterImport = (specifier: string, parentUrl: URL): string => {
   return moduleResolve(
     specifier,
     parentUrl,
-    new Set(["node", "import", "development"]),
+    new Set(["node", "development"]),
   ).href;
 };
 

--- a/packages/sdk/src/package-adapters.ts
+++ b/packages/sdk/src/package-adapters.ts
@@ -1,8 +1,8 @@
 import { readdir, readFile } from "node:fs/promises";
-import type { Dirent } from "node:fs";
+import { existsSync, type Dirent } from "node:fs";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
-import { resolve as resolveImport } from "import-meta-resolve";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { moduleResolve } from "import-meta-resolve";
 import {
   isVoydPackageAdapter,
   VOYD_PACKAGE_ADAPTER_ABI,
@@ -138,8 +138,8 @@ const loadAdapter = async (
   const specifier = adapterSpecifier(provider, "node");
   const parentUrl = pathToFileURL(
     path.join(path.resolve(startDir), "__voyd_adapter_resolver.mjs"),
-  ).href;
-  const resolved = resolveImport(specifier, parentUrl);
+  );
+  const resolved = resolveAdapterImport(specifier, parentUrl);
   const loaded = (await import(resolved)) as {
     default?: unknown;
   };
@@ -149,6 +149,25 @@ const loadAdapter = async (
     );
   }
   return loaded.default;
+};
+
+const resolveAdapterImport = (specifier: string, parentUrl: URL): string => {
+  try {
+    const resolved = moduleResolve(specifier, parentUrl);
+    if (resolved.protocol !== "file:" || existsSync(fileURLToPath(resolved))) {
+      return resolved.href;
+    }
+  } catch {
+    // Retry below with the workspace development condition.
+  }
+
+  // Workspace packages can expose TypeScript through a development condition
+  // while their published import target is created only during build.
+  return moduleResolve(
+    specifier,
+    parentUrl,
+    new Set(["node", "import", "development"]),
+  ).href;
 };
 
 const adapterSpecifier = (

--- a/packages/sdk/src/shared/compile.ts
+++ b/packages/sdk/src/shared/compile.ts
@@ -61,6 +61,7 @@ export const compileWithLoader = async ({
   loadModuleGraph,
   testScope,
   boundaryExports,
+  externalDeclarations,
   cache,
   setupPhasesMs,
   finalizeSuccess,
@@ -76,6 +77,7 @@ export const compileWithLoader = async ({
   loadModuleGraph: LoadModuleGraphFn;
   testScope?: TestScope;
   boundaryExports?: BoundaryExportsOption;
+  externalDeclarations?: boolean;
   cache?: CompilerReuseCache;
   setupPhasesMs?: Readonly<Record<string, number>>;
   finalizeSuccess?: (
@@ -136,11 +138,13 @@ export const compileWithLoader = async ({
       ...optimizationCodegenOption,
       ...runtimeDiagnosticsCodegenOption,
       boundaryExports: boundaryExports ?? "auto",
+      externalDeclarations: externalDeclarations ?? false,
     } as const;
     const testCodegenOption = {
       ...optimizationCodegenOption,
       ...runtimeDiagnosticsCodegenOption,
       boundaryExports: false,
+      externalDeclarations: false,
     } as const;
 
     const dependencySnapshotReuse = prepareDependencySnapshotReuse({

--- a/packages/sdk/src/shared/host.ts
+++ b/packages/sdk/src/shared/host.ts
@@ -38,9 +38,16 @@ export const runWithHandlers = async <T = unknown>({
   imports,
   bufferSize,
   defaultAdapters,
+  adapters,
   args,
 }: RunOptions): Promise<T> => {
-  const host = await createHost({ wasm, imports, bufferSize, defaultAdapters });
+  const host = await createHost({
+    wasm,
+    imports,
+    bufferSize,
+    defaultAdapters,
+    adapters,
+  });
   if (handlersByLabelSuffix) {
     registerHandlersByLabelSuffix({ host, handlersByLabelSuffix });
   }

--- a/packages/sdk/src/shared/result.ts
+++ b/packages/sdk/src/shared/result.ts
@@ -1,6 +1,7 @@
 import {
   buildHandlerKey,
   parseEffectTable,
+  parseExternalRequirements,
   resolveEffectOp,
   resolveSignatureHashForOp,
   toHostProtocolTable,
@@ -10,6 +11,7 @@ import type { CompileArtifactsSuccess } from "./compile.js";
 import { createHost, registerHandlers, registerHandlersByLabelSuffix } from "./host.js";
 import { createTestCollection } from "./tests.js";
 import type { CompileSuccessResult, RunOptions } from "./types.js";
+import type { VoydPackageAdapter } from "@voyd-lang/js-host";
 
 const DEFAULT_EFFECT_TABLE_VERSION = 2;
 
@@ -72,8 +74,10 @@ const createEffectsInfo = ({
 
 const createRun = ({
   wasm,
+  resolveAdapters,
 }: {
   wasm: Uint8Array;
+  resolveAdapters?: (wasm: Uint8Array) => Promise<readonly VoydPackageAdapter[]>;
 }): CompileSuccessResult["run"] => {
   return async <T = unknown>({
     entryName,
@@ -82,13 +86,16 @@ const createRun = ({
     imports,
     bufferSize,
     defaultAdapters,
+    adapters,
     args,
   }: Omit<RunOptions, "wasm">): Promise<T> => {
+    const resolvedAdapters = adapters ?? (resolveAdapters ? await resolveAdapters(wasm) : undefined);
     const host = await createHost({
       wasm,
       imports,
       bufferSize,
       defaultAdapters,
+      adapters: resolvedAdapters,
     });
     if (handlersByLabelSuffix) {
       registerHandlersByLabelSuffix({ host, handlersByLabelSuffix });
@@ -102,16 +109,23 @@ const createRun = ({
 
 export const createCompileResult = async (
   artifacts: CompileArtifactsSuccess,
+  options: {
+    resolveAdapters?: (wasm: Uint8Array) => Promise<readonly VoydPackageAdapter[]>;
+  } = {},
 ): Promise<CompileSuccessResult> => {
-  const run = createRun({ wasm: artifacts.wasm });
+  const run = createRun({ wasm: artifacts.wasm, resolveAdapters: options.resolveAdapters });
   const effects = createEffectsInfo({
     table: buildEffectsTable(artifacts.wasm),
   });
+  const external = parseExternalRequirements(
+    new WebAssembly.Module(artifacts.wasm as Uint8Array<ArrayBuffer>),
+  );
   const testsWasm = artifacts.testsWasm ?? artifacts.wasm;
   const tests = artifacts.tests
     ? createTestCollection({
         cases: artifacts.tests,
         wasm: testsWasm,
+        resolveAdapters: options.resolveAdapters,
       })
     : undefined;
 
@@ -120,6 +134,7 @@ export const createCompileResult = async (
     wasm: artifacts.wasm,
     wasmText: artifacts.wasmText,
     effects,
+    external,
     run,
     tests,
   };

--- a/packages/sdk/src/shared/tests.ts
+++ b/packages/sdk/src/shared/tests.ts
@@ -11,6 +11,7 @@ import type {
 } from "./types.js";
 import { createHost, registerHandlers } from "./host.js";
 import type { VoydHost } from "@voyd-lang/js-host";
+import type { VoydPackageAdapter } from "@voyd-lang/js-host";
 
 class TestFailure extends Error {
   constructor(message?: string) {
@@ -204,6 +205,7 @@ const createTestHost = async ({
     imports: options.imports,
     bufferSize: options.bufferSize,
     defaultAdapters: options.defaultAdapters,
+    adapters: options.adapters,
   });
   registerTestHandlers({ host, handlers: options.handlers, onLog });
   return host;
@@ -333,14 +335,26 @@ const runTests = async ({
 export const createTestCollection = ({
   cases,
   wasm,
+  resolveAdapters,
 }: {
   cases: readonly TestCase[];
   wasm: Uint8Array;
+  resolveAdapters?: (wasm: Uint8Array) => Promise<readonly VoydPackageAdapter[]>;
 }): TestCollection => {
   const hasOnly = cases.some((test) => test.modifiers.only);
   return {
     cases,
     hasOnly,
-    run: (runOptions) => runTests({ cases, wasm, options: runOptions }),
+    run: async (runOptions) =>
+      runTests({
+        cases,
+        wasm,
+        options: {
+          ...runOptions,
+          adapters:
+            runOptions.adapters ??
+            (resolveAdapters ? await resolveAdapters(wasm) : undefined),
+        },
+      }),
   };
 };

--- a/packages/sdk/src/shared/types.ts
+++ b/packages/sdk/src/shared/types.ts
@@ -13,6 +13,8 @@ import type {
   SignatureHash,
   VoydRuntimeDiagnostics,
   VoydRuntimeError,
+  VoydPackageAdapter,
+  ParsedExternalRequirements,
 } from "@voyd-lang/js-host";
 
 export type {
@@ -25,6 +27,7 @@ export type {
   HostProtocolTable,
   ModuleRoots,
   OptimizationLevel,
+  ParsedExternalRequirements,
   SignatureHash,
   VoydRuntimeDiagnostics,
   VoydRuntimeError,
@@ -55,6 +58,8 @@ export type CompileOptions = {
   /** @deprecated Use `optimizationLevel`. true maps to `release`; false maps to `none`. */
   optimize?: boolean;
   boundaryExports?: BoundaryExportsOption;
+  /** @internal Include external declarations for adapter binding generation. */
+  externalDeclarations?: boolean;
   /**
    * Emit runtime trap-to-source metadata.
    * Defaults to false; pass true to include trap metadata.
@@ -68,6 +73,7 @@ export type CompileSuccessResult = {
   wasm: Uint8Array;
   wasmText?: string;
   effects: EffectsInfo;
+  external: ParsedExternalRequirements;
   tests?: TestCollection;
   run: <T = unknown>(opts: Omit<RunOptions, "wasm">) => Promise<T>;
 };
@@ -128,6 +134,7 @@ export type RunOptions = {
   imports?: WebAssembly.Imports;
   bufferSize?: number;
   defaultAdapters?: boolean | DefaultAdapterOptions;
+  adapters?: readonly VoydPackageAdapter[];
 };
 
 export type TestCollection = {
@@ -172,6 +179,7 @@ export type TestRunOptions = {
   imports?: WebAssembly.Imports;
   bufferSize?: number;
   defaultAdapters?: boolean | DefaultAdapterOptions;
+  adapters?: readonly VoydPackageAdapter[];
   filter?: (info: TestInfo) => boolean;
   isolation?: "per-test" | "shared";
 };

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -11,6 +11,7 @@
     "lint": "echo 'no lint configured'"
   },
   "dependencies": {
+    "@voyd-lang/markdown": "^0.2.0",
     "@voyd-lang/sdk": "^0.2.0",
     "@voyd-lang/vx-dom": "^0.2.0",
     "voyd_semver": "0.1.0"

--- a/tests/integration/src/vx-dom.test.ts
+++ b/tests/integration/src/vx-dom.test.ts
@@ -53,6 +53,10 @@ const wideValueModelEntryPath = path.join(
   fixtureRoot,
   "vx-wide-value-model.voyd",
 );
+const markdownEntryPath = path.resolve(
+  import.meta.dirname,
+  "../../../examples/markdown.voyd",
+);
 
 const expectCompileSuccess = (
   result: CompileResult,
@@ -67,6 +71,21 @@ const expectCompileSuccess = (
 };
 
 describe("integration: compiled VX DOM rendering", () => {
+  it("renders a JS-backed Markdown package as an ordinary VX component", async () => {
+    const result = expectCompileSuccess(
+      await createSdk().compile({ entryPath: markdownEntryPath }),
+    );
+    const tree = await result.run<unknown>({
+      entryName: "main",
+    });
+    const container = document.createElement("div");
+    const renderer = renderMsgPackNode(tree, container);
+
+    expect(container.querySelector("h1")?.textContent).toContain("Voyd Markdown");
+    expect(container.querySelector("article")?.className).toBe("markdown-example");
+    renderer.dispose();
+  });
+
   it("rejects explicit component state ids", async () => {
     const sdk = createSdk();
     const result = await sdk.compile({ entryPath: explicitStateIdEntryPath });

--- a/tsconfig.typecheck.base.json
+++ b/tsconfig.typecheck.base.json
@@ -17,6 +17,8 @@
       ],
       "@voyd-lang/js-host": ["packages/js-host/src/index.ts"],
       "@voyd-lang/js-host/*": ["packages/js-host/src/*"],
+      "@voyd-lang/package-adapter": ["packages/package-adapter/src/index.ts"],
+      "@voyd-lang/markdown/adapter": ["packages/markdown/host/adapter.ts"],
       "@voyd-lang/vx-dom": ["packages/vx-dom/src/index.ts"],
       "@voyd-lang/vx-dom/*": [
         "packages/vx-dom/src/*/index.ts",


### PR DESCRIPTION
## Summary

- add the VX-agnostic `defineVoydPackageAdapter` contract package and first-class `@external` functions/effects
- add compiler, JS-host, SDK discovery, browser registry, and CLI generation support for external packages
- add `@voyd-lang/markdown`, backed by Marked and exposed as ordinary Voyd/VX functions without `innerHTML`
- generate transport-neutral DTO contracts, TypeScript bindings, and WIT with whole-interface fingerprints and collision validation
- document package authoring, runtime integration, security boundaries, and the Component Model migration path

## Motivation

Voyd applications need a straightforward way to consume existing JavaScript and other host-language libraries without coupling the package ABI to VX. This establishes a function-based adapter boundary that works with the current core-Wasm/DTO runtime and preserves the package and adapter source model when linking moves to the WebAssembly Component Model.

## User and developer impact

Package authors can declare bodyless synchronous functions or asynchronous effects with `@external`, generate typed adapter bindings from the CLI, and publish adapters discoverable by Node or statically registered for browsers. Application authors can import those Voyd APIs normally. The Markdown package is the complete reference implementation.

The Markdown adapter emits inert structured nodes, sanitizes active URL schemes and raw HTML behavior, and applies source/token/nesting budgets for untrusted wiki content.

## Validation

- `npm test` — 18/18 packages passed
- `npm run typecheck` — 17/17 affected tasks passed
- `npm run test:audit`
- `git diff --check`
- iterative implementation-gap, correctness, and long-term architecture review loops completed cleanly
