### PR TITLE
Prepare Voyd 0.3.0 release - Gaia BH1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,93 @@
 # Changelog
 
+## Voyd v0.3.0 - Gaia BH1 (2026-07-12)
+
+Voyd `0.3.0` is the full-stack web release. VX grew into a typed application
+runtime, the new web package brings HTTP routing and server rendering to Voyd,
+and external package adapters open a path to the JavaScript ecosystem without
+making host details part of application code.
+
+### Highlights
+
+- Added the typed VX application architecture: `Program<Model, Msg>`,
+  `program`, `next`, commands, subscriptions, async task commands, component
+  state, browser event handling, DOM patching, hydration, and server rendering.
+- Added `voyd bootstrap` templates for a client-side VX application and a
+  full-stack server-rendered application.
+- Added `std::http` client and server APIs and the new `@voyd-lang/web` package,
+  with typed routing, extractors, middleware, response conversion, static files,
+  cookies, request limits, cooperative timeouts, and VX-backed HTML responses.
+- Added first-class external package functions and effects through `@external`,
+  host package adapters, Node discovery, browser registries, generated
+  TypeScript contracts, and generated WIT interfaces.
+- Added `@voyd-lang/markdown`, the first external-package reference
+  implementation. It converts Markdown into inert structured VX nodes without
+  an `innerHTML` escape hatch.
+- Added automatic typed SDK boundary exports for scalar and DTO values,
+  including recursive optional DTOs, boundary validation, callback retention,
+  and a direct scalar ABI fast path.
+- Added `enum` to the standard prelude, `Eq` for `String` and `StringSlice`,
+  `std::fs::remove`, optional structural fields, and fixes across overload
+  resolution, generic inference, default parameters, closures, and effect
+  lowering.
+- Expanded release optimization with tiered `none`, `balanced`, and `release`
+  policies, whole-program analysis, array and dispatch fast paths, effect
+  specialization, call-shape specialization, and Binaryen closed-world GC
+  optimization.
+- Reduced aggregate raw Wasm by 6.66% and gzip size by 2.91% across the release
+  optimizer scorecard. A minimal typed `i32` export dropped from 17,111 bytes to
+  783 bytes and became 6.17x faster to dispatch through `runPure`.
+- Reorganized validation into compiler-neutral conformance, public integration,
+  and opt-in performance suites, with split CI lanes and regression budgets.
+
+### Breaking Changes
+
+- `std::fetch` has been removed. Use `std::http::client` for outbound HTTP.
+- VX applications now use `app() -> Program<Model, Msg>` with `program({ init,
+  step, view, subscriptions })` and return transitions through `next(...)`.
+  Component state IDs are generated from stable call sites; the previous
+  user-supplied `state(id:)` form has been removed.
+- Runtime diagnostics and Binaryen validation are disabled by default for
+  unoptimized compilation. Pass `runtimeDiagnostics: true` when those checks
+  are required.
+- Reference-bound (`~`) parameters cannot declare default values. Use an
+  overload or callee-owned local storage instead.
+
+### New Packages
+
+- `@voyd-lang/web@0.3.0`
+- `@voyd-lang/vx-dom@0.3.0`
+- `@voyd-lang/package-adapter@0.3.0`
+- `@voyd-lang/markdown@0.3.0`
+
+### Package Versions
+
+- `@voyd-lang/cli@0.3.0`
+- `@voyd-lang/compiler@0.3.0`
+- `@voyd-lang/js-host@0.3.0`
+- `@voyd-lang/language-server@0.3.0`
+- `@voyd-lang/lib@0.3.0`
+- `@voyd-lang/markdown@0.3.0`
+- `@voyd-lang/package-adapter@0.3.0`
+- `@voyd-lang/reference@0.3.0`
+- `@voyd-lang/sdk@0.3.0`
+- `@voyd-lang/std@0.3.0`
+- `@voyd-lang/vx-dom@0.3.0`
+- `@voyd-lang/web@0.3.0`
+- `voyd-vscode@0.3.0`
+
+### Upgrade Notes
+
+Install or update the CLI:
+
+```sh
+npm i -g @voyd-lang/cli@0.3.0
+```
+
+Update all directly consumed Voyd packages together. Existing VX applications
+should migrate to the `Program<Model, Msg>` app contract, and code using
+`std::fetch` should move to `std::http::client` before upgrading.
+
 ## Voyd v0.2.0 - M87* (2026-06-03)
 
 Voyd `0.2.0` is a runtime and compiler release. The big theme is making

--- a/docs/release/publishing.md
+++ b/docs/release/publishing.md
@@ -17,11 +17,12 @@ Before a full `--all` release can publish successfully:
 - add the `VSCE_PAT` GitHub Actions secret for the VS Code Marketplace
 - make sure the release workflow can create GitHub tags and releases
 
-For `0.2.0`, the known blockers are:
+For `0.3.0`, bootstrap and configure trusted publishing for these new targets
+before dispatching the release:
 
-- `VSCE_PAT` is not configured in GitHub Actions secrets
-- `@voyd-lang/language-server` does not exist on npm yet
-- `@voyd-lang/reference` does not exist on npm yet
+- `@voyd-lang/vx-dom`
+- `@voyd-lang/package-adapter`
+- `@voyd-lang/markdown`
 
 See [GitHub and Token Setup](#github-and-token-setup) for the exact setup
 steps.
@@ -31,9 +32,9 @@ steps.
 Prepare the release commit from a clean release branch:
 
 ```sh
-git switch -c release/v0.2.0
-npm run release:prepare -- --all --version 0.2.0
-git push -u origin release/v0.2.0
+git switch -c release/v0.3.0
+npm run release:prepare -- --all --version 0.3.0
+git push -u origin release/v0.3.0
 ```
 
 Open and merge a pull request into `main`. This keeps branch protection and the
@@ -62,7 +63,7 @@ npm run release:publish -- --all --dry-run
 Publish a subset:
 
 ```sh
-npm run release:prepare -- --targets @voyd-lang/std,@voyd-lang/lib --version 0.2.0
+npm run release:prepare -- --targets @voyd-lang/std,@voyd-lang/lib --version 0.3.0
 npm run release:publish -- --targets @voyd-lang/std,@voyd-lang/lib
 ```
 
@@ -75,7 +76,7 @@ npm run release:publish -- --all --skip-github-release
 Use an explicit notes file:
 
 ```sh
-npm run release:publish -- --all --notes-file docs/release/v0.2.0-notes.md
+npm run release:publish -- --all --notes-file docs/release/v0.3.0-notes.md
 ```
 
 ## What The Commands Do
@@ -93,7 +94,7 @@ npm run release:publish -- --all --notes-file docs/release/v0.2.0-notes.md
 Pass `--no-commit` to leave the release changes staged:
 
 ```sh
-npm run release:prepare -- --all --version 0.2.0 --no-commit
+npm run release:prepare -- --all --version 0.3.0 --no-commit
 ```
 
 `release:publish`:
@@ -117,6 +118,10 @@ The GitHub workflow then:
 ## Supported Targets
 
 - `@voyd-lang/std`
+- `@voyd-lang/web`
+- `@voyd-lang/package-adapter`
+- `@voyd-lang/markdown`
+- `@voyd-lang/vx-dom`
 - `@voyd-lang/lib`
 - `@voyd-lang/compiler`
 - `@voyd-lang/js-host`
@@ -175,34 +180,37 @@ fails.
 
 ### npm Bootstrap For New Packages
 
-Trusted publishing needs the package to exist on npm first. For `0.2.0`,
-bootstrap these missing packages from the current `0.1.0` `main` before merging
-the `0.2.0` release PR:
+Trusted publishing needs the package to exist on npm first. For `0.3.0`,
+bootstrap these missing packages at `0.2.0` from a clean, current `main` after
+their release targets land and before preparing the `0.3.0` version bump:
 
-- `@voyd-lang/language-server`
-- `@voyd-lang/reference`
+- `@voyd-lang/vx-dom`
+- `@voyd-lang/package-adapter`
+- `@voyd-lang/markdown`
 
 Bootstrap from a clean, current `main` checkout:
 
 ```sh
 git switch main
 git pull --ff-only origin main
-npm publish --workspace @voyd-lang/language-server --access public
-npm publish --workspace @voyd-lang/reference --access public
+npm publish --workspace @voyd-lang/package-adapter --access public
+npm publish --workspace @voyd-lang/markdown --access public
+npm publish --workspace @voyd-lang/vx-dom --access public
 ```
 
 Use your normal npm interactive login or a one-time npm automation token for
-that bootstrap. After these packages exist at `0.1.0`, configure trusted
-publishing for them, then let the release workflow publish `0.2.0`.
+that bootstrap. After these packages exist at `0.2.0`, configure trusted
+publishing for them, then let the release workflow publish `0.3.0`.
 
-Do not bootstrap the missing packages at `0.2.0` before the release workflow.
-If `0.2.0` already exists, the workflow cannot publish that same version.
+Do not bootstrap the missing packages at `0.3.0` before the release workflow.
+If `0.3.0` already exists, the workflow cannot publish that same version.
 
 Verify package existence:
 
 ```sh
-npm view @voyd-lang/language-server version
-npm view @voyd-lang/reference version
+npm view @voyd-lang/package-adapter version
+npm view @voyd-lang/markdown version
+npm view @voyd-lang/vx-dom version
 ```
 
 ### npm Trusted Publishing
@@ -240,8 +248,11 @@ a GitHub Actions environment, so the npm environment field should stay blank.
 
 Configure these packages:
 
-
 - `@voyd-lang/std`
+- `@voyd-lang/web`
+- `@voyd-lang/package-adapter`
+- `@voyd-lang/markdown`
+- `@voyd-lang/vx-dom`
 - `@voyd-lang/lib`
 - `@voyd-lang/compiler`
 - `@voyd-lang/js-host`

--- a/docs/release/publishing.md
+++ b/docs/release/publishing.md
@@ -8,7 +8,10 @@ Voyd has two public release commands:
 Everything else in `scripts/release/` is an internal maintenance helper. The
 documented release flow should go through the two root commands above.
 
-## One-Time Setup
+Keep this guide release-agnostic. Put version-specific package lists, bootstrap
+checklists, and coordination notes in the materials for that release.
+
+## One-Time Repository Setup
 
 Before a full `--all` release can publish successfully:
 
@@ -16,13 +19,6 @@ Before a full `--all` release can publish successfully:
 - bootstrap any npm package that does not exist yet
 - add the `VSCE_PAT` GitHub Actions secret for the VS Code Marketplace
 - make sure the release workflow can create GitHub tags and releases
-
-For `0.3.0`, bootstrap and configure trusted publishing for these new targets
-before dispatching the release:
-
-- `@voyd-lang/vx-dom`
-- `@voyd-lang/package-adapter`
-- `@voyd-lang/markdown`
 
 See [GitHub and Token Setup](#github-and-token-setup) for the exact setup
 steps.
@@ -32,10 +28,14 @@ steps.
 Prepare the release commit from a clean release branch:
 
 ```sh
-git switch -c release/v0.3.0
-npm run release:prepare -- --all --version 0.3.0
-git push -u origin release/v0.3.0
+VERSION=X.Y.Z
+BRANCH="release/v${VERSION}"
+git switch -c "$BRANCH"
+npm run release:prepare -- --all --version "$VERSION"
+git push -u origin "$BRANCH"
 ```
+
+Replace `X.Y.Z` with the version being published.
 
 Open and merge a pull request into `main`. This keeps branch protection and the
 required `test` status check in front of the release commit.
@@ -63,7 +63,8 @@ npm run release:publish -- --all --dry-run
 Publish a subset:
 
 ```sh
-npm run release:prepare -- --targets @voyd-lang/std,@voyd-lang/lib --version 0.3.0
+VERSION=X.Y.Z
+npm run release:prepare -- --targets @voyd-lang/std,@voyd-lang/lib --version "$VERSION"
 npm run release:publish -- --targets @voyd-lang/std,@voyd-lang/lib
 ```
 
@@ -76,7 +77,8 @@ npm run release:publish -- --all --skip-github-release
 Use an explicit notes file:
 
 ```sh
-npm run release:publish -- --all --notes-file docs/release/v0.3.0-notes.md
+VERSION=X.Y.Z
+npm run release:publish -- --all --notes-file "docs/release/v${VERSION}-notes.md"
 ```
 
 ## What The Commands Do
@@ -94,7 +96,8 @@ npm run release:publish -- --all --notes-file docs/release/v0.3.0-notes.md
 Pass `--no-commit` to leave the release changes staged:
 
 ```sh
-npm run release:prepare -- --all --version 0.3.0 --no-commit
+VERSION=X.Y.Z
+npm run release:prepare -- --all --version "$VERSION" --no-commit
 ```
 
 `release:publish`:
@@ -180,38 +183,76 @@ fails.
 
 ### npm Bootstrap For New Packages
 
-Trusted publishing needs the package to exist on npm first. For `0.3.0`,
-bootstrap these missing packages at `0.2.0` from a clean, current `main` after
-their release targets land and before preparing the `0.3.0` version bump:
+Trusted publishing needs a package to exist on npm before GitHub Actions can
+publish it through OIDC. Bootstrap each new npm package once before including it
+in a normal release.
 
-- `@voyd-lang/vx-dom`
-- `@voyd-lang/package-adapter`
-- `@voyd-lang/markdown`
+Before bootstrapping a package:
 
-Bootstrap from a clean, current `main` checkout:
+1. Make sure it is an npm workspace with a unique `name` and the version to use
+   for the initial publish in its `package.json`.
+2. Add an `npmTarget` entry to `scripts/release/manifest.mjs`. The entry must
+   identify the workspace and directory, describe the package contents that
+   must or must not be published, and select the relevant release tests. For
+   example:
+
+   ```js
+   "@voyd-lang/example": npmTarget({
+     workspace: "@voyd-lang/example",
+     cwd: "packages/example",
+     description: "Example package",
+     packRequiredFiles: ["package.json", "dist/index.js", "dist/index.d.ts"],
+     packForbiddenPatterns: [/^src\//],
+     relatedTests: ["own", "integration"],
+   }),
+   ```
+
+   Choose the package-content rules and tests for the package rather than
+   copying this example unchanged. The manifest is the authoritative allowlist
+   used by `release:prepare`, `release:publish`, and direct publish validation.
+3. Set `repository.url` in the workspace `package.json` to
+   `https://github.com/voyd-lang/voyd` and add the publish guard:
+
+   ```json
+   {
+     "scripts": {
+       "prepublishOnly": "node ../../scripts/release/enforce-workspace-release.mjs"
+     }
+   }
+   ```
+
+   Preserve the workspace's other scripts. The guard runs the manifest-backed
+   release check during `npm publish`; without the release target, it fails with
+   `Unknown release target`.
+4. Merge the workspace, manifest entry, package metadata, and tests into `main`.
+
+Start from a clean, current `main` checkout and set `PACKAGE` to the workspace
+name:
 
 ```sh
 git switch main
 git pull --ff-only origin main
-npm publish --workspace @voyd-lang/package-adapter --access public
-npm publish --workspace @voyd-lang/markdown --access public
-npm publish --workspace @voyd-lang/vx-dom --access public
+PACKAGE=@voyd-lang/example
+npm view "$PACKAGE" version
+```
+
+If `npm view` reports that the package does not exist, validate and publish the
+workspace at the version already recorded in its `package.json`:
+
+```sh
+node scripts/release/check.mjs --targets "$PACKAGE"
+npm publish --workspace "$PACKAGE" --access public
+npm view "$PACKAGE" version
 ```
 
 Use your normal npm interactive login or a one-time npm automation token for
-that bootstrap. After these packages exist at `0.2.0`, configure trusted
-publishing for them, then let the release workflow publish `0.3.0`.
+this bootstrap. Then configure the package's trusted publisher before using the
+normal release workflow.
 
-Do not bootstrap the missing packages at `0.3.0` before the release workflow.
-If `0.3.0` already exists, the workflow cannot publish that same version.
-
-Verify package existence:
-
-```sh
-npm view @voyd-lang/package-adapter version
-npm view @voyd-lang/markdown version
-npm view @voyd-lang/vx-dom version
-```
+Do not bootstrap a package at the version that the next release workflow is
+supposed to publish. npm will reject a second publish of the same package
+version. The bootstrap should publish the package's current manifest version;
+`release:prepare` will assign the upcoming version later.
 
 ### npm Trusted Publishing
 

--- a/docs/release/v0.3.0-benchmark.md
+++ b/docs/release/v0.3.0-benchmark.md
@@ -24,8 +24,10 @@ The release profile is measured with one compile warmup, three fresh-process
 compile samples, eleven runtime warmups, and five recorded runtime samples. The
 runtime warmups keep Node's WebAssembly tiers out of the comparison:
 
-- `scalar-aggregate` updates short-lived mutable vectors in a hot loop.
-- `call-shape-defaults` combines recursion with default arguments.
+- `scalar-aggregate` updates short-lived mutable vectors across one million
+  particle steps.
+- `call-shape-defaults` combines recursion with default arguments across five
+  million calls.
 - `std-math-transcendentals` exercises standard-library math calls.
 - `tier1-trait-call` records the fixed cost of typed SDK boundary exports.
 - `vtrace-main` is a small ray tracer with effects, trait dispatch, mutable
@@ -34,6 +36,17 @@ runtime warmups keep Node's WebAssembly tiers out of the comparison:
 The benchmark harness and file-backed fixtures come from `--head` and are copied
 into both worktrees. This makes the corpus identical even when files changed
 after v0.2.0.
+
+The two scaled runtime workloads take milliseconds rather than fractions of a
+millisecond, keeping WebAssembly tiering and timer resolution from dominating
+the result. Standard-library math and the trait-boundary fixture remain useful
+compile-time and artifact-size checks; their runtimes are below useful timing
+resolution.
+
+The script records two comparisons in the output:
+
+- `scenarios` compares the v0.2.0 and Gaia release profiles.
+- `gaiaOptimization` compares Gaia's unoptimized and release profiles.
 
 Vtrace is recorded as a Gaia-only showcase rather than a v0.2.0 comparison.
 The fixture's render completed in about 631 ms when it first entered the
@@ -46,8 +59,8 @@ not run or report it.
 ## Reading the result
 
 The output is JSON so the raw samples, exact revisions, corpus hashes, tool
-versions, artifact sizes, and computed percentage changes can be audited. A
-short summary is also printed to the terminal.
+versions, artifact sizes, release-profile speedups, and computed percentage
+changes can be audited. A short summary is also printed to the terminal.
 
 Runtime measurements vary with the host and background load. Use the recorded
 raw samples when updating prose, and avoid interpreting sub-hundredth-millisecond

--- a/docs/release/v0.3.0-benchmark.md
+++ b/docs/release/v0.3.0-benchmark.md
@@ -21,8 +21,8 @@ worktrees are removed when the run finishes.
 ## Workloads
 
 The release profile is measured with one compile warmup, three fresh-process
-compile samples, four runtime warmups, and five recorded runtime samples. The
-extra runtime warmups keep Node's JIT startup tiers out of the comparison:
+compile samples, eleven runtime warmups, and five recorded runtime samples. The
+runtime warmups keep Node's WebAssembly tiers out of the comparison:
 
 - `scalar-aggregate` updates short-lived mutable vectors in a hot loop.
 - `call-shape-defaults` combines recursion with default arguments.
@@ -35,14 +35,13 @@ The benchmark harness and file-backed fixtures come from `--head` and are copied
 into both worktrees. This makes the corpus identical even when files changed
 after v0.2.0.
 
-The v0.2.0 vtrace artifact is compiled separately so its compile time and size
-remain available. Its runtime worker is stopped after 60 seconds by default;
-that worker performs one warmup and one measured run. Change the bound with
-`--vtrace-timeout-ms`, for example:
-
-```bash
-npm run bench:release:v0.3.0 -- --vtrace-timeout-ms 120000
-```
+Vtrace is recorded as a Gaia-only showcase rather than a v0.2.0 comparison.
+The fixture's render completed in about 631 ms when it first entered the
+repository at `85ce8509`. The v0.2.0 tag compiles the same render but exhibits a
+historical runtime regression: both its original runner and the release harness
+remained at full CPU for more than a minute. Using that timeout as the v0.2.0
+baseline would overstate the release-to-release improvement, so the script does
+not run or report it.
 
 ## Reading the result
 

--- a/docs/release/v0.3.0-benchmark.md
+++ b/docs/release/v0.3.0-benchmark.md
@@ -1,0 +1,55 @@
+# Voyd v0.3.0 Release Benchmark
+
+This benchmark reproduces the release-build comparison in the Gaia BH1 release
+post. It compares `v0.2.0` with a selected v0.3.0 revision using the same
+benchmark harness and source corpus in isolated Git worktrees.
+
+Run it from the repository root:
+
+```bash
+npm run bench:release:v0.3.0 -- \
+  --base v0.2.0 \
+  --head HEAD \
+  --output ./voyd-v0.3.0-release-benchmark.json
+```
+
+The script pins Node 22.23.1 and npm 10.9.4 through `npx`. npm 10 is required
+because the v0.2.0 lockfile is not accepted by newer npm releases. The first run
+needs network access to fetch those tools and install both revisions. Temporary
+worktrees are removed when the run finishes.
+
+## Workloads
+
+The release profile is measured with one compile warmup, three fresh-process
+compile samples, four runtime warmups, and five recorded runtime samples. The
+extra runtime warmups keep Node's JIT startup tiers out of the comparison:
+
+- `scalar-aggregate` updates short-lived mutable vectors in a hot loop.
+- `call-shape-defaults` combines recursion with default arguments.
+- `std-math-transcendentals` exercises standard-library math calls.
+- `tier1-trait-call` records the fixed cost of typed SDK boundary exports.
+- `vtrace-main` is a small ray tracer with effects, trait dispatch, mutable
+  vectors, recursive bounces, arrays, and a large object graph.
+
+The benchmark harness and file-backed fixtures come from `--head` and are copied
+into both worktrees. This makes the corpus identical even when files changed
+after v0.2.0.
+
+The v0.2.0 vtrace artifact is compiled separately so its compile time and size
+remain available. Its runtime worker is stopped after 60 seconds by default;
+that worker performs one warmup and one measured run. Change the bound with
+`--vtrace-timeout-ms`, for example:
+
+```bash
+npm run bench:release:v0.3.0 -- --vtrace-timeout-ms 120000
+```
+
+## Reading the result
+
+The output is JSON so the raw samples, exact revisions, corpus hashes, tool
+versions, artifact sizes, and computed percentage changes can be audited. A
+short summary is also printed to the terminal.
+
+Runtime measurements vary with the host and background load. Use the recorded
+raw samples when updating prose, and avoid interpreting sub-hundredth-millisecond
+differences as meaningful.

--- a/docs/release/v0.3.0-notes.md
+++ b/docs/release/v0.3.0-notes.md
@@ -1,0 +1,143 @@
+# Voyd 0.3.0 - Gaia BH1
+
+Voyd `0.3.0` turns the runtime and compiler work from the first two releases
+into a practical full-stack web platform. It adds a typed VX application
+runtime, HTTP client and server APIs, a web framework, server rendering and
+hydration, project scaffolding, external package adapters, and a substantially
+stronger release optimizer.
+
+## Highlights
+
+- Build typed browser applications around `Program<Model, Msg>`, with commands,
+  subscriptions, async tasks, DOM patching, hydration, and server rendering.
+- Scaffold a VX SPA or full-stack SSR application with `voyd bootstrap`.
+- Build HTTP services with `std::http` and `@voyd-lang/web`, including typed
+  routing and extraction, middleware, static files, cookies, limits, and
+  cooperative timeouts.
+- Integrate host-language packages through `@external` functions and effects,
+  generated TypeScript contracts and WIT, automatic Node discovery, and static
+  browser registries.
+- Render Markdown through the new `@voyd-lang/markdown` reference adapter as
+  sanitized structured nodes, without passing HTML strings into the DOM.
+- Call exported Voyd functions through automatic typed SDK boundaries, with a
+  direct fast path for scalar signatures and validated serialization for DTOs.
+- Produce smaller and faster release builds through new whole-program compiler
+  passes and Binaryen closed-world optimization.
+
+## Breaking changes
+
+- `std::fetch` has been removed. Migrate outbound requests to
+  `std::http::client`.
+- VX apps now expose `app() -> Program<Model, Msg>` and use
+  `program({ init, step, view, subscriptions })` plus `next(...)`. The previous
+  explicit `state(id:)` API has been removed in favor of stable generated
+  call-site IDs.
+- Runtime diagnostics and Binaryen validation are now opt-in for unoptimized
+  compilation. Set `runtimeDiagnostics: true` to restore them.
+- Default values on reference-bound (`~`) parameters are rejected. Prefer an
+  overload or copy the value into callee-owned storage.
+
+## Install
+
+```sh
+npm i -g @voyd-lang/cli@0.3.0
+```
+
+All directly consumed Voyd packages should be updated together.
+
+## Performance
+
+The release optimization profile now enables closed-world GC optimization and
+uses a larger set of compiler-owned whole-program facts. Across the six-scenario
+optimizer scorecard, raw Wasm fell from 162,288 to 151,474 bytes (`-6.66%`) and
+gzip size fell from 56,469 to 54,824 bytes (`-2.91%`). The representative
+vtrace workload became 6.71% faster in the closed-world comparison.
+
+Typed scalar exports also bypass the serialized DTO wrapper when the public
+type maps directly to the physical Wasm signature. For a minimal
+`pub fn main() -> i32`, the typed release artifact fell from 17,111 bytes to 783
+bytes and warm `runPure` dispatch improved from 0.901 µs to 0.146 µs per call.
+
+## All merged pull requests
+
+This release contains 68 merged changes since `v0.2.0`.
+
+### VX, web, HTTP, and examples
+
+- [#642 Add functional VX DOM runtime, docs, and playground examples](https://github.com/voyd-lang/voyd/pull/642)
+- [#643 Implement typed VX boundary](https://github.com/voyd-lang/voyd/pull/643)
+- [#645 Add typed boundary SDK exports](https://github.com/voyd-lang/voyd/pull/645)
+- [#646 Decouple VX state and app APIs from compiler internals](https://github.com/voyd-lang/voyd/pull/646)
+- [#648 Fix labeled object inference for VX program calls](https://github.com/voyd-lang/voyd/pull/648)
+- [#649 Fix recursive optional object resolution](https://github.com/voyd-lang/voyd/pull/649)
+- [#650 Support recursive optional boundary DTOs](https://github.com/voyd-lang/voyd/pull/650)
+- [#644 Add bootstrap scaffolding for VX starter apps](https://github.com/voyd-lang/voyd/pull/644)
+- [#627 Add web proposals](https://github.com/voyd-lang/voyd/pull/627)
+- [#667 Adopt semantic web proposal API style](https://github.com/voyd-lang/voyd/pull/667)
+- [#668 Implement standard-library HTTP](https://github.com/voyd-lang/voyd/pull/668)
+- [#669 Update web framework handler extraction proposal](https://github.com/voyd-lang/voyd/pull/669)
+- [#670 Implement the web framework package](https://github.com/voyd-lang/voyd/pull/670)
+- [#671 Fix imported effect handler codegen metadata handling](https://github.com/voyd-lang/voyd/pull/671)
+- [#672 Add hermetic web static-file tests](https://github.com/voyd-lang/voyd/pull/672)
+- [#673 Implement web framework phase 2](https://github.com/voyd-lang/voyd/pull/673)
+- [#674 Add the SSR app bootstrap](https://github.com/voyd-lang/voyd/pull/674)
+- [#676 Add async task support to VX DOM and the host runtime](https://github.com/voyd-lang/voyd/pull/676)
+- [#678 Add compiler-safe VX task and program mapping APIs](https://github.com/voyd-lang/voyd/pull/678)
+- [#682 Rewrite the VX reference docs](https://github.com/voyd-lang/voyd/pull/682)
+- [#683 Expand VX runtime commands and subscriptions](https://github.com/voyd-lang/voyd/pull/683)
+- [#684 Fix overloaded return-only type argument inference](https://github.com/voyd-lang/voyd/pull/684)
+- [#688 Make string UTF-8 exports return an isolated copy](https://github.com/voyd-lang/voyd/pull/688)
+- [#695 Rebuild mini-wikipedia with Voyd and VX](https://github.com/voyd-lang/voyd/pull/695)
+- [#696 Fix full `EventOptions` Wasm lowering](https://github.com/voyd-lang/voyd/pull/696)
+- [#710 Add external package adapters and Markdown integration](https://github.com/voyd-lang/voyd/pull/710)
+
+### Language, standard library, and correctness
+
+- [#641 Add a Voyd quick reference for compiler and std contributors](https://github.com/voyd-lang/voyd/pull/641)
+- [#656 Fix `use ...::all` effect-op collisions and restore `std::log`](https://github.com/voyd-lang/voyd/pull/656)
+- [#665 Add the `enum` macro to the standard prelude](https://github.com/voyd-lang/voyd/pull/665)
+- [#679 Reject subsuming labeled overload definitions](https://github.com/voyd-lang/voyd/pull/679)
+- [#680 Allow object literals to satisfy optional structural fields](https://github.com/voyd-lang/voyd/pull/680)
+- [#681 Refactor overload resolution scoring](https://github.com/voyd-lang/voyd/pull/681)
+- [#690 Fix generic escaped closure continuations](https://github.com/voyd-lang/voyd/pull/690)
+- [#691 Enforce self return types for init methods](https://github.com/voyd-lang/voyd/pull/691)
+- [#692 Fix free operator resolution in impl methods](https://github.com/voyd-lang/voyd/pull/692)
+- [#694 Add `std::fs::remove`](https://github.com/voyd-lang/voyd/pull/694)
+- [#697 Add `Eq` support for `String` and `StringSlice`](https://github.com/voyd-lang/voyd/pull/697)
+- [#699 Reject reference-bound default parameters](https://github.com/voyd-lang/voyd/pull/699)
+- [#700 Lower effectful default-parameter continuations](https://github.com/voyd-lang/voyd/pull/700)
+- [#702 Make default-argument presence first-class](https://github.com/voyd-lang/voyd/pull/702)
+- [#704 Improve parser diagnostics for missing commas and invalid module access](https://github.com/voyd-lang/voyd/pull/704)
+- [#709 Refactor the compiler surface-syntax boundary](https://github.com/voyd-lang/voyd/pull/709)
+
+### Compiler and runtime performance
+
+- [#640 Disable runtime diagnostics by default](https://github.com/voyd-lang/voyd/pull/640)
+- [#651 Remove standalone pure direct-call inlining](https://github.com/voyd-lang/voyd/pull/651)
+- [#652 Optimize local tail effect handlers](https://github.com/voyd-lang/voyd/pull/652)
+- [#653 Remove scalar object local replacement](https://github.com/voyd-lang/voyd/pull/653)
+- [#654 Fix optimized tail effects across dynamic dispatch](https://github.com/voyd-lang/voyd/pull/654)
+- [#655 Optimize closed receiver dispatch](https://github.com/voyd-lang/voyd/pull/655)
+- [#657 Add tier-two optimizer passes and benchmarks](https://github.com/voyd-lang/voyd/pull/657)
+- [#658 Remove inline aggregate fixed-array storage](https://github.com/voyd-lang/voyd/pull/658)
+- [#659 Add `std::Array` `len`/`at` fast paths with value-object support](https://github.com/voyd-lang/voyd/pull/659)
+- [#660 Add safe array-loop fast paths for bounds checks](https://github.com/voyd-lang/voyd/pull/660)
+- [#661 Add whole-program escape-analysis facts and benchmarks](https://github.com/voyd-lang/voyd/pull/661)
+- [#662 Consume escape facts for scalar replacement](https://github.com/voyd-lang/voyd/pull/662)
+- [#663 Fix safe array-loop proof invalidation](https://github.com/voyd-lang/voyd/pull/663)
+- [#664 Preserve mutable scalar aggregates in call lowering](https://github.com/voyd-lang/voyd/pull/664)
+- [#685 Reuse dependency semantic snapshots for app edits](https://github.com/voyd-lang/voyd/pull/685)
+- [#686 Add SDK compiler performance attribution](https://github.com/voyd-lang/voyd/pull/686)
+- [#698 Optimize the compiler pipeline end to end](https://github.com/voyd-lang/voyd/pull/698)
+- [#701 Harden the optimizer scorecard against peak-RSS flakiness](https://github.com/voyd-lang/voyd/pull/701)
+- [#703 Modularize and harden the compiler optimization pipeline](https://github.com/voyd-lang/voyd/pull/703)
+- [#706 Improve release optimization and scalar boundary exports](https://github.com/voyd-lang/voyd/pull/706)
+- [#707 Eliminate recursive static-effect ABI overhead](https://github.com/voyd-lang/voyd/pull/707)
+
+### Tooling, tests, and dependencies
+
+- [#675 Update vulnerable dependencies](https://github.com/voyd-lang/voyd/pull/675)
+- [#687 Clarify full and affected test scripts](https://github.com/voyd-lang/voyd/pull/687)
+- [#689 Normalize lightningcss lockfile entries](https://github.com/voyd-lang/voyd/pull/689)
+- [#693 Use `npm ci` in Codex environment setup](https://github.com/voyd-lang/voyd/pull/693)
+- [#705 Reorganize test architecture and split CI](https://github.com/voyd-lang/voyd/pull/705)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bench:optimizer:ci": "node --conditions=development --import tsx scripts/bench-optimizer.ts --preset ci",
     "bench:optimizer:ablate": "node --conditions=development --import tsx scripts/bench-optimizer.ts --preset full --modes release --binaryen-ablation-matrix",
     "bench:optimizer:compare": "node scripts/ci/check-optimizer-bench-regression.mjs",
+    "bench:release:v0.3.0": "node scripts/release/benchmark-v0.3.0.mjs",
     "bench:compiler-latency": "tsx --conditions=development scripts/bench-v375-compiler-latency.ts && npm run --workspace @voyd-lang/compiler bench:typing",
     "typecheck": "turbo run typecheck --affected",
     "lint": "turbo run lint --affected --parallel",

--- a/packages/reference/docs/releases.md
+++ b/packages/reference/docs/releases.md
@@ -4,6 +4,270 @@ order: 5
 
 # Releases
 
+## Voyd v0.3.0 - Gaia BH1
+
+Voyd `0.3.0` is the full-stack web release. The work since `0.2.0` connects
+Voyd's type system, effects, tasks, WebAssembly compiler, and host runtime into
+one application model: typed VX apps in the browser, HTTP services and server
+rendering on Node, and external packages that still look like ordinary Voyd
+APIs.
+
+This release spans 68 merged changes. The visible theme is web development, but
+the compiler underneath it also changed substantially: typed host boundaries,
+stronger whole-program optimization, faster incremental app edits, better
+diagnostics, and clearer compiler and test architecture.
+
+### Highlights
+
+- VX now has a typed `Program<Model, Msg>` architecture with commands,
+  subscriptions, async task commands, browser events, DOM patching, server
+  rendering, and hydration.
+- `std::http` provides HTTP client and server primitives. The new
+  `@voyd-lang/web` package adds routing, typed extraction, middleware, response
+  conversion, static files, cookies, limits, timeouts, and VX-backed HTML.
+- `voyd bootstrap` can scaffold either a VX single-page app or a full-stack SSR
+  app.
+- `@external` functions and effects let Voyd packages use host-language
+  implementations through generated contracts and adapters. The new
+  `@voyd-lang/markdown` package is the first complete example.
+- Typed SDK exports validate DTOs automatically and use direct Wasm calls for
+  compatible scalar signatures.
+- Release builds gain whole-program analysis, effect and call-shape
+  specialization, array and dispatch fast paths, and Binaryen closed-world GC
+  optimization.
+
+### VX becomes an application runtime
+
+The VX API is now organized around a small, typed state machine:
+
+```voyd
+use std::number::cast::to_string
+use std::vx::all
+
+obj Model {
+  count: i32
+}
+
+enum Msg
+  Increment
+  Decrement
+
+pub fn app() -> Program<Model, Msg>
+  program({ init, step, view })
+
+fn init() -> Model
+  Model { count: 0 }
+
+fn step(model: Model, msg: Msg) -> Program<Model, Msg>
+  match(msg)
+    Msg::Increment:
+      next(Model { count: model.count + 1 })
+    Msg::Decrement:
+      next(Model { count: model.count - 1 })
+
+fn view(model: Model) -> Html<Msg>
+  <main>
+    <button on_click={Msg::Decrement {}}>-</button>
+    <span>{to_string(model.count)}</span>
+    <button on_click={Msg::Increment {}}>+</button>
+  </main>
+```
+
+`Model` is durable application state. `Msg` is the closed set of events that
+can change it. `step` returns the next model plus optional command work, while
+`subscriptions` describes ongoing outside input. The runtime owns DOM patches,
+listener and subscription lifetimes, async command execution, and hydration.
+
+Commands now cover tasks, HTTP, clipboard access, document titles, navigation,
+history, scrolling, selection, opening URLs, and browser storage. Subscriptions
+cover keyboard input, connectivity, window size and focus, visibility,
+animation frames, media queries, location changes, storage events,
+`BroadcastChannel`, and custom host input.
+
+The same typed virtual tree renders in the browser or on the server. VX's
+boundary schema validates models, messages, commands, subscriptions, and event
+payloads while keeping the serialized transport behind the runtime contract.
+
+Read the full [VX reference](./vx.md).
+
+### HTTP and a Voyd web framework
+
+`std::http` replaces the earlier `std::fetch` API with client and server
+primitives. On top of that, `pkg::web` lets handlers receive typed values and
+return ordinary Voyd values:
+
+```voyd
+use pkg::web::all
+use std::error::HostError
+use std::http::server
+use std::result::types::all
+use std::task
+
+type UserParams = {
+  id: String
+}
+
+pub fn main(): (server::HttpServer, task::TaskRuntime) -> Result<Unit, HostError>
+  serve(port: 3000) routes():
+    get("/health") do:
+      "ok"
+
+    get("/users/:id") do(params: UserParams):
+      params.id
+```
+
+The framework includes static and parameterized routes, nested route groups,
+middleware, params/query/header/cookie/body extraction, response conversion,
+JSON DTO helpers, static files, body and request limits, cooperative handler
+timeouts, server backpressure controls, VX server rendering, and hydration
+helpers. The Node SDK also exposes `serveWebApp` for host lifecycle management.
+
+The `web-ssr` bootstrap connects these pieces into a runnable project. The
+mini-wikipedia example now exercises the complete stack: Voyd owns the server,
+API routes, JSON persistence, search, validation, SSR view, hydration state,
+and client-side VX state machine.
+
+Read the full [Web reference](./web.md).
+
+### External packages without framework coupling
+
+Voyd packages can now declare bodyless functions and asynchronous effects whose
+implementations come from JavaScript or another host language:
+
+```voyd
+@external(id: "example:markdown/renderer@1")
+pub fn render(source: String) -> StaticHtml
+```
+
+Package authors can run `voyd generate adapter` to emit a portable contract,
+typed TypeScript bindings, an adapter helper, and a WIT interface. Node runs
+discover installed adapters automatically. Browser applications generate a
+static registry so bundlers can see every required import.
+
+The API is independent of VX. Renderers, parsers, database clients, and crypto
+libraries all use the same boundary. Synchronous functions use the direct host
+adapter path, while host work that may suspend is represented as an external
+Voyd effect.
+
+`@voyd-lang/markdown` is the first reference package. It uses Marked in its host
+adapter, but exposes ordinary Voyd functions and a VX component. Markdown is
+converted to a bounded, inert node DTO: raw HTML is text, active URL schemes
+are rejected, and the VX renderer never receives an `innerHTML` escape hatch.
+
+Read [External packages](./external-packages.md) for the package format and
+runtime contracts.
+
+### Typed boundaries for ordinary exports
+
+Typed boundary exports are no longer VX-specific. Public functions that accept
+or return boundary-compatible values can be called through the SDK with normal
+JavaScript values. The compiler emits a schema, the host validates and converts
+arguments and results, and recursive optional DTOs are represented through
+schema references while rejecting actual cyclic runtime values.
+
+Scalar signatures take a faster path. When `bool`, `i32`, `i64`, `f32`, `f64`,
+or `void` maps directly to the physical Wasm ABI, the release build avoids the
+serialized wrapper and most supporting runtime reachability. For the minimal
+`pub fn main() -> i32` case, the typed artifact shrank from 17,111 bytes to 783
+bytes and warm `runPure` dispatch improved from 0.901 µs to 0.146 µs per call.
+
+### A stronger release optimizer
+
+The SDK and compiler now expose explicit `none`, `balanced`, and `release`
+optimization levels. The release pipeline combines compiler-owned semantic
+facts with Binaryen's aggressive and closed-world GC passes.
+
+Compiler work in this release includes:
+
+- local tail-effect specialization and static-effect specialization across
+  recursive call graphs;
+- receiver and trait-dispatch specialization;
+- safe `Array.len` and `Array.at` fast paths, including proven-safe loops;
+- whole-program escape analysis and scalar aggregate replacement;
+- redundant runtime type-check elimination and semantic copy forwarding;
+- compact call shapes for default arguments;
+- indexed worklists, dependency-aware scheduling, bounded fixed points, and
+  explicit specialization budgets;
+- cached dependency semantic snapshots for faster application edits.
+
+Across the six-scenario optimizer scorecard, closed-world release optimization
+reduced raw Wasm from 162,288 to 151,474 bytes (`-6.66%`) and gzip size from
+56,469 to 54,824 bytes (`-2.91%`). The vtrace workload improved by 6.71% in the
+same comparison. Static-effect specialization also removes the residual effect
+ABI from eligible recursive functions, restoring tail calls and allowing the
+representative evaluator to complete at depth 250,000 instead of overflowing.
+
+Optimization is now measured in CI through differential correctness checks,
+corpus hashes, size and runtime scorecards, compile-phase telemetry, and
+regression budgets.
+
+### Language and standard-library polish
+
+Several smaller changes add up to a smoother language:
+
+- `enum` is now in the standard prelude.
+- `String` and `StringSlice` implement `Eq`.
+- `std::fs::remove` removes files, symlinks, and empty directories.
+- Object literals can satisfy optional structural fields.
+- Overload scoring and generic inference handle labeled structural arguments,
+  static generic methods, and return-only type parameters more reliably.
+- Effectful default expressions now suspend and resume through the full
+  parameter-initialization sequence.
+- Imported effect metadata, generic escaped closures, free operators in impls,
+  mutable aggregates, `EventOptions`, and UTF-8 export isolation received
+  correctness fixes.
+- Missing commas and invalid single-colon module access now produce focused
+  parser diagnostics instead of cascaded module or typing errors.
+
+### Conformance and compiler architecture
+
+The former mixed smoke suite has been split into three explicit contracts:
+compiler-neutral conformance, public cross-package integration, and opt-in
+performance tests. The initial conformance manifest contains 118 portable cases
+and can load another compiler through `VOYD_CONFORMANCE_ADAPTER`.
+
+CI now separates unit, conformance, integration, codegen, packaged CLI, and
+conditional optimizer lanes, records timings, enforces checked-in budgets, and
+cancels superseded runs.
+
+Inside the compiler, parser-owned surface views now normalize context-free
+syntax once for the module graph, macro expansion, documentation, binding, and
+lowering. The optimizer has likewise moved from a monolithic pipeline to
+explicit indexes, passes, scheduling, mutation contracts, and telemetry. These
+boundaries do not change the language by themselves, but they make future
+compiler work considerably safer.
+
+### Breaking changes
+
+- `std::fetch` has been removed. Use `std::http::client` for outbound HTTP.
+- VX applications now expose `app() -> Program<Model, Msg>`, construct the app
+  with `program`, and return transitions with `next`. Component state IDs are
+  generated from stable call sites; remove explicit `state(id:)` arguments.
+- Runtime diagnostics and Binaryen validation are disabled by default for
+  unoptimized builds. Set `runtimeDiagnostics: true` when investigating runtime
+  traps or validating generated Wasm.
+- Reference-bound (`~`) parameters cannot have defaults. Use an overload or
+  callee-owned local storage.
+
+### Upgrade notes
+
+Install the new CLI with:
+
+```bash
+npm i -g @voyd-lang/cli@0.3.0
+```
+
+Update all directly consumed Voyd packages together. For existing applications,
+the two source migrations to check first are `std::fetch` imports and the VX
+`Program<Model, Msg>` app shape.
+
+New projects can start from either template:
+
+```bash
+voyd bootstrap my-app --template vx-spa
+voyd bootstrap my-app --template web-ssr
+```
+
 ## Voyd v0.2.0 - M87*
 
 This first minor release since launch brings a few new features and a whole ton

--- a/packages/reference/docs/releases.md
+++ b/packages/reference/docs/releases.md
@@ -6,39 +6,40 @@ order: 5
 
 ## Voyd v0.3.0 - Gaia BH1
 
-Voyd `0.3.0` is the full-stack web release. The work since `0.2.0` connects
-Voyd's type system, effects, tasks, WebAssembly compiler, and host runtime into
-one application model: typed VX apps in the browser, HTTP services and server
-rendering on Node, and external packages that still look like ordinary Voyd
-APIs.
+Voyd `0.3.0` is the release where you can build a complete interactive web
+application in Voyd. You can define the browser state machine, render its UI,
+serve HTTP routes, render the first page on the server, hydrate it in the
+browser, call APIs, persist data, and package host-language libraries behind
+typed Voyd APIs.
 
-This release spans 68 merged changes. The visible theme is web development, but
-the compiler underneath it also changed substantially: typed host boundaries,
-stronger whole-program optimization, faster incremental app edits, better
-diagnostics, and clearer compiler and test architecture.
+To exercise the whole stack, I rebuilt the mini-wikipedia example as a real
+Voyd application. It supports article creation, editing, deletion, search,
+direct links, server rendering, browser hydration, and JSON-file persistence.
+The server, API routes, validation, shared article model, and interactive VX
+app are all written in Voyd.
 
-### Highlights
+That is the heart of Gaia BH1: Voyd now has an end-to-end story for building a
+web product.
 
-- VX now has a typed `Program<Model, Msg>` architecture with commands,
-  subscriptions, async task commands, browser events, DOM patching, server
-  rendering, and hydration.
-- `std::http` provides HTTP client and server primitives. The new
-  `@voyd-lang/web` package adds routing, typed extraction, middleware, response
-  conversion, static files, cookies, limits, timeouts, and VX-backed HTML.
-- `voyd bootstrap` can scaffold either a VX single-page app or a full-stack SSR
-  app.
-- `@external` functions and effects let Voyd packages use host-language
-  implementations through generated contracts and adapters. The new
-  `@voyd-lang/markdown` package is the first complete example.
-- Typed SDK exports validate DTOs automatically and use direct Wasm calls for
-  compatible scalar signatures.
-- Release builds gain whole-program analysis, effect and call-shape
-  specialization, array and dispatch fast paths, and Binaryen closed-world GC
-  optimization.
+### Start a new app
 
-### VX becomes an application runtime
+The CLI ships with two project templates:
 
-The VX API is now organized around a small, typed state machine:
+```bash
+voyd bootstrap my-app --template vx-spa
+voyd bootstrap my-app --template web-ssr
+```
+
+`vx-spa` creates a browser application with Vite, Tailwind, Voyd compilation,
+and a typed VX starter. `web-ssr` creates a server-rendered application with an
+HTTP server, shared VX views, browser hydration, static assets, and a development
+workflow.
+
+### Build an interactive UI with VX
+
+A VX app is a typed state machine. `Model` holds the current application state,
+`Msg` describes every event, `step` calculates the next state, and `view`
+renders it:
 
 ```voyd
 use std::number::cast::to_string
@@ -74,27 +75,42 @@ fn view(model: Model) -> Html<Msg>
 ```
 
 `Model` is durable application state. `Msg` is the closed set of events that
-can change it. `step` returns the next model plus optional command work, while
-`subscriptions` describes ongoing outside input. The runtime owns DOM patches,
-listener and subscription lifetimes, async command execution, and hydration.
+can change it. A button click produces a `Msg`, `step` produces a new `Model`,
+and VX patches the DOM from the next `view` result. The signatures connect each
+part of the loop, so a view can only emit messages that the app knows how to
+handle.
 
-Commands now cover tasks, HTTP, clipboard access, document titles, navigation,
+Real applications also need work that completes later. `Cmd::task` runs Voyd
+task code and maps the result back into a message:
+
+```voyd
+fn save_command(article: Article): (HttpClient, TaskRuntime) -> Cmd<Msg>
+  Cmd::task(
+    work: () -> bool => save_article(article),
+    handler: (ok: bool) -> Msg => Msg::SaveFinished { ok: ok }
+  )
+```
+
+This gives `step` a clean shape: accept a message, update the model, and return
+the work to start. VX runs the task and dispatches `SaveFinished` when it
+completes.
+
+VX includes commands for tasks, clipboard access, document titles, navigation,
 history, scrolling, selection, opening URLs, and browser storage. Subscriptions
 cover keyboard input, connectivity, window size and focus, visibility,
 animation frames, media queries, location changes, storage events,
 `BroadcastChannel`, and custom host input.
 
-The same typed virtual tree renders in the browser or on the server. VX's
-boundary schema validates models, messages, commands, subscriptions, and event
-payloads while keeping the serialized transport behind the runtime contract.
-
 Read the full [VX reference](./vx.md).
 
-### HTTP and a Voyd web framework
+### Serve the application from Voyd
 
-`std::http` replaces the earlier `std::fetch` API with client and server
-primitives. On top of that, `pkg::web` lets handlers receive typed values and
-return ordinary Voyd values:
+`std::http` provides HTTP client and server capabilities. `pkg::web` adds the
+application layer: routes, typed request data, middleware, responses, cookies,
+static files, limits, timeouts, and server-rendered VX HTML.
+
+A route handler can ask for the values it needs in its parameter list and
+return an ordinary Voyd value:
 
 ```voyd
 use pkg::web::all
@@ -116,157 +132,199 @@ pub fn main(): (server::HttpServer, task::TaskRuntime) -> Result<Unit, HostError
       params.id
 ```
 
-The framework includes static and parameterized routes, nested route groups,
-middleware, params/query/header/cookie/body extraction, response conversion,
-JSON DTO helpers, static files, body and request limits, cooperative handler
-timeouts, server backpressure controls, VX server rendering, and hydration
-helpers. The Node SDK also exposes `serveWebApp` for host lifecycle management.
+Path parameters, query values, headers, cookies, and JSON bodies can all be
+decoded into typed records. Return values such as `String`, `JsonValue`,
+`Response`, `Option<T>`, and `Result<T, E>` become HTTP responses through the
+same handler model.
 
-The `web-ssr` bootstrap connects these pieces into a runnable project. The
-mini-wikipedia example now exercises the complete stack: Voyd owns the server,
-API routes, JSON persistence, search, validation, SSR view, hydration state,
-and client-side VX state machine.
+The mini-wikipedia API saves a decoded `Article` directly:
+
+```voyd
+serve(port: 3000) routes():
+  put("/api/articles", body: json_body()) do(article: Article):
+    save_article(article)
+
+  delete("/api/articles/:slug") do(ctx: Context):
+    delete_article(ctx.param("slug") ?? "")
+```
+
+The page route renders the VX tree on the server and includes the model needed
+for hydration:
+
+```voyd
+fn article_page(model: Model) -> Response
+  Response::ok()
+    .with(header: "content-type", value: "text/html; charset=utf-8")
+    .text(document<Msg, Model>(
+      view: page_view(model),
+      hydrate: hydrate<Model>(
+        target: "#wiki-app",
+        entry: "/assets/client.js",
+        model: model
+      )
+    ))
+```
+
+The browser starts from that model, attaches the VX runtime to the rendered
+tree, and continues through the same `Msg` and `step` loop. The shared view
+function owns the server page and the interactive browser updates.
 
 Read the full [Web reference](./web.md).
 
-### External packages without framework coupling
+### Use packages backed by JavaScript
 
-Voyd packages can now declare bodyless functions and asynchronous effects whose
-implementations come from JavaScript or another host language:
+Voyd packages can now expose a typed Voyd API implemented by JavaScript or
+another host language. The application imports the package through the normal
+`pkg::` namespace.
 
-```voyd
-@external(id: "example:markdown/renderer@1")
-pub fn render(source: String) -> StaticHtml
+The first package built this way is `@voyd-lang/markdown`:
+
+```bash
+npm install @voyd-lang/markdown
 ```
 
-Package authors can run `voyd generate adapter` to emit a portable contract,
-typed TypeScript bindings, an adapter helper, and a WIT interface. Node runs
-discover installed adapters automatically. Browser applications generate a
-static registry so bundlers can see every required import.
+```voyd
+use pkg::markdown::Markdown
+use std::vx::all
 
-The API is independent of VX. Renderers, parsers, database clients, and crypto
-libraries all use the same boundary. Synchronous functions use the direct host
-adapter path, while host work that may suspend is represented as an external
-Voyd effect.
+fn Article({ source: String }) -> Html<AppMsg>
+  <article class="wiki-article">
+    <Markdown source={source} />
+  </article>
+```
 
-`@voyd-lang/markdown` is the first reference package. It uses Marked in its host
-adapter, but exposes ordinary Voyd functions and a VX component. Markdown is
-converted to a bounded, inert node DTO: raw HTML is text, active URL schemes
-are rejected, and the VX renderer never receives an `innerHTML` escape hatch.
+The component calls a JavaScript adapter powered by Marked. The adapter returns
+a restricted tree of text, elements, and attributes. Voyd turns that tree into
+ordinary VX nodes, so Markdown content participates in normal validation,
+rendering, and DOM updates. Raw HTML becomes text, and active link and image
+schemes are rejected.
+
+Package authors declare host-backed functions with `@external` and generate the
+adapter contract from the CLI:
+
+```voyd
+@external(id: "example:search/index@1")
+pub fn search(query: String) -> Array<SearchResult>
+```
+
+```bash
+voyd generate adapter ./src --out ./generated
+```
+
+The generated output includes typed TypeScript bindings, runtime contract
+metadata, and a WIT interface. Node discovers installed adapters during a run.
+Browser builds use a generated static registry for their adapter imports.
 
 Read [External packages](./external-packages.md) for the package format and
 runtime contracts.
 
-### Typed boundaries for ordinary exports
+### Call Voyd from JavaScript with typed values
 
-Typed boundary exports are no longer VX-specific. Public functions that accept
-or return boundary-compatible values can be called through the SDK with normal
-JavaScript values. The compiler emits a schema, the host validates and converts
-arguments and results, and recursive optional DTOs are represented through
-schema references while rejecting actual cyclic runtime values.
+Public Voyd functions can now cross the SDK boundary with booleans, numbers,
+strings, arrays, records, optional values, results, and enum variants. JavaScript
+passes plain values, and the generated boundary schema validates every argument
+and result.
 
-Scalar signatures take a faster path. When `bool`, `i32`, `i64`, `f32`, `f64`,
-or `void` maps directly to the physical Wasm ABI, the release build avoids the
-serialized wrapper and most supporting runtime reachability. For the minimal
-`pub fn main() -> i32` case, the typed artifact shrank from 17,111 bytes to 783
-bytes and warm `runPure` dispatch improved from 0.901 µs to 0.146 µs per call.
+Here is a Voyd function that accepts and returns a record:
 
-### A stronger release optimizer
+```voyd
+obj Point {
+  x: i32,
+  y: i32
+}
 
-The SDK and compiler now expose explicit `none`, `balanced`, and `release`
-optimization levels. The release pipeline combines compiler-owned semantic
-facts with Binaryen's aggressive and closed-world GC passes.
+pub fn translate(point: Point, dx: i32, dy: i32) -> Point
+  Point { x: point.x + dx, y: point.y + dy }
+```
 
-Compiler work in this release includes:
+The SDK call uses a normal JavaScript object:
 
-- local tail-effect specialization and static-effect specialization across
-  recursive call graphs;
-- receiver and trait-dispatch specialization;
-- safe `Array.len` and `Array.at` fast paths, including proven-safe loops;
-- whole-program escape analysis and scalar aggregate replacement;
-- redundant runtime type-check elimination and semantic copy forwarding;
-- compact call shapes for default arguments;
-- indexed worklists, dependency-aware scheduling, bounded fixed points, and
-  explicit specialization budgets;
-- cached dependency semantic snapshots for faster application edits.
+```ts
+const point = await result.run({
+  entryName: "translate",
+  args: [{ x: 1, y: 2 }, 10, 20],
+});
 
-Across the six-scenario optimizer scorecard, closed-world release optimization
-reduced raw Wasm from 162,288 to 151,474 bytes (`-6.66%`) and gzip size from
-56,469 to 54,824 bytes (`-2.91%`). The vtrace workload improved by 6.71% in the
-same comparison. Static-effect specialization also removes the residual effect
-ABI from eligible recursive functions, restoring tail calls and allowing the
-representative evaluator to complete at depth 250,000 instead of overflowing.
+// { x: 11, y: 22 }
+```
 
-Optimization is now measured in CI through differential correctness checks,
-corpus hashes, size and runtime scorecards, compile-phase telemetry, and
-regression budgets.
+Enum values arrive as tagged objects, arrays arrive as JavaScript arrays, and
+recursive optional DTOs support data such as trees. Scalar signatures map
+directly to Wasm with JavaScript-side type validation.
 
-### Language and standard-library polish
+Read the [SDK reference](./sdk.md) for supported boundary shapes and embedding
+APIs.
 
-Several smaller changes add up to a smoother language:
+### Ship smaller, faster Wasm
 
-- `enum` is now in the standard prelude.
-- `String` and `StringSlice` implement `Eq`.
+Use the release optimization profile when building an application for
+deployment:
+
+```bash
+voyd --emit-wasm --opt ./src > app.wasm
+```
+
+Across the release benchmark suite, Gaia BH1 reduced raw Wasm size by 6.66% and
+gzip size by 2.91%. The representative vtrace application ran 6.71% faster.
+
+Small exported functions see an especially large improvement. A minimal typed
+`pub fn main() -> i32` release build dropped from 17,111 bytes to 783 bytes, and
+warm SDK calls improved from 0.901 µs to 0.146 µs per call.
+
+Release optimization now recognizes common array loops, known method targets,
+handled effects, recursive tail calls, short default-argument call shapes, and
+non-escaping values. Warm application edits also reuse analyzed dependency
+state, which shortens recompilation during development.
+
+### Everyday language improvements
+
+Gaia BH1 also smooths out several parts of day-to-day Voyd code:
+
+- `enum` is available from the standard prelude.
+- `String` and `StringSlice` implement `Eq`, so they work naturally with APIs
+  that accept equality-constrained values.
 - `std::fs::remove` removes files, symlinks, and empty directories.
-- Object literals can satisfy optional structural fields.
-- Overload scoring and generic inference handle labeled structural arguments,
-  static generic methods, and return-only type parameters more reliably.
-- Effectful default expressions now suspend and resume through the full
-  parameter-initialization sequence.
-- Imported effect metadata, generic escaped closures, free operators in impls,
-  mutable aggregates, `EventOptions`, and UTF-8 export isolation received
-  correctness fixes.
-- Missing commas and invalid single-colon module access now produce focused
-  parser diagnostics instead of cascaded module or typing errors.
+- Object literals can fill structural types that contain optional fields.
+- Generic inference understands more labeled arguments, static generic methods,
+  and return-driven type arguments.
+- Default expressions can perform effects and resume through the remaining
+  parameter initialization.
+- Missing commas and invalid module access produce focused parser diagnostics
+  at the source location.
+- Fixes cover imported effects, escaped generic closures, operators in impls,
+  mutable values, browser event options, and UTF-8 exports.
 
-### Conformance and compiler architecture
+### Upgrade an existing project
 
-The former mixed smoke suite has been split into three explicit contracts:
-compiler-neutral conformance, public cross-package integration, and opt-in
-performance tests. The initial conformance manifest contains 118 portable cases
-and can load another compiler through `VOYD_CONFORMANCE_ADAPTER`.
-
-CI now separates unit, conformance, integration, codegen, packaged CLI, and
-conditional optimizer lanes, records timings, enforces checked-in budgets, and
-cancels superseded runs.
-
-Inside the compiler, parser-owned surface views now normalize context-free
-syntax once for the module graph, macro expansion, documentation, binding, and
-lowering. The optimizer has likewise moved from a monolithic pipeline to
-explicit indexes, passes, scheduling, mutation contracts, and telemetry. These
-boundaries do not change the language by themselves, but they make future
-compiler work considerably safer.
-
-### Breaking changes
-
-- `std::fetch` has been removed. Use `std::http::client` for outbound HTTP.
-- VX applications now expose `app() -> Program<Model, Msg>`, construct the app
-  with `program`, and return transitions with `next`. Component state IDs are
-  generated from stable call sites; remove explicit `state(id:)` arguments.
-- Runtime diagnostics and Binaryen validation are disabled by default for
-  unoptimized builds. Set `runtimeDiagnostics: true` when investigating runtime
-  traps or validating generated Wasm.
-- Reference-bound (`~`) parameters cannot have defaults. Use an overload or
-  callee-owned local storage.
-
-### Upgrade notes
-
-Install the new CLI with:
+Install the new CLI and update directly consumed Voyd packages together:
 
 ```bash
 npm i -g @voyd-lang/cli@0.3.0
 ```
 
-Update all directly consumed Voyd packages together. For existing applications,
-the two source migrations to check first are `std::fetch` imports and the VX
-`Program<Model, Msg>` app shape.
+Outbound HTTP now lives in `std::http::client`. Update `std::fetch` imports and
+calls to the client API:
 
-New projects can start from either template:
+```voyd
+use std::http::client::self as http_client
 
-```bash
-voyd bootstrap my-app --template vx-spa
-voyd bootstrap my-app --template web-ssr
+let response = http_client::get("https://example.com/api")
 ```
+
+VX applications expose `app() -> Program<Model, Msg>`, construct the app with
+`program({ init, step, view, subscriptions })`, and return transitions through
+`next(...)`. Component state IDs now come from stable call sites, so explicit
+`state(id:)` arguments should be removed.
+
+Runtime diagnostics and Binaryen validation are opt-in for unoptimized builds.
+Set `runtimeDiagnostics: true` when investigating a runtime trap or validating
+generated Wasm. Reference-bound (`~`) parameters cannot declare defaults; an
+overload or callee-owned local value expresses that API shape.
+
+If you want to see the release working as one application, explore
+[The Small Knowledge](https://github.com/voyd-lang/voyd/tree/main/examples/mini-wikipedia),
+the file-backed wiki built with Voyd, VX, `pkg::web`, SSR, hydration, HTTP, and
+filesystem effects.
 
 ## Voyd v0.2.0 - M87*
 

--- a/packages/reference/docs/releases.md
+++ b/packages/reference/docs/releases.md
@@ -6,35 +6,20 @@ order: 5
 
 ## Voyd v0.3.0 - Gaia BH1
 
-This release is centered around Voyd's full-stack web development experience.
-Gaia BH1 fills in both sides of Voyd's web stack. VX brings an Elm-inspired
-architecture to interactive UIs, while new HTTP client and server APIs in `std`
-and the `pkg::web` framework support server-side applications. Stronger release
-optimizations, a new bootstrap command, and more round out the release.
+This release is centered around Voyd's full-stack web development experience. Gaia BH1
+introduces the VX UI framework, HTTP client and server APIs, the
+`pkg::web` framework, server rendering and hydration, external package adapters,
+and substantially stronger release optimization.
 
-All these features should come together to make developing real production
-full stack web applications both practical and pleasant.
-
-### New `voyd bootstrap` Command
-
-The CLI ships with two project templates:
-
-```bash
-voyd bootstrap my-app --template vx-spa
-voyd bootstrap my-app --template web-ssr
-```
-
-`vx-spa` creates a browser application with Vite, Tailwind, Voyd compilation,
-and a typed VX starter. `web-ssr` creates a server-rendered application with an
-HTTP server, shared VX views, browser hydration, static assets, and a development
-workflow.
+Together, these additions let one Voyd project share typed models and views
+across the server and browser, integrate host-language packages without exposing
+host details to application code, and produce smaller, faster deployments.
 
 ### The VX UI Framework
 
-Gaia BH1 introduces VX, an Elm-inspired framework for building interactive
-UIs with idiomatic Voyd. VX gives an application a typed architecture for state,
-events, effects, and rendering, with views that can render in the browser or on
-the server.
+VX is an Elm-inspired framework for building interactive UIs with idiomatic
+Voyd. It provides a typed architecture for state, events, effects, and rendering,
+with views that can run in the browser or on the server.
 
 A VX app is a typed state machine. `Model` holds the current application state,
 `Msg` describes every event, `step` calculates the next state, and `view`
@@ -84,22 +69,16 @@ fn start_timer() -> Cmd<Msg>
       Msg::TimerFinished {}
 ```
 
-`Model` is durable application state. `Msg` is the closed set of events that
-can change it. A button click produces a `Msg`, and `step` returns the next
-`Model` plus any command to run. VX patches the DOM from the next `view` result,
-then sends command results back through the same message loop. The signatures
-connect each part, so a view can only emit messages that the app knows how to
-handle.
+`Model` stores durable application state, while `Msg` defines every event that
+can change it. `step` returns the next model and any work to start; `view`
+renders that model. In this example, `Cmd::task` performs the wait and maps its
+result to `TimerFinished`, which returns through the same typed message loop.
+HTTP requests, database writes, and other asynchronous operations follow the
+same command-to-message pattern.
 
-`StartTimer` shows how asynchronous work fits into the loop. Its `step` branch
-immediately changes the status to `Steeping...` and returns a command created by
-`start_timer`. `Cmd::task` runs the wait as a Voyd task and maps its result to
-`TimerFinished`; VX dispatches that message when the delay ends, and `step`
-changes the status to `Tea is ready!`.
-
-This keeps `step` focused on transitions: accept a message, choose the next
-model, and describe any work to start. HTTP requests, database writes, and other
-asynchronous operations follow the same command-to-message pattern.
+The signatures connect every part of the application, so a view can emit only
+messages the app knows how to handle. VX patches the DOM after each transition
+and runs commands without moving that work into `step`.
 
 VX includes commands for tasks, clipboard access, document titles, navigation,
 history, scrolling, selection, opening URLs, and browser storage. Subscriptions
@@ -119,7 +98,7 @@ both sides of HTTP. Applications can send outbound requests through
 These APIs are useful directly when an application needs control over the HTTP
 lifecycle. They also provide the foundation for higher-level server frameworks.
 
-### The New `pkg::web` Server Framework
+### The `pkg::web` Server Framework
 
 `pkg::web` is a server-side HTTP application framework built on `std::http`. It
 adds routes, typed request extraction, middleware, response conversion, cookies,
@@ -159,17 +138,6 @@ decoded into typed records. Return values such as `String`, `JsonValue`,
 `Response`, `Option<T>`, and `Result<T, E>` become HTTP responses through the
 same handler model.
 
-The mini-wikipedia API saves a decoded `Article` directly:
-
-```voyd
-serve(port: 3000) routes():
-  put("/api/articles", body: json_body()) do(article: Article):
-    save_article(article)
-
-  delete("/api/articles/:slug") do(ctx: Context):
-    delete_article(ctx.param("slug") ?? "")
-```
-
 The page route renders the VX tree on the server and includes the model needed
 for hydration:
 
@@ -177,9 +145,9 @@ for hydration:
 fn article_page(model: Model) -> Response
   Response::ok()
     .with(header: "content-type", value: "text/html; charset=utf-8")
-    .text(document<Msg, Model>(
+    .text(document(
       view: page_view(model),
-      hydrate: hydrate<Model>(
+      hydrate: hydrate(
         target: "#wiki-app",
         entry: "/assets/client.js",
         model: model
@@ -187,11 +155,24 @@ fn article_page(model: Model) -> Response
     ))
 ```
 
-The browser starts from that model, attaches the VX runtime to the rendered
-tree, and continues through the same `Msg` and `step` loop. The shared view
-function owns the server page and the interactive browser updates.
+The browser starts from that model, attaches VX to the rendered tree, and
+continues through the same `Msg` and `step` loop. One shared view function owns
+both the server-rendered page and its interactive updates.
 
 Read the full [Web reference](./web.md).
+
+### New `voyd bootstrap` Command
+
+The CLI ships with templates for both sides of the web stack:
+
+```bash
+voyd bootstrap my-app --template vx-spa
+voyd bootstrap my-app --template web-ssr
+```
+
+`vx-spa` creates a browser application with Vite, Tailwind, Voyd compilation,
+and a typed VX starter. `web-ssr` adds an HTTP server, shared VX views, browser
+hydration, static assets, and a development workflow.
 
 ### External Package Adapters
 
@@ -221,21 +202,10 @@ ordinary VX nodes, so Markdown content participates in normal validation,
 rendering, and DOM updates. Raw HTML becomes text, and active link and image
 schemes are rejected.
 
-Package authors declare host-backed functions with `@external` and generate the
-adapter contract from the CLI:
-
-```voyd
-@external(id: "example:search/index@1")
-pub fn search(query: String) -> Array<SearchResult>
-```
-
-```bash
-voyd generate adapter ./src --out ./generated
-```
-
-The generated output includes typed TypeScript bindings, runtime contract
-metadata, and a WIT interface. Node discovers installed adapters during a run.
-Browser builds use a generated static registry for their adapter imports.
+Package authors declare host-backed functions with `@external`, then use the
+CLI to generate typed TypeScript bindings, runtime contract metadata, and a WIT
+interface. Node discovers installed adapters during a run, while browser builds
+use a generated static registry for their adapter imports.
 
 Read [External packages](./external-packages.md) for the package format and
 runtime contracts.
@@ -277,7 +247,7 @@ directly to Wasm with JavaScript-side type validation.
 Read the [SDK reference](./sdk.md) for supported boundary shapes and embedding
 APIs.
 
-### Faster Release Builds
+### Stronger Release Optimization
 
 Use the release optimization profile when building an application for
 deployment:
@@ -286,10 +256,10 @@ deployment:
 voyd --emit-wasm --opt ./src > app.wasm
 ```
 
-I compared Gaia BH1 with the `v0.2.0` tag using identical source files, Node
-22.23.1 on Apple silicon, three fresh-process compile samples, and five runtime
-samples per workload after eleven warmups. The complete setup is checked in as
-the `docs/release/v0.3.0-benchmark.md` release benchmark.
+The Gaia BH1 benchmark compares the release with the `v0.2.0` tag using
+identical source files, Node 22.23.1 on Apple silicon, three fresh-process
+compile samples, and five runtime samples per workload after eleven warmups.
+The complete setup is checked in at `docs/release/v0.3.0-benchmark.md`.
 
 | Workload                                  | v0.2.0 runtime | Gaia BH1 runtime |   Runtime change |          Raw Wasm |              gzip |
 | ----------------------------------------- | -------------: | ---------------: | ---------------: | ----------------: | ----------------: |
@@ -303,7 +273,6 @@ and much smaller than the development profile:
 | ----------------------------------------- | ----------: | --------: | ---------------: | ----------------: |
 | One million mutable particle steps        |   15.515 ms |  4.334 ms | **3.58x faster** | **97.2% smaller** |
 | Five million calls with default arguments |   47.278 ms | 25.549 ms | **1.85x faster** | **97.8% smaller** |
-
 
 Release optimization now recognizes common array loops, known method targets,
 locally handled effects, recursive tail calls, short default-argument call
@@ -365,10 +334,9 @@ Set `runtimeDiagnostics: true` when investigating a runtime trap or validating
 generated Wasm. Reference-bound (`~`) parameters cannot declare defaults; an
 overload or callee-owned local value expresses that API shape.
 
-If you want to see the release working as one application, explore
-[The Small Knowledge](https://github.com/voyd-lang/voyd/tree/main/examples/mini-wikipedia),
-the file-backed wiki built with Voyd, VX, `pkg::web`, SSR, hydration, HTTP, and
-filesystem effects.
+[The Small Knowledge](https://github.com/voyd-lang/voyd/tree/main/examples/mini-wikipedia)
+shows the release working as one application: a file-backed wiki built with
+Voyd, VX, `pkg::web`, SSR, hydration, HTTP, and filesystem effects.
 
 ## Voyd v0.2.0 - M87*
 

--- a/packages/reference/docs/releases.md
+++ b/packages/reference/docs/releases.md
@@ -6,11 +6,14 @@ order: 5
 
 ## Voyd v0.3.0 - Gaia BH1
 
-Voyd `0.3.0` is the release where you can build a complete interactive web
-application in Voyd. You can define the browser state machine, render its UI,
-serve HTTP routes, render the first page on the server, hydrate it in the
-browser, call APIs, persist data, and package host-language libraries behind
-typed Voyd APIs.
+This release is centered around Voyd's full-stack web development experience.
+Gaia BH1 brings together typed browser applications, HTTP services, server-side
+rendering, hydration, host-language package adapters, and the tooling needed to
+start and ship a project.
+
+You can define a browser state machine, render its UI, serve HTTP routes, render
+the first page on the server, hydrate it in the browser, call APIs, persist
+data, and package host-language libraries behind typed Voyd APIs.
 
 To exercise the whole stack, I rebuilt the mini-wikipedia example as a real
 Voyd application. It supports article creation, editing, deletion, search,
@@ -21,7 +24,7 @@ app are all written in Voyd.
 That is the heart of Gaia BH1: Voyd now has an end-to-end story for building a
 web product.
 
-### Start a new app
+### New `voyd bootstrap` Command
 
 The CLI ships with two project templates:
 
@@ -35,7 +38,7 @@ and a typed VX starter. `web-ssr` creates a server-rendered application with an
 HTTP server, shared VX views, browser hydration, static assets, and a development
 workflow.
 
-### Build an interactive UI with VX
+### Typed VX Application Runtime
 
 A VX app is a typed state machine. `Model` holds the current application state,
 `Msg` describes every event, `step` calculates the next state, and `view`
@@ -103,7 +106,7 @@ animation frames, media queries, location changes, storage events,
 
 Read the full [VX reference](./vx.md).
 
-### Serve the application from Voyd
+### `std::http` and the New `pkg::web` Framework
 
 `std::http` provides HTTP client and server capabilities. `pkg::web` adds the
 application layer: routes, typed request data, middleware, responses, cookies,
@@ -171,7 +174,7 @@ function owns the server page and the interactive browser updates.
 
 Read the full [Web reference](./web.md).
 
-### Use packages backed by JavaScript
+### External Package Adapters
 
 Voyd packages can now expose a typed Voyd API implemented by JavaScript or
 another host language. The application imports the package through the normal
@@ -218,7 +221,7 @@ Browser builds use a generated static registry for their adapter imports.
 Read [External packages](./external-packages.md) for the package format and
 runtime contracts.
 
-### Call Voyd from JavaScript with typed values
+### Typed SDK Boundary Exports
 
 Public Voyd functions can now cross the SDK boundary with booleans, numbers,
 strings, arrays, records, optional values, results, and enum variants. JavaScript
@@ -255,7 +258,7 @@ directly to Wasm with JavaScript-side type validation.
 Read the [SDK reference](./sdk.md) for supported boundary shapes and embedding
 APIs.
 
-### Ship smaller, faster Wasm
+### Faster Release Builds
 
 Use the release optimization profile when building an application for
 deployment:
@@ -276,7 +279,7 @@ handled effects, recursive tail calls, short default-argument call shapes, and
 non-escaping values. Warm application edits also reuse analyzed dependency
 state, which shortens recompilation during development.
 
-### Everyday language improvements
+### Language and Standard Library Improvements
 
 Gaia BH1 also smooths out several parts of day-to-day Voyd code:
 
@@ -294,7 +297,7 @@ Gaia BH1 also smooths out several parts of day-to-day Voyd code:
 - Fixes cover imported effects, escaped generic closures, operators in impls,
   mutable values, browser event options, and UTF-8 exports.
 
-### Upgrade an existing project
+### Upgrading from 0.2.0
 
 Install the new CLI and update directly consumed Voyd packages together:
 

--- a/packages/reference/docs/releases.md
+++ b/packages/reference/docs/releases.md
@@ -267,17 +267,38 @@ deployment:
 voyd --emit-wasm --opt ./src > app.wasm
 ```
 
-Across the release benchmark suite, Gaia BH1 reduced raw Wasm size by 6.66% and
-gzip size by 2.91%. The representative vtrace application ran 6.71% faster.
+I compared Gaia BH1 with the `v0.2.0` tag using identical source files, Node
+22.23.1 on Apple silicon, three fresh-process compile samples, and five runtime
+samples per workload.
 
-Small exported functions see an especially large improvement. A minimal typed
-`pub fn main() -> i32` release build dropped from 17,111 bytes to 783 bytes, and
-warm SDK calls improved from 0.901 µs to 0.146 µs per call.
+| Workload | v0.2.0 runtime | Gaia BH1 runtime | Runtime change | Raw Wasm | gzip |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Mutable scalar aggregates in a hot loop | 1.199 ms | 0.378 ms | **3.17x faster** | **21.6% smaller** | **11.7% smaller** |
+| Recursive calls with default arguments | 0.392 ms | 0.278 ms | **29.0% faster** | **2.2% smaller** | 1.9% larger |
+| Standard-library transcendental math | under 0.02 ms | under 0.02 ms | below useful timing resolution | **4.0% smaller** | **2.1% smaller** |
+| vtrace ray tracer | did not complete | 146.8 ms | **minutes to milliseconds** | **30.5% smaller** | **12.4% smaller** |
+
+The `v0.2.0` vtrace scorecard stayed at full CPU for more than 12 minutes during
+its warmup and five-sample batch, so I stopped it and left the exact multiplier
+unstated. Gaia BH1 completed five runs between 146.1 and 147.7 ms and produced
+the same checksum. This workload exercises effects, trait dispatch, mutable
+vectors, recursive ray bounces, arrays, and a large object graph.
 
 Release optimization now recognizes common array loops, known method targets,
-handled effects, recursive tail calls, short default-argument call shapes, and
-non-escaping values. Warm application edits also reuse analyzed dependency
-state, which shortens recompilation during development.
+locally handled effects, recursive tail calls, short default-argument call
+shapes, and non-escaping values. These improvements account for the runtime and
+size reductions in the larger workloads.
+
+The stronger release optimizer performs more compile-time analysis. The scalar
+and default-argument fixtures took 41–51% longer to compile, the math fixture
+took 44% longer, and the tiny trait fixture took 95% longer. Vtrace compilation
+was roughly flat at 3.1–3.25 seconds. Development builds default to the
+unoptimized profile.
+
+Typed SDK boundaries also add a fixed runtime surface to tiny modules that
+expose generic public functions. The trait-only fixture stayed below 0.01 ms at
+runtime and grew from 1.1 KB to 20.0 KB. Scalar-only exports use the direct Wasm
+boundary path described in [Typed SDK Boundary Exports](#typed-sdk-boundary-exports).
 
 ### Language and Standard Library Improvements
 

--- a/packages/reference/docs/releases.md
+++ b/packages/reference/docs/releases.md
@@ -7,22 +7,12 @@ order: 5
 ## Voyd v0.3.0 - Gaia BH1
 
 This release is centered around Voyd's full-stack web development experience.
-Gaia BH1 brings together typed browser applications, HTTP services, server-side
-rendering, hydration, host-language package adapters, and the tooling needed to
-start and ship a project.
+Gaia BH1 brings VX (an elm inspired application framework), a fresh http client
+and server API to std, a server side web pkg, powerful release optimizations,
+a new bootstrap command and more.
 
-You can define a browser state machine, render its UI, serve HTTP routes, render
-the first page on the server, hydrate it in the browser, call APIs, persist
-data, and package host-language libraries behind typed Voyd APIs.
-
-To exercise the whole stack, I rebuilt the mini-wikipedia example as a real
-Voyd application. It supports article creation, editing, deletion, search,
-direct links, server rendering, browser hydration, and JSON-file persistence.
-The server, API routes, validation, shared article model, and interactive VX
-app are all written in Voyd.
-
-That is the heart of Gaia BH1: Voyd now has an end-to-end story for building a
-web product.
+All these features should come together to make developing real production
+full stack web applications both practical and pleasant.
 
 ### New `voyd bootstrap` Command
 
@@ -38,9 +28,13 @@ and a typed VX starter. `web-ssr` creates a server-rendered application with an
 HTTP server, shared VX views, browser hydration, static assets, and a development
 workflow.
 
-### Typed VX Application Runtime
+### The VX Application Framework
 
-A VX app is a typed state machine. `Model` holds the current application state,
+Gaia BH1 introduces `vx`, an elm inspired web application framework that takes
+full advantage of idiomatic voyd. The goal of `vx` is to make it easy and enjoyable
+to build highly maintainable web applications.
+
+A `vx` app is a typed state machine. `Model` holds the current application state,
 `Msg` describes every event, `step` calculates the next state, and `view`
 renders it:
 

--- a/packages/reference/docs/releases.md
+++ b/packages/reference/docs/releases.md
@@ -291,11 +291,10 @@ I compared Gaia BH1 with the `v0.2.0` tag using identical source files, Node
 samples per workload after eleven warmups. The complete setup is checked in as
 the `docs/release/v0.3.0-benchmark.md` release benchmark.
 
-| Workload                                  | v0.2.0 runtime | Gaia BH1 runtime |                 Runtime change |          Raw Wasm |              gzip |
-| ----------------------------------------- | -------------: | ---------------: | -----------------------------: | ----------------: | ----------------: |
-| One million mutable particle steps        |      11.264 ms |         4.334 ms |               **2.60x faster** | **21.6% smaller** | **11.7% smaller** |
-| Five million calls with default arguments |      37.459 ms |        25.549 ms |               **31.8% faster** |  **2.2% smaller** |       1.9% larger |
-| Standard-library transcendental math      |  under 0.02 ms |    under 0.02 ms | below useful timing resolution |  **4.0% smaller** |  **2.1% smaller** |
+| Workload                                  | v0.2.0 runtime | Gaia BH1 runtime |   Runtime change |          Raw Wasm |              gzip |
+| ----------------------------------------- | -------------: | ---------------: | ---------------: | ----------------: | ----------------: |
+| One million mutable particle steps        |      11.264 ms |         4.334 ms | **2.60x faster** | **21.6% smaller** | **11.7% smaller** |
+| Five million calls with default arguments |      37.459 ms |        25.549 ms | **31.8% faster** |  **2.2% smaller** |       1.9% larger |
 
 Within Gaia BH1, the release profile also makes the two scaled workloads faster
 and much smaller than the development profile:
@@ -305,11 +304,6 @@ and much smaller than the development profile:
 | One million mutable particle steps        |   15.515 ms |  4.334 ms | **3.58x faster** | **97.2% smaller** |
 | Five million calls with default arguments |   47.278 ms | 25.549 ms | **1.85x faster** | **97.8% smaller** |
 
-Gaia BH1 also renders the vtrace ray tracer in a median of 143.5 ms, with five
-runs between 143.0 and 144.8 ms producing the same checksum. Its release build
-is 35.6 KB, or 13.0 KB compressed. This workload exercises effects, trait
-dispatch, mutable vectors, recursive ray bounces, arrays, and a large object
-graph.
 
 Release optimization now recognizes common array loops, known method targets,
 locally handled effects, recursive tail calls, short default-argument call

--- a/packages/reference/docs/releases.md
+++ b/packages/reference/docs/releases.md
@@ -7,9 +7,10 @@ order: 5
 ## Voyd v0.3.0 - Gaia BH1
 
 This release is centered around Voyd's full-stack web development experience.
-Gaia BH1 brings VX (an elm inspired application framework), a fresh http client
-and server API to std, a server side web pkg, powerful release optimizations,
-a new bootstrap command and more.
+Gaia BH1 fills in both sides of Voyd's web stack. VX brings an Elm-inspired
+architecture to interactive UIs, while new HTTP client and server APIs in `std`
+and the `pkg::web` framework support server-side applications. Stronger release
+optimizations, a new bootstrap command, and more round out the release.
 
 All these features should come together to make developing real production
 full stack web applications both practical and pleasant.
@@ -28,13 +29,14 @@ and a typed VX starter. `web-ssr` creates a server-rendered application with an
 HTTP server, shared VX views, browser hydration, static assets, and a development
 workflow.
 
-### The VX Application Framework
+### The VX UI Framework
 
-Gaia BH1 introduces `vx`, an elm inspired web application framework that takes
-full advantage of idiomatic voyd. The goal of `vx` is to make it easy and enjoyable
-to build highly maintainable web applications.
+Gaia BH1 introduces VX, an Elm-inspired framework for building interactive
+UIs with idiomatic Voyd. VX gives an application a typed architecture for state,
+events, effects, and rendering, with views that can render in the browser or on
+the server.
 
-A `vx` app is a typed state machine. `Model` holds the current application state,
+A VX app is a typed state machine. `Model` holds the current application state,
 `Msg` describes every event, `step` calculates the next state, and `view`
 renders it:
 
@@ -100,11 +102,27 @@ animation frames, media queries, location changes, storage events,
 
 Read the full [VX reference](./vx.md).
 
-### `std::http` and the New `pkg::web` Framework
+### HTTP in the Standard Library
 
-`std::http` provides HTTP client and server capabilities. `pkg::web` adds the
-application layer: routes, typed request data, middleware, responses, cookies,
-static files, limits, timeouts, and server-rendered VX HTML.
+`std::http` provides the shared protocol types and low-level capabilities for
+both sides of HTTP. Applications can send outbound requests through
+`std::http::client`, or listen, accept requests, and respond through
+`std::http::server`.
+
+These APIs are useful directly when an application needs control over the HTTP
+lifecycle. They also provide the foundation for higher-level server frameworks.
+
+### The New `pkg::web` Server Framework
+
+`pkg::web` is a server-side HTTP application framework built on `std::http`. It
+adds routes, typed request extraction, middleware, response conversion, cookies,
+static files, limits, and timeouts while leaving the underlying HTTP types and
+capabilities in the standard library.
+
+VX and `pkg::web` meet at server rendering: `pkg::web` can return a rendered VX
+view, embed its hydration state, and serve its browser assets. Once the page
+loads, VX owns the interactive UI. Each framework can also be used without the
+other.
 
 A route handler can ask for the values it needs in its parameter list and
 return an ordinary Voyd value:

--- a/packages/reference/docs/releases.md
+++ b/packages/reference/docs/releases.md
@@ -269,21 +269,20 @@ voyd --emit-wasm --opt ./src > app.wasm
 
 I compared Gaia BH1 with the `v0.2.0` tag using identical source files, Node
 22.23.1 on Apple silicon, three fresh-process compile samples, and five runtime
-samples per workload after four warmups. The complete setup is checked in as the
-`docs/release/v0.3.0-benchmark.md` release benchmark.
+samples per workload after eleven warmups. The complete setup is checked in as
+the `docs/release/v0.3.0-benchmark.md` release benchmark.
 
 | Workload                                |   v0.2.0 runtime | Gaia BH1 runtime |                 Runtime change |          Raw Wasm |              gzip |
 | --------------------------------------- | ---------------: | ---------------: | -----------------------------: | ----------------: | ----------------: |
-| Mutable scalar aggregates in a hot loop |         1.174 ms |         0.326 ms |               **3.60x faster** | **21.6% smaller** | **11.7% smaller** |
-| Recursive calls with default arguments  |         0.390 ms |         0.268 ms |               **31.3% faster** |  **2.2% smaller** |       1.9% larger |
+| Mutable scalar aggregates in a hot loop |         1.158 ms |         0.045 ms |              **25.97x faster** | **21.6% smaller** | **11.7% smaller** |
+| Recursive calls with default arguments  |         0.378 ms |         0.259 ms |               **31.6% faster** |  **2.2% smaller** |       1.9% larger |
 | Standard-library transcendental math    |    under 0.02 ms |    under 0.02 ms | below useful timing resolution |  **4.0% smaller** |  **2.1% smaller** |
-| vtrace ray tracer                       | did not complete |         145.8 ms |    **minutes to milliseconds** | **30.5% smaller** | **12.4% smaller** |
 
-The bounded `v0.2.0` vtrace worker did not finish its warmup and first measured
-run within 60 seconds, so I left the exact multiplier unstated. Gaia BH1
-completed five runs between 145.5 and 148.0 ms and produced the same checksum.
-This workload exercises effects, trait dispatch, mutable vectors, recursive ray
-bounces, arrays, and a large object graph.
+Gaia BH1 also renders the vtrace ray tracer in a median of 146.2 ms, with five
+runs between 145.2 and 146.5 ms producing the same checksum. Its release build
+is 35.6 KB, or 13.0 KB compressed. This workload exercises effects, trait
+dispatch, mutable vectors, recursive ray bounces, arrays, and a large object
+graph.
 
 Release optimization now recognizes common array loops, known method targets,
 locally handled effects, recursive tail calls, short default-argument call
@@ -291,10 +290,9 @@ shapes, and non-escaping values. These improvements account for the runtime and
 size reductions in the larger workloads.
 
 The stronger release optimizer performs more compile-time analysis. The scalar
-and default-argument fixtures took 50% longer to compile, the math fixture took
-46% longer, and the tiny trait fixture took 96% longer. Vtrace compilation was
-roughly flat at 3.12–3.25 seconds. Development builds default to the
-unoptimized profile.
+and default-argument fixtures took 51% longer to compile, the math fixture took
+46% longer, and the tiny trait fixture took 94% longer. Vtrace compiled in 3.23
+seconds. Development builds default to the unoptimized profile.
 
 Typed SDK boundaries also add a fixed runtime surface to tiny modules that
 expose generic public functions. The trait-only fixture stayed below 0.01 ms at

--- a/packages/reference/docs/releases.md
+++ b/packages/reference/docs/releases.md
@@ -269,20 +269,21 @@ voyd --emit-wasm --opt ./src > app.wasm
 
 I compared Gaia BH1 with the `v0.2.0` tag using identical source files, Node
 22.23.1 on Apple silicon, three fresh-process compile samples, and five runtime
-samples per workload.
+samples per workload after four warmups. The complete setup is checked in as the
+`docs/release/v0.3.0-benchmark.md` release benchmark.
 
-| Workload | v0.2.0 runtime | Gaia BH1 runtime | Runtime change | Raw Wasm | gzip |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| Mutable scalar aggregates in a hot loop | 1.199 ms | 0.378 ms | **3.17x faster** | **21.6% smaller** | **11.7% smaller** |
-| Recursive calls with default arguments | 0.392 ms | 0.278 ms | **29.0% faster** | **2.2% smaller** | 1.9% larger |
-| Standard-library transcendental math | under 0.02 ms | under 0.02 ms | below useful timing resolution | **4.0% smaller** | **2.1% smaller** |
-| vtrace ray tracer | did not complete | 146.8 ms | **minutes to milliseconds** | **30.5% smaller** | **12.4% smaller** |
+| Workload                                |   v0.2.0 runtime | Gaia BH1 runtime |                 Runtime change |          Raw Wasm |              gzip |
+| --------------------------------------- | ---------------: | ---------------: | -----------------------------: | ----------------: | ----------------: |
+| Mutable scalar aggregates in a hot loop |         1.174 ms |         0.326 ms |               **3.60x faster** | **21.6% smaller** | **11.7% smaller** |
+| Recursive calls with default arguments  |         0.390 ms |         0.268 ms |               **31.3% faster** |  **2.2% smaller** |       1.9% larger |
+| Standard-library transcendental math    |    under 0.02 ms |    under 0.02 ms | below useful timing resolution |  **4.0% smaller** |  **2.1% smaller** |
+| vtrace ray tracer                       | did not complete |         145.8 ms |    **minutes to milliseconds** | **30.5% smaller** | **12.4% smaller** |
 
-The `v0.2.0` vtrace scorecard stayed at full CPU for more than 12 minutes during
-its warmup and five-sample batch, so I stopped it and left the exact multiplier
-unstated. Gaia BH1 completed five runs between 146.1 and 147.7 ms and produced
-the same checksum. This workload exercises effects, trait dispatch, mutable
-vectors, recursive ray bounces, arrays, and a large object graph.
+The bounded `v0.2.0` vtrace worker did not finish its warmup and first measured
+run within 60 seconds, so I left the exact multiplier unstated. Gaia BH1
+completed five runs between 145.5 and 148.0 ms and produced the same checksum.
+This workload exercises effects, trait dispatch, mutable vectors, recursive ray
+bounces, arrays, and a large object graph.
 
 Release optimization now recognizes common array loops, known method targets,
 locally handled effects, recursive tail calls, short default-argument call
@@ -290,9 +291,9 @@ shapes, and non-escaping values. These improvements account for the runtime and
 size reductions in the larger workloads.
 
 The stronger release optimizer performs more compile-time analysis. The scalar
-and default-argument fixtures took 41–51% longer to compile, the math fixture
-took 44% longer, and the tiny trait fixture took 95% longer. Vtrace compilation
-was roughly flat at 3.1–3.25 seconds. Development builds default to the
+and default-argument fixtures took 50% longer to compile, the math fixture took
+46% longer, and the tiny trait fixture took 96% longer. Vtrace compilation was
+roughly flat at 3.12–3.25 seconds. Development builds default to the
 unoptimized profile.
 
 Typed SDK boundaries also add a fixed runtime surface to tiny modules that

--- a/packages/reference/docs/releases.md
+++ b/packages/reference/docs/releases.md
@@ -274,12 +274,20 @@ the `docs/release/v0.3.0-benchmark.md` release benchmark.
 
 | Workload                                |   v0.2.0 runtime | Gaia BH1 runtime |                 Runtime change |          Raw Wasm |              gzip |
 | --------------------------------------- | ---------------: | ---------------: | -----------------------------: | ----------------: | ----------------: |
-| Mutable scalar aggregates in a hot loop |         1.158 ms |         0.045 ms |              **25.97x faster** | **21.6% smaller** | **11.7% smaller** |
-| Recursive calls with default arguments  |         0.378 ms |         0.259 ms |               **31.6% faster** |  **2.2% smaller** |       1.9% larger |
+| One million mutable particle steps      |        11.264 ms |         4.334 ms |               **2.60x faster** | **21.6% smaller** | **11.7% smaller** |
+| Five million calls with default arguments |      37.459 ms |        25.549 ms |               **31.8% faster** |  **2.2% smaller** |       1.9% larger |
 | Standard-library transcendental math    |    under 0.02 ms |    under 0.02 ms | below useful timing resolution |  **4.0% smaller** |  **2.1% smaller** |
 
-Gaia BH1 also renders the vtrace ray tracer in a median of 146.2 ms, with five
-runs between 145.2 and 146.5 ms producing the same checksum. Its release build
+Within Gaia BH1, the release profile also makes the two scaled workloads faster
+and much smaller than the development profile:
+
+| Workload | Unoptimized | Release | Runtime change | Raw Wasm change |
+| --- | ---: | ---: | ---: | ---: |
+| One million mutable particle steps | 15.515 ms | 4.334 ms | **3.58x faster** | **97.2% smaller** |
+| Five million calls with default arguments | 47.278 ms | 25.549 ms | **1.85x faster** | **97.8% smaller** |
+
+Gaia BH1 also renders the vtrace ray tracer in a median of 143.5 ms, with five
+runs between 143.0 and 144.8 ms producing the same checksum. Its release build
 is 35.6 KB, or 13.0 KB compressed. This workload exercises effects, trait
 dispatch, mutable vectors, recursive ray bounces, arrays, and a large object
 graph.
@@ -290,8 +298,8 @@ shapes, and non-escaping values. These improvements account for the runtime and
 size reductions in the larger workloads.
 
 The stronger release optimizer performs more compile-time analysis. The scalar
-and default-argument fixtures took 51% longer to compile, the math fixture took
-46% longer, and the tiny trait fixture took 94% longer. Vtrace compiled in 3.23
+and default-argument fixtures took 52% longer to compile, the math fixture took
+48% longer, and the tiny trait fixture took 97% longer. Vtrace compiled in 3.17
 seconds. Development builds default to the unoptimized profile.
 
 Typed SDK boundaries also add a fixed runtime surface to tiny modules that

--- a/packages/reference/docs/releases.md
+++ b/packages/reference/docs/releases.md
@@ -41,58 +41,65 @@ A VX app is a typed state machine. `Model` holds the current application state,
 renders it:
 
 ```voyd
-use std::number::cast::to_string
+use std::string::type::String
+use std::time::{ Duration }
+use std::time
 use std::vx::all
 
 obj Model {
-  count: i32
+  status: String
 }
 
 enum Msg
-  Increment
-  Decrement
+  StartTimer
+  TimerFinished
 
 pub fn app() -> Program<Model, Msg>
   program({ init, step, view })
 
 fn init() -> Model
-  Model { count: 0 }
+  Model { status: "Ready" }
 
 fn step(model: Model, msg: Msg) -> Program<Model, Msg>
   match(msg)
-    Msg::Increment:
-      next(Model { count: model.count + 1 })
-    Msg::Decrement:
-      next(Model { count: model.count - 1 })
+    Msg::StartTimer:
+      next(
+        model: Model { status: "Steeping..." },
+        cmd: start_timer()
+      )
+    Msg::TimerFinished:
+      next(Model { status: "Tea is ready!" })
 
 fn view(model: Model) -> Html<Msg>
   <main>
-    <button on_click={Msg::Decrement {}}>-</button>
-    <span>{to_string(model.count)}</span>
-    <button on_click={Msg::Increment {}}>+</button>
+    <p>{model.status}</p>
+    <button on_click={Msg::StartTimer {}}>Start tea timer</button>
   </main>
+
+fn start_timer() -> Cmd<Msg>
+  Cmd::task
+    work():
+      time::sleep(Duration::from_secs(180i64))
+    handler(_result):
+      Msg::TimerFinished {}
 ```
 
 `Model` is durable application state. `Msg` is the closed set of events that
-can change it. A button click produces a `Msg`, `step` produces a new `Model`,
-and VX patches the DOM from the next `view` result. The signatures connect each
-part of the loop, so a view can only emit messages that the app knows how to
+can change it. A button click produces a `Msg`, and `step` returns the next
+`Model` plus any command to run. VX patches the DOM from the next `view` result,
+then sends command results back through the same message loop. The signatures
+connect each part, so a view can only emit messages that the app knows how to
 handle.
 
-Real applications also need work that completes later. `Cmd::task` runs Voyd
-task code and maps the result back into a message:
+`StartTimer` shows how asynchronous work fits into the loop. Its `step` branch
+immediately changes the status to `Steeping...` and returns a command created by
+`start_timer`. `Cmd::task` runs the wait as a Voyd task and maps its result to
+`TimerFinished`; VX dispatches that message when the delay ends, and `step`
+changes the status to `Tea is ready!`.
 
-```voyd
-fn save_command(article: Article): (HttpClient, TaskRuntime) -> Cmd<Msg>
-  Cmd::task(
-    work: () -> bool => save_article(article),
-    handler: (ok: bool) -> Msg => Msg::SaveFinished { ok: ok }
-  )
-```
-
-This gives `step` a clean shape: accept a message, update the model, and return
-the work to start. VX runs the task and dispatches `SaveFinished` when it
-completes.
+This keeps `step` focused on transitions: accept a message, choose the next
+model, and describe any work to start. HTTP requests, database writes, and other
+asynchronous operations follow the same command-to-message pattern.
 
 VX includes commands for tasks, clipboard access, document titles, navigation,
 history, scrolling, selection, opening URLs, and browser storage. Subscriptions
@@ -284,19 +291,19 @@ I compared Gaia BH1 with the `v0.2.0` tag using identical source files, Node
 samples per workload after eleven warmups. The complete setup is checked in as
 the `docs/release/v0.3.0-benchmark.md` release benchmark.
 
-| Workload                                |   v0.2.0 runtime | Gaia BH1 runtime |                 Runtime change |          Raw Wasm |              gzip |
-| --------------------------------------- | ---------------: | ---------------: | -----------------------------: | ----------------: | ----------------: |
-| One million mutable particle steps      |        11.264 ms |         4.334 ms |               **2.60x faster** | **21.6% smaller** | **11.7% smaller** |
+| Workload                                  | v0.2.0 runtime | Gaia BH1 runtime |                 Runtime change |          Raw Wasm |              gzip |
+| ----------------------------------------- | -------------: | ---------------: | -----------------------------: | ----------------: | ----------------: |
+| One million mutable particle steps        |      11.264 ms |         4.334 ms |               **2.60x faster** | **21.6% smaller** | **11.7% smaller** |
 | Five million calls with default arguments |      37.459 ms |        25.549 ms |               **31.8% faster** |  **2.2% smaller** |       1.9% larger |
-| Standard-library transcendental math    |    under 0.02 ms |    under 0.02 ms | below useful timing resolution |  **4.0% smaller** |  **2.1% smaller** |
+| Standard-library transcendental math      |  under 0.02 ms |    under 0.02 ms | below useful timing resolution |  **4.0% smaller** |  **2.1% smaller** |
 
 Within Gaia BH1, the release profile also makes the two scaled workloads faster
 and much smaller than the development profile:
 
-| Workload | Unoptimized | Release | Runtime change | Raw Wasm change |
-| --- | ---: | ---: | ---: | ---: |
-| One million mutable particle steps | 15.515 ms | 4.334 ms | **3.58x faster** | **97.2% smaller** |
-| Five million calls with default arguments | 47.278 ms | 25.549 ms | **1.85x faster** | **97.8% smaller** |
+| Workload                                  | Unoptimized |   Release |   Runtime change |   Raw Wasm change |
+| ----------------------------------------- | ----------: | --------: | ---------------: | ----------------: |
+| One million mutable particle steps        |   15.515 ms |  4.334 ms | **3.58x faster** | **97.2% smaller** |
+| Five million calls with default arguments |   47.278 ms | 25.549 ms | **1.85x faster** | **97.8% smaller** |
 
 Gaia BH1 also renders the vtrace ray tracer in a median of 143.5 ms, with five
 runs between 143.0 and 144.8 ms producing the same checksum. Its release build

--- a/scripts/bench-optimizer.ts
+++ b/scripts/bench-optimizer.ts
@@ -134,7 +134,7 @@ fn step_particle(seed: i32) -> i32
 pub fn main() -> i32
   var i = 0
   var total = 0
-  while i < 10000:
+  while i < 1000000:
     total = total + step_particle(i)
     i = i + 1
   total
@@ -158,7 +158,7 @@ fn sum_default(n: i32, { step: i32 = 1 }) -> i32
 pub fn main() -> i32
   var i = 0
   var total = 0
-  while i < 50000:
+  while i < 5000000:
     total = total + sum_default(10) + sum_default(10, step: 2)
     i = i + 1
   total
@@ -175,13 +175,13 @@ const SCENARIOS: readonly Scenario[] = [
     name: "scalar-aggregate",
     source: SCALAR_AGGREGATE_SOURCE,
     entryName: "main",
-    expected: 1_100_340_000,
+    expected: 622_754_944,
   },
   {
     name: "call-shape-defaults",
     source: CALL_SHAPE_SOURCE,
     entryName: "main",
-    expected: 4_250_000,
+    expected: 425_000_000,
   },
   {
     name: "std-math-transcendentals",

--- a/scripts/release/benchmark-v0.3.0.mjs
+++ b/scripts/release/benchmark-v0.3.0.mjs
@@ -92,7 +92,13 @@ const install = (directory, name) => {
   );
 };
 
-const runScorecard = ({ directory, scenarios, corpusPath, output }) => {
+const runScorecard = ({
+  directory,
+  scenarios,
+  corpusPath,
+  output,
+  modes = ["release"],
+}) => {
   run(
     "npx",
     nodeArgs([
@@ -103,7 +109,7 @@ const runScorecard = ({ directory, scenarios, corpusPath, output }) => {
       "--preset",
       "full",
       "--modes",
-      "release",
+      modes.join(","),
       "--scenarios",
       scenarios.join(","),
       "--compile-warmups",
@@ -134,7 +140,9 @@ const runScorecard = ({ directory, scenarios, corpusPath, output }) => {
 };
 
 const rowsByScenario = (scorecard) =>
-  Object.fromEntries(scorecard.rows.map((row) => [row.scenario, row]));
+  Object.fromEntries(
+    scorecard.rows.map((row) => [`${row.scenario}:${row.mode}`, row]),
+  );
 
 const percentChange = (base, head) => ((head - base) / base) * 100;
 
@@ -171,6 +179,46 @@ const compareRows = ({ base, head }) => ({
     head: {
       compileMs: head.compileSamplesMs,
       runtimeMs: head.runtimeSamplesMs,
+    },
+  },
+});
+
+const compareOptimizationRows = ({ unoptimized, release }) => ({
+  compileMs: {
+    unoptimized: unoptimized.compileMedianMs,
+    release: release.compileMedianMs,
+    percentChange: percentChange(
+      unoptimized.compileMedianMs,
+      release.compileMedianMs,
+    ),
+  },
+  runtimeMs: {
+    unoptimized: unoptimized.runtimeMedianMs,
+    release: release.runtimeMedianMs,
+    speedup: unoptimized.runtimeMedianMs / release.runtimeMedianMs,
+    percentChange: percentChange(
+      unoptimized.runtimeMedianMs,
+      release.runtimeMedianMs,
+    ),
+  },
+  wasmBytes: {
+    unoptimized: unoptimized.wasmBytes,
+    release: release.wasmBytes,
+    percentChange: percentChange(unoptimized.wasmBytes, release.wasmBytes),
+  },
+  gzipBytes: {
+    unoptimized: unoptimized.gzipBytes,
+    release: release.gzipBytes,
+    percentChange: percentChange(unoptimized.gzipBytes, release.gzipBytes),
+  },
+  samples: {
+    unoptimized: {
+      compileMs: unoptimized.compileSamplesMs,
+      runtimeMs: unoptimized.runtimeSamplesMs,
+    },
+    release: {
+      compileMs: release.compileSamplesMs,
+      runtimeMs: release.runtimeSamplesMs,
     },
   },
 });
@@ -227,6 +275,7 @@ try {
     scenarios: CORE_SCENARIOS,
     corpusPath,
     output: path.join(tempRoot, "head-core.json"),
+    modes: ["unoptimized", "release"],
   });
 
   console.log("Running Gaia BH1 vtrace scorecard...");
@@ -242,11 +291,23 @@ try {
   const scenarios = Object.fromEntries(
     CORE_SCENARIOS.map((name) => [
       name,
-      compareRows({ base: baseRows[name], head: headRows[name] }),
+      compareRows({
+        base: baseRows[`${name}:release`],
+        head: headRows[`${name}:release`],
+      }),
+    ]),
+  );
+  const gaiaOptimization = Object.fromEntries(
+    CORE_SCENARIOS.map((name) => [
+      name,
+      compareOptimizationRows({
+        unoptimized: headRows[`${name}:unoptimized`],
+        release: headRows[`${name}:release`],
+      }),
     ]),
   );
   const result = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     generatedAt: new Date().toISOString(),
     environment: {
       platform: `${process.platform}-${process.arch}`,
@@ -263,6 +324,7 @@ try {
     },
     corpusHashes: headScorecard.corpusHashes,
     scenarios,
+    gaiaOptimization,
     vtrace: {
       head: {
         compileMedianMs: headVtrace.compileMedianMs,
@@ -281,6 +343,12 @@ try {
     const speedup = metrics.runtimeMs.base / metrics.runtimeMs.head;
     console.log(
       `${name}: ${speedup.toFixed(2)}x runtime, ${metrics.wasmBytes.percentChange.toFixed(1)}% Wasm`,
+    );
+  });
+  ["scalar-aggregate", "call-shape-defaults"].forEach((name) => {
+    const metrics = gaiaOptimization[name];
+    console.log(
+      `${name} release profile: ${metrics.runtimeMs.speedup.toFixed(2)}x runtime, ${metrics.wasmBytes.percentChange.toFixed(1)}% Wasm`,
     );
   });
   console.log(

--- a/scripts/release/benchmark-v0.3.0.mjs
+++ b/scripts/release/benchmark-v0.3.0.mjs
@@ -8,7 +8,7 @@ import path from "node:path";
 const NODE_VERSION = "22.23.1";
 const NPM_VERSION = "10.9.4";
 const RECORDED_RUNTIME_SAMPLES = 5;
-const EXTRA_RUNTIME_WARMUPS = 3;
+const EXTRA_RUNTIME_WARMUPS = 10;
 const CORE_SCENARIOS = [
   "scalar-aggregate",
   "call-shape-defaults",
@@ -22,20 +22,11 @@ const option = (name, fallback) => {
   return index < 0 ? fallback : process.argv[index + 1];
 };
 
-const positiveIntegerOption = (name, fallback) => {
-  const value = Number(option(name, fallback));
-  if (!Number.isInteger(value) || value <= 0) {
-    throw new Error(`${name} must be a positive integer`);
-  }
-  return value;
-};
-
 const baseRef = option("--base", "v0.2.0");
 const headRef = option("--head", "HEAD");
 const outputPath = path.resolve(
   option("--output", "voyd-v0.3.0-release-benchmark.json"),
 );
-const vtraceTimeoutMs = positiveIntegerOption("--vtrace-timeout-ms", 60_000);
 const repoRoot = process.cwd();
 const tempRoot = mkdtempSync(path.join(tmpdir(), "voyd-release-bench-"));
 const worktrees = [];
@@ -142,35 +133,6 @@ const runScorecard = ({ directory, scenarios, corpusPath, output }) => {
   return scorecard;
 };
 
-const runWorker = ({ directory, config, timeout }) => {
-  const result = spawnSync(
-    "npx",
-    nodeArgs([
-      "--conditions=development",
-      "--import",
-      "tsx",
-      "scripts/bench-optimizer.ts",
-      "--worker-config",
-      Buffer.from(JSON.stringify(config)).toString("base64url"),
-    ]),
-    {
-      cwd: directory,
-      encoding: "utf8",
-      maxBuffer: 50 * 1024 * 1024,
-      timeout,
-    },
-  );
-  if (result.status === 0) {
-    return { status: "completed", result: JSON.parse(result.stdout) };
-  }
-  if (result.error?.code === "ETIMEDOUT" || result.signal === "SIGTERM") {
-    return { status: "timed_out", timeoutMs: timeout };
-  }
-  throw new Error(
-    `${baseRef} vtrace worker failed: ${result.stderr?.trim() || result.error?.message}`,
-  );
-};
-
 const rowsByScenario = (scorecard) =>
   Object.fromEntries(scorecard.rows.map((row) => [row.scenario, row]));
 
@@ -275,28 +237,6 @@ try {
     output: path.join(tempRoot, "head-vtrace.json"),
   }).rows[0];
 
-  console.log(`Running bounded ${baseRef} vtrace checks...`);
-  const baseVtraceArtifact = runWorker({
-    directory: baseDirectory,
-    config: {
-      scenarioName: VTRACE_SCENARIO,
-      mode: "release",
-      runtimeSamples: 0,
-      collectArtifactDetails: true,
-      sourceOverride: corpus[VTRACE_SCENARIO],
-    },
-  });
-  const baseVtraceRuntime = runWorker({
-    directory: baseDirectory,
-    config: {
-      scenarioName: VTRACE_SCENARIO,
-      mode: "release",
-      runtimeSamples: 1,
-      collectArtifactDetails: false,
-      sourceOverride: corpus[VTRACE_SCENARIO],
-    },
-    timeout: vtraceTimeoutMs,
-  });
   const baseRows = rowsByScenario(baseScorecard);
   const headRows = rowsByScenario(headScorecard);
   const scenarios = Object.fromEntries(
@@ -305,7 +245,6 @@ try {
       compareRows({ base: baseRows[name], head: headRows[name] }),
     ]),
   );
-  const baseArtifact = baseVtraceArtifact.result;
   const result = {
     schemaVersion: 1,
     generatedAt: new Date().toISOString(),
@@ -325,12 +264,6 @@ try {
     corpusHashes: headScorecard.corpusHashes,
     scenarios,
     vtrace: {
-      base: {
-        compileMs: baseArtifact.sample.durationMs,
-        wasmBytes: baseArtifact.sample.wasmBytes,
-        gzipBytes: baseArtifact.gzipBytes,
-        runtime: baseVtraceRuntime,
-      },
       head: {
         compileMedianMs: headVtrace.compileMedianMs,
         compileSamplesMs: headVtrace.compileSamplesMs,
@@ -339,14 +272,6 @@ try {
         wasmBytes: headVtrace.wasmBytes,
         gzipBytes: headVtrace.gzipBytes,
       },
-      wasmPercentChange: percentChange(
-        baseArtifact.sample.wasmBytes,
-        headVtrace.wasmBytes,
-      ),
-      gzipPercentChange: percentChange(
-        baseArtifact.gzipBytes,
-        headVtrace.gzipBytes,
-      ),
     },
   };
 
@@ -359,7 +284,7 @@ try {
     );
   });
   console.log(
-    `vtrace: ${baseVtraceRuntime.status} on ${baseRef}; ${headVtrace.runtimeMedianMs.toFixed(1)} ms on ${headRef}`,
+    `vtrace: ${headVtrace.runtimeMedianMs.toFixed(1)} ms on ${headRef}`,
   );
 } finally {
   worktrees.reverse().forEach((directory) => {

--- a/scripts/release/benchmark-v0.3.0.mjs
+++ b/scripts/release/benchmark-v0.3.0.mjs
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const NODE_VERSION = "22.23.1";
+const NPM_VERSION = "10.9.4";
+const RECORDED_RUNTIME_SAMPLES = 5;
+const EXTRA_RUNTIME_WARMUPS = 3;
+const CORE_SCENARIOS = [
+  "scalar-aggregate",
+  "call-shape-defaults",
+  "std-math-transcendentals",
+  "tier1-trait-call",
+];
+const VTRACE_SCENARIO = "vtrace-main";
+
+const option = (name, fallback) => {
+  const index = process.argv.indexOf(name);
+  return index < 0 ? fallback : process.argv[index + 1];
+};
+
+const positiveIntegerOption = (name, fallback) => {
+  const value = Number(option(name, fallback));
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+};
+
+const baseRef = option("--base", "v0.2.0");
+const headRef = option("--head", "HEAD");
+const outputPath = path.resolve(
+  option("--output", "voyd-v0.3.0-release-benchmark.json"),
+);
+const vtraceTimeoutMs = positiveIntegerOption("--vtrace-timeout-ms", 60_000);
+const repoRoot = process.cwd();
+const tempRoot = mkdtempSync(path.join(tmpdir(), "voyd-release-bench-"));
+const worktrees = [];
+
+const run = (
+  command,
+  args,
+  { cwd = repoRoot, label, stdio = "pipe", timeout } = {},
+) => {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 50 * 1024 * 1024,
+    stdio,
+    timeout,
+  });
+  if (result.status !== 0) {
+    const detail =
+      result.stderr?.trim() || result.error?.message || "no error output";
+    throw new Error(`${label ?? command} failed: ${detail}`);
+  }
+  return result.stdout?.trim() ?? "";
+};
+
+const capture = (command, args, label) => run(command, args, { label });
+const gitFile = (revision, file) =>
+  capture(
+    "git",
+    ["show", `${revision}:${file}`],
+    `read ${file} at ${revision}`,
+  );
+const nodeArgs = (args) => [
+  "--yes",
+  `--package=node@${NODE_VERSION}`,
+  "--",
+  "node",
+  ...args,
+];
+
+const addWorktree = (name, revision) => {
+  const directory = path.join(tempRoot, name);
+  run("git", ["worktree", "add", "--detach", directory, revision], {
+    label: `create ${name} worktree`,
+    stdio: "inherit",
+  });
+  worktrees.push(directory);
+  return directory;
+};
+
+const install = (directory, name) => {
+  console.log(`Installing ${name} with npm ${NPM_VERSION}...`);
+  run(
+    "npx",
+    [
+      "--yes",
+      `--package=npm@${NPM_VERSION}`,
+      "--",
+      "npm",
+      "ci",
+      "--include=optional",
+    ],
+    { cwd: directory, label: `install ${name}`, stdio: "inherit" },
+  );
+};
+
+const runScorecard = ({ directory, scenarios, corpusPath, output }) => {
+  run(
+    "npx",
+    nodeArgs([
+      "--conditions=development",
+      "--import",
+      "tsx",
+      "scripts/bench-optimizer.ts",
+      "--preset",
+      "full",
+      "--modes",
+      "release",
+      "--scenarios",
+      scenarios.join(","),
+      "--compile-warmups",
+      "1",
+      "--compile-samples",
+      "3",
+      "--runtime-samples",
+      String(RECORDED_RUNTIME_SAMPLES + EXTRA_RUNTIME_WARMUPS),
+      "--corpus-snapshot",
+      corpusPath,
+      "--output",
+      output,
+    ]),
+    { cwd: directory, label: `benchmark ${path.basename(directory)}` },
+  );
+  const scorecard = JSON.parse(readFileSync(output, "utf8"));
+  scorecard.rows = scorecard.rows.map((row) => {
+    const runtimeSamplesMs = row.runtimeSamplesMs.slice(
+      -RECORDED_RUNTIME_SAMPLES,
+    );
+    return {
+      ...row,
+      runtimeMedianMs: median(runtimeSamplesMs),
+      runtimeSamplesMs,
+    };
+  });
+  return scorecard;
+};
+
+const runWorker = ({ directory, config, timeout }) => {
+  const result = spawnSync(
+    "npx",
+    nodeArgs([
+      "--conditions=development",
+      "--import",
+      "tsx",
+      "scripts/bench-optimizer.ts",
+      "--worker-config",
+      Buffer.from(JSON.stringify(config)).toString("base64url"),
+    ]),
+    {
+      cwd: directory,
+      encoding: "utf8",
+      maxBuffer: 50 * 1024 * 1024,
+      timeout,
+    },
+  );
+  if (result.status === 0) {
+    return { status: "completed", result: JSON.parse(result.stdout) };
+  }
+  if (result.error?.code === "ETIMEDOUT" || result.signal === "SIGTERM") {
+    return { status: "timed_out", timeoutMs: timeout };
+  }
+  throw new Error(
+    `${baseRef} vtrace worker failed: ${result.stderr?.trim() || result.error?.message}`,
+  );
+};
+
+const rowsByScenario = (scorecard) =>
+  Object.fromEntries(scorecard.rows.map((row) => [row.scenario, row]));
+
+const percentChange = (base, head) => ((head - base) / base) * 100;
+
+const median = (values) => {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+};
+
+const comparison = ({ base, head }) => ({
+  base,
+  head,
+  percentChange: percentChange(base, head),
+});
+
+const compareRows = ({ base, head }) => ({
+  compileMs: comparison({
+    base: base.compileMedianMs,
+    head: head.compileMedianMs,
+  }),
+  runtimeMs: comparison({
+    base: base.runtimeMedianMs,
+    head: head.runtimeMedianMs,
+  }),
+  wasmBytes: comparison({ base: base.wasmBytes, head: head.wasmBytes }),
+  gzipBytes: comparison({ base: base.gzipBytes, head: head.gzipBytes }),
+  samples: {
+    base: {
+      compileMs: base.compileSamplesMs,
+      runtimeMs: base.runtimeSamplesMs,
+    },
+    head: {
+      compileMs: head.compileSamplesMs,
+      runtimeMs: head.runtimeSamplesMs,
+    },
+  },
+});
+
+try {
+  const baseRevision = capture(
+    "git",
+    ["rev-parse", baseRef],
+    `resolve ${baseRef}`,
+  );
+  const headRevision = capture(
+    "git",
+    ["rev-parse", headRef],
+    `resolve ${headRef}`,
+  );
+  const baseDirectory = addWorktree("base", baseRevision);
+  const headDirectory = addWorktree("head", headRevision);
+
+  const harness = gitFile(headRevision, "scripts/bench-optimizer.ts");
+  writeFileSync(
+    path.join(baseDirectory, "scripts", "bench-optimizer.ts"),
+    harness,
+  );
+  writeFileSync(
+    path.join(headDirectory, "scripts", "bench-optimizer.ts"),
+    harness,
+  );
+
+  const corpus = {
+    "std-math-transcendentals": gitFile(
+      headRevision,
+      "tests/integration/fixtures/std-math-transcendentals.voyd",
+    ),
+    "vtrace-main": gitFile(
+      headRevision,
+      "tests/performance/fixtures/vtrace-compute-benchmark.voyd",
+    ),
+  };
+  const corpusPath = path.join(tempRoot, "corpus.json");
+  writeFileSync(corpusPath, JSON.stringify(corpus));
+
+  install(baseDirectory, baseRef);
+  install(headDirectory, headRef);
+
+  console.log("Running representative release workloads...");
+  const baseScorecard = runScorecard({
+    directory: baseDirectory,
+    scenarios: CORE_SCENARIOS,
+    corpusPath,
+    output: path.join(tempRoot, "base-core.json"),
+  });
+  const headScorecard = runScorecard({
+    directory: headDirectory,
+    scenarios: CORE_SCENARIOS,
+    corpusPath,
+    output: path.join(tempRoot, "head-core.json"),
+  });
+
+  console.log("Running Gaia BH1 vtrace scorecard...");
+  const headVtrace = runScorecard({
+    directory: headDirectory,
+    scenarios: [VTRACE_SCENARIO],
+    corpusPath,
+    output: path.join(tempRoot, "head-vtrace.json"),
+  }).rows[0];
+
+  console.log(`Running bounded ${baseRef} vtrace checks...`);
+  const baseVtraceArtifact = runWorker({
+    directory: baseDirectory,
+    config: {
+      scenarioName: VTRACE_SCENARIO,
+      mode: "release",
+      runtimeSamples: 0,
+      collectArtifactDetails: true,
+      sourceOverride: corpus[VTRACE_SCENARIO],
+    },
+  });
+  const baseVtraceRuntime = runWorker({
+    directory: baseDirectory,
+    config: {
+      scenarioName: VTRACE_SCENARIO,
+      mode: "release",
+      runtimeSamples: 1,
+      collectArtifactDetails: false,
+      sourceOverride: corpus[VTRACE_SCENARIO],
+    },
+    timeout: vtraceTimeoutMs,
+  });
+  const baseRows = rowsByScenario(baseScorecard);
+  const headRows = rowsByScenario(headScorecard);
+  const scenarios = Object.fromEntries(
+    CORE_SCENARIOS.map((name) => [
+      name,
+      compareRows({ base: baseRows[name], head: headRows[name] }),
+    ]),
+  );
+  const baseArtifact = baseVtraceArtifact.result;
+  const result = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    environment: {
+      platform: `${process.platform}-${process.arch}`,
+      node: NODE_VERSION,
+      packageManager: `npm ${NPM_VERSION}`,
+      compileWarmups: 1,
+      compileSamples: 3,
+      runtimeWarmups: 1 + EXTRA_RUNTIME_WARMUPS,
+      runtimeSamples: RECORDED_RUNTIME_SAMPLES,
+    },
+    revisions: {
+      base: { ref: baseRef, revision: baseRevision },
+      head: { ref: headRef, revision: headRevision },
+    },
+    corpusHashes: headScorecard.corpusHashes,
+    scenarios,
+    vtrace: {
+      base: {
+        compileMs: baseArtifact.sample.durationMs,
+        wasmBytes: baseArtifact.sample.wasmBytes,
+        gzipBytes: baseArtifact.gzipBytes,
+        runtime: baseVtraceRuntime,
+      },
+      head: {
+        compileMedianMs: headVtrace.compileMedianMs,
+        compileSamplesMs: headVtrace.compileSamplesMs,
+        runtimeMedianMs: headVtrace.runtimeMedianMs,
+        runtimeSamplesMs: headVtrace.runtimeSamplesMs,
+        wasmBytes: headVtrace.wasmBytes,
+        gzipBytes: headVtrace.gzipBytes,
+      },
+      wasmPercentChange: percentChange(
+        baseArtifact.sample.wasmBytes,
+        headVtrace.wasmBytes,
+      ),
+      gzipPercentChange: percentChange(
+        baseArtifact.gzipBytes,
+        headVtrace.gzipBytes,
+      ),
+    },
+  };
+
+  writeFileSync(outputPath, `${JSON.stringify(result, null, 2)}\n`);
+  console.log(`Benchmark results written to ${outputPath}`);
+  Object.entries(scenarios).forEach(([name, metrics]) => {
+    const speedup = metrics.runtimeMs.base / metrics.runtimeMs.head;
+    console.log(
+      `${name}: ${speedup.toFixed(2)}x runtime, ${metrics.wasmBytes.percentChange.toFixed(1)}% Wasm`,
+    );
+  });
+  console.log(
+    `vtrace: ${baseVtraceRuntime.status} on ${baseRef}; ${headVtrace.runtimeMedianMs.toFixed(1)} ms on ${headRef}`,
+  );
+} finally {
+  worktrees.reverse().forEach((directory) => {
+    spawnSync("git", ["worktree", "remove", "--force", directory], {
+      cwd: repoRoot,
+      stdio: "ignore",
+    });
+  });
+  rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/scripts/release/list.mjs
+++ b/scripts/release/list.mjs
@@ -1,5 +1,10 @@
-import { orderedTargetNames } from "./manifest.mjs";
+import {
+  assertReleaseTargetCoverage,
+  orderedTargetNames,
+} from "./manifest.mjs";
 import { describeTargets } from "./runner.mjs";
+
+assertReleaseTargetCoverage();
 
 const targets = describeTargets(orderedTargetNames);
 

--- a/scripts/release/manifest.mjs
+++ b/scripts/release/manifest.mjs
@@ -41,6 +41,55 @@ export const releaseTargets = {
     packRequiredFiles: ["package.json", "src/pkg.voyd", "dist/.placeholder"],
     relatedTests: ["own", "conformance", "integration"],
   }),
+  "@voyd-lang/package-adapter": npmTarget({
+    workspace: "@voyd-lang/package-adapter",
+    cwd: "packages/package-adapter",
+    description: "Host-language adapter contracts for Voyd packages",
+    packRequiredFiles: ["package.json", "dist/index.js", "dist/index.d.ts"],
+    packForbiddenPatterns: [
+      /^src\//,
+      /^dist\/.*\.test\./,
+      /^dist\/.*\/src\//,
+    ],
+    relatedTests: ["own", "integration"],
+  }),
+  "@voyd-lang/markdown": npmTarget({
+    workspace: "@voyd-lang/markdown",
+    cwd: "packages/markdown",
+    description: "JS-backed Markdown rendering for Voyd and VX",
+    packRequiredFiles: [
+      "package.json",
+      "src/pkg.voyd",
+      "dist/host/adapter.js",
+      "dist/host/adapter.d.ts",
+      "generated/contract.json",
+      "generated/contract.ts",
+      "generated/interface.wit",
+      "generated/voyd-adapter.ts",
+    ],
+    packForbiddenPatterns: [/^host\//, /^dist\/.*\.test\./],
+    relatedTests: ["own", "integration"],
+  }),
+  "@voyd-lang/vx-dom": npmTarget({
+    workspace: "@voyd-lang/vx-dom",
+    cwd: "packages/vx-dom",
+    description: "Voyd VX browser and server DOM renderer",
+    packRequiredFiles: [
+      "package.json",
+      "dist/index.js",
+      "dist/index.d.ts",
+      "dist/browser.js",
+      "dist/browser.d.ts",
+      "dist/server.js",
+      "dist/server.d.ts",
+    ],
+    packForbiddenPatterns: [
+      /^src\//,
+      /^dist\/.*\.test\./,
+      /^dist\/.*\/src\//,
+    ],
+    relatedTests: ["own", "integration"],
+  }),
   "@voyd-lang/lib": npmTarget({
     workspace: "@voyd-lang/lib",
     cwd: "packages/lib",
@@ -217,7 +266,32 @@ export const listWorkspacePackageJsonPaths = () =>
       .filter((packageJsonPath) => fs.existsSync(packageJsonPath));
   });
 
+export const assertReleaseTargetCoverage = () => {
+  const releaseTargetNames = new Set(
+    Object.values(releaseTargets).map((target) => target.workspace),
+  );
+  const missingTargets = listWorkspacePackageJsonPaths()
+    .map(readJson)
+    .filter(
+      (packageJson) =>
+        packageJson.scripts?.prepublishOnly ===
+        "node ../../scripts/release/enforce-workspace-release.mjs",
+    )
+    .map((packageJson) => packageJson.name)
+    .filter((workspaceName) => !releaseTargetNames.has(workspaceName));
+
+  if (missingTargets.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `Publishable workspaces are missing release targets: ${missingTargets.join(", ")}`,
+  );
+};
+
 export const parseTargetSelection = (argv) => {
+  assertReleaseTargetCoverage();
+
   const targets = [];
   let all = false;
 


### PR DESCRIPTION
## Summary

- draft the Voyd 0.3.0 “Gaia BH1” reference release post, changelog entry, and GitHub release notes
- categorize and link all 68 pull requests merged since v0.2.0
- add @voyd-lang/vx-dom, @voyd-lang/package-adapter, and @voyd-lang/markdown to the release manifest
- validate required package contents and ensure every workspace using the release prepublish hook has an authoritative release target
- update the publishing runbook for the v0.3.0 flow and new-package bootstrap requirements

## Why

The v0.3.0 release content was ready to draft, but three public packages introduced since v0.2.0 were absent from the release manifest. That omission kept them out of version synchronization, dependency-aware publish ordering, release validation, and npm publishing.

The new coverage invariant makes future omissions fail during target selection and release listing instead of surfacing late in publishing.

## User and developer impact

Voyd 0.3.0 now has complete release copy centered on the typed VX runtime, web framework, external packages, typed boundaries, and optimizer improvements. Once the new npm names are bootstrapped at 0.2.0 and configured for trusted publishing, the normal v0.3.0 release workflow will version, validate, and publish them with the rest of the workspace.

## Validation

- `npm -w @voyd-lang/reference run build`
- `node scripts/release/check.mjs --targets @voyd-lang/package-adapter,@voyd-lang/markdown,@voyd-lang/vx-dom`
  - package tests: 103 assertions
  - integration: 16 files / 130 assertions
  - package-content dry runs passed for all three targets
- `npm test` — 18/18 workspace tasks
- `npm run typecheck` — 9/9 affected tasks
- `npm run test:audit`
- `git diff --check`

## One-time release setup

The three new package names are not yet present on npm. After this release-target change lands on main, bootstrap them at 0.2.0 and configure `release.yml` as their npm trusted publisher before preparing the v0.3.0 version bump. The publishing runbook contains the exact commands.