### PR TITLE
Restore homepage type models

### DIFF
--- a/apps/site/app/routes/home.tsx
+++ b/apps/site/app/routes/home.tsx
@@ -172,7 +172,17 @@ fn run_twice<T>(work: fn() -> T) -> Array<T>
       },
     ],
     codeLabel: "models.voyd",
-    code: `fn ids(items: Array<{ id: String }>) -> Array<String>
+    code: `obj User {
+  id: String,
+  name: String
+}
+
+obj Project {
+  id: String,
+  title: String
+}
+
+fn ids(items: Array<{ id: String }>) -> Array<String>
   items.map(item => item.id)`,
   },
   {


### PR DESCRIPTION
## Summary

- restore the `User` and `Project` model declarations in the homepage type-system example
- keep the intentionally simplified structural `ids` function

## Why

The previous edit simplified the entire example when the intended change was only to simplify `ids`. Restoring the model declarations makes the structural-typing example concrete without reintroducing complexity in the function itself.

## Impact

Visitors can see two distinct application types accepted through the same structural `{ id: String }` boundary, while the sample remains short and copyable.

## Validation

- compiled the exact displayed Voyd snippet through the Node SDK
- `npm run build -w voyd.dev`
- `npm run typecheck`
- `npm test`
- `npm run test:audit`