### PR TITLE
Allow contextual lambdas to omit trailing parameters

### DIFF
--- a/packages/compiler/src/codegen/expressions/lambdas.ts
+++ b/packages/compiler/src/codegen/expressions/lambdas.ts
@@ -242,8 +242,8 @@ const emitLambdaFunction = ({
   if (desc.kind !== "function") {
     throw new Error("lambda missing function type");
   }
-  if (desc.parameters.length !== expr.parameters.length) {
-    throw new Error("lambda parameter count mismatch");
+  if (desc.parameters.length < expr.parameters.length) {
+    throw new Error("lambda declares more parameters than its function type");
   }
 
   const params = [env.base.interfaceType, ...env.base.paramTypes];

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/lambda_typing.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/lambda_typing.voyd
@@ -4,8 +4,14 @@ fn applyTwice(f: fn(i32) -> i32, value: i32) -> i32
 fn makeIncrementer(delta: i32) -> (fn(i32) -> i32)
   (value) => value + delta
 
+fn call_three(callback: fn(i32, i32, i32) -> i32) -> i32
+  callback(3, 5, 7)
+
 pub fn main() -> i32
   let result = applyTwice((x) => x * 2, 3)
   let inc = makeIncrementer(1)
   let trimmed = result.((n) => n - 1)
-  trimmed + inc(4)
+  let ignored = call_three(() => 11)
+  let leading = call_three((first) => first)
+  let later = call_three((_first, second) => second)
+  trimmed + inc(4) + ignored + leading + later

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/overload_lambda_probe_retyping.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/overload_lambda_probe_retyping.voyd
@@ -4,5 +4,14 @@ fn pick(flag: bool, mapper: fn(i32) -> i32) -> i32
 fn pick(flag: i32, mapper: fn(bool) -> i32) -> i32
   mapper(false)
 
+fn invoke(mapper: fn() -> i32) -> i32
+  mapper()
+
+fn invoke(mapper: fn(i32) -> i32) -> i32
+  mapper(1)
+
 pub fn main() -> i32
   pick(true, x => x + 1)
+
+pub fn exact_lambda_arity() -> i32
+  invoke(() => 4)

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/overload_lambda_probe_retyping.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/overload_lambda_probe_retyping.voyd
@@ -10,8 +10,17 @@ fn invoke(mapper: fn() -> i32) -> i32
 fn invoke(mapper: fn(i32) -> i32) -> i32
   mapper(1)
 
+fn choose(mapper: fn() -> bool) -> i32
+  if mapper() then: 1 else: 0
+
+fn choose(mapper: fn(i32) -> i32) -> i32
+  mapper(2)
+
 pub fn main() -> i32
   pick(true, x => x + 1)
 
 pub fn exact_lambda_arity() -> i32
   invoke(() => 4)
+
+pub fn omitted_lambda_return_compatibility() -> i32
+  choose(() => 5)

--- a/packages/compiler/src/semantics/typing/__tests__/call-diagnostics.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/call-diagnostics.test.ts
@@ -4,9 +4,35 @@ import { describe, expect, it } from "vitest";
 import { semanticsPipeline } from "../../pipeline.js";
 import { loadAst } from "../../__tests__/load-ast.js";
 import { DiagnosticError } from "../../../diagnostics/index.js";
+import { parse } from "../../../parser/parser.js";
 import { getSymbolTable } from "../../_internal/symbol-table.js";
 
 describe("call diagnostics", () => {
+  it("does not infer omitted lambda parameters from its own call arguments", () => {
+    const ast = parse(
+      `
+pub fn main() -> i32
+  (() => 1)(42)
+`,
+      "/proj/src/immediate-lambda.voyd"
+    );
+
+    let caught: unknown;
+    try {
+      semanticsPipeline(ast);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught instanceof DiagnosticError).toBe(true);
+    if (!(caught instanceof DiagnosticError)) {
+      return;
+    }
+
+    expect(caught.diagnostic.code).toBe("TY0005");
+    expect(caught.diagnostic.message).toMatch(/cannot call a non-function/i);
+  });
+
   it("reports diagnostics for calling non-function values", () => {
     const ast = loadAst("non_function_call.voyd");
 

--- a/packages/compiler/src/semantics/typing/__tests__/lambda-typing.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/lambda-typing.test.ts
@@ -63,5 +63,55 @@ describe("lambda typing", () => {
     if (trimmedType.kind !== "function") return;
     expect(trimmedType.parameters.map((param) => param.type)).toEqual([i32]);
     expect(trimmedType.returnType).toBe(i32);
+
+    const ignored = Array.from(hir.expressions.values()).find(
+      (expr): expr is HirLambdaExpr =>
+        expr.exprKind === "lambda" && expr.parameters.length === 0,
+    );
+    expect(ignored).toBeDefined();
+    if (!ignored) return;
+    const ignoredTypeId = typing.table.getExprType(ignored.id);
+    expect(ignoredTypeId).toBeDefined();
+    if (ignoredTypeId === undefined) return;
+    const ignoredType = typing.arena.get(ignoredTypeId);
+    expect(ignoredType.kind).toBe("function");
+    if (ignoredType.kind !== "function") return;
+    expect(ignoredType.parameters.map((param) => param.type)).toEqual([
+      i32,
+      i32,
+      i32,
+    ]);
+
+    const leading = lambdaByParam(hir, symbolTable, "first");
+    expect(leading).toBeDefined();
+    if (!leading) return;
+    const leadingTypeId = typing.table.getExprType(leading.id);
+    expect(leadingTypeId).toBeDefined();
+    if (leadingTypeId === undefined) return;
+    const leadingType = typing.arena.get(leadingTypeId);
+    expect(leadingType.kind).toBe("function");
+    if (leadingType.kind !== "function") return;
+    expect(leading.parameters).toHaveLength(1);
+    expect(leadingType.parameters.map((param) => param.type)).toEqual([
+      i32,
+      i32,
+      i32,
+    ]);
+
+    const later = lambdaByParam(hir, symbolTable, "second");
+    expect(later).toBeDefined();
+    if (!later) return;
+    const laterTypeId = typing.table.getExprType(later.id);
+    expect(laterTypeId).toBeDefined();
+    if (laterTypeId === undefined) return;
+    const laterType = typing.arena.get(laterTypeId);
+    expect(laterType.kind).toBe("function");
+    if (laterType.kind !== "function") return;
+    expect(later.parameters).toHaveLength(2);
+    expect(laterType.parameters.map((param) => param.type)).toEqual([
+      i32,
+      i32,
+      i32,
+    ]);
   });
 });

--- a/packages/compiler/src/semantics/typing/__tests__/overload-lambda-context.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/overload-lambda-context.test.ts
@@ -38,5 +38,19 @@ describe("overload lambda context", () => {
     expect(call).toBeDefined();
     if (!call) return;
     expect(typing.table.getExprType(call.id)).toBe(i32);
+
+    const exactArityLambda = Array.from(hir.expressions.values()).find(
+      (expr): expr is HirLambdaExpr =>
+        expr.exprKind === "lambda" && expr.parameters.length === 0,
+    );
+    expect(exactArityLambda).toBeDefined();
+    if (!exactArityLambda) return;
+    const exactArityTypeId = typing.table.getExprType(exactArityLambda.id);
+    expect(exactArityTypeId).toBeDefined();
+    if (exactArityTypeId === undefined) return;
+    const exactArityType = typing.arena.get(exactArityTypeId);
+    expect(exactArityType.kind).toBe("function");
+    if (exactArityType.kind !== "function") return;
+    expect(exactArityType.parameters).toHaveLength(0);
   });
 });

--- a/packages/compiler/src/semantics/typing/__tests__/overload-lambda-context.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/overload-lambda-context.test.ts
@@ -39,18 +39,17 @@ describe("overload lambda context", () => {
     if (!call) return;
     expect(typing.table.getExprType(call.id)).toBe(i32);
 
-    const exactArityLambda = Array.from(hir.expressions.values()).find(
+    const zeroParameterLambdas = Array.from(hir.expressions.values()).filter(
       (expr): expr is HirLambdaExpr =>
         expr.exprKind === "lambda" && expr.parameters.length === 0,
     );
-    expect(exactArityLambda).toBeDefined();
-    if (!exactArityLambda) return;
-    const exactArityTypeId = typing.table.getExprType(exactArityLambda.id);
-    expect(exactArityTypeId).toBeDefined();
-    if (exactArityTypeId === undefined) return;
-    const exactArityType = typing.arena.get(exactArityTypeId);
-    expect(exactArityType.kind).toBe("function");
-    if (exactArityType.kind !== "function") return;
-    expect(exactArityType.parameters).toHaveLength(0);
+    const contextualParameterCounts = zeroParameterLambdas
+      .map((lambda) => typing.table.getExprType(lambda.id))
+      .filter((typeId): typeId is number => typeId !== undefined)
+      .map((typeId) => typing.arena.get(typeId))
+      .filter((type) => type.kind === "function")
+      .map((type) => type.parameters.length)
+      .sort();
+    expect(contextualParameterCounts).toEqual([0, 1]);
   });
 });

--- a/packages/compiler/src/semantics/typing/expressions.ts
+++ b/packages/compiler/src/semantics/typing/expressions.ts
@@ -36,6 +36,8 @@ export { formatFunctionInstanceKey, validateGenericFunctionBody };
 
 export type TypeExpressionOptions = {
   expectedType?: TypeId;
+  /** Whether a contextual function type may supply omitted trailing lambda parameters. */
+  allowOmittedLambdaParameters?: boolean;
   /** When true, the expression's resulting value is not used (statement context). */
   discardValue?: boolean;
 };
@@ -212,7 +214,13 @@ const resolveExpressionType = (
     case "continue":
       return typeContinueExpr(expr, ctx);
     case "lambda":
-      return typeLambdaExpr(expr, ctx, state, expectedType);
+      return typeLambdaExpr(
+        expr,
+        ctx,
+        state,
+        expectedType,
+        options.allowOmittedLambdaParameters !== false
+      );
     default:
       throw new Error(`unsupported expression kind: ${expr.exprKind}`);
   }

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -6061,8 +6061,26 @@ const scoreOverloadMatchesByLambdaCompatibility = <
   const compatibilityNarrowed = lambdaCompatible.length < matches.length;
   const returnNarrowed =
     lambdaReturnCompatible.length < lambdaCompatible.length;
+  const arityPreferenceCandidates = returnNarrowed
+    ? lambdaReturnCompatible
+    : lambdaCompatible;
+  const exactArityCandidates = arityPreferenceCandidates.filter(
+    (candidate) =>
+      inlineLambdaCompatibility({
+        candidate,
+        args: argsForCandidate ? argsForCandidate(candidate) : args,
+        typeArguments,
+        targetTypeArguments,
+        ctx,
+        state,
+      }) === "exact",
+  );
+  const arityNarrowed =
+    exactArityCandidates.length > 0 &&
+    exactArityCandidates.length < arityPreferenceCandidates.length;
   const compatibleSet = new Set(lambdaCompatible);
   const returnCompatibleSet = new Set(lambdaReturnCompatible);
+  const exactAritySet = new Set(exactArityCandidates);
 
   return new Map(
     matches.map((candidate) => {
@@ -6070,9 +6088,14 @@ const scoreOverloadMatchesByLambdaCompatibility = <
         !compatibilityNarrowed || compatibleSet.has(candidate) ? 1 : 0;
       const returnScore =
         returnNarrowed && returnCompatibleSet.has(candidate) ? 1 : 0;
+      const arityScore =
+        arityNarrowed && exactAritySet.has(candidate) ? 1 : 0;
       return [
         candidate,
-        { lambdaCompatibility: compatibilityScore + returnScore },
+        {
+          lambdaCompatibility:
+            compatibilityScore + returnScore + arityScore,
+        },
       ];
     }),
   );
@@ -6245,11 +6268,8 @@ const narrowOverloadMatchesByLambdaCompatibility = <
   const compatible = matches.filter(
     (candidate) => compatibility.get(candidate) !== "incompatible",
   );
-  const exact = compatible.filter(
-    (candidate) => compatibility.get(candidate) === "exact",
-  );
   const candidatesForScoring =
-    exact.length > 0 ? exact : compatible.length > 0 ? compatible : matches;
+    compatible.length > 0 ? compatible : matches;
   if (candidatesForScoring.length === 1) {
     return candidatesForScoring;
   }

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -648,6 +648,7 @@ export const typeCallExpr = (
 
   const calleeType = typeExpression(expr.callee, ctx, state, {
     expectedType: expectedCalleeType(args, ctx),
+    allowOmittedLambdaParameters: false,
   });
 
   if (

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -6229,17 +6229,27 @@ const narrowOverloadMatchesByLambdaCompatibility = <
     return matches;
   }
 
-  const compatible = matches.filter((candidate) =>
-    candidateAcceptsInlineLambdas({
+  const compatibility = new Map(
+    matches.map((candidate) => [
       candidate,
-      args: argsForCandidate ? argsForCandidate(candidate) : args,
-      typeArguments,
-      targetTypeArguments,
-      ctx,
-      state,
-    }),
+      inlineLambdaCompatibility({
+        candidate,
+        args: argsForCandidate ? argsForCandidate(candidate) : args,
+        typeArguments,
+        targetTypeArguments,
+        ctx,
+        state,
+      }),
+    ]),
   );
-  const candidatesForScoring = compatible.length > 0 ? compatible : matches;
+  const compatible = matches.filter(
+    (candidate) => compatibility.get(candidate) !== "incompatible",
+  );
+  const exact = compatible.filter(
+    (candidate) => compatibility.get(candidate) === "exact",
+  );
+  const candidatesForScoring =
+    exact.length > 0 ? exact : compatible.length > 0 ? compatible : matches;
   if (candidatesForScoring.length === 1) {
     return candidatesForScoring;
   }
@@ -6271,7 +6281,9 @@ const narrowOverloadMatchesByLambdaCompatibility = <
     : matches;
 };
 
-const candidateAcceptsInlineLambdas = <
+type InlineLambdaCompatibility = "exact" | "omitted-trailing" | "incompatible";
+
+const inlineLambdaCompatibility = <
   T extends { symbol: SymbolId; signature: FunctionSignature },
 >({
   candidate,
@@ -6287,7 +6299,7 @@ const candidateAcceptsInlineLambdas = <
   targetTypeArguments?: readonly TypeId[] | undefined;
   ctx: TypingContext;
   state: TypingState;
-}): boolean => {
+}): InlineLambdaCompatibility => {
   const params = specializeOverloadParametersWithTargetTypeArguments({
     symbol: candidate.symbol,
     signature: candidate.signature,
@@ -6296,6 +6308,7 @@ const candidateAcceptsInlineLambdas = <
     ctx,
   }).filter((param) => !isStableCallsiteIdParam(param));
   const callArgs = callArgInputsFromArgs(args);
+  let omittedTrailing = false;
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index]!;
@@ -6322,7 +6335,10 @@ const candidateAcceptsInlineLambdas = <
       continue;
     }
     if (expectedDesc.parameters.length < lambdaExpr.parameters.length) {
-      return false;
+      return "incompatible";
+    }
+    if (expectedDesc.parameters.length > lambdaExpr.parameters.length) {
+      omittedTrailing = true;
     }
     for (let paramIndex = 0; paramIndex < lambdaExpr.parameters.length; paramIndex += 1) {
       const actualParam = lambdaExpr.parameters[paramIndex]!;
@@ -6349,11 +6365,11 @@ const candidateAcceptsInlineLambdas = <
         !typeSatisfies(actualType, expectedParam.type, ctx, state) &&
         !typeSatisfies(expectedParam.type, actualType, ctx, state)
       ) {
-        return false;
+        return "incompatible";
       }
     }
   }
-  return true;
+  return omittedTrailing ? "omitted-trailing" : "exact";
 };
 
 const inlineLambdaExpectedTypeParamPenalty = <

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -6321,7 +6321,7 @@ const candidateAcceptsInlineLambdas = <
     if (expectedDesc.kind !== "function") {
       continue;
     }
-    if (expectedDesc.parameters.length !== lambdaExpr.parameters.length) {
+    if (expectedDesc.parameters.length < lambdaExpr.parameters.length) {
       return false;
     }
     for (let paramIndex = 0; paramIndex < lambdaExpr.parameters.length; paramIndex += 1) {

--- a/packages/compiler/src/semantics/typing/expressions/lambda.ts
+++ b/packages/compiler/src/semantics/typing/expressions/lambda.ts
@@ -250,13 +250,19 @@ export const typeLambdaExpr = (
     ctx
   );
 
-  const finalParams = appliedParams.map((param) => ({
-    label: param.label,
-    type: ctx.arena.substitute(param.resolvedType, finalSubstitution),
-    optional: param.optional ?? false,
-    defaulted: typeof param.defaultValue === "number",
-    bindingKind: param.pattern.bindingKind,
-  }));
+  const finalParams = [
+    ...appliedParams.map((param) => ({
+      label: param.label,
+      type: ctx.arena.substitute(param.resolvedType, finalSubstitution),
+      optional: param.optional ?? false,
+      defaulted: typeof param.defaultValue === "number",
+      bindingKind: param.pattern.bindingKind,
+    })),
+    ...(expectedFn?.parameters.slice(expr.parameters.length).map((param) => ({
+      ...param,
+      type: ctx.arena.substitute(param.type, finalSubstitution),
+    })) ?? []),
+  ];
   const substitutedBodyType = ctx.arena.substitute(bodyType, finalSubstitution);
   const annotatedReturnApplied =
     typeof annotatedReturn === "number"

--- a/packages/compiler/src/semantics/typing/expressions/lambda.ts
+++ b/packages/compiler/src/semantics/typing/expressions/lambda.ts
@@ -35,7 +35,8 @@ export const typeLambdaExpr = (
   expr: HirLambdaExpr,
   ctx: TypingContext,
   state: TypingState,
-  expectedType?: TypeId
+  expectedType?: TypeId,
+  allowOmittedParameters = true
 ): TypeId => {
   const appliedExpected =
     typeof expectedType === "number"
@@ -258,10 +259,12 @@ export const typeLambdaExpr = (
       defaulted: typeof param.defaultValue === "number",
       bindingKind: param.pattern.bindingKind,
     })),
-    ...(expectedFn?.parameters.slice(expr.parameters.length).map((param) => ({
-      ...param,
-      type: ctx.arena.substitute(param.type, finalSubstitution),
-    })) ?? []),
+    ...(allowOmittedParameters
+      ? expectedFn?.parameters.slice(expr.parameters.length).map((param) => ({
+          ...param,
+          type: ctx.arena.substitute(param.type, finalSubstitution),
+        })) ?? []
+      : []),
   ];
   const substitutedBodyType = ctx.arena.substitute(bodyType, finalSubstitution);
   const annotatedReturnApplied =

--- a/tests/conformance/cases/runtime/core-language.voyd
+++ b/tests/conformance/cases/runtime/core-language.voyd
@@ -120,10 +120,25 @@ fn apply_twice(transform: fn(i32) -> i32, value: i32) -> i32
 fn make_incrementer(delta: i32) -> (fn(i32) -> i32)
   (value) => value + delta
 
+fn call_three(callback: fn(i32, i32, i32) -> i32) -> i32
+  callback(2, 5, 9)
+
+fn call_three_labeled({ handler: fn(i32, i32, i32) -> i32 }) -> i32
+  handler(3, 7, 11)
+
 pub fn contextual_lambda_typing() -> i32
   let doubled = apply_twice((value) => value * 2, 3)
   let increment = make_incrementer(1)
   doubled + increment(4)
+
+pub fn contextual_lambda_omitted_trailing() -> i32
+  let ignored = call_three(() => 1)
+  let leading = call_three((first) => first)
+  let later = call_three((_first, second) => second)
+  let clause = call_three_labeled
+    handler():
+      4
+  ignored + leading + later + clause
 
 pub fn integer_modulo() -> i32
   10 % 3

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -633,6 +633,12 @@
           "expect": { "kind": "equals", "value": 17 }
         },
         {
+          "id": "runtime.lambdas.omitted-trailing-parameters",
+          "title": "allows contextually typed lambdas to omit trailing parameters",
+          "entryName": "contextual_lambda_omitted_trailing",
+          "expect": { "kind": "equals", "value": 12 }
+        },
+        {
           "id": "runtime.operators.integer-modulo",
           "title": "evaluates integer modulo",
           "entryName": "integer_modulo",

--- a/tests/integration/fixtures/vx-async-task-command.voyd
+++ b/tests/integration/fixtures/vx-async-task-command.voyd
@@ -12,6 +12,7 @@ obj Model {
 
 enum Msg
   Save
+  SaveIgnored
   Saved { value: i32 }
 
 pub fn app() -> Program<Model, Msg>
@@ -30,15 +31,31 @@ fn step(model: Model, msg: Msg): tasks::TaskRuntime -> Program<Model, Msg>
           handler: (value: MsgPack) -> Msg => Msg::Saved { value: saved_value(value) }
         )
       )
+    Msg::SaveIgnored:
+      next(
+        model: Model { status: "Ignoring..." },
+        cmd: ignored_task()
+      )
     Msg::Saved { value }:
       next(Model { status: saved_label(value) })
 
 fn view(model: Model) -> Html<Msg>
-  <button type="button" on_click={Msg::Save {}}>{model.status}</button>
+  <div>
+    <button type="button" data-testid="typed-result" on_click={Msg::Save {}}>{model.status}</button>
+    <button type="button" data-testid="ignored-result" on_click={Msg::SaveIgnored {}}>Ignore result</button>
+  </div>
+
+fn ignored_task(): tasks::TaskRuntime -> Cmd<Msg>
+  Cmd<Msg>::task
+    work():
+      msgpack::make_i32(99)
+    handler():
+      Msg::Saved { value: 42 }
 
 fn saved_label(value: i32) -> String
   if
     value == 41: "Saved: 41"
+    value == 42: "Saved: 42"
     else: "Saved"
 
 fn saved_value(value: MsgPack) -> i32

--- a/tests/integration/src/vx-dom.test.ts
+++ b/tests/integration/src/vx-dom.test.ts
@@ -282,6 +282,16 @@ describe("integration: compiled VX DOM rendering", () => {
 
     expect(container.querySelector("button")?.textContent).toBe("Saved: 41");
 
+    container
+      .querySelector<HTMLButtonElement>('[data-testid="ignored-result"]')
+      ?.click();
+    await waitForTextContaining(container, "button", "Saved: 42");
+
+    expect(
+      container.querySelector<HTMLButtonElement>('[data-testid="typed-result"]')
+        ?.textContent,
+    ).toBe("Saved: 42");
+
     mounted.dispose();
     expect(container.innerHTML).toBe("");
   });


### PR DESCRIPTION
## Summary

- allow contextually typed lambdas to declare only the leading prefix of expected positional parameters
- preserve the full contextual function signature and Wasm closure ABI while binding only declared parameters
- contextualize shortened lambdas per overload candidate without relaxing standalone function arity
- cover inline and callback-clause execution, including `Cmd::task handler():`

## Root cause

Lambda typing built the resulting function type solely from the parameters explicitly declared in HIR. That made a zero-parameter handler incompatible with an expected `fn(T) -> R`, and codegen also assumed the typed descriptor and declared HIR parameter counts were identical.

## Impact

Callbacks can now omit any unused trailing suffix while retaining the expected runtime calling convention. Excess parameters and incompatible parameter/return types continue to use the existing diagnostics, and effect inference is unchanged.

## Validation

- `npm test` (18/18 packages)
- `npm run typecheck`
- `npm run test:audit`
- focused compiler lambda/overload/method-context tests
- focused runtime conformance case
- focused mounted VX `Cmd::task` integration test
- agentic implementation-gap, architecture, and correctness reviews: clean

Linear: [V-421](https://linear.app/voyd-lang/issue/V-421/allow-contextually-typed-lambdas-to-omit-unused-trailing-parameters)