### PR TITLE
V-423 Propagate generic bounds into constrained object types

### DIFF
--- a/apps/site/app/routes/home.tsx
+++ b/apps/site/app/routes/home.tsx
@@ -171,19 +171,20 @@ fn run_twice<T>(work: fn() -> T) -> Array<T>
         detail: "Catch incompatible changes before runtime.",
       },
     ],
-    codeLabel: "models.voyd",
-    code: `obj User {
-  id: String,
-  name: String
+    codeLabel: "repo.voyd",
+    code: `trait Persistable
+  fn id(self) -> String
+
+obj Repo<T: Persistable> {
+  items: Array<T>
 }
 
-obj Project {
-  id: String,
-  title: String
-}
-
-fn ids(items: Array<{ id: String }>) -> Array<String>
-  items.map(item => item.id)`,
+impl<T: Persistable> Repo<T>
+  fn upsert(~self, value: T) -> void
+    self.items = self.items.filter(
+      item => item.id() != value.id()
+    )
+    self.items.push(value)`,
   },
   {
     id: "syntax",

--- a/packages/compiler/src/modules/semantic-snapshot.ts
+++ b/packages/compiler/src/modules/semantic-snapshot.ts
@@ -30,6 +30,7 @@ export const cloneSemanticsForTypingState = ({
       typeAliases: typing.typeAliases.clone(),
       objects: typing.objects.clone(),
       traits: typing.traits.clone(),
+      typeParameterConstraints: new Map(typing.typeParameterConstraints),
       primitives: {
         cache: new Map(typing.primitives.cache),
         bool: typing.primitives.bool,

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_cross_module/dep.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_cross_module/dep.voyd
@@ -28,6 +28,10 @@ pub obj Repo<T: Persistable> {
   value: T
 }
 
+pub type RepoAlias<T: Persistable> = Repo<T>
+
 pub obj StructuralRepo<T: { id: i32 }> {
   value: T
 }
+
+pub type StructuralRepoAlias<T: { id: i32 }> = StructuralRepo<T>

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_cross_module/dep.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_cross_module/dep.voyd
@@ -30,6 +30,16 @@ pub obj Repo<T: Persistable> {
 
 pub type RepoAlias<T: Persistable> = Repo<T>
 
+pub trait Named
+  fn name(self) -> String
+
+pub obj Pair<A: Persistable, B: Named> {
+  first: A,
+  second: B
+}
+
+pub type PairAlias<A: Persistable, B: Named> = Pair<A, B>
+
 pub obj StructuralRepo<T: { id: i32 }> {
   value: T
 }

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_cross_module/dep.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_cross_module/dep.voyd
@@ -20,3 +20,14 @@ impl<K: Key<K>, V> DictLike<K, V>
 
   pub fn key_matches(self, key: K) -> bool
     self.key.matches(key)
+
+pub trait Persistable
+  fn id(self) -> i32
+
+pub obj Repo<T: Persistable> {
+  value: T
+}
+
+pub obj StructuralRepo<T: { id: i32 }> {
+  value: T
+}

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_cross_module/invalid_alias_main.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_cross_module/invalid_alias_main.voyd
@@ -1,0 +1,4 @@
+use src::dep::{ RepoAlias }
+
+fn invalid_alias<T>(value: T) -> RepoAlias<T>
+  value

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_cross_module/main.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_cross_module/main.voyd
@@ -1,4 +1,4 @@
-use src::dep::{ DictLike, IntKey, Persistable, Repo, RepoAlias, StructuralRepo, StructuralRepoAlias }
+use src::dep::{ DictLike, IntKey, Named, Pair, PairAlias, Persistable, Repo, RepoAlias, StructuralRepo, StructuralRepoAlias }
 
 obj User {
   id: i32
@@ -9,6 +9,9 @@ fn repo<T: Persistable>(value: T) -> Repo<T>
 
 fn repo_alias<T: Persistable>(value: T) -> RepoAlias<T>
   Repo<T> { value: value }
+
+fn pair_alias<T: Persistable & Named>(first: T, second: T) -> PairAlias<T, T>
+  Pair<T, T> { first: first, second: second }
 
 fn structural_repo<T: User>(value: T) -> StructuralRepo<T>
   StructuralRepo<T> { value: value }

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_cross_module/main.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_cross_module/main.voyd
@@ -1,4 +1,4 @@
-use src::dep::{ DictLike, IntKey, Persistable, Repo, StructuralRepo }
+use src::dep::{ DictLike, IntKey, Persistable, Repo, RepoAlias, StructuralRepo, StructuralRepoAlias }
 
 obj User {
   id: i32
@@ -7,7 +7,13 @@ obj User {
 fn repo<T: Persistable>(value: T) -> Repo<T>
   Repo<T> { value: value }
 
+fn repo_alias<T: Persistable>(value: T) -> RepoAlias<T>
+  Repo<T> { value: value }
+
 fn structural_repo<T: User>(value: T) -> StructuralRepo<T>
+  StructuralRepo<T> { value: value }
+
+fn structural_repo_alias<T: User>(value: T) -> StructuralRepoAlias<T>
   StructuralRepo<T> { value: value }
 
 pub fn main() -> i32

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_cross_module/main.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_cross_module/main.voyd
@@ -1,4 +1,14 @@
-use src::dep::{ DictLike, IntKey }
+use src::dep::{ DictLike, IntKey, Persistable, Repo, StructuralRepo }
+
+obj User {
+  id: i32
+}
+
+fn repo<T: Persistable>(value: T) -> Repo<T>
+  Repo<T> { value: value }
+
+fn structural_repo<T: User>(value: T) -> StructuralRepo<T>
+  StructuralRepo<T> { value: value }
 
 pub fn main() -> i32
   let dict = DictLike<IntKey, i32>::init(IntKey { value: 7 }, 1)

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_parameter_mismatch.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_parameter_mismatch.voyd
@@ -2,9 +2,13 @@ obj Animal {
   id: i32
 }
 
+obj Named {
+  name: String
+}
+
 obj Box<T: Animal> {
   value: T
 }
 
-fn weaker_bound<T>(value: T) -> Box<T>
+fn mismatched_bound<T: Named>(value: T) -> Box<T>
   Box<T> { value: value }

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_parameter_propagation.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_parameter_propagation.voyd
@@ -1,0 +1,58 @@
+trait Persistable
+  fn id(self) -> String
+
+trait Named
+  fn name(self) -> String
+
+obj Entity {
+  id: String
+}
+
+obj TraitRepo<T: Persistable> {
+  value: T
+}
+
+impl<T: Persistable> TraitRepo<T>
+  fn replace(~self, value: T) -> void
+    self.value = value
+
+fn trait_repo<T: Persistable>(value: T) -> TraitRepo<T>
+  TraitRepo<T> { value: value }
+
+fn trait_repo_value<T: Persistable>(repo: TraitRepo<T>) -> T
+  repo.value
+
+obj NominalRepo<T: Entity> {
+  value: T
+}
+
+impl<T: Entity> NominalRepo<T>
+  fn replace(~self, value: T) -> void
+    self.value = value
+
+fn nominal_repo<T: Entity>(value: T) -> NominalRepo<T>
+  NominalRepo<T> { value: value }
+
+obj StructuralRepo<T: { id: String }> {
+  value: T
+}
+
+impl<T: { id: String }> StructuralRepo<T>
+  fn replace(~self, value: T) -> void
+    self.value = value
+
+fn structural_repo<T: { id: String }>(value: T) -> StructuralRepo<T>
+  StructuralRepo<T> { value: value }
+
+obj IntersectionRepo<T: Persistable & Named> {
+  value: T
+}
+
+impl<T: Persistable & Named> IntersectionRepo<T>
+  fn replace(~self, value: T) -> void
+    self.value = value
+
+fn intersection_repo<T: Persistable & Named>(
+  value: T
+) -> IntersectionRepo<T>
+  IntersectionRepo<T> { value: value }

--- a/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_parameter_propagation.voyd
+++ b/packages/compiler/src/semantics/__tests__/__fixtures__/generic_constraints_parameter_propagation.voyd
@@ -22,6 +22,9 @@ fn trait_repo<T: Persistable>(value: T) -> TraitRepo<T>
 fn trait_repo_value<T: Persistable>(repo: TraitRepo<T>) -> T
   repo.value
 
+fn later_parameter_bound<R: TraitRepo<T>, T: Persistable>(repo: R) -> R
+  repo
+
 obj NominalRepo<T: Entity> {
   value: T
 }

--- a/packages/compiler/src/semantics/__tests__/pipeline.test.ts
+++ b/packages/compiler/src/semantics/__tests__/pipeline.test.ts
@@ -690,6 +690,13 @@ describe("semanticsPipeline", () => {
     );
   });
 
+  it("rejects constrained object instantiations with mismatched bounds", () => {
+    const ast = loadAst("generic_constraints_parameter_mismatch.voyd");
+    expect(() => semanticsPipeline(ast)).toThrow(
+      /does not satisfy.*constraint/i
+    );
+  });
+
   it("accepts trait instantiations when trait type arguments satisfy constraints", () => {
     const ast = loadAst("generic_constraints_trait_instantiation_success.voyd");
     const result = semanticsPipeline(ast);
@@ -711,6 +718,12 @@ describe("semanticsPipeline", () => {
 
   it("accepts constrained generic re-instantiation inside constrained impl methods", () => {
     const ast = loadAst("generic_constraints_reinstantiation_success.voyd");
+    const result = semanticsPipeline(ast);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("propagates declaration bounds into constrained object instantiations", () => {
+    const ast = loadAst("generic_constraints_parameter_propagation.voyd");
     const result = semanticsPipeline(ast);
     expect(result.diagnostics).toHaveLength(0);
   });

--- a/packages/compiler/src/semantics/__tests__/pipeline.test.ts
+++ b/packages/compiler/src/semantics/__tests__/pipeline.test.ts
@@ -783,6 +783,20 @@ describe("semanticsPipeline", () => {
     });
 
     expect(mainSemantics.diagnostics).toHaveLength(0);
+
+    const invalidMain = buildModule({
+      fixture: "generic_constraints_cross_module/invalid_alias_main.voyd",
+      segments: ["invalid_alias_main"],
+      dependencies: [dependency],
+    });
+    expect(() =>
+      semanticsPipeline({
+        module: invalidMain.module,
+        graph: invalidMain.graph,
+        exports: new Map([[dep.module.id, depSemantics.exports]]),
+        dependencies: new Map([[dep.module.id, depSemantics]]),
+      }),
+    ).toThrow(/does not satisfy.*constraint for type alias/i);
   });
 
   it("accepts constrained generic object methods with transitive key-type dependencies", () => {

--- a/packages/compiler/src/semantics/typing/context-from-typing-result.ts
+++ b/packages/compiler/src/semantics/typing/context-from-typing-result.ts
@@ -67,6 +67,7 @@ export const createTypingContextFromTypingResult = ({
   functions: typing.functions,
   objects: typing.objects,
   traits: typing.traits,
+  typeParameterConstraints: new Map(typing.typeParameterConstraints),
   typeAliases: typing.typeAliases,
   primitives: typing.primitives,
   intrinsicTypes: typing.intrinsicTypes,

--- a/packages/compiler/src/semantics/typing/context.ts
+++ b/packages/compiler/src/semantics/typing/context.ts
@@ -109,6 +109,7 @@ export const createTypingContext = (inputs: TypingInputs): TypingContext => {
     functions,
     objects,
     traits,
+    typeParameterConstraints: new Map(),
     typeAliases,
     primitives: {
       cache: new Map(),

--- a/packages/compiler/src/semantics/typing/import-symbol-mapping.ts
+++ b/packages/compiler/src/semantics/typing/import-symbol-mapping.ts
@@ -445,6 +445,11 @@ export const registerImportedObjectTemplate = ({
     typeParam: mapTypeParam(param.typeParam, typeParamMap, ctx),
     constraint: param.constraint ? translation(param.constraint) : undefined,
   }));
+  params.forEach((param) => {
+    if (typeof param.constraint === "number") {
+      ctx.typeParameterConstraints.set(param.typeParam, param.constraint);
+    }
+  });
 
   const dependencyTraitSymbols = new Set<SymbolId>();
   const addDependencyTraitSymbols = (

--- a/packages/compiler/src/semantics/typing/imports.ts
+++ b/packages/compiler/src/semantics/typing/imports.ts
@@ -2,7 +2,10 @@ import { createTypingState } from "./context.js";
 import {
   ensureObjectType,
   ensureTraitType,
+  getSymbolName,
+  resolveTypeExpr,
   resolveTypeAlias,
+  typeSatisfies,
   validateObjectTypeArgumentConstraints,
 } from "./type-system.js";
 import { applyImportableMetadata } from "../imports/metadata.js";
@@ -307,6 +310,7 @@ export const resolveImportedTypeExpr = ({
 
   const depCtx = makeDependencyContext(dependency, ctx);
   const depState = createTypingState(state.mode);
+  const localValidationState = createTypingState(state.mode);
 
   if (
     typingContextsShareInterners({
@@ -316,6 +320,16 @@ export const resolveImportedTypeExpr = ({
       targetEffects: ctx.effects,
     })
   ) {
+    validateImportedAliasConstraints({
+      symbol: target.symbol,
+      dependencyArgs: typeArgs,
+      localArgs: typeArgs,
+      dependencyCtx: depCtx,
+      dependencyState: depState,
+      localCtx: ctx,
+      localState: localValidationState,
+      translateToLocal: (type) => type,
+    });
     const aliasResolved = resolveImportedAlias(
       target.symbol,
       typeArgs,
@@ -371,6 +385,16 @@ export const resolveImportedTypeExpr = ({
   forwardParamMap.forEach((targetParam, sourceParam) => {
     reverseParamMap.set(targetParam, sourceParam);
   });
+  validateImportedAliasConstraints({
+    symbol: target.symbol,
+    dependencyArgs: depArgs,
+    localArgs: typeArgs,
+    dependencyCtx: depCtx,
+    dependencyState: depState,
+    localCtx: ctx,
+    localState: localValidationState,
+    translateToLocal: back,
+  });
   const aliasResolved = resolveImportedAlias(
     target.symbol,
     depArgs,
@@ -411,6 +435,81 @@ const resolveImportedAlias = (
     return undefined;
   }
   return resolveTypeAlias(symbol, ctx, state, args);
+};
+
+const validateImportedAliasConstraints = ({
+  symbol,
+  dependencyArgs,
+  localArgs,
+  dependencyCtx,
+  dependencyState,
+  localCtx,
+  localState,
+  translateToLocal,
+}: {
+  symbol: SymbolId;
+  dependencyArgs: readonly TypeId[];
+  localArgs: readonly TypeId[];
+  dependencyCtx: TypingContext;
+  dependencyState: ReturnType<typeof createTypingState>;
+  localCtx: TypingContext;
+  localState: ReturnType<typeof createTypingState>;
+  translateToLocal: (type: TypeId) => TypeId;
+}): void => {
+  const template = dependencyCtx.typeAliases.getTemplate(symbol);
+  if (!template || template.params.length !== dependencyArgs.length) {
+    return;
+  }
+
+  const typeParamMap = new Map(
+    template.params.map((param, index) => [
+      param.symbol,
+      dependencyArgs[index]!,
+    ]),
+  );
+  template.params.forEach((param, index) => {
+    if (!param.constraint) {
+      return;
+    }
+    const localArg = localArgs[index] ?? localCtx.primitives.unknown;
+    if (localArg === localCtx.primitives.unknown) {
+      return;
+    }
+    const dependencyConstraint = resolveTypeExpr(
+      param.constraint,
+      dependencyCtx,
+      dependencyState,
+      dependencyCtx.primitives.unknown,
+      typeParamMap,
+    );
+    const localConstraint = translateToLocal(dependencyConstraint);
+    ensureImportedOwnerTemplatesAvailable({
+      types: [localConstraint],
+      ctx: localCtx,
+    });
+    if (!typeSatisfies(localArg, localConstraint, localCtx, localState)) {
+      throw new Error(
+        `type argument for ${getSymbolName(
+          param.symbol,
+          dependencyCtx,
+        )} does not satisfy constraint for type alias ${getSymbolName(
+          symbol,
+          dependencyCtx,
+        )}`,
+      );
+    }
+
+    const dependencyArg = dependencyArgs[index]!;
+    const dependencyArgDesc = dependencyCtx.arena.get(dependencyArg);
+    if (dependencyArgDesc.kind === "type-param-ref") {
+      // Caller-side validation makes this bound safe to assume while the
+      // dependency resolves nested constrained types in the alias target.
+      dependencyCtx.typeParameterConstraints.set(
+        dependencyArgDesc.param,
+        dependencyConstraint,
+      );
+    }
+  });
 };
 
 const resolveImportedObject = (

--- a/packages/compiler/src/semantics/typing/imports.ts
+++ b/packages/compiler/src/semantics/typing/imports.ts
@@ -15,7 +15,7 @@ import type {
   FunctionSignature,
   TypingContext,
 } from "./types.js";
-import type { HirNamedTypeExpr } from "../hir/index.js";
+import type { HirNamedTypeExpr, HirTypeExpr } from "../hir/index.js";
 import type {
   SymbolId,
   TypeId,
@@ -467,6 +467,10 @@ const validateImportedAliasConstraints = ({
       dependencyArgs[index]!,
     ]),
   );
+  const assumptionsByTypeParam = new Map<
+    TypeParamId,
+    { expression: HirTypeExpr; resolved: TypeId }[]
+  >();
   template.params.forEach((param, index) => {
     if (!param.constraint) {
       return;
@@ -502,13 +506,43 @@ const validateImportedAliasConstraints = ({
     const dependencyArg = dependencyArgs[index]!;
     const dependencyArgDesc = dependencyCtx.arena.get(dependencyArg);
     if (dependencyArgDesc.kind === "type-param-ref") {
-      // Caller-side validation makes this bound safe to assume while the
-      // dependency resolves nested constrained types in the alias target.
-      dependencyCtx.typeParameterConstraints.set(
-        dependencyArgDesc.param,
-        dependencyConstraint,
-      );
+      const assumptions = assumptionsByTypeParam.get(dependencyArgDesc.param);
+      if (assumptions) {
+        assumptions.push({
+          expression: param.constraint,
+          resolved: dependencyConstraint,
+        });
+        return;
+      }
+      assumptionsByTypeParam.set(dependencyArgDesc.param, [
+        { expression: param.constraint, resolved: dependencyConstraint },
+      ]);
     }
+  });
+
+  assumptionsByTypeParam.forEach((assumptions, typeParam) => {
+    // Caller-side validation makes these bounds safe to assume while the
+    // dependency resolves nested constrained types in the alias target.
+    const unique = assumptions.filter(
+      ({ resolved }, index) =>
+        assumptions.findIndex((entry) => entry.resolved === resolved) === index,
+    );
+    const constraint =
+      unique.length === 1
+        ? unique[0]!.resolved
+        : resolveTypeExpr(
+            {
+              typeKind: "intersection",
+              ast: unique[0]!.expression.ast,
+              span: unique[0]!.expression.span,
+              members: unique.map(({ expression }) => expression),
+            },
+            dependencyCtx,
+            dependencyState,
+            dependencyCtx.primitives.unknown,
+            typeParamMap,
+          );
+    dependencyCtx.typeParameterConstraints.set(typeParam, constraint);
   });
 };
 

--- a/packages/compiler/src/semantics/typing/imports.ts
+++ b/packages/compiler/src/semantics/typing/imports.ts
@@ -3,6 +3,7 @@ import {
   ensureObjectType,
   ensureTraitType,
   resolveTypeAlias,
+  validateObjectTypeArgumentConstraints,
 } from "./type-system.js";
 import { applyImportableMetadata } from "../imports/metadata.js";
 import type {
@@ -295,6 +296,15 @@ export const resolveImportedTypeExpr = ({
     );
   }
 
+  const objectConstraintsValidated = ctx.objects.getTemplate(symbol)
+    ? validateObjectTypeArgumentConstraints(
+        symbol,
+        ctx,
+        createTypingState(state.mode),
+        typeArgs,
+      )
+    : false;
+
   const depCtx = makeDependencyContext(dependency, ctx);
   const depState = createTypingState(state.mode);
 
@@ -306,10 +316,21 @@ export const resolveImportedTypeExpr = ({
       targetEffects: ctx.effects,
     })
   ) {
-    const aliasResolved = resolveImportedAlias(target.symbol, typeArgs, depCtx, depState);
+    const aliasResolved = resolveImportedAlias(
+      target.symbol,
+      typeArgs,
+      depCtx,
+      depState,
+    );
     const resolved =
       aliasResolved ??
-      resolveImportedObject(target.symbol, typeArgs, depCtx, depState) ??
+      resolveImportedObject(
+        target.symbol,
+        typeArgs,
+        depCtx,
+        depState,
+        objectConstraintsValidated,
+      ) ??
       resolveImportedTrait(target.symbol, typeArgs, depCtx, depState);
     if (typeof resolved === "number") {
       ensureImportedOwnerTemplatesAvailable({
@@ -350,10 +371,21 @@ export const resolveImportedTypeExpr = ({
   forwardParamMap.forEach((targetParam, sourceParam) => {
     reverseParamMap.set(targetParam, sourceParam);
   });
-  const aliasResolved = resolveImportedAlias(target.symbol, depArgs, depCtx, depState);
+  const aliasResolved = resolveImportedAlias(
+    target.symbol,
+    depArgs,
+    depCtx,
+    depState,
+  );
   const resolved =
     aliasResolved ??
-    resolveImportedObject(target.symbol, depArgs, depCtx, depState) ??
+    resolveImportedObject(
+      target.symbol,
+      depArgs,
+      depCtx,
+      depState,
+      objectConstraintsValidated,
+    ) ??
     resolveImportedTrait(target.symbol, depArgs, depCtx, depState);
 
   const localType = typeof resolved === "number" ? back(resolved) : undefined;
@@ -386,12 +418,15 @@ const resolveImportedObject = (
   args: readonly TypeId[],
   ctx: TypingContext,
   state: ReturnType<typeof createTypingState>,
+  constraintsAlreadyValidated: boolean,
 ): TypeId | undefined => {
   const template = ctx.objects.getTemplate(symbol);
   if (!template) {
     return undefined;
   }
-  return ensureObjectType(symbol, ctx, state, args)?.type;
+  return ensureObjectType(symbol, ctx, state, args, {
+    constraintsAlreadyValidated,
+  })?.type;
 };
 
 const resolveImportedTrait = (

--- a/packages/compiler/src/semantics/typing/registry.ts
+++ b/packages/compiler/src/semantics/typing/registry.ts
@@ -141,13 +141,15 @@ const resolveConstraintTypeParameters = ({
     if (!constraintExpr) {
       return;
     }
-    param.constraint = resolveTypeExpr(
+    const constraint = resolveTypeExpr(
       constraintExpr,
       ctx,
       state,
       ctx.primitives.unknown,
       typeParamMap,
     );
+    param.constraint = constraint;
+    ctx.typeParameterConstraints.set(param.typeParam, constraint);
   });
 
   return { typeParams, typeParamMap };

--- a/packages/compiler/src/semantics/typing/registry.ts
+++ b/packages/compiler/src/semantics/typing/registry.ts
@@ -111,6 +111,107 @@ const normalizeConstraintTypeParameters = ({
   declParams?.map((param) => ({ symbol: param.symbol })) ??
   [];
 
+const childTypeExpressions = (expr: HirTypeExpr): readonly HirTypeExpr[] => {
+  switch (expr.typeKind) {
+    case "named":
+      return expr.typeArguments ?? [];
+    case "object":
+      return expr.fields.map((field) => field.type);
+    case "tuple":
+      return expr.elements;
+    case "union":
+    case "intersection":
+      return expr.members;
+    case "function":
+      return [
+        ...(expr.typeParameters?.flatMap((param) => [
+          param.constraint,
+          param.defaultType,
+        ]) ?? []),
+        ...expr.parameters.map((parameter) => parameter.type),
+        expr.returnType,
+        expr.effectType,
+      ].filter((child): child is HirTypeExpr => child !== undefined);
+    case "self":
+      return [];
+  }
+};
+
+const referencedTypeParameterSymbols = ({
+  expr,
+  parameterSymbols,
+  out = new Set<SymbolId>(),
+}: {
+  expr: HirTypeExpr | undefined;
+  parameterSymbols: ReadonlySet<SymbolId>;
+  out?: Set<SymbolId>;
+}): ReadonlySet<SymbolId> => {
+  if (!expr) {
+    return out;
+  }
+
+  switch (expr.typeKind) {
+    case "named":
+      if (
+        typeof expr.symbol === "number" &&
+        parameterSymbols.has(expr.symbol)
+      ) {
+        out.add(expr.symbol);
+      }
+      break;
+    default:
+      break;
+  }
+
+  childTypeExpressions(expr).forEach((child) =>
+    referencedTypeParameterSymbols({ expr: child, parameterSymbols, out }),
+  );
+  return out;
+};
+
+const orderConstraintTypeParametersByDependency = (
+  params: readonly ConstraintTypeParameterDecl[],
+): readonly ConstraintTypeParameterDecl[] => {
+  const parameterSymbols = new Set(params.map((param) => param.symbol));
+  const paramsBySymbol = new Map(
+    params.map((param) => [param.symbol, param] as const),
+  );
+  const dependencies = new Map(
+    params.map((param) => [
+      param.symbol,
+      referencedTypeParameterSymbols({
+        expr: param.constraint,
+        parameterSymbols,
+      }),
+    ]),
+  );
+  const ordered: ConstraintTypeParameterDecl[] = [];
+  const visiting = new Set<SymbolId>();
+  const visited = new Set<SymbolId>();
+
+  const visit = (param: ConstraintTypeParameterDecl): void => {
+    if (visited.has(param.symbol) || visiting.has(param.symbol)) {
+      return;
+    }
+    visiting.add(param.symbol);
+    dependencies.get(param.symbol)?.forEach((dependencySymbol) => {
+      if (dependencySymbol === param.symbol) {
+        return;
+      }
+      const dependency = paramsBySymbol.get(dependencySymbol);
+      if (dependency) {
+        visit(dependency);
+      }
+    });
+    visiting.delete(param.symbol);
+    visited.add(param.symbol);
+    ordered.push(param);
+  };
+
+  params.forEach(visit);
+  return ordered;
+};
+
 const resolveConstraintTypeParameters = ({
   params,
   ctx,
@@ -136,8 +237,12 @@ const resolveConstraintTypeParameters = ({
     };
   });
 
-  typeParams.forEach((param, index) => {
-    const constraintExpr = params[index]?.constraint;
+  const typeParamsBySymbol = new Map(
+    typeParams.map((param) => [param.symbol, param] as const),
+  );
+  orderConstraintTypeParametersByDependency(params).forEach((declaration) => {
+    const param = typeParamsBySymbol.get(declaration.symbol)!;
+    const constraintExpr = declaration.constraint;
     if (!constraintExpr) {
       return;
     }

--- a/packages/compiler/src/semantics/typing/type-system.ts
+++ b/packages/compiler/src/semantics/typing/type-system.ts
@@ -750,13 +750,11 @@ const enforceResolvedTypeParameterConstraints = ({
   state: TypingState;
   context: string;
 }): ReadonlyMap<TypeParamId, TypeId> => {
-  const substitution = new Map<TypeParamId, TypeId>();
-  params.forEach((param, index) =>
-    substitution.set(
-      param.typeParam,
-      appliedArgs[index] ?? ctx.primitives.unknown,
-    ),
-  );
+  const substitution = resolvedTypeParameterSubstitution({
+    params,
+    appliedArgs,
+    unknown: ctx.primitives.unknown,
+  });
 
   params.forEach((param, index) => {
     if (!param.constraint) {
@@ -779,6 +777,22 @@ const enforceResolvedTypeParameterConstraints = ({
 
   return substitution;
 };
+
+const resolvedTypeParameterSubstitution = ({
+  params,
+  appliedArgs,
+  unknown,
+}: {
+  params: readonly { typeParam: TypeParamId }[];
+  appliedArgs: readonly TypeId[];
+  unknown: TypeId;
+}): ReadonlyMap<TypeParamId, TypeId> =>
+  new Map(
+    params.map((param, index) => [
+      param.typeParam,
+      appliedArgs[index] ?? unknown,
+    ]),
+  );
 
 export const registerPrimitive = (
   ctx: TypingContext,
@@ -2114,13 +2128,15 @@ export const getObjectTemplate = (
       paramMap.set(symbol, ref);
       const constraintExpr = decl.typeParameters?.[index]?.constraint;
       if (constraintExpr) {
-        params[index]!.constraint = resolveTypeExpr(
+        const constraint = resolveTypeExpr(
           constraintExpr,
           ctx,
           state,
           ctx.primitives.unknown,
           paramMap,
         );
+        params[index]!.constraint = constraint;
+        ctx.typeParameterConstraints.set(params[index]!.typeParam, constraint);
       }
     });
 
@@ -2302,6 +2318,7 @@ export const ensureObjectType = (
   ctx: TypingContext,
   state: TypingState,
   typeArgs: readonly TypeId[] = [],
+  options: { constraintsAlreadyValidated?: boolean } = {},
 ): ObjectTypeInfo | undefined => {
   if (ctx.objects.isResolving(symbol)) {
     return ctx.objects.getActiveResolution(
@@ -2335,13 +2352,19 @@ export const ensureObjectType = (
     }
   }
 
-  const subst = enforceResolvedTypeParameterConstraints({
-    params: template.params,
-    appliedArgs: normalized.applied,
-    ctx,
-    state,
-    context: `object ${objectName}`,
-  });
+  const subst = options.constraintsAlreadyValidated
+    ? resolvedTypeParameterSubstitution({
+        params: template.params,
+        appliedArgs: normalized.applied,
+        unknown: ctx.primitives.unknown,
+      })
+    : enforceResolvedTypeParameterConstraints({
+        params: template.params,
+        appliedArgs: normalized.applied,
+        ctx,
+        state,
+        context: `object ${objectName}`,
+      });
 
   const nominal = ctx.arena.substitute(template.nominal, subst);
   const structural = ctx.arena.substitute(template.structural, subst);
@@ -2404,6 +2427,35 @@ export const ensureObjectType = (
     ctx.valueTypes.set(symbol, type);
   }
   return info;
+};
+
+export const validateObjectTypeArgumentConstraints = (
+  symbol: SymbolId,
+  ctx: TypingContext,
+  state: TypingState,
+  typeArgs: readonly TypeId[],
+): boolean => {
+  const template = getObjectTemplate(symbol, ctx, state);
+  if (!template) {
+    return false;
+  }
+
+  const objectName = getSymbolName(symbol, ctx);
+  const normalized = normalizeDeclarationTypeArgs({
+    typeArgs,
+    paramCount: template.params.length,
+    ctx,
+    state,
+    context: `object ${objectName}`,
+  });
+  enforceResolvedTypeParameterConstraints({
+    params: template.params,
+    appliedArgs: normalized.applied,
+    ctx,
+    state,
+    context: `object ${objectName}`,
+  });
+  return true;
 };
 
 export const ensureTraitType = (
@@ -2938,6 +2990,20 @@ export const typeSatisfies = (
     return false;
   }
 
+  const actualDesc = ctx.arena.get(actual);
+  if (actualDesc.kind === "type-param-ref") {
+    const constraint = resolveTypeParameterConstraint({
+      typeParam: actualDesc.param,
+      activeConstraints,
+      ctx,
+    });
+    if (typeof constraint === "number") {
+      if (typeSatisfies(constraint, expected, ctx, state)) {
+        return true;
+      }
+    }
+  }
+
   const expectedDesc = ctx.arena.get(expected);
   if (expectedDesc.kind === "function") {
     return functionTypeSatisfies({ actual, expected, ctx, state });
@@ -3036,6 +3102,37 @@ export const typeSatisfies = (
     ctx,
   });
   return compatibility.ok;
+};
+
+const resolveTypeParameterConstraint = ({
+  typeParam,
+  activeConstraints,
+  ctx,
+}: {
+  typeParam: TypeParamId;
+  activeConstraints: ReadonlyMap<TypeParamId, TypeId> | undefined;
+  ctx: TypingContext;
+}): TypeId | undefined => {
+  const visited = new Set<TypeParamId>();
+  let current = typeParam;
+
+  while (!visited.has(current)) {
+    visited.add(current);
+    const constraint =
+      activeConstraints?.get(current) ??
+      ctx.typeParameterConstraints.get(current);
+    if (typeof constraint !== "number") {
+      return undefined;
+    }
+
+    const constraintDesc = ctx.arena.get(constraint);
+    if (constraintDesc.kind !== "type-param-ref") {
+      return constraint;
+    }
+    current = constraintDesc.param;
+  }
+
+  return undefined;
 };
 
 const currentFunctionConstraintMap = (

--- a/packages/compiler/src/semantics/typing/types.ts
+++ b/packages/compiler/src/semantics/typing/types.ts
@@ -69,6 +69,7 @@ export interface TypingResult {
   typeAliases: TypeAliasStore;
   objects: ObjectStore;
   traits: TraitStore;
+  typeParameterConstraints: ReadonlyMap<TypeParamId, TypeId>;
   memberMetadata: ReadonlyMap<SymbolId, MemberMetadata>;
   primitives: PrimitiveTypes;
   intrinsicTypes: Map<string, TypeId>;
@@ -722,6 +723,8 @@ export interface TypingContext {
   functions: FunctionStore;
   objects: ObjectStore;
   traits: TraitStore;
+  /** Declared bounds keyed by the arena-local type parameter they constrain. */
+  typeParameterConstraints: Map<TypeParamId, TypeId>;
   typeAliases: TypeAliasStore;
   primitives: PrimitiveTypes;
   intrinsicTypes: Map<string, TypeId>;

--- a/packages/compiler/src/semantics/typing/typing.ts
+++ b/packages/compiler/src/semantics/typing/typing.ts
@@ -93,6 +93,7 @@ const snapshotTypingResult = ({
     typeAliases: ctx.typeAliases,
     objects: ctx.objects,
     traits: ctx.traits,
+    typeParameterConstraints: new Map(ctx.typeParameterConstraints),
     primitives: ctx.primitives,
     effects: ctx.effects,
     intrinsicTypes: ctx.intrinsicTypes,


### PR DESCRIPTION
## Summary

- register resolved generic bounds in the arena-local typing context so declaration typing can prove parameter-to-parameter constraints
- validate imported constrained object arguments in the caller context while preserving canonical dependency TypeIds
- cover trait, nominal, structural, intersection, weaker, mismatched, and cross-module cases
- restore the homepage `Persistable` / `Repo<T: Persistable>` example

## Root cause

`typeSatisfies` could only discover bounds from the current function scope, and only trait satisfaction consulted them. Impl heads and declaration signatures therefore lost their type-parameter evidence. Imported object instantiation also needed validation in the caller context so caller-owned nominal bounds remain resolvable without changing canonical imported type identity.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run test:audit`
- `npm run test:codegen` (299 tests)
- `npx turbo run build --affected --output-logs=errors-only`
- typing benchmark regression gate (worst delta +0.63%, threshold +15%)
- exact restored homepage snippet compiled with `vt --emit-wasm-text`
- agentic implementation-gap, architecture, and correctness review loop completed cleanly

Linear: V-423