### PR TITLE
Fix release prepare path staging

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,6 +74,8 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: npm ci --include=optional
       - run: npm run test:audit
+      - name: Run release tooling tests
+        run: npm run test:release
       - run: mkdir -p test-timings
       # Package-local units run separately from portable conformance and integration.
       - name: Run affected package units

--- a/docs/testing/test-inventory.json
+++ b/docs/testing/test-inventory.json
@@ -2336,6 +2336,12 @@
     "rationale": "Keep co-located: protects CI, release, or repository tooling behavior."
   },
   {
+    "file": "scripts/release/changed-paths.test.mjs",
+    "owner": "package-unit",
+    "disposition": "package-local",
+    "rationale": "Keep co-located: protects release tooling path discovery against Git porcelain parsing regressions."
+  },
+  {
     "file": "tests/conformance/src/effects.test.ts",
     "owner": "language-conformance",
     "disposition": "portable-conformance",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "packageManager": "npm@11.5.2",
   "scripts": {
     "build": "turbo run build --affected",
-    "test": "turbo run test --output-logs=errors-only",
+    "test": "turbo run test --output-logs=errors-only && npm run test:release",
+    "test:release": "vitest run scripts/release",
     "test:affected": "turbo run test --affected --output-logs=errors-only",
     "test:affected:ci": "turbo run test --affected --output-logs=errors-only --concurrency=3",
     "test:unit:affected:ci": "turbo run test --affected --filter=!@voyd-lang/conformance-tests --filter=!@voyd-lang/integration-tests --filter=!@voyd-lang/performance-tests --output-logs=errors-only --concurrency=3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "packageManager": "npm@11.5.2",
   "scripts": {
     "build": "turbo run build --affected",
-    "test": "turbo run test --output-logs=errors-only && npm run test:release",
+    "test": "npm run test:release && turbo run test --output-logs=errors-only",
     "test:release": "vitest run scripts/release",
     "test:affected": "turbo run test --affected --output-logs=errors-only",
     "test:affected:ci": "turbo run test --affected --output-logs=errors-only --concurrency=3",

--- a/scripts/release/changed-paths.mjs
+++ b/scripts/release/changed-paths.mjs
@@ -1,0 +1,11 @@
+import { execFileSync } from "node:child_process";
+import { repoRoot } from "./manifest.mjs";
+
+export const changedPaths = ({ cwd = repoRoot } = {}) =>
+  execFileSync("git", ["diff", "--name-only", "-z", "--"], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["inherit", "pipe", "pipe"],
+  })
+    .split("\0")
+    .filter(Boolean);

--- a/scripts/release/changed-paths.test.mjs
+++ b/scripts/release/changed-paths.test.mjs
@@ -1,0 +1,60 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { changedPaths } from "./changed-paths.mjs";
+
+let repository;
+
+afterEach(() => {
+  if (repository) {
+    rmSync(repository, { recursive: true, force: true });
+    repository = undefined;
+  }
+});
+
+it("reads unstaged paths without truncating or unquoting them", () => {
+  repository = mkdtempSync(path.join(tmpdir(), "voyd-release-paths-"));
+  const paths = [
+    "apps/cli/package.json",
+    'release files/package "notes".json',
+  ];
+
+  execFileSync("git", ["init", "--quiet"], { cwd: repository });
+  paths.forEach((relativePath) => {
+    const absolutePath = path.join(repository, relativePath);
+    mkdirSync(path.dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, "before\n");
+  });
+  execFileSync("git", ["add", "--", ...paths], { cwd: repository });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=Voyd Test",
+      "-c",
+      "user.email=test@voyd.dev",
+      "commit",
+      "--quiet",
+      "-m",
+      "fixture",
+    ],
+    { cwd: repository },
+  );
+
+  expect(changedPaths({ cwd: repository })).toEqual([]);
+
+  paths.forEach((relativePath) => {
+    writeFileSync(path.join(repository, relativePath), "after\n");
+  });
+
+  const porcelain = execFileSync("git", ["status", "--porcelain=v1"], {
+    cwd: repository,
+    encoding: "utf8",
+  });
+  const statuses = porcelain.split("\n").filter(Boolean);
+  expect(statuses).toHaveLength(paths.length);
+  expect(statuses.every((status) => status.startsWith(" M "))).toBe(true);
+  expect(changedPaths({ cwd: repository })).toEqual(paths);
+});

--- a/scripts/release/prepare.mjs
+++ b/scripts/release/prepare.mjs
@@ -3,6 +3,7 @@ import {
   parseTargetSelection,
   repoRoot,
 } from "./manifest.mjs";
+import { changedPaths } from "./changed-paths.mjs";
 import {
   assertCleanWorktree,
   runCommand,
@@ -58,17 +59,6 @@ const assertOnBranch = () => {
     throw new Error("release:prepare should run from a release branch. Use `git switch -c release/vX.Y.Z` first.");
   }
 };
-
-const changedPaths = () =>
-  readStdout({
-    command: "git",
-    args: ["status", "--porcelain=v1"],
-  })
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => line.slice(3).trim())
-    .map((path) => path.replace(/^"|"$/g, ""));
 
 const argv = process.argv.slice(2);
 const targetNames = parseTargetSelection(argv);


### PR DESCRIPTION
## Summary

- replace manual `git status --porcelain=v1` parsing with NUL-delimited `git diff --name-only -z` output
- preserve paths containing spaces and Git-quoted characters when staging versioned files
- add a temporary-repository regression test for leading-space unstaged statuses and clean/empty diffs
- run release tooling tests in the default test command and PR CI

## Root cause

`changedPaths()` trimmed each porcelain line before removing the two status columns and separator. For unstaged changes, trimming removed the leading status-column space, so the later slice removed the first character of the actual path.

## Impact

`release:prepare` now stages every tracked file changed by versioning without truncating its path. A clean versioning result still produces no paths, so the existing empty-release refusal remains in effect.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run test:audit`

Linear: [V-424](https://linear.app/voyd-lang/issue/V-424/fix-releaseprepare-truncating-changed-file-paths-before-git)