### PR TITLE
Fix static method access through type aliases

### DIFF
--- a/packages/compiler/src/semantics/binding/binders/expressions.ts
+++ b/packages/compiler/src/semantics/binding/binders/expressions.ts
@@ -632,7 +632,7 @@ type ImportMeta = {
   };
 };
 
-const ensureStaticMethodImport = ({
+export const ensureStaticMethodImport = ({
   targetSymbol,
   memberName,
   syntax,

--- a/packages/compiler/src/semantics/binding/binders/module.ts
+++ b/packages/compiler/src/semantics/binding/binders/module.ts
@@ -7,7 +7,7 @@ import { toSourceSpan } from "../../../parser/surface/utils.js";
 import { bindFunctionDecl } from "./function.js";
 import { bindModuleLetDecl } from "./module-let.js";
 import { bindObjectDecl } from "./object.js";
-import { bindTypeAlias, seedEnumAliasNamespaces } from "./type-alias.js";
+import { bindTypeAlias, seedTypeAliasNamespaces } from "./type-alias.js";
 import { bindTraitDecl } from "./trait.js";
 import { bindImplDecl, flushPendingStaticMethods } from "./impl.js";
 import { bindEffectDecl } from "./effect.js";
@@ -133,7 +133,7 @@ export const bindModule = (
   }
 
   flushPendingStaticMethods(ctx);
-  seedEnumAliasNamespaces(ctx);
+  seedTypeAliasNamespaces(ctx);
 
   if (tracker.depth() !== 1) {
     throw new Error("binder scope stack imbalance after traversal");

--- a/packages/compiler/src/semantics/binding/binders/type-alias.ts
+++ b/packages/compiler/src/semantics/binding/binders/type-alias.ts
@@ -15,10 +15,12 @@ import {
   bindTypeExpr,
   ensureConstructorImport,
   ensureModuleMemberImport,
+  ensureStaticMethodImport,
 } from "./expressions.js";
 import {
   enumNamespaceMetadataFromAliasTarget,
   enumVariantTypeNamesFromAliasTarget,
+  importedSymbolTargetFromMetadata,
 } from "../../enum-namespace.js";
 import type { SymbolId } from "../../ids.js";
 import {
@@ -192,7 +194,7 @@ const duplicateTypeAliasInScope = ({
   return undefined;
 };
 
-export const seedEnumAliasNamespaces = (ctx: BindingContext): void => {
+export const seedTypeAliasNamespaces = (ctx: BindingContext): void => {
   ctx.decls.typeAliases.forEach((alias) => {
     seedEnumVariantNamespace({
       aliasSymbol: alias.symbol,
@@ -202,7 +204,7 @@ export const seedEnumAliasNamespaces = (ctx: BindingContext): void => {
     });
   });
 
-  seedObjectAliasConstructorNamespaces(ctx);
+  seedNominalAliasStaticMethodNamespaces(ctx);
 };
 
 const seedEnumVariantNamespace = ({
@@ -269,7 +271,7 @@ const resolveObjectTypeSymbol = ({
   return symbol;
 };
 
-const seedObjectAliasConstructorNamespaces = (ctx: BindingContext): void => {
+const seedNominalAliasStaticMethodNamespaces = (ctx: BindingContext): void => {
   const aliasConstructorSymbols = new Map<string, SymbolId>();
   let changed = true;
   while (changed) {
@@ -340,31 +342,83 @@ const seedObjectAliasConstructorNamespaces = (ctx: BindingContext): void => {
         scope: aliasScope,
         ctx,
       });
-      const constructors = ctx.staticMethods.get(targetSymbol)?.get("init");
-      if (!constructors || constructors.size === 0) {
+      ensureImportedStaticMethods({
+        targetSymbol,
+        syntax: alias.target,
+        scope: aliasScope,
+        ctx,
+      });
+      const targetMethods = ctx.staticMethods.get(targetSymbol);
+      if (!targetMethods) {
         return;
       }
       const bucket = ctx.staticMethods.get(alias.symbol) ?? new Map();
-      const aliasConstructors = bucket.get("init") ?? new Set<SymbolId>();
-      const sizeBefore = aliasConstructors.size;
-      constructors.forEach((constructorSymbol) => {
-        const aliasConstructor = ensureAliasConstructorSymbol({
-          alias,
-          aliasScope,
-          constructorSymbol,
-          aliasConstructorSymbols,
-          ctx,
+      let aliasChanged = false;
+      targetMethods.forEach((methodSymbols, name) => {
+        const aliasMethods = bucket.get(name) ?? new Set<SymbolId>();
+        const sizeBefore = aliasMethods.size;
+        methodSymbols.forEach((methodSymbol) => {
+          const aliasMethod =
+            name === "init"
+              ? ensureAliasConstructorSymbol({
+                  alias,
+                  aliasScope,
+                  constructorSymbol: methodSymbol,
+                  aliasConstructorSymbols,
+                  ctx,
+                })
+              : methodSymbol;
+          aliasMethods.add(aliasMethod);
         });
-        aliasConstructors.add(aliasConstructor);
+        if (aliasMethods.size === sizeBefore) {
+          return;
+        }
+        bucket.set(name, aliasMethods);
+        aliasChanged = true;
+        changed = true;
       });
-      if (aliasConstructors.size === sizeBefore) {
+      if (!aliasChanged) {
         return;
       }
-      bucket.set("init", aliasConstructors);
       ctx.staticMethods.set(alias.symbol, bucket);
-      changed = true;
     });
   }
+};
+
+const ensureImportedStaticMethods = ({
+  targetSymbol,
+  syntax,
+  scope,
+  ctx,
+}: {
+  targetSymbol: SymbolId;
+  syntax: ParsedTypeAliasDecl["target"];
+  scope: ScopeId;
+  ctx: BindingContext;
+}): void => {
+  const targetRecord = ctx.symbolTable.getSymbol(targetSymbol);
+  const importedTarget = importedSymbolTargetFromMetadata(
+    targetRecord.metadata as Record<string, unknown> | undefined,
+  );
+  if (!importedTarget) {
+    return;
+  }
+  const dependency = ctx.dependencies.get(importedTarget.moduleId);
+  const methodNames = dependency?.staticMethods
+    .get(importedTarget.symbol)
+    ?.keys();
+  if (!methodNames) {
+    return;
+  }
+  Array.from(methodNames).forEach((memberName) =>
+    ensureStaticMethodImport({
+      targetSymbol,
+      memberName,
+      syntax,
+      scope,
+      ctx,
+    }),
+  );
 };
 
 const ensureAliasConstructorSymbol = ({

--- a/packages/compiler/src/semantics/binding/binders/type-alias.ts
+++ b/packages/compiler/src/semantics/binding/binders/type-alias.ts
@@ -24,7 +24,9 @@ import {
 } from "../../enum-namespace.js";
 import type { SymbolId } from "../../ids.js";
 import {
+  composeNominalTypeTargetMetadata,
   nominalTypeTargetMetadataFromAliasTarget,
+  nominalTypeTargetMetadataFromSource,
   resolveNominalTypeSymbol,
 } from "../../nominal-type-target.js";
 import { importedModuleIdFrom } from "../../imports/metadata.js";
@@ -311,30 +313,18 @@ const seedNominalAliasStaticMethodNamespaces = (ctx: BindingContext): void => {
       if (targetRecord.kind !== "type") {
         return;
       }
-      const aliasRecord = ctx.symbolTable.getSymbol(alias.symbol);
-      const aliasMetadata = aliasRecord.metadata as
-        | {
-            nominalTargetTypeArguments?: unknown;
-            nominalTargetTypeParameterNames?: unknown;
-          }
-        | undefined;
-      const targetMetadata = targetRecord.metadata as
-        | {
-            nominalTargetTypeArguments?: unknown;
-            nominalTargetTypeParameterNames?: unknown;
-          }
-        | undefined;
-      const canCopyTargetNominalMetadata =
-        (alias.typeParameters?.length ?? 0) === 0 &&
-        !Array.isArray(aliasMetadata?.nominalTargetTypeArguments) &&
-        Array.isArray(targetMetadata?.nominalTargetTypeArguments);
-      if (canCopyTargetNominalMetadata) {
-        ctx.symbolTable.setSymbolMetadata(alias.symbol, {
-          nominalTargetTypeArguments:
-            targetMetadata?.nominalTargetTypeArguments,
-          nominalTargetTypeParameterNames:
-            targetMetadata?.nominalTargetTypeParameterNames,
-        });
+      const nominalTargetMetadata = composeNominalTypeTargetMetadata({
+        alias: nominalTypeTargetMetadataFromAliasTarget({
+          target: alias.target,
+          typeParameterNames:
+            alias.typeParameters?.map((parameter) => parameter.name) ?? [],
+        }),
+        target: nominalTypeTargetMetadataFromSource({
+          source: targetRecord.metadata as Record<string, unknown> | undefined,
+        }),
+      });
+      if (nominalTargetMetadata) {
+        ctx.symbolTable.setSymbolMetadata(alias.symbol, nominalTargetMetadata);
       }
       ensureConstructorImport({
         targetSymbol,

--- a/packages/compiler/src/semantics/lowering/expressions/static-access.ts
+++ b/packages/compiler/src/semantics/lowering/expressions/static-access.ts
@@ -328,15 +328,15 @@ const lowerStaticMethodCall = ({
     resolution,
     ctx,
   });
-  const aliasConstructorTypeArguments =
-    calleeExpr.value === "init"
-      ? lowerAliasConstructorTypeArgumentsForSymbol({
-          symbol: targetSymbol,
-          namespaceTypeArguments: combinedTypeArguments,
-          scope: scopes.current(),
-          ctx,
-        })
-      : { consumeNamespaceTypeArguments: false as const };
+  const aliasTargetTypeArguments = lowerAliasTargetTypeArgumentsForSymbol({
+    symbol: targetSymbol,
+    namespaceTypeArguments:
+      calleeExpr.value === "init"
+        ? combinedTypeArguments
+        : namespaceTypeArguments,
+    scope: scopes.current(),
+    ctx,
+  });
   const constructorResolution =
     callResolution.kind === "symbol" &&
     ctx.symbolTable.getSymbol(callResolution.symbol).kind === "type"
@@ -352,9 +352,18 @@ const lowerStaticMethodCall = ({
     ctx,
   });
   const callTypeArguments =
-    aliasConstructorTypeArguments.consumeNamespaceTypeArguments
-      ? aliasConstructorTypeArguments.typeArguments
+    calleeExpr.value === "init" &&
+    aliasTargetTypeArguments.consumeNamespaceTypeArguments
+      ? aliasTargetTypeArguments.typeArguments
       : typeArguments;
+  const callTargetTypeArguments =
+    calleeExpr.value === "init"
+      ? aliasTargetTypeArguments.consumeNamespaceTypeArguments
+        ? undefined
+        : namespaceTypeArguments
+      : aliasTargetTypeArguments.consumeNamespaceTypeArguments
+        ? aliasTargetTypeArguments.typeArguments
+        : namespaceTypeArguments;
 
   return ctx.builder.addExpression({
     kind: "expr",
@@ -368,9 +377,8 @@ const lowerStaticMethodCall = ({
         ? callTypeArguments
         : undefined,
     targetTypeArguments:
-      !aliasConstructorTypeArguments.consumeNamespaceTypeArguments &&
-      namespaceTypeArguments.length > 0
-        ? namespaceTypeArguments
+      callTargetTypeArguments && callTargetTypeArguments.length > 0
+        ? callTargetTypeArguments
         : undefined,
   });
 };
@@ -405,7 +413,7 @@ const lowerEnumNamespaceMemberTypeArguments = ({
   });
 };
 
-const lowerAliasConstructorTypeArgumentsForSymbol = ({
+const lowerAliasTargetTypeArgumentsForSymbol = ({
   symbol,
   namespaceTypeArguments,
   scope,
@@ -530,10 +538,10 @@ const lowerModuleQualifiedCall = ({
     const moduleName = ctx.symbolTable.getSymbol(moduleSymbol).name;
     throw new Error(`module ${moduleName} does not export ${calleeExpr.value}`);
   }
-  const aliasConstructorTypeArguments =
+  const aliasTargetTypeArguments =
     baseResolution.kind === "symbol" &&
     ctx.symbolTable.getSymbol(baseResolution.symbol).kind === "type"
-      ? lowerAliasConstructorTypeArgumentsForSymbol({
+      ? lowerAliasTargetTypeArgumentsForSymbol({
           symbol: baseResolution.symbol,
           namespaceTypeArguments: combinedTypeArguments,
           scope: scopes.current(),
@@ -557,8 +565,8 @@ const lowerModuleQualifiedCall = ({
     ctx,
   });
   const callTypeArguments =
-    aliasConstructorTypeArguments.consumeNamespaceTypeArguments
-      ? aliasConstructorTypeArguments.typeArguments
+    aliasTargetTypeArguments.consumeNamespaceTypeArguments
+      ? aliasTargetTypeArguments.typeArguments
       : typeArguments;
 
   return ctx.builder.addExpression({
@@ -573,7 +581,7 @@ const lowerModuleQualifiedCall = ({
         ? callTypeArguments
         : undefined,
     targetTypeArguments:
-      !aliasConstructorTypeArguments.consumeNamespaceTypeArguments &&
+      !aliasTargetTypeArguments.consumeNamespaceTypeArguments &&
       targetCallTypeArguments &&
       targetCallTypeArguments.length > 0
         ? targetCallTypeArguments

--- a/packages/compiler/src/semantics/nominal-type-target.ts
+++ b/packages/compiler/src/semantics/nominal-type-target.ts
@@ -1,6 +1,8 @@
 import {
+  Form,
   type Expr,
   formCallsInternal,
+  isCallForm,
   isForm,
   isIdentifierAtom,
   isInternalIdentifierAtom,
@@ -17,6 +19,34 @@ export type NominalTypeTarget = {
 export type NominalTypeTargetMetadata = {
   nominalTargetTypeArguments: readonly Expr[];
   nominalTargetTypeParameterNames: readonly string[];
+};
+
+export const composeNominalTypeTargetMetadata = ({
+  alias,
+  target,
+}: {
+  alias?: NominalTypeTargetMetadata;
+  target?: NominalTypeTargetMetadata;
+}): NominalTypeTargetMetadata | undefined => {
+  if (!alias) {
+    return target;
+  }
+  if (!target) {
+    return alias;
+  }
+
+  const substitutions = new Map(
+    target.nominalTargetTypeParameterNames.map((name, index) => [
+      name,
+      alias.nominalTargetTypeArguments[index],
+    ]),
+  );
+  return {
+    nominalTargetTypeArguments: target.nominalTargetTypeArguments.map((entry) =>
+      substituteTypeParameterExpr(entry, substitutions),
+    ),
+    nominalTargetTypeParameterNames: alias.nominalTargetTypeParameterNames,
+  };
 };
 
 export const extractNominalTypeTarget = (
@@ -100,6 +130,21 @@ export const nominalTypeTargetTypeArgumentsFromMetadata = ({
       typeParameterNames: readonly string[];
     }
   | undefined => {
+  const metadata = nominalTypeTargetMetadataFromSource({ source });
+  if (!metadata) {
+    return undefined;
+  }
+  return {
+    typeArguments: metadata.nominalTargetTypeArguments,
+    typeParameterNames: metadata.nominalTargetTypeParameterNames,
+  };
+};
+
+export const nominalTypeTargetMetadataFromSource = ({
+  source,
+}: {
+  source?: Record<string, unknown>;
+}): NominalTypeTargetMetadata | undefined => {
   const meta = source as
     | {
         nominalTargetTypeArguments?: unknown;
@@ -109,16 +154,40 @@ export const nominalTypeTargetTypeArgumentsFromMetadata = ({
   if (!Array.isArray(meta?.nominalTargetTypeArguments)) {
     return undefined;
   }
-  const typeArguments = meta.nominalTargetTypeArguments as readonly Expr[];
-  const typeParameterNames = Array.isArray(meta?.nominalTargetTypeParameterNames)
-    ? meta.nominalTargetTypeParameterNames.filter(
-        (entry): entry is string => typeof entry === "string",
-      )
-    : [];
   return {
-    typeArguments,
-    typeParameterNames,
+    nominalTargetTypeArguments:
+      meta.nominalTargetTypeArguments as readonly Expr[],
+    nominalTargetTypeParameterNames: Array.isArray(
+      meta.nominalTargetTypeParameterNames,
+    )
+      ? meta.nominalTargetTypeParameterNames.filter(
+          (entry): entry is string => typeof entry === "string",
+        )
+      : [],
   };
+};
+
+const substituteTypeParameterExpr = (
+  expr: Expr,
+  substitutions: ReadonlyMap<string, Expr | undefined>,
+): Expr => {
+  if (isIdentifierAtom(expr) || isInternalIdentifierAtom(expr)) {
+    return substitutions.get(expr.value) ?? expr;
+  }
+  if (!isForm(expr)) {
+    return expr;
+  }
+
+  const elements = expr
+    .toArray()
+    .map((entry) => substituteTypeParameterExpr(entry, substitutions));
+  const rebuilt = new Form({
+    location: expr.location?.clone(),
+    elements,
+  });
+  const result = isCallForm(expr) ? rebuilt.toCall() : rebuilt;
+  result.attributes = expr.attributes ? { ...expr.attributes } : undefined;
+  return result;
 };
 
 export const lowerNominalTargetTypeArgumentsFromMetadata = <TypeExpr>({

--- a/tests/conformance/cases/runtime/static-access-and-closures.voyd
+++ b/tests/conformance/cases/runtime/static-access-and-closures.voyd
@@ -44,6 +44,21 @@ pub fn static_target_overload_ranking() -> i32
 pub fn static_alias_target_overload_ranking() -> i32
   I32OverloadBox::pick(1) + I32OverloadBox::pick(true)
 
+pub obj PairOverloadBox<Left, Right> {}
+
+impl<Left, Right> PairOverloadBox<Left, Right>
+  fn pick(value: Left) -> i32
+    11
+
+  fn pick<T>(value: T) -> i32
+    3
+
+type I32PairOverloadBox<Right> = PairOverloadBox<i32, Right>
+type I32BoolPairOverloadBox = I32PairOverloadBox<bool>
+
+pub fn static_transitive_alias_target_overload_ranking() -> i32
+  I32BoolPairOverloadBox::pick(1) + I32BoolPairOverloadBox::pick(true)
+
 pub fn curried_optional_call() -> i32
   let lift = (base: i32) => (delta?: i32) =>
     match(delta)

--- a/tests/conformance/cases/runtime/static-access-and-closures.voyd
+++ b/tests/conformance/cases/runtime/static-access-and-closures.voyd
@@ -36,8 +36,13 @@ impl<Owner> OverloadBox<Owner>
   fn pick<T>(value: T) -> i32
     3
 
+type I32OverloadBox = OverloadBox<i32>
+
 pub fn static_target_overload_ranking() -> i32
   OverloadBox<i32>::pick(1) + OverloadBox<i32>::pick(true)
+
+pub fn static_alias_target_overload_ranking() -> i32
+  I32OverloadBox::pick(1) + I32OverloadBox::pick(true)
 
 pub fn curried_optional_call() -> i32
   let lift = (base: i32) => (delta?: i32) =>

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -553,6 +553,12 @@
           "expect": { "kind": "equals", "value": 14 }
         },
         {
+          "id": "runtime.static-access.transitive-alias-overload-ranking",
+          "title": "composes target arguments through transitive aliases",
+          "entryName": "static_transitive_alias_target_overload_ranking",
+          "expect": { "kind": "equals", "value": 14 }
+        },
+        {
           "id": "runtime.closures.curried-optional",
           "title": "runs curried closure calls with optional arguments",
           "entryName": "curried_optional_call",

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -547,6 +547,12 @@
           "expect": { "kind": "equals", "value": 14 }
         },
         {
+          "id": "runtime.static-access.alias-overload-ranking",
+          "title": "resolves static methods through fixed generic aliases",
+          "entryName": "static_alias_target_overload_ranking",
+          "expect": { "kind": "equals", "value": 14 }
+        },
+        {
           "id": "runtime.closures.curried-optional",
           "title": "runs curried closure calls with optional arguments",
           "entryName": "curried_optional_call",


### PR DESCRIPTION
## Summary

- propagate nominal targets' full static-method namespaces through local, transitive, and imported type aliases
- preserve constructor-specific alias wrappers while remapping fixed and generic alias target arguments for ordinary static calls
- add conformance coverage for overload selection through a fixed generic alias

## Root cause

Type-alias namespace seeding copied only `init` constructors. Static lookup therefore found no method table for calls such as `Color::empty()`. Extending namespace propagation alone would also lose fixed/generic target arguments during overload selection, so lowering now maps alias arguments onto the underlying nominal target before typing the call.

## Impact

Aliases now expose the same static methods as their nominal targets, including overloaded methods on fixed generic aliases and methods reached through imported or transitive aliases.

## Validation

- `npm test` — 18/18 packages passed
- `npm run typecheck` — 17/17 tasks passed
- `npm run test:audit` — passed
- `npm run lint` — 9/9 tasks passed
- focused static-access conformance suite — 7/7 cases passed

Fixes V-300.