### PR TITLE
Rewrite VX and Web reference docs

### DIFF
--- a/packages/reference/docs/vx.md
+++ b/packages/reference/docs/vx.md
@@ -76,7 +76,7 @@ fn view(model: Model) -> Html<Msg>
     <input
       id="name"
       value={model.name}
-      on_input={(event: InputEvent) -> Msg =>
+      on_input={(event) =>
         Msg::NameChanged { value: event.value }
       }
     />
@@ -278,18 +278,19 @@ Use a closure when the message depends on local data:
 ```voyd
 <button
   type="button"
-  on_click={() -> Msg => Msg::Select { id: todo.id }}
+  on_click={() => Msg::Select { id: todo.id }}
 >
   Select
 </button>
 ```
 
-Use a typed event when you need browser data:
+Use an event handler when the message depends on browser data. VX infers the
+event type from the attribute:
 
 ```voyd
 <input
   value={model.search}
-  on_input={(event: InputEvent) -> Msg =>
+  on_input={(event) =>
     Msg::SearchChanged { value: event.value }
   }
 />
@@ -315,7 +316,7 @@ Prevent a form's browser submission with `EventOptions`:
   <input
     name="title"
     value={model.draft}
-    on_input={(event: InputEvent) -> Msg =>
+    on_input={(event) =>
       Msg::DraftChanged { value: event.value }
     }
   />
@@ -343,8 +344,8 @@ use std::task::TaskRuntime
 
 fn load_todos(): TaskRuntime -> Cmd<Msg>
   Cmd::task(
-    work: () -> Result<Array<Todo>, String> => fetch_todos(),
-    handler: (result: Result<Array<Todo>, String>) -> Msg =>
+    work: () => fetch_todos(),
+    handler: (result) =>
       Msg::TodosLoaded { result: result }
   )
 ```
@@ -386,8 +387,8 @@ fn fetch_message(): http_client::HttpClient -> Result<String, String>
 
 fn load_message(): (http_client::HttpClient, TaskRuntime) -> Cmd<Msg>
   Cmd::task(
-    work: () -> Result<String, String> => fetch_message(),
-    handler: (result: Result<String, String>) -> Msg =>
+    work: () => fetch_message(),
+    handler: (result) =>
       Msg::MessageLoaded { result: result }
   )
 ```
@@ -462,7 +463,7 @@ a typed payload:
 ```voyd
 window_on_resize(
   key: "viewport",
-  handler: (size: WindowSize) -> Msg =>
+  handler: (size) =>
     Msg::ViewportChanged { width: size.width, height: size.height }
 )
 ```
@@ -496,7 +497,7 @@ fn step(model: Model, msg: Msg) -> Program<Model, Msg>
 fn subscriptions(_model: Model) -> Sub<Msg>
   location_on_change(
     key: "location",
-    handler: (location: Location) -> Msg =>
+    handler: (location) =>
       Msg::LocationChanged { path: location.pathname }
   )
 
@@ -590,12 +591,12 @@ fn step(model: AppModel, msg: AppMsg): TaskRuntime -> Program<AppModel, AppMsg>
       let child = todos::step(model.todos, value)
       let with_parent_model = map_model(
         child,
-        (next_todos: todos::Model) -> AppModel =>
+        (next_todos) =>
           AppModel { todos: next_todos, signed_in: model.signed_in }
       )
       map_message(
         with_parent_model,
-        (child_msg: todos::Msg) -> AppMsg =>
+        (child_msg) =>
           AppMsg::Todos { value: child_msg }
       )
     AppMsg::SignedOut:
@@ -606,7 +607,7 @@ The parent view uses `map_html` so child events become `AppMsg::Todos`:
 
 ```voyd
 fn view(model: AppModel) -> Html<AppMsg>
-  let to_app = (msg: todos::Msg) -> AppMsg => AppMsg::Todos { value: msg }
+  let to_app = (msg: todos::Msg) => AppMsg::Todos { value: msg }
   <main>
     {map_html(
       html: todos::view(model.todos),
@@ -616,7 +617,7 @@ fn view(model: AppModel) -> Html<AppMsg>
 
 fn subscriptions(model: AppModel) -> Sub<AppMsg>
   todos::subscriptions(model.todos).map(
-    (msg: todos::Msg) -> AppMsg => AppMsg::Todos { value: msg }
+    (msg) => AppMsg::Todos { value: msg }
   )
 ```
 
@@ -730,7 +731,7 @@ Sub::runtime_configured(
   kind: "websocket",
   key: "project:".concat(model.project_id),
   value: msgpack::make_string(model.socket_url),
-  handler: (message: String) -> Msg =>
+  handler: (message) =>
     Msg::SocketMessage { value: message }
 )
 ```

--- a/packages/reference/docs/vx.md
+++ b/packages/reference/docs/vx.md
@@ -4,300 +4,192 @@ order: 8
 
 # VX
 
-VX is Voyd's web application framework. Inspired by Elm, it gives a Voyd program
-a typed way to describe browser UI, respond to user input, run async work,
-subscribe to outside events, and render the same virtual tree in the browser or
-on the server.
+VX is Voyd's framework for interactive user interfaces. You describe the UI as
+typed HTML, keep application state in a model, and handle every change through a
+message. VX renders the result in a browser and can render the same views on a
+server.
 
-The shape is deliberately small:
+This guide starts with a working browser app and then covers the patterns and
+APIs you need as the app grows.
+
+## Create A VX App
+
+Install the Voyd CLI and scaffold the browser starter:
+
+```bash
+npm install -g @voyd-lang/cli
+voyd bootstrap my-app --template vx-spa
+cd my-app
+npm install
+npm run dev
+```
+
+The starter includes Vite, Tailwind CSS, Voyd compilation, the JavaScript host,
+and the VX browser runtime. Its main files are:
+
+- `src/main.voyd`: your model, messages, application logic, and views.
+- `src/main.ts`: loads the compiled Wasm module and mounts the app.
+- `src/style.css`: global styles and Tailwind configuration.
+- `scripts/compile-voyd.mjs`: compiles Voyd and generates host adapters.
+
+Use `npm run build` for a production build and `npm run preview` to serve that
+build locally.
+
+## Your First App
+
+A VX application has a model, a message type, a transition function, and a view:
 
 ```voyd
+use std::enums::{ enum }
+use std::string::type::String
+use std::vx::all
+
+obj Model {
+  name: String,
+  greeting: String
+}
+
+enum Msg
+  NameChanged { value: String }
+  Greet
+
 pub fn app() -> Program<Model, Msg>
-  program({ init, step, view, subscriptions })
+  program<Model, Msg>({ init, step, view })
+
+fn init() -> Model
+  Model { name: String::init(), greeting: "Hello!" }
+
+fn step(model: Model, msg: Msg) -> Program<Model, Msg>
+  match(msg)
+    Msg::NameChanged { value }:
+      next(Model { name: value, greeting: model.greeting })
+    Msg::Greet:
+      next(Model {
+        name: model.name,
+        greeting: "Hello, ".concat(model.name)
+      })
+
+fn view(model: Model) -> Html<Msg>
+  <main>
+    <h1>{model.greeting}</h1>
+    <label for="name">Name</label>
+    <input
+      id="name"
+      value={model.name}
+      on_input={(event: InputEvent) -> Msg =>
+        Msg::NameChanged { value: event.value }
+      }
+    />
+    <button type="button" on_click={Msg::Greet {}}>Greet</button>
+  </main>
 ```
 
-`Model` is the durable state of the feature. `Msg` is the closed set of events
-that can change that state. `step` receives the current model and one message,
-then returns the next model plus any one-off commands. `view` turns a model into
-HTML. `subscriptions` describes ongoing outside events that should be active for
-the latest model.
+The browser runtime calls `init`, renders `view(model)`, and waits for a message.
+When the input or button produces one, VX calls `step(model, msg)`, stores the
+returned model, and renders again.
 
-That is the core loop:
-
-```text
-init() -> model and optional startup commands
-view(model) -> virtual HTML
-user event, command result, or subscription event -> Msg
-step(model, Msg) -> next model and optional commands
-view(next model)
-subscriptions(next model) are reconciled
-commands are run
-```
-
-VX code should read as a small state machine. The browser runtime owns DOM
-patching, event listener lifetimes, command execution, subscription disposal,
-and callback retention.
-
-## Importing VX
-
-Most applications import the full VX surface:
+The exported `app` function is the standard entrypoint. Import the full public
+surface with:
 
 ```voyd
 use std::vx::all
 ```
 
-The main public types are:
+## The Application Loop
 
-- `Program<Model, Msg>`: either an app descriptor or one transition result.
-- `Html<Msg>`: typed virtual HTML that can dispatch `Msg`.
-- `Attr<Msg>`: an attribute, property, style, or event descriptor for `Html`.
-- `Cmd<Msg>`: one-off work that may dispatch a later `Msg`.
-- `Sub<Msg>`: ongoing outside input that may dispatch many `Msg` values.
-- `EventOptions`: browser event listener options.
-- `Ref<T>` and `DomElement`: typed DOM targets for focus and scrolling commands.
-- `StateHandle<T>`: a handle for restricted component-local state.
+VX applications are state machines:
 
-`Html<Msg>`, `Attr<Msg>`, `Cmd<Msg>`, `Sub<Msg>`, and `Program<Model, Msg>` are
-typed values that cross the Wasm boundary. Application code should construct
-them through the VX helpers.
+```text
+init -> Model
+Model -> view -> Html<Msg>
+event, command, or subscription -> Msg
+Model + Msg -> step -> next Model and optional Cmd<Msg>
+```
 
-Messages, models, command values, and subscription values must be
-boundary-compatible data: primitives, `String`, arrays, records or objects with
-public DTO fields, value objects, and enum variants made from those values. Keep
-functions, trait objects, arbitrary dictionaries, DOM nodes, and recursive
-object graphs out of lifecycle data.
+The main types are:
 
-## The App Contract
+- `Program<Model, Msg>`: an application descriptor or transition result.
+- `Html<Msg>`: virtual HTML that can produce `Msg` values.
+- `Attr<Msg>`: an attribute, property, style, or event for that HTML.
+- `Cmd<Msg>`: one-off work, such as a request or navigation.
+- `Sub<Msg>`: an ongoing source of messages, such as a timer or global listener.
 
-A full app usually has these pieces:
+Add a `subscriptions` function when the app needs ongoing outside input:
 
 ```voyd
-obj Model {
-  count: i32
-}
-
-enum Msg
-  Increment
-  Decrement
-
 pub fn app() -> Program<Model, Msg>
-  program({ init, step, view })
-
-fn init() -> Model
-  Model { count: 0 }
-
-fn step(model: Model, msg: Msg) -> Program<Model, Msg>
-  match(msg)
-    Msg::Increment:
-      next(Model { count: model.count + 1 })
-    Msg::Decrement:
-      next(Model { count: model.count - 1 })
-
-fn view(model: Model) -> Html<Msg>
-  <main>
-    <button on_click={Msg::Decrement {}}>-</button>
-    <span>{count_label(model.count)}</span>
-    <button on_click={Msg::Increment {}}>+</button>
-  </main>
+  program<Model, Msg>({ init, step, view, subscriptions })
 ```
 
-The canonical typed VX app entrypoint is `app`. The transition function used by
-the standard helpers and generated runtime descriptor is `step`.
-
-When the local function names match the labels, prefer the struct shorthand call:
+If startup needs a command, return a transition from `init`:
 
 ```voyd
-program({ init, step, view, subscriptions })
+fn init(): TaskRuntime -> Program<Model, Msg>
+  next(model: initial_model(), cmd: load_profile())
 ```
 
-The return type on `app` and the signatures of `init`, `step`, `view`, and
-`subscriptions` give the compiler enough context to infer `Model` and `Msg`.
-Use explicit labels when local function names differ from the program labels:
+Otherwise, `init` can return `Model` directly. In `step`, use `next(model)` for a
+pure update and `next(model:, cmd:)` when the update also starts work.
 
-```voyd
-program(
-  init: initialize,
-  step: handle_message,
-  view: render,
-  subscriptions: active_subscriptions
-)
-```
+Keep lifecycle data safe to pass across the Wasm boundary. Models, messages,
+command inputs, and subscription inputs can contain primitives, strings, arrays,
+boundary-safe records or objects, and enum variants made from those values. Do
+not put functions, DOM nodes, trait objects, arbitrary dictionaries, or recursive
+object graphs in them.
 
-There are two useful `program` forms for app descriptors:
+## Model And Messages
 
-```voyd
-program(
-  init: fn() -> Model,
-  step: fn(Model, Msg) -> Program<Model, Msg>,
-  view: fn(Model) -> Html<Msg>,
-  subscriptions: fn(Model) -> Sub<Msg> = ...
-)
-```
+Put durable application state in `Model`: loaded data, form values, selected
+ids, URLs, loading flags, validation errors, and feature state.
 
-Use this when startup is pure and only returns the initial model.
-
-```voyd
-program(
-  init: fn() -> Program<Model, Msg>,
-  step: fn(Model, Msg) -> Program<Model, Msg>,
-  view: fn(Model) -> Html<Msg>,
-  subscriptions: fn(Model) -> Sub<Msg> = ...
-)
-```
-
-Use this when startup also needs commands, for example loading data. In that
-case `init` returns `next(model: initial_model, cmd: load())`.
-
-Inside `step`, return `next`:
-
-```voyd
-next(next_model)
-next(model: next_model, cmd: save_title(next_model.title))
-```
-
-`next` is a pure constructor. It only describes the transition result; command
-execution, DOM patching, and subscription management happen in the runtime.
-
-## Models And Messages
-
-Put durable state in `Model`: server data, form data that other code needs,
-URLs, selected ids, loading flags, validation errors, pending request status,
-feature state, and anything you want to test as application behavior.
-
-Use `Msg` for every event that can change that model. Prefer messages that
-describe the event that occurred and leave implementation choices in `step`:
+Use one `Msg` variant for each event that can change the model. Name messages
+after what happened, not the code you intend to run:
 
 ```voyd
 enum Msg
   DraftChanged { value: String }
-  Submit
+  Submitted
   SaveFinished { result: Result<Todo, String> }
-  CancelEdit
+  EditCancelled
 ```
 
-This keeps `step` readable. Each branch answers two questions:
-
-- What is the next model?
-- Is there one-off work to start?
+Then make `step` a readable transition table:
 
 ```voyd
 fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
   match(msg)
     Msg::DraftChanged { value }:
-      next(Model { draft: value, saving: model.saving })
-    Msg::Submit:
-      next(
-        model: Model { draft: model.draft, saving: true },
-        cmd: save_draft(model.draft)
-      )
+      next(with_draft(model, value))
+    Msg::Submitted:
+      next(model: saving(model), cmd: save_todo(model.draft))
+    Msg::SaveFinished { result }:
+      match(result)
+        Ok { value }:
+          next(saved(model, value))
+        Err { error }:
+          next(failed(model, error))
+    Msg::EditCancelled:
+      next(cancelled(model))
 ```
 
-For expected failures, make the task return a `Result` and map the `Result` into
-a message. If a task itself fails, the browser runtime reports the error through
-its runtime error handler; application messages remain focused on domain
-outcomes.
+Extract model-building helpers when a branch becomes noisy. This keeps the
+important decision—message in, next state and work out—visible in one place.
 
-## The Step Function
+Expected failures should normally travel through a `Result` in a result message.
+Unexpected task or runtime failures are reported by the browser runtime's error
+handler.
 
-`step` is the transition table for an app or feature.
+## Views And Components
 
-```voyd
-fn step(model: Model, msg: Msg) -> Program<Model, Msg>
-```
-
-It receives the current model and one message. It returns a `Program` transition
-containing the next model and any command work that should begin after the model
-has been accepted.
-
-Most branches have this shape:
-
-```voyd
-Msg::DraftChanged { value }:
-  next(with_draft(model, value))
-Msg::Submit:
-  next(model: saving_now(model), cmd: save_draft(model.draft))
-```
-
-Use `next(next_model)` for a pure state transition. Use
-`next(model:, cmd:)` when the transition also starts one-off work.
-
-Commands returned from `step` are descriptions. The runtime runs them after it
-stores the next model, renders, and reconciles subscriptions. That ordering lets
-`step` stay easy to test: given a model and message, it produces a transition
-value.
-
-When a branch becomes large, extract the model update into a named helper:
-
-```voyd
-Msg::Saved { result }:
-  match(result)
-    Ok { value }:
-      next(saved(model, value))
-    Err { error }:
-      next(with_error(model, error))
-
-fn saved(model: Model, todo: Todo) -> Model
-  Model {
-    todos: replace_todo(model.todos, todo),
-    draft: model.draft,
-    loading: false,
-    saving: false,
-    error: String::init()
-  }
-```
-
-The helper name should describe the state transition. Keep command constructors
-similarly named:
-
-```voyd
-Msg::Refresh:
-  next(model: loading(model), cmd: load_todos())
-```
-
-This keeps the branch readable without hiding the architecture: message in,
-model out, commands described.
-
-Use effects on `step` only when constructing the returned transition needs that
-effect. For example, a `step` branch that calls a helper using `Cmd.task` needs
-`TaskRuntime`:
-
-```voyd
-fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
-  match(msg)
-    Msg::Submit:
-      next(model: saving_now(model), cmd: save_draft(model.draft))
-```
-
-The task itself completes later and returns to the app as another `Msg`.
-
-## Views
-
-Views are plain functions from model to `Html<Msg>`.
+A view is an ordinary function from data to `Html<Msg>`:
 
 ```voyd
 fn view(model: Model) -> Html<Msg>
-  <main class="editor">
-    <label for="title">Title</label>
-    <input
-      id="title"
-      value={model.title}
-      on_input={(event: InputEvent) -> Msg =>
-        Msg::TitleChanged { value: event.value }
-      }
-    />
-    <button type="button" on_click={Msg::Save {}}>Save</button>
+  <main class="page">
+    <Toolbar saving={model.saving} />
+    <p>{model.status}</p>
   </main>
-```
 
-VX HTML is virtual DOM. A render builds a tree of text, fragment, and element
-nodes. The browser runtime compares the new tree with the previous tree and
-patches real DOM nodes.
-
-### Components
-
-Components are ordinary functions that return `Html<Msg>`.
-
-```voyd
 fn Toolbar({ saving: bool }) -> Html<Msg>
   <div class="toolbar">
     <button type="button" disabled={saving} on_click={Msg::Save {}}>
@@ -307,79 +199,49 @@ fn Toolbar({ saving: bool }) -> Html<Msg>
   </div>
 ```
 
-Call components with element syntax:
+Components are functions. Their parameters are props, and calls use element
+syntax. Prefer passing data down and emitting messages up; shared or durable
+state still belongs in the parent model.
 
-```voyd
-fn view(model: Model) -> Html<Msg>
-  <main>
-    <Toolbar saving={model.saving} />
-  </main>
-```
+### Children And Lists
 
-Component parameters are just function parameters. Keep components mostly
-presentational when possible. If a component needs to change durable app state,
-pass it enough model data and let it emit parent messages.
-
-### Children
-
-Text children can be string literals or interpolated values:
+String literals and string expressions can be children:
 
 ```voyd
 <p>Hello, {model.name}</p>
 ```
 
-Use arrays of `Html<Msg>` for lists:
+Render a list from an array and give each item a stable key:
 
 ```voyd
 <ul>
-  {model.todos.map((todo) => <li key={todo.id}>{todo.title}</li>)}
+  {model.todos.map((todo) =>
+    <li key={todo.id}>
+      <span>{todo.title}</span>
+      <button
+        type="button"
+        on_click={Msg::Delete { id: todo.id }}
+      >
+        Delete
+      </button>
+    </li>
+  )}
 </ul>
 ```
 
-Use `key` on list children with stable identity. A key tells the renderer that
-an item is the same logical item after insertion, deletion, or reordering.
+Keys preserve DOM and component identity when items are inserted, removed, or
+reordered. Use an id from the data, not the array position.
 
 ### Attributes, Properties, And Styles
 
-Most HTML syntax maps directly to attributes:
+Normal HTML attributes use familiar syntax:
 
 ```voyd
-<button id="save" class="primary" type="button">Save</button>
+<button id="save" class="primary" aria-label="Save">Save</button>
 ```
 
-Attribute helpers return `Attr<Msg>` values. They are useful when a helper
-function returns an attribute list, or when an element is built with the
-lower-level constructors:
-
-```voyd
-fn SaveButton() -> Html<Msg>
-  html_element(
-    tag: "button",
-    attrs: [
-      id("save"),
-      class("primary"),
-      input_type("button"),
-      attr(name: "aria-label", value: "Save")
-    ],
-    children: [text("Save")]
-  )
-```
-
-The individual attribute helpers are:
-
-```voyd
-id("save")
-class("primary")
-classes(["primary", "wide"])
-role("button")
-name("title")
-placeholder("Untitled")
-input_type("text")
-tab_index(0)
-attr(name: "aria-label", value: "Save")
-```
-
-Use properties for live DOM state such as `value`, `checked`, and `disabled`:
+`value`, `checked`, and `disabled` update live DOM properties, which makes them
+the right choice for controlled form elements:
 
 ```voyd
 <input value={model.draft} />
@@ -387,73 +249,31 @@ Use properties for live DOM state such as `value`, `checked`, and `disabled`:
 <button disabled={model.saving}>Save</button>
 ```
 
-The lower-level helpers are:
+For computed attributes and lower-level helpers, use:
 
 ```voyd
-value(model.draft)
-checked(model.enabled)
-disabled(model.saving)
+id("save")
+class("primary")
+classes(["primary", "wide"])
+role("button")
+attr(name: "aria-label", value: "Save")
 prop(name: "value", value: model.draft)
-```
-
-Styles are explicit property/value pairs:
-
-```voyd
 style(name: "display", value: "grid")
-style(name: "grid-template-columns", value: "1fr auto")
 styles([("display", "grid"), ("gap", "0.5rem")])
 ```
 
-The runtime validates tag names, attribute names, and CSS property names. Invalid
-frames fail before malformed DOM can be produced.
+HTML syntax is preferred. `text`, `fragment`, `html_element`, and `element` are
+available for helpers that build trees dynamically.
 
-### Refs
+## Events And Forms
 
-`Ref<T>` is a typed way to identify a DOM element for a later command.
-
-```voyd
-let editor = Ref<DomElement> { id: "editor" }
-
-fn view(model: Model) -> Html<Msg>
-  <input data-vx-ref="editor" value={model.draft} />
-```
-
-The helper form is clearer when building attributes manually:
-
-```voyd
-ref<DomElement>(editor)
-```
-
-Refs are looked up by `data-vx-ref`. They are useful with `Cmd.focus` and
-`Cmd.scroll_into_view`.
-
-### Lower-Level Render Constructors
-
-HTML syntax is the normal surface. These functions are available for generated
-code, interop, and advanced helpers:
-
-```voyd
-text("hello")
-fragment(children)
-element(tag: "section", attrs: attrs, children: children)
-html_element(tag: "section", attrs: attrs, children: children)
-frame(root)
-```
-
-`frame(root)` wraps a root node in the versioned VX render-frame format used by
-the browser and server renderers.
-
-## Events
-
-Events turn browser input into messages.
-
-Use a fixed message when the event payload can be ignored:
+Use a fixed message when the event payload is irrelevant:
 
 ```voyd
 <button type="button" on_click={Msg::Save {}}>Save</button>
 ```
 
-Use a zero-argument closure when you need to compute the message:
+Use a closure when the message depends on local data:
 
 ```voyd
 <button
@@ -464,7 +284,7 @@ Use a zero-argument closure when you need to compute the message:
 </button>
 ```
 
-Use a typed payload closure when the browser event contains the data:
+Use a typed event when you need browser data:
 
 ```voyd
 <input
@@ -475,54 +295,15 @@ Use a typed payload closure when the browser event contains the data:
 />
 ```
 
-The standard event payload types are:
+The common payload types are:
 
-```voyd
-MouseEvent {
-  kind: String,
-  x: f64,
-  y: f64,
-  client_x: f64,
-  client_y: f64,
-  button: i32,
-  alt_key: bool,
-  ctrl_key: bool,
-  meta_key: bool,
-  shift_key: bool,
-  delta_x: f64,
-  delta_y: f64
-}
+- `InputEvent`: `value`, `checked`, and `input_type`.
+- `SubmitEvent`: `form_keys` and `form_values`.
+- `MouseEvent`: coordinates, button, wheel deltas, and modifier keys.
+- `KeyboardEvent`: `key`, `code`, and modifier keys.
+- `GenericEvent`: event name for events without a richer payload.
 
-KeyboardEvent {
-  kind: String,
-  key: String,
-  code: String,
-  alt_key: bool,
-  ctrl_key: bool,
-  meta_key: bool,
-  shift_key: bool
-}
-
-InputEvent {
-  kind: String,
-  value: String,
-  checked: bool,
-  input_type: String
-}
-
-SubmitEvent {
-  kind: String,
-  form_keys: Array<String>,
-  form_values: Array<String>
-}
-
-GenericEvent {
-  kind: String,
-  event: String
-}
-```
-
-Use `EventOptions` for browser listener behavior:
+Prevent a form's browser submission with `EventOptions`:
 
 ```voyd
 <form
@@ -531,703 +312,266 @@ Use `EventOptions` for browser listener behavior:
     message: Msg::Submit {}
   )}
 >
-  ...
+  <input
+    name="title"
+    value={model.draft}
+    on_input={(event: InputEvent) -> Msg =>
+      Msg::DraftChanged { value: event.value }
+    }
+  />
+  <button type="submit" disabled={model.saving}>Add</button>
 </form>
 ```
 
-The options are `prevent_default`, `stop_propagation`, `capture`, and `passive`.
+`EventOptions` also supports `stop_propagation`, `capture`, and `passive`.
+Named helpers cover click, double-click, pointer, mouse, keyboard, input,
+change, submit, focus, blur, scroll, wheel, drag, drop, and context-menu events.
+Use `event_message` when no named helper fits.
 
-The event helper pattern is consistent:
+## One-Off Work With Commands
 
-```voyd
-on_click_message(Msg::Save {})
-on_click_with(options: EventOptions { prevent_default: true }, message: Msg::Save {})
-event_message<InputEvent, Msg>(
-  name: "input",
-  message: (event: InputEvent) -> Msg => Msg::Edit { value: event.value }
-)
-```
+`Cmd<Msg>` describes work that should happen after VX accepts the next model.
+Return commands from `init` or `step`; do not perform browser work in `view`.
 
-The named event families are:
+### Async Tasks
 
-- Mouse: `on_click`, `on_double_click`, `on_mouse_down`, `on_mouse_up`,
-  `on_mouse_move`, `on_mouse_enter`, `on_mouse_leave`.
-- Pointer: `on_pointer_down`, `on_pointer_up`, `on_pointer_move`.
-- Keyboard: `on_key_down`, `on_key_up`.
-- Form/input: `on_input`, `on_change`, `on_submit`.
-- Focus/scroll/wheel: `on_focus`, `on_blur`, `on_scroll`, `on_wheel`.
-- Drag/drop/context: `on_drag_start`, `on_drag`, `on_drag_end`, `on_drop`,
-  `on_context_menu`.
-
-Each family has forms for retained handler ids, typed messages, typed event
-closures, and `EventOptions`. Application code usually needs the HTML attribute
-syntax, fixed typed messages, typed event closures, and the `_with` helpers for
-options.
-
-## Component-Local State
-
-Most state belongs in `Model`. Reach for component-local state for small local
-UI details outside app behavior: a small open/closed flag, an uncontrolled input
-draft inside a reusable widget, or a temporary visual value.
-
-Component-local state is intentionally restricted to small boundary-safe values,
-with direct helpers for `String` and `i32`.
+Use `Cmd.task` for API calls, storage services, and other Voyd tasks. Map the
+result back into the application as a message:
 
 ```voyd
-fn Disclosure(): Component -> Html<Msg>
-  let (panel, set_panel) = state(initial: "closed")
-  <section>
-    <button
-      type="button"
-      on_click={() => set_panel("open")}
-    >
-      Open
-    </button>
-    <p>{panel}</p>
-  </section>
-```
+use std::task::TaskRuntime
 
-For more control, use a handle:
-
-```voyd
-fn CounterButton(): Component -> Html<Msg>
-  let handle = state_handle(initial: 0)
-  <button on_click={() => handle.set(handle.value + 1)}>
-    Increment
-  </button>
-```
-
-`StateHandle<T>` methods:
-
-- `set(value)` replaces state and schedules the component runtime.
-- `update(value)` replaces state and returns a new handle with the updated
-  value.
-
-Keep server data, shared feature data, command inputs, URL state, and testable
-application behavior in `Model`.
-
-## Commands
-
-`Cmd<Msg>` describes one-off work. A command value is returned from `init` or
-`step`, and the browser runtime handles the command after it has stored the new
-model, rendered the new view, and reconciled subscriptions.
-
-Most command constructors only build data. `Cmd.task` is the important exception:
-it detaches a Voyd task while constructing the command, stores the task id in the
-command, and the browser runtime later observes that task and dispatches the
-mapped result. That is why any function that calls `Cmd.task` needs the
-`TaskRuntime` effect.
-
-Commands exist so state transitions stay explicit. `step` decides what should
-happen next; command constructors isolate outside work from the model update.
-
-### Command Constructors
-
-`Cmd.none()` does nothing.
-
-```voyd
-Cmd<Msg>::none()
-```
-
-Use it when a helper has to return a command for an empty branch.
-
-`Cmd.message(value)` queues a typed message.
-
-```voyd
-Cmd::message(Msg::Saved {})
-```
-
-Use it to split a state-machine transition into a follow-up message. Message
-loops can occur if every handling of a message immediately commands the same
-message again.
-
-`Cmd.delay(millis:, value:)` dispatches a typed message after a timer.
-
-```voyd
-Cmd::delay(millis: 250i64, value: Msg::Autosave {})
-```
-
-The browser runtime clears pending delays when the app is disposed.
-
-`Cmd.batch(values)` runs several commands.
-
-```voyd
-Cmd::batch([focus_editor(), announce_saved()])
-```
-
-The browser runtime walks command batches in order. A batch is useful when one
-transition needs independent side effects, such as starting a request and moving
-focus.
-
-`Cmd.task(work:, handler:)` starts one detached Voyd task and dispatches the
-handler result when the task completes.
-
-```voyd
-fn save_title(title: String): TaskRuntime -> Cmd<Msg>
-  Cmd::task(
-    work: () -> Result<Todo, String> => api_save_title(title),
-    handler: (result: Result<Todo, String>) -> Msg =>
-      Msg::SaveFinished { result: result }
-  )
-```
-
-Use `Cmd.task` for API requests, database writes, and other async work. The
-function that creates the task needs the `TaskRuntime` effect because the task is
-detached as part of constructing the command.
-
-`Cmd.perform` is the lower-level task command. Use it when you already have a
-`Task<T>` or a task id and want to attach a retained result mapper yourself.
-
-```voyd
-Cmd::perform(
-  task: task_value,
-  handler: (value: Todo) -> Msg =>
-    Msg::Saved { result: Ok { value: value } }
-)
-Cmd<Msg>::perform(task_id: task_id, handler_id: mapper_id)
-```
-
-Most application code should prefer `Cmd.task`.
-
-`Cmd.copy_to_clipboard(value:)` copies text to the browser clipboard.
-
-```voyd
-Cmd<Msg>::copy_to_clipboard("Saved URL")
-```
-
-`Cmd.read_clipboard(handler:)` reads text from the browser clipboard and
-dispatches the handler result.
-
-```voyd
-Cmd<Msg>::read_clipboard(
-  (value: String) -> Msg => Msg::ClipboardRead { value: value }
-)
-```
-
-Clipboard reads can fail because of browser permissions or unavailable APIs.
-Those failures are reported through the runtime command error path. Use
-`Cmd.task` when the response-producing work should be owned by Voyd task code
-instead of the browser runtime host.
-
-`Cmd.focus(target)` focuses a DOM element found by `data-vx-ref`.
-
-```voyd
-let editor = Ref<DomElement> { id: "editor" }
-Cmd<Msg>::focus(editor)
-```
-
-`Cmd.scroll_into_view(target)` scrolls a DOM element found by `data-vx-ref`.
-
-```voyd
-Cmd<Msg>::scroll_into_view(editor)
-```
-
-`Cmd.select_text(target)` selects text in an input-like DOM element found by
-`data-vx-ref`.
-
-```voyd
-Cmd<Msg>::select_text(editor)
-```
-
-`Cmd.set_document_title(value:)`, `Cmd.push_url(value:)`,
-`Cmd.replace_url(value:)`, `Cmd.set_hash(value:)`, `Cmd.navigate_back()`, and
-`Cmd.navigate_forward()` cover common document and history effects.
-
-```voyd
-Cmd::batch([
-  Cmd<Msg>::set_document_title("Editing"),
-  Cmd<Msg>::push_url("/todos/active")
-])
-```
-
-`Cmd.scroll_window_to(x:, y:)` and `Cmd.scroll_window_by(x:, y:)` control the
-browser window scroll position.
-
-```voyd
-Cmd<Msg>::scroll_window_to(x: 0.0, y: 240.0)
-Cmd<Msg>::scroll_window_by(x: 0.0, y: 80.0)
-```
-
-`Cmd.local_storage_set(key:, value:)`, `Cmd.local_storage_remove(key:)`,
-`Cmd.local_storage_clear()`, `Cmd.session_storage_set(key:, value:)`,
-`Cmd.session_storage_remove(key:)`, and `Cmd.session_storage_clear()` cover
-string storage writes and removals.
-
-```voyd
-Cmd<Msg>::local_storage_set(key: "draft", value: model.draft)
-Cmd<Msg>::session_storage_remove("wizard-step")
-```
-
-`Cmd.open_url(value:)` opens a URL in a new browser context. Use the labeled
-form to choose the browser target.
-
-```voyd
-Cmd<Msg>::open_url("https://voyd.dev")
-Cmd<Msg>::open_url(url: "/help", target: "_self")
-```
-
-`Cmd.runtime(kind:)` creates a host command envelope for custom browser or
-application capabilities.
-
-```voyd
-Cmd<Msg>::runtime(kind: "analytics_track", value: analytics_payload(event))
-```
-
-The browser host must register a command executor for the `kind`. Use runtime
-commands when the effect is app-specific or not part of VX's built-in browser
-host.
-
-`Cmd.map(handler)` lifts child commands into parent message space.
-
-```voyd
-child_cmd.map(
-  (msg: ChildMsg) -> AppMsg => AppMsg::Child { value: msg }
-)
-```
-
-Use `Cmd.map` when composing features. It keeps child features independent of
-the parent's message type.
-
-### Command Design
-
-Name command constructors after the work they describe:
-
-```voyd
 fn load_todos(): TaskRuntime -> Cmd<Msg>
   Cmd::task(
-    work: () -> Result<Array<Todo>, String> => api_load_todos(),
+    work: () -> Result<Array<Todo>, String> => fetch_todos(),
     handler: (result: Result<Array<Todo>, String>) -> Msg =>
-      Msg::Loaded { result: result }
+      Msg::TodosLoaded { result: result }
   )
 ```
 
-Then `step` stays focused on transitions:
+The function that constructs a `Cmd.task` needs the `TaskRuntime` effect. Handle
+loading, success, and expected failure in `step`:
 
 ```voyd
 Msg::Refresh:
   next(model: loading(model), cmd: load_todos())
+Msg::TodosLoaded { result }:
+  match(result)
+    Ok { value }:
+      next(loaded(model, value))
+    Err { error }:
+      next(failed(model, error))
 ```
 
-This is the main VX habit: isolate outside work in command constructors and keep
-model changes visible in `step`.
-
-## Subscriptions
-
-`Sub<Msg>` describes ongoing outside input. A subscription can dispatch many
-messages over time: timer ticks, global keyboard shortcuts, browser connection
-state, WebSocket messages, host events, or any other listener managed by the
-runtime.
-
-The `subscriptions` function is part of the app contract:
+For example, load text from an HTTP endpoint with `std::http::client`:
 
 ```voyd
-fn subscriptions(model: Model) -> Sub<Msg>
-  ...
+use std::error::HostError
+use std::http::{ HttpError, Response }
+use std::http::client::self as http_client
+use std::result::types::all
+use std::string::type::String
+use std::task::TaskRuntime
+
+fn fetch_message(): http_client::HttpClient -> Result<String, String>
+  match(http_client::get("/api/message"))
+    Ok<Response> { value }:
+      match(value.text())
+        Ok<String> { value }:
+          Ok<String> { value: value }
+        Err<HttpError> { error }:
+          Err<String> { error: error.message }
+    Err<HostError> { error }:
+      Err<String> { error: error.message }
+
+fn load_message(): (http_client::HttpClient, TaskRuntime) -> Cmd<Msg>
+  Cmd::task(
+    work: () -> Result<String, String> => fetch_message(),
+    handler: (result: Result<String, String>) -> Msg =>
+      Msg::MessageLoaded { result: result }
+  )
 ```
 
-VX calls it after `init` and after every `step`. The returned value is the full
-set of listeners that should be active for the current model. When the model
-changes, VX compares the latest subscription set with the previous one and
-updates the running listeners.
+List `http_client::HttpClient` and `TaskRuntime` on any `step` or helper that
+constructs this command. For JSON, call `response.json()` and convert the
+returned `JsonValue` into the boundary-safe application type your API expects.
 
-```text
-init or step produces a model
-view renders that model
-subscriptions(model) returns the active subscription set
-VX starts new listeners
-VX disposes listeners that disappeared
-VX replaces listeners whose descriptor changed
-```
+### Command Reference
 
-This makes subscriptions model-driven. Editing mode can enable an Escape key
-listener. Leaving editing mode removes it:
+The built-in commands cover common browser work:
+
+- Flow: `Cmd.none`, `Cmd.message`, `Cmd.delay`, `Cmd.batch`, and `Cmd.task`.
+- Clipboard: `copy_to_clipboard` and `read_clipboard`.
+- Document and history: `set_document_title`, `push_url`, `replace_url`,
+  `set_hash`, `navigate_back`, `navigate_forward`, and `open_url`.
+- Scrolling: `scroll_window_to` and `scroll_window_by`.
+- Local storage: `local_storage_set`, `local_storage_remove`, and
+  `local_storage_clear`.
+- Session storage: `session_storage_set`, `session_storage_remove`, and
+  `session_storage_clear`.
+- Element refs: `focus`, `scroll_into_view`, and `select_text`.
+
+Batch independent effects when one transition needs several:
 
 ```voyd
-fn subscriptions(model: Model) -> Sub<Msg>
-  if
-    model.editing_id.len() > 0:
-      keyboard_on_key_down(key: "Escape", value: Msg::CancelEdit {})
-    else:
-      Sub<Msg>::none()
+Cmd::batch([
+  Cmd<Msg>::set_document_title("Editing todo"),
+  Cmd<Msg>::push_url("/todos/edit"),
+  Cmd<Msg>::focus(editor_ref)
+])
 ```
 
-The subscription value is data. Creating the value only describes the listener.
-The browser runtime attaches, updates, and disposes the listener after it has
-accepted the latest model.
+`Cmd.perform` is the lower-level task API for an existing `Task<T>` or task id.
+Most applications should use `Cmd.task`.
 
-### Keys And Identity
+## Ongoing Input With Subscriptions
 
-Every active subscription needs a stable key. The runtime uses the subscription
-kind plus key, and any message mapping chain, as its identity. Use ids that
-represent the logical listener, such as `"clock"`, `"escape"`, or
-`"todo:" + todo.id`.
-
-A stable key lets VX keep the same listener alive across renders. If the key
-changes, VX treats the next descriptor as a different listener.
-
-```voyd
-Sub::every(key: "clock", millis: 1000i64, value: Msg::Tick {})
-```
-
-The string `"clock"` means "the app's clock listener." It should stay the same
-even though the model changes after each tick.
-
-Use model data in a key when the listener really belongs to one model entity:
-
-```voyd
-Sub::runtime(
-  kind: "todo_status",
-  key: "todo:" + model.selected_id
-)
-```
-
-When `selected_id` changes, the old selected-todo listener is disposed and a new
-selected-todo listener starts.
-
-### Empty And Batch
-
-`Sub.none()` creates an empty subscription set.
-
-```voyd
-Sub<Msg>::none()
-```
-
-Use it when a model state has no outside input to listen to.
-
-`Sub.batch(values)` combines several subscriptions into one value. This is the
-normal shape once a screen has more than one active listener:
+`Sub<Msg>` describes listeners that should be active for the current model. VX
+re-evaluates `subscriptions(model)` after every transition, starts new listeners,
+and disposes listeners that disappear.
 
 ```voyd
 fn subscriptions(model: Model) -> Sub<Msg>
   if
-    model.editing_id.len() > 0:
+    model.editor_open:
       Sub::batch([
-        Sub::every(key: "clock", millis: 1000i64, value: Msg::Tick {}),
-        keyboard_on_key_down(key: "Escape", value: Msg::CancelEdit {})
+        keyboard_on_key_down(key: "Escape", value: Msg::CloseEditor {}),
+        Sub::every(key: "autosave", millis: 5000i64, value: Msg::Autosave {})
       ])
     else:
-      Sub::every(key: "clock", millis: 1000i64, value: Msg::Tick {})
-```
-
-`Sub.batch` can contain `Sub.none()` values. Empty children are ignored by the
-runtime.
-
-### Intervals
-
-`Sub.every(key:, millis:, value:)` dispatches a typed message at an interval.
-
-```voyd
-Sub::every(key: "autosave", millis: 5000i64, value: Msg::Autosave {})
-```
-
-Use intervals for polling, clocks, debounced reminders, and periodic autosave
-checks. The `value` is the message dispatched on every tick.
-
-```voyd
-enum Msg
-  Tick
-  Autosave
-
-fn subscriptions(model: Model) -> Sub<Msg>
-  Sub::batch([
-    Sub::every(key: "clock", millis: 1000i64, value: Msg::Tick {}),
-    Sub::every(key: "autosave", millis: 5000i64, value: Msg::Autosave {})
-  ])
-```
-
-A message produced by an interval goes through the same `step` function as a
-button click or command result:
-
-```voyd
-fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
-  match(msg)
-    Msg::Tick:
-      next(Model { ticks: model.ticks + 1 })
-    Msg::Autosave:
-      next(model: model, cmd: save_draft(model.draft))
-```
-
-### Keyboard
-
-Keyboard helpers subscribe to global browser keyboard events:
-
-```voyd
-keyboard_on_key_down(key: "Escape", value: Msg::CancelEdit {})
-keyboard_on_key_up(key: "Enter", value: Msg::Submit {})
-```
-
-The `key` parameter is both the browser key filter and the stable key for the
-subscription. The dispatched `value` is a typed message.
-
-Use the `handler` form when the app needs the normalized keyboard payload:
-
-```voyd
-keyboard_on_key_down(
-  key: "Escape",
-  handler: (event: KeyboardEvent) -> Msg =>
-    Msg::KeyPressed { key: event.key, code: event.code }
-)
-```
-
-The handler receives the same `KeyboardEvent` payload shape used by typed DOM
-keyboard event handlers.
-
-Keyboard subscriptions are especially useful for mode-dependent shortcuts:
-
-```voyd
-fn subscriptions(model: Model) -> Sub<Msg>
-  if
-    model.modal_open:
-      keyboard_on_key_down(key: "Escape", value: Msg::CloseModal {})
-    else:
       Sub<Msg>::none()
 ```
 
-### Browser State Subscriptions
+Every subscription needs stable identity. Use a key that names the logical
+listener, such as `"autosave"` or `"project:".concat(model.project_id)`. A
+changed key replaces the old listener.
 
-The default browser runtime host also exposes subscriptions for common window
-and document state:
+Built-in subscriptions include:
+
+- `Sub.every` for intervals.
+- `keyboard_on_key_down` and `keyboard_on_key_up`.
+- `online_status`, `window_on_resize`, and
+  `document_on_visibility_change`.
+- `location_on_change`, `window_on_focus`, and `window_on_blur`.
+- `animation_frame` and `media_query`.
+- `storage_on_change` and `broadcast_channel`.
+
+Most helpers have a `value:` form for a fixed message and a `handler:` form for
+a typed payload:
 
 ```voyd
-online_status(
-  key: "network",
-  handler: (online: bool) -> Msg =>
-    Msg::OnlineChanged { online: online }
-)
-
 window_on_resize(
   key: "viewport",
   handler: (size: WindowSize) -> Msg =>
     Msg::ViewportChanged { width: size.width, height: size.height }
 )
-
-document_on_visibility_change(
-  key: "visibility",
-  handler: (visibility: DocumentVisibility) -> Msg =>
-    Msg::VisibilityChanged { hidden: visibility.hidden }
-)
-
-location_on_change(
-  key: "location",
-  handler: (location: Location) -> Msg =>
-    Msg::LocationChanged { href: location.href }
-)
-
-window_on_focus(key: "focus", value: Msg::WindowFocused {})
-window_on_blur(key: "blur", value: Msg::WindowBlurred {})
 ```
 
-Each helper also has a fixed-message form with `value:` when the app only needs
-to know that the event happened.
+Use `Sub.batch` to combine listeners and `Sub.none` when none should be active.
+The runtime cleans up timers and browser listeners when a subscription disappears
+or the app is disposed.
 
-For rendering loops and browser preferences, use animation frame and media query
-subscriptions:
+## URL Routing In A SPA
 
-```voyd
-animation_frame(
-  key: "render-loop",
-  handler: (frame: AnimationFrame) -> Msg =>
-    Msg::Frame { timestamp: frame.timestamp }
-)
-
-media_query(
-  query: "(prefers-reduced-motion: reduce)",
-  handler: (query: MediaQuery) -> Msg =>
-    Msg::ReducedMotionChanged { enabled: query.matches }
-)
-```
-
-For cross-tab and cross-context coordination, use storage and broadcast channel
-subscriptions:
-
-```voyd
-storage_on_change(
-  key: "storage",
-  handler: (change: StorageChange) -> Msg =>
-    Msg::StorageChanged { key: change.key }
-)
-
-broadcast_channel<String, Msg>(
-  name: "updates",
-  handler: (value: String) -> Msg =>
-    Msg::Broadcast { value: value }
-)
-```
-
-`StorageChange.key`, `old_value`, and `new_value` are optional because browser
-storage events use `null` for clears, missing old values, and removals.
-
-### Runtime Subscriptions
-
-`Sub.runtime_payload(kind:, key:, handler:)` creates a host subscription
-envelope and maps incoming host payloads through a typed handler.
-
-```voyd
-enum Msg
-  OnlineChanged { online: bool }
-
-fn subscriptions(model: Model) -> Sub<Msg>
-  Sub::runtime_payload(
-    kind: "online_status",
-    key: "network",
-    handler: (online: bool) -> Msg =>
-      Msg::OnlineChanged { online: online }
-  )
-```
-
-The browser host must register a subscription runner for the `kind` through
-`runtimeHost.subscriptions`. The runner receives the subscription descriptor and
-a `context` with `dispatch`, `signal`, and `reportError`.
-
-```ts
-await mountVxApp({
-  container,
-  app,
-  runtimeHost: {
-    subscriptions: {
-      online_status: (subscription, context) => {
-        const dispatch = () => {
-          void context.dispatch({
-            kind: "subscription",
-            subscriptionKind: "online_status",
-            key: String(subscription.key),
-            payload: navigator.onLine,
-          });
-        };
-
-        window.addEventListener("online", dispatch);
-        window.addEventListener("offline", dispatch);
-        dispatch();
-
-        return () => {
-          window.removeEventListener("online", dispatch);
-          window.removeEventListener("offline", dispatch);
-        };
-      },
-    },
-  },
-});
-```
-
-The runner returns an optional disposer that VX calls when the subscription
-disappears or is replaced. In this example, the host dispatches a `bool` payload
-and the Voyd `handler` closure turns that payload into `Msg::OnlineChanged`.
-
-Use `Sub.runtime_configured(kind:, key:, value:, handler:)` when the host runner
-needs configuration:
-
-```voyd
-Sub::runtime_configured(
-  kind: "websocket",
-  key: "project:" + model.project_id,
-  value: websocket_config(model.project_id),
-  handler: (message: String) -> Msg =>
-    Msg::SocketMessage { value: message }
-)
-```
-
-The `value` field is sent to the host in the subscription descriptor. It is
-configuration for starting the listener, such as a channel name, URL, or topic.
-Data from the listener reaches Voyd when the host runner calls
-`context.dispatch`.
-
-The lower-level composition form is still available:
-
-```voyd
-Sub<String>::runtime(kind: "websocket", key: "project:" + model.project_id)
-  .map((message: String) -> Msg => Msg::SocketMessage { value: message })
-```
-
-### Mapping Child Subscriptions
-
-`Sub.map(handler)` lifts child subscriptions into parent message space. Use it
-when a feature module owns its own `Msg` type:
-
-```voyd
-fn subscriptions(model: AppModel) -> Sub<AppMsg>
-  todos::subscriptions(model.todos).map(
-    (msg: todos::Msg) -> AppMsg => AppMsg::Todos { value: msg }
-  )
-```
-
-Mapping becomes part of subscription identity. The runtime keeps mapped child
-subscriptions separate from unmapped subscriptions with the same kind and key.
-
-### Choosing The Shape
-
-Start with `Sub.none()`. Add a subscription when the app needs ongoing input
-from outside the current message. Keep the subscription constructor close to the
-feature that handles its messages:
+Keep the current path in the model. A navigation message changes browser
+history, while the location subscription updates the model for links,
+back/forward navigation, and the initial page load:
 
 ```voyd
 obj Model {
-  editing_id: String
+  path: String
 }
 
 enum Msg
-  StartEdit { id: String }
-  CancelEdit
-
-fn subscriptions(model: Model) -> Sub<Msg>
-  if
-    model.editing_id.len() > 0:
-      keyboard_on_key_down(key: "Escape", value: Msg::CancelEdit {})
-    else:
-      Sub<Msg>::none()
+  Navigate { path: String }
+  LocationChanged { path: String }
 
 fn step(model: Model, msg: Msg) -> Program<Model, Msg>
   match(msg)
-    Msg::StartEdit { id }:
-      next(Model { editing_id: id })
-    Msg::CancelEdit:
-      next(Model { editing_id: String::init() })
+    Msg::Navigate { path }:
+      next(model: model, cmd: Cmd<Msg>::push_url(path))
+    Msg::LocationChanged { path }:
+      next(Model { path: path })
+
+fn subscriptions(_model: Model) -> Sub<Msg>
+  location_on_change(
+    key: "location",
+    handler: (location: Location) -> Msg =>
+      Msg::LocationChanged { path: location.pathname }
+  )
+
+fn SettingsLink() -> Html<Msg>
+  <a
+    href="/settings"
+    on_click={on_click_with(
+      options: EventOptions { prevent_default: true },
+      message: Msg::Navigate { path: "/settings" }
+    )}
+  >
+    Settings
+  </a>
 ```
 
-When `StartEdit` sets `editing_id`, the next subscription pass starts the Escape
-listener. When `CancelEdit` clears `editing_id`, the next subscription pass
-disposes it.
+`location_on_change` emits the current location when it starts, then emits again
+for `push_url`, `replace_url`, hash changes, and browser back/forward navigation.
+Render the page that matches `model.path`; use `replace_url` when the previous
+URL should not remain in history.
 
-## Feature Composition
+## Element Refs
 
-Large VX apps should be built from features. A feature can own its own `Model`,
-`Msg`, `step`, `view`, command constructors, and subscriptions. The parent app
-stores the child model and wraps child messages in a parent message variant.
-
-In a `todos` module, the feature can define a small state machine:
+A `Ref<T>` identifies a rendered element for a later command:
 
 ```voyd
-obj Model {
-  items: Array<Todo>,
-  draft: String,
-  saving: bool,
-  error: String
-}
+let editor = Ref<DomElement> { id: "editor" }
 
-enum Msg
-  DraftChanged { value: String }
-  Submit
-  Created { result: Result<Todo, String> }
+fn view(model: Model) -> Html<Msg>
+  <input data-vx-ref="editor" value={model.draft} />
 
-pub fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
-  match(msg)
-    Msg::DraftChanged { value }:
-      next(with_draft(model, value))
-    Msg::Submit:
-      next(model: saving_now(model), cmd: create_todo(model.draft))
-    Msg::Created { result }:
-      match(result)
-        Ok { value }:
-          next(adding(model, value))
-        Err { error }:
-          next(with_error(model, error))
+fn focus_editor() -> Cmd<Msg>
+  Cmd<Msg>::focus(editor)
 ```
 
-The parent model keeps the feature model as a field:
+When building attributes manually, `ref<DomElement>(editor)` produces the same
+reference attribute. Refs are intended for focus, selection, and scrolling;
+application data still belongs in the model.
+
+## Component-Local State
+
+Use the application model by default. Component-local state is useful for small,
+self-contained UI details such as whether a disclosure is open.
+
+```voyd
+fn Disclosure(): Component -> Html<Msg>
+  let (state, set_state) = state(initial: "closed")
+  <section>
+    <button type="button" on_click={() => set_state("open")}>Open</button>
+    <p>{state}</p>
+  </section>
+```
+
+For direct access to the current value, use `state_handle`:
+
+```voyd
+fn CounterButton(): Component -> Html<Msg>
+  let count = state_handle(initial: 0)
+  <button on_click={() => count.set(count.value + 1)}>
+    Increment
+  </button>
+```
+
+Local state currently has direct helpers for `String` and `i32`. Keep server
+data, shared feature data, URLs, command inputs, and behavior you need to test in
+the application model.
+
+## Organizing A Larger App
+
+Give each feature its own model, messages, `step`, `view`, commands, and
+subscriptions. The parent stores the feature model and wraps its messages:
 
 ```voyd
 obj AppModel {
   todos: todos::Model,
-  session: Session
+  signed_in: bool
 }
 
 enum AppMsg
@@ -1235,93 +579,106 @@ enum AppMsg
   SignedOut
 ```
 
-When a child message arrives, delegate to the child `step`, then lift the child
-transition into the parent app:
+In the parent `step`, delegate the child message. `map_model` rebuilds the
+parent model around the next child model, and `map_message` wraps messages that
+the child transition's commands may produce later:
 
 ```voyd
-AppMsg::Todos { value }:
-  let child = todos::step(model.todos, value)
-  let with_model = map_model(
-    child,
-    (next_todos: todos::Model) -> AppModel =>
-      AppModel { todos: next_todos, session: model.session }
-  )
-  map_message(
-    with_model,
-    (child_msg: todos::Msg) -> AppMsg =>
-      AppMsg::Todos { value: child_msg }
-  )
+fn step(model: AppModel, msg: AppMsg): TaskRuntime -> Program<AppModel, AppMsg>
+  match(msg)
+    AppMsg::Todos { value }:
+      let child = todos::step(model.todos, value)
+      let with_parent_model = map_model(
+        child,
+        (next_todos: todos::Model) -> AppModel =>
+          AppModel { todos: next_todos, signed_in: model.signed_in }
+      )
+      map_message(
+        with_parent_model,
+        (child_msg: todos::Msg) -> AppMsg =>
+          AppMsg::Todos { value: child_msg }
+      )
+    AppMsg::SignedOut:
+      next(AppModel { todos: model.todos, signed_in: false })
 ```
 
-`map_model` replaces the child transition model with a parent model. The mapper
-receives the next `todos::Model`, then rebuilds `AppModel` with the existing
-parent state around it.
-
-`map_message` lifts every child message inside the child transition into the
-parent message type. That includes messages produced later by child commands and
-subscriptions.
-
-Views, commands, and subscriptions have matching mappers:
+The parent view uses `map_html` so child events become `AppMsg::Todos`:
 
 ```voyd
 fn view(model: AppModel) -> Html<AppMsg>
-  let handler_id = retain_typed_message_mapper(
-    (msg: todos::Msg) -> AppMsg => AppMsg::Todos { value: msg }
-  )
+  let to_app = (msg: todos::Msg) -> AppMsg => AppMsg::Todos { value: msg }
   <main>
     {map_html(
       html: todos::view(model.todos),
-      handler_id: handler_id
+      handler_id: retain_typed_message_mapper(to_app)
     )}
   </main>
 
-fn app_subscriptions(model: AppModel) -> Sub<AppMsg>
+fn subscriptions(model: AppModel) -> Sub<AppMsg>
   todos::subscriptions(model.todos).map(
-    (msg: todos::Msg) -> AppMsg => AppMsg::Todos { value: msg }
-  )
-
-fn load_todos_for_app(): TaskRuntime -> Cmd<AppMsg>
-  todos::load_todos().map(
     (msg: todos::Msg) -> AppMsg => AppMsg::Todos { value: msg }
   )
 ```
 
-Use the mapper that matches the value being composed:
+Use `Cmd.map` in the same way when a parent starts a child command directly.
+Together, `map_model`, `map_message`, `map_html`, `Cmd.map`, and `Sub.map` keep
+feature-specific state and effects out of a single application-wide state
+machine.
 
-- `map_html(html:, handler_id:)` lifts child HTML after you retain a message
-  mapper with `retain_typed_message_mapper`.
-- `Cmd.map` lifts child commands.
-- `Sub.map` lifts child subscriptions.
-- `map_model` lifts the model inside a child `Program`.
-- `map_message` lifts messages inside a child `Program`.
+## Server Rendering And Hydration
 
-This is the main tool for keeping feature state local. A todos feature can grow
-its own loading flags, edit form, persistence commands, and keyboard
-subscriptions while the parent app only knows that todos has a model field and a
-message wrapper.
+The `web-ssr` starter renders VX HTML on the server and hydrates it in the
+browser:
 
-## Runtime And Interop
+```bash
+voyd bootstrap my-site --template web-ssr
+```
 
-The default browser path is:
+The server sends a complete document, the initial model, and a client entry URL.
+The browser creates the same VX application with that model and calls
+`hydrateVxApp`, preserving the server-rendered DOM. See [Web](./web.md) for the
+complete server and hydration workflow.
+
+## Browser Runtime Integration
+
+The browser starter already wires the Wasm module to VX. Its `src/main.ts` uses
+this setup:
 
 ```ts
 import { createVoydHost } from "@voyd-lang/sdk/js-host";
 import { createVoydVxAppRuntime, mountVxApp } from "@voyd-lang/vx-dom/browser";
+import wasmUrl from "./generated/main.wasm?url";
+import { adapters } from "./generated/voyd-adapters";
 
+const container = document.getElementById("root");
+if (!container) throw new Error("Missing #root element");
+
+const wasm = new Uint8Array(await (await fetch(wasmUrl)).arrayBuffer());
 const host = await createVoydHost({
   wasm,
   bufferSize: 256 * 1024,
+  adapters,
 });
-
 const app = createVoydVxAppRuntime({ host });
+const mounted = await mountVxApp({ container, app });
+
+import.meta.hot?.dispose(() => mounted.dispose());
+```
+
+Report runtime failures through the mount-level `onError` hook:
+
+```ts
 const mounted = await mountVxApp({
-  container: document.getElementById("root")!,
+  container,
   app,
+  onError: (error, context) => {
+    console.error(`VX ${context.phase} failed`, error);
+  },
 });
 ```
 
-`createVoydVxAppRuntime` looks for an exported `app` by default. If you are
-using custom exports, pass them explicitly:
+`createVoydVxAppRuntime` uses the exported `app` function by default. For a
+legacy or custom module, you can name lifecycle exports explicitly:
 
 ```ts
 const app = createVoydVxAppRuntime({
@@ -1335,708 +692,130 @@ const app = createVoydVxAppRuntime({
 });
 ```
 
-Use `runtimeHost` to add custom commands and subscriptions:
+### Custom Host Capabilities
+
+Use a runtime command for fire-and-forget work implemented in JavaScript:
+
+```voyd
+use std::msgpack::self as msgpack
+
+Cmd<Msg>::runtime(
+  kind: "analytics_track",
+  value: msgpack::make_string(event_name)
+)
+```
+
+Register an executor when mounting:
 
 ```ts
-await mountVxApp({
+const mounted = await mountVxApp({
   container,
   app,
   runtimeHost: {
     commands: {
-      copy_to_clipboard: async (command) => {
-        if (typeof command.value === "string") {
-          await navigator.clipboard.writeText(command.value);
-        }
-      },
-    },
-    subscriptions: {
-      online_status: (subscription, context) => {
-        const dispatch = () =>
-          context.dispatch({
-            kind: "subscription",
-            subscriptionKind: "online_status",
-            key: String(subscription.key),
-            payload: navigator.onLine,
-          });
-        window.addEventListener("online", dispatch);
-        window.addEventListener("offline", dispatch);
-        dispatch();
-        return () => {
-          window.removeEventListener("online", dispatch);
-          window.removeEventListener("offline", dispatch);
-        };
+      analytics_track: async (command) => {
+        await analytics.track(command.value);
       },
     },
   },
 });
 ```
 
-Command handlers receive the command descriptor that Voyd produced. The
-descriptor always has `type: "cmd"` and `kind`; constructors that take input put
-that input in `value` after boundary encoding. A handler may be synchronous or
-async. Unknown command kinds, thrown errors, and rejected promises are reported
-through the runtime error handler with `phase: "commands"`. Runtime commands are
-best for fire-and-forget host effects. Use `Cmd.task` when the work should
-produce a typed result message through Voyd's task runtime.
+For an ongoing host listener, use a configured runtime subscription:
 
-Subscription runners receive the subscription descriptor that Voyd produced. The
-descriptor always has `type: "sub"`, `kind`, and a stable `key`; optional
-configuration is in `value`. A runner starts the listener and returns an
-optional disposer. VX calls the disposer when the descriptor disappears, when the
-same kind/key is replaced by a changed descriptor, and when the app is disposed.
+```voyd
+use std::msgpack::self as msgpack
 
-Send data back by calling `context.dispatch`:
+Sub::runtime_configured(
+  kind: "websocket",
+  key: "project:".concat(model.project_id),
+  value: msgpack::make_string(model.socket_url),
+  handler: (message: String) -> Msg =>
+    Msg::SocketMessage { value: message }
+)
+```
+
+The JavaScript runner starts the listener, dispatches payloads, and returns a
+cleanup function:
 
 ```ts
-context.dispatch({
-  kind: "subscription",
-  subscriptionKind: String(subscription.kind),
-  key: String(subscription.key),
-  payload: nextValue,
-});
-```
-
-The `payload` becomes the input to the Voyd `handler:` or `Sub.map` closure. If
-the dispatched message includes `value`, VX treats it as a fixed message and the
-payload is still available to custom runtime code but is not passed to the Voyd
-mapper. `context.signal` is aborted during teardown, and `context.reportError`
-reports asynchronous listener failures with `phase: "subscriptions"`.
-
-The built-in browser runtime host already handles:
-
-- Commands: `delay`, `task`, `copy_to_clipboard`, `focus`,
-  `read_clipboard`, `scroll_into_view`, `select_text`, `set_document_title`,
-  `push_url`, `replace_url`, `set_hash`, `navigate_back`,
-  `navigate_forward`, `open_url`, `scroll_window_to`, `scroll_window_by`,
-  `local_storage_set`, `local_storage_remove`, `local_storage_clear`,
-  `session_storage_set`, `session_storage_remove`, `session_storage_clear`.
-- Subscriptions: `interval`, `keyboard`, `online_status`, `window_resize`,
-  `visibility_change`, `location_change`, `window_focus`, `window_blur`,
-  `animation_frame`, `media_query`, `storage`, `broadcast_channel`.
-
-Lower-level renderer APIs are available for integration work:
-
-- `createVxDomRenderer(container)` returns a renderer that can render, hydrate,
-  dispose, and expose a snapshot.
-- `renderVxToString(...)` renders a VX frame or Wasm component to HTML on the
-  server.
-- `renderNodeToString(vnode)` renders an already-normalized node.
-
-Server rendering produces a frame and hydration data. Browser commands and
-browser subscriptions begin on the client after hydration, through normal message
-handling and `subscriptions(model)`.
-
-Runtime errors are reported by phase: `init`, `dispatch`, `render`,
-`subscriptions`, `commands`, or `dispose`. Malformed frames, invalid tag names,
-invalid attributes, invalid CSS names, unknown command kinds, unknown
-subscription kinds, and malformed envelopes are errors.
-
-## Testing VX Code
-
-The easiest tests target pure pieces:
-
-- `step` with a model and message.
-- model helper functions such as `with_error` or `adding`.
-- command constructors by checking the command structure when the boundary matters.
-- subscriptions by checking they appear and disappear for the right model states.
-
-Prefer one integration test at the public boundary for browser behavior: mount
-the app, dispatch events, and assert the DOM or runtime messages. Keep
-state-machine assertions at one layer.
-
-## Guide: Database-Backed Todos
-
-The rest of this page builds a todos app in pieces, then shows the complete file.
-The example is a vehicle for the VX shape: model data is durable, messages
-describe events, `step` chooses the next model, commands isolate outside work,
-subscriptions describe ambient input, and the view renders the current model.
-
-### 1. Data And State
-
-Start with the data the app owns.
-
-```voyd
-obj Todo {
-  id: String,
-  title: String,
-  done: bool
-}
-
-obj Model {
-  todos: Array<Todo>,
-  draft: String,
-  editing_id: String,
-  editing_title: String,
-  loading: bool,
-  saving: bool,
-  error: String
-}
-```
-
-This model is intentionally explicit. It tracks the list, the new-todo draft,
-the edit form, and UI state for loading, saving, and errors. A richer app might
-use `Option<String>` for `editing_id`; this example keeps strings to stay focused
-on VX.
-
-### 2. Messages
-
-Every way the model can change becomes a message.
-
-```voyd
-enum Msg
-  Load
-  Loaded { result: Result<Array<Todo>, String> }
-  DraftChanged { value: String }
-  Submit
-  Created { result: Result<Todo, String> }
-  StartEdit { id: String, title: String }
-  EditChanged { value: String }
-  SaveEdit
-  Saved { result: Result<Todo, String> }
-  Delete { id: String }
-  Deleted { result: Result<String, String> }
-  CancelEdit
-```
-
-The async result messages carry `Result`. That makes expected persistence
-failures part of the state machine and keeps runtime exceptions for unexpected
-runtime failures.
-
-### 3. Entrypoint And Startup
-
-The app should load todos immediately, so `init` returns a `Program` with an
-initial model and a command.
-
-```voyd
-pub fn app() -> Program<Model, Msg>
-  program({ init, step, view, subscriptions })
-
-fn init(): TaskRuntime -> Program<Model, Msg>
-  next(
-    model: Model {
-      todos: Array<Todo>::init(),
-      draft: String::init(),
-      editing_id: String::init(),
-      editing_title: String::init(),
-      loading: true,
-      saving: false,
-      error: String::init()
+runtimeHost: {
+  subscriptions: {
+    websocket: (subscription, context) => {
+      const socket = new WebSocket(String(subscription.value));
+      socket.addEventListener("message", (event) => {
+        void context.dispatch({
+          kind: "subscription",
+          subscriptionKind: "websocket",
+          key: String(subscription.key),
+          payload: String(event.data),
+        });
+      });
+      return () => socket.close();
     },
-    cmd: load_todos()
-  )
+  },
+}
 ```
 
-`init` has a `TaskRuntime` effect because `load_todos` uses `Cmd.task`.
+Use `Cmd.task` when work should produce a typed Voyd result. Use runtime commands
+and subscriptions for capabilities owned by the browser or another host.
 
-### 4. Transitions
+Runtime errors are reported with a phase such as `init`, `dispatch`, `render`,
+`subscriptions`, `commands`, or `dispose`. Use `mountVxApp({ onError })` or
+`runtimeHost.onError` when you need monitoring or user-facing recovery.
 
-`step` is the center of the app. Database work is represented as command data.
+## Testing A VX App
 
-```voyd
-fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
-  match(msg)
-    Msg::Load:
-      next(model: loading(model), cmd: load_todos())
-    Msg::Loaded { result }:
-      match(result)
-        Ok { value }:
-          next(with_todos(model, value))
-        Err { error }:
-          next(with_error(model, error))
-    Msg::DraftChanged { value }:
-      next(with_draft(model, value))
-    Msg::Submit:
-      next(model: saving_now(model), cmd: create_todo(model.draft))
-    Msg::Created { result }:
-      match(result)
-        Ok { value }:
-          next(adding(model, value))
-        Err { error }:
-          next(with_error(model, error))
-    Msg::StartEdit { id, title }:
-      next(start_edit(model, id, title))
-    Msg::EditChanged { value }:
-      next(with_edit(model, value))
-    Msg::SaveEdit:
-      next(
-        model: saving_now(model),
-        cmd: save_todo(model.editing_id, model.editing_title)
-      )
-    Msg::Saved { result }:
-      match(result)
-        Ok { value }:
-          next(replacing(model, value))
-        Err { error }:
-          next(with_error(model, error))
-    Msg::Delete { id }:
-      next(model: saving_now(model), cmd: delete_todo(id))
-    Msg::Deleted { result }:
-      match(result)
-        Ok { value }:
-          next(removing(model, value))
-        Err { error }:
-          next(with_error(model, error))
-    Msg::CancelEdit:
-      next(cancel_edit(model))
-```
-
-This example is pessimistic: it waits for persistence to succeed before changing
-the todo list. An optimistic version would update the list before returning the
-command and roll back if a result message reports failure.
-
-### 5. Command Constructors
-
-Each persistence operation gets a named command constructor.
+Put pure state changes in a helper and test them with Voyd's test syntax:
 
 ```voyd
-fn load_todos(): TaskRuntime -> Cmd<Msg>
-  Cmd::task(
-    work: () -> Result<Array<Todo>, String> => Ok { value: db_load_todos() },
-    handler: (result: Result<Array<Todo>, String>) -> Msg =>
-      Msg::Loaded { result: result }
-  )
-
-fn create_todo(title: String): TaskRuntime -> Cmd<Msg>
-  Cmd::task(
-    work: () -> Result<Todo, String> => Ok { value: db_create_todo(title) },
-    handler: (result: Result<Todo, String>) -> Msg =>
-      Msg::Created { result: result }
-  )
-```
-
-Keep command constructors small. If an operation needs retries, authentication,
-or richer error mapping, keep that detail inside the command constructor or the
-API layer it calls. `step` should still read as a transition table.
-
-### 6. Subscriptions
-
-While editing, Escape should cancel the edit. Outside edit mode, the app returns
-an empty subscription set.
-
-```voyd
-fn subscriptions(model: Model) -> Sub<Msg>
-  if
-    model.editing_id.len() > 0:
-      keyboard_on_key_down(key: "Escape", value: Msg::CancelEdit {})
-    else:
-      Sub<Msg>::none()
-```
-
-The runtime starts the keyboard subscription when editing begins and disposes it
-when editing ends.
-
-### 7. View
-
-The view is split into a form, a list, and one row component.
-
-```voyd
-fn view(model: Model) -> Html<Msg>
-  <main>
-    <form on_submit={on_submit_with(options: EventOptions { prevent_default: true }, message: Msg::Submit {})}>
-      <input value={model.draft} on_input={(event: InputEvent) -> Msg => Msg::DraftChanged { value: event.value }} />
-      <button type="submit" disabled={model.saving}>Add</button>
-    </form>
-    <ul>
-      {model.todos.map((todo) =>
-        <TodoRow key={todo.id} todo={todo} model={model} />
-      )}
-    </ul>
-  </main>
-```
-
-`TodoRow` renders either a read-only row or the edit controls:
-
-```voyd
-fn TodoRow({ todo: Todo, model: Model }) -> Html<Msg>
-  if editing_todo(model, todo):
-    <li>
-      <input
-        value={model.editing_title}
-        on_input={(event: InputEvent) -> Msg => Msg::EditChanged { value: event.value }}
-      />
-      <button type="button" on_click={Msg::SaveEdit {}}>Save</button>
-      <button type="button" on_click={Msg::CancelEdit {}}>Cancel</button>
-    </li>
-  else:
-    <li>
-      <span>{todo.title}</span>
-      <button type="button" on_click={Msg::StartEdit { id: todo.id, title: todo.title }}>Edit</button>
-      <button type="button" on_click={Msg::Delete { id: todo.id }}>Delete</button>
-    </li>
-```
-
-### Complete Example
-
-```voyd
-use std::array::Array
 use std::enums::{ enum }
-use std::result::types::all
-use std::string::type::String
-use std::task::TaskRuntime
-use std::vx::all
+use std::test::assertions::all
 
-obj Todo {
-  id: String,
-  title: String,
-  done: bool
+obj Counter {
+  count: i32
 }
 
-obj Model {
-  todos: Array<Todo>,
-  draft: String,
-  editing_id: String,
-  editing_title: String,
-  loading: bool,
-  saving: bool,
-  error: String
-}
+enum CounterMsg
+  Increment
 
-enum Msg
-  Load
-  Loaded { result: Result<Array<Todo>, String> }
-  DraftChanged { value: String }
-  Submit
-  Created { result: Result<Todo, String> }
-  StartEdit { id: String, title: String }
-  EditChanged { value: String }
-  SaveEdit
-  Saved { result: Result<Todo, String> }
-  Delete { id: String }
-  Deleted { result: Result<String, String> }
-  CancelEdit
-
-pub fn app() -> Program<Model, Msg>
-  program({ init, step, view, subscriptions })
-
-fn init(): TaskRuntime -> Program<Model, Msg>
-  next(
-    model: Model {
-      todos: Array<Todo>::init(),
-      draft: String::init(),
-      editing_id: String::init(),
-      editing_title: String::init(),
-      loading: true,
-      saving: false,
-      error: String::init()
-    },
-    cmd: load_todos()
-  )
-
-fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
+fn update(model: Counter, msg: CounterMsg) -> Counter
   match(msg)
-    Msg::Load:
-      next(model: loading(model), cmd: load_todos())
-    Msg::Loaded { result }:
-      match(result)
-        Ok { value }:
-          next(with_todos(model, value))
-        Err { error }:
-          next(with_error(model, error))
-    Msg::DraftChanged { value }:
-      next(with_draft(model, value))
-    Msg::Submit:
-      next(model: saving_now(model), cmd: create_todo(model.draft))
-    Msg::Created { result }:
-      match(result)
-        Ok { value }:
-          next(adding(model, value))
-        Err { error }:
-          next(with_error(model, error))
-    Msg::StartEdit { id, title }:
-      next(start_edit(model, id, title))
-    Msg::EditChanged { value }:
-      next(with_edit(model, value))
-    Msg::SaveEdit:
-      next(
-        model: saving_now(model),
-        cmd: save_todo(model.editing_id, model.editing_title)
-      )
-    Msg::Saved { result }:
-      match(result)
-        Ok { value }:
-          next(replacing(model, value))
-        Err { error }:
-          next(with_error(model, error))
-    Msg::Delete { id }:
-      next(model: saving_now(model), cmd: delete_todo(id))
-    Msg::Deleted { result }:
-      match(result)
-        Ok { value }:
-          next(removing(model, value))
-        Err { error }:
-          next(with_error(model, error))
-    Msg::CancelEdit:
-      next(cancel_edit(model))
+    CounterMsg::Increment:
+      Counter { count: model.count + 1 }
 
-fn load_todos(): TaskRuntime -> Cmd<Msg>
-  Cmd::task(
-    work: () -> Result<Array<Todo>, String> =>
-      Ok { value: db_load_todos() },
-    handler: (result: Result<Array<Todo>, String>) -> Msg =>
-      Msg::Loaded { result: result }
-  )
-
-fn create_todo(title: String): TaskRuntime -> Cmd<Msg>
-  Cmd::task(
-    work: () -> Result<Todo, String> =>
-      Ok { value: db_create_todo(title) },
-    handler: (result: Result<Todo, String>) -> Msg =>
-      Msg::Created { result: result }
-  )
-
-fn save_todo(id: String, title: String): TaskRuntime -> Cmd<Msg>
-  Cmd::task(
-    work: () -> Result<Todo, String> =>
-      Ok { value: db_save_todo(id, title) },
-    handler: (result: Result<Todo, String>) -> Msg =>
-      Msg::Saved { result: result }
-  )
-
-fn delete_todo(id: String): TaskRuntime -> Cmd<Msg>
-  Cmd::task(
-    work: () -> Result<String, String> =>
-      Ok { value: db_delete_todo(id) },
-    handler: (result: Result<String, String>) -> Msg =>
-      Msg::Deleted { result: result }
-  )
-
-fn subscriptions(model: Model) -> Sub<Msg>
-  if
-    model.editing_id.len() > 0:
-      keyboard_on_key_down(key: "Escape", value: Msg::CancelEdit {})
-    else:
-      Sub<Msg>::none()
-
-fn view(model: Model) -> Html<Msg>
-  <main>
-    <form on_submit={on_submit_with(options: EventOptions { prevent_default: true }, message: Msg::Submit {})}>
-      <input value={model.draft} on_input={(event: InputEvent) -> Msg => Msg::DraftChanged { value: event.value }} />
-      <button type="submit" disabled={model.saving}>Add</button>
-    </form>
-
-    <ul>
-      {model.todos.map((todo) =>
-        <TodoRow key={todo.id} todo={todo} model={model} />
-      )}
-    </ul>
-
-    {loading_status(model)}
-    {error_status(model)}
-  </main>
-
-fn loading_status(model: Model) -> Html<Msg>
-  if model.loading:
-    <p>Loading...</p>
-  else:
-    <span></span>
-
-fn error_status(model: Model) -> Html<Msg>
-  if model.error.len() > 0:
-    <p role="alert">{model.error}</p>
-  else:
-    <span></span>
-
-fn TodoRow({ todo: Todo, model: Model }) -> Html<Msg>
-  if editing_todo(model, todo):
-    <li>
-      <input
-        value={model.editing_title}
-        on_input={(event: InputEvent) -> Msg => Msg::EditChanged { value: event.value }}
-      />
-      <button type="button" on_click={Msg::SaveEdit {}}>Save</button>
-      <button type="button" on_click={Msg::CancelEdit {}}>Cancel</button>
-    </li>
-  else:
-    <li>
-      <span>{todo.title}</span>
-      <button type="button" on_click={Msg::StartEdit { id: todo.id, title: todo.title }}>Edit</button>
-      <button type="button" on_click={Msg::Delete { id: todo.id }}>Delete</button>
-    </li>
-
-fn loading(model: Model) -> Model
-  Model {
-    todos: model.todos,
-    draft: model.draft,
-    editing_id: model.editing_id,
-    editing_title: model.editing_title,
-    loading: true,
-    saving: false,
-    error: String::init()
-  }
-
-fn with_todos(model: Model, todos: Array<Todo>) -> Model
-  Model {
-    todos: todos,
-    draft: model.draft,
-    editing_id: model.editing_id,
-    editing_title: model.editing_title,
-    loading: false,
-    saving: false,
-    error: String::init()
-  }
-
-fn with_draft(model: Model, draft: String) -> Model
-  Model {
-    todos: model.todos,
-    draft: draft,
-    editing_id: model.editing_id,
-    editing_title: model.editing_title,
-    loading: model.loading,
-    saving: model.saving,
-    error: model.error
-  }
-
-fn saving_now(model: Model) -> Model
-  Model {
-    todos: model.todos,
-    draft: model.draft,
-    editing_id: model.editing_id,
-    editing_title: model.editing_title,
-    loading: false,
-    saving: true,
-    error: String::init()
-  }
-
-fn with_error(model: Model, error: String) -> Model
-  Model {
-    todos: model.todos,
-    draft: model.draft,
-    editing_id: model.editing_id,
-    editing_title: model.editing_title,
-    loading: false,
-    saving: false,
-    error: error
-  }
-
-fn adding(model: Model, todo: Todo) -> Model
-  let ~todos = model.todos
-  todos.push(todo)
-  Model {
-    todos: todos,
-    draft: String::init(),
-    editing_id: model.editing_id,
-    editing_title: model.editing_title,
-    loading: false,
-    saving: false,
-    error: String::init()
-  }
-
-fn start_edit(model: Model, id: String, title: String) -> Model
-  Model {
-    todos: model.todos,
-    draft: model.draft,
-    editing_id: id,
-    editing_title: title,
-    loading: model.loading,
-    saving: model.saving,
-    error: model.error
-  }
-
-fn with_edit(model: Model, title: String) -> Model
-  Model {
-    todos: model.todos,
-    draft: model.draft,
-    editing_id: model.editing_id,
-    editing_title: title,
-    loading: model.loading,
-    saving: model.saving,
-    error: model.error
-  }
-
-fn replacing(model: Model, todo: Todo) -> Model
-  let ~todos = Array<Todo>::init()
-  var index = 0
-  while index < model.todos.len():
-    let current = model.todos.at(index)
-    if current.id == todo.id:
-      todos.push(todo)
-    else:
-      todos.push(current)
-    index = index + 1
-  Model {
-    todos: todos,
-    draft: model.draft,
-    editing_id: String::init(),
-    editing_title: String::init(),
-    loading: false,
-    saving: false,
-    error: String::init()
-  }
-
-fn removing(model: Model, id: String) -> Model
-  let ~todos = Array<Todo>::init()
-  var index = 0
-  while index < model.todos.len():
-    let current = model.todos.at(index)
-    if current.id != id:
-      todos.push(current)
-    index = index + 1
-  Model {
-    todos: todos,
-    draft: model.draft,
-    editing_id: model.editing_id,
-    editing_title: model.editing_title,
-    loading: false,
-    saving: false,
-    error: String::init()
-  }
-
-fn cancel_edit(model: Model) -> Model
-  Model {
-    todos: model.todos,
-    draft: model.draft,
-    editing_id: String::init(),
-    editing_title: String::init(),
-    loading: model.loading,
-    saving: false,
-    error: String::init()
-  }
-
-fn editing_todo(model: Model, todo: Todo) -> bool
-  model.editing_id == todo.id
-
-fn db_load_todos() -> Array<Todo>
-  let ~todos = Array<Todo>::init()
-  todos.push(Todo { id: "1", title: "Ship VX", done: false })
-  todos
-
-fn db_create_todo(title: String) -> Todo
-  Todo { id: title, title: title, done: false }
-
-fn db_save_todo(id: String, title: String) -> Todo
-  Todo { id: id, title: title, done: false }
-
-fn db_delete_todo(id: String) -> String
-  id
+test "increment updates the count":
+  let result = update(Counter { count: 1 }, CounterMsg::Increment {})
+  assert(result.count, eq: 2)
 ```
 
-The same structure scales beyond todos. Add features by giving each feature its
-own model, messages, view, commands, and subscriptions. Let parents compose those
-pieces with the VX mapping helpers. Keep outside work behind commands and
-subscriptions, and keep durable behavior visible in `step`.
-
-## Markdown
-
-The optional `@voyd-lang/markdown` package demonstrates the intended external
-package integration:
+Run tests in the starter with:
 
 ```bash
-npm install @voyd-lang/markdown
+npx voyd test ./src
 ```
 
-```voyd
-use pkg::markdown::Markdown
-use std::vx::all
+Most behavior can stay outside a browser:
 
-fn Article({ source: String }) -> Html<AppMsg>
-  <article class="wiki-article">
-    <Markdown source={source} />
-  </article>
-```
+- Make `step` wrap a tested update helper with `next(...)`.
+- Test validation and result handling as pure functions.
+- Verify subscriptions appear only for the model states that need them.
+- Test command constructors when their descriptor is part of your integration
+  contract.
 
-`Markdown` is an ordinary Voyd component function. Its underlying
-`render_static` function is implemented by a generic package adapter; neither
-the adapter contract nor `defineVoydPackageAdapter` depends on VX. The adapter
-returns a restricted static-node DTO, turns raw HTML into text, and blocks active
-link and image schemes. The Voyd wrapper converts that DTO into ordinary VX
-nodes, which are validated, rendered, and diffed like any other component tree.
+Add a smaller number of browser tests for behavior that depends on rendering:
+mount the app, interact with the DOM, and assert what the user sees. This keeps
+most tests fast while still protecting the Wasm, runtime, and DOM boundary.
+
+## Production Checklist
+
+Before shipping a VX app:
+
+- Build with `npm run build` and serve the generated assets over HTTPS.
+- Dispose mounted apps during hot reload or page teardown.
+- Use stable keys for dynamic lists and subscriptions.
+- Represent loading and expected failures in the model.
+- Keep secrets and trusted authorization decisions on the server.
+- Report runtime errors from the JavaScript host.
+- Test keyboard access, focus behavior, and semantic HTML as you would in any
+  web application.

--- a/packages/reference/docs/vx.md
+++ b/packages/reference/docs/vx.md
@@ -4,10 +4,10 @@ order: 8
 
 # VX
 
-VX is Voyd's framework for interactive user interfaces. You describe the UI as
-typed HTML, keep application state in a model, and handle every change through a
-message. VX renders the result in a browser and can render the same views on a
-server.
+VX is Voyd's framework for interactive user interfaces. Its model-view-update
+architecture is inspired by Elm. You describe the UI as typed HTML, keep
+application state in a model, and handle every change through a message. VX
+renders the result in a browser and can render the same views on a server.
 
 This guide starts with a working browser app and then covers the patterns and
 APIs you need as the app grows.
@@ -88,8 +88,8 @@ The browser runtime calls `init`, renders `view(model)`, and waits for a message
 When the input or button produces one, VX calls `step(model, msg)`, stores the
 returned model, and renders again.
 
-The exported `app` function is the standard entrypoint. Import the full public
-surface with:
+The exported `app` function is the standard VX entrypoint. Most application
+files import VX's public types and helpers with:
 
 ```voyd
 use std::vx::all
@@ -173,7 +173,7 @@ fn step(model: Model, msg: Msg): TaskRuntime -> Program<Model, Msg>
 ```
 
 Extract model-building helpers when a branch becomes noisy. This keeps the
-important decision—message in, next state and work out—visible in one place.
+important decision visible in one place: message in, next state and work out.
 
 Expected failures should normally travel through a `Result` in a result message.
 Unexpected task or runtime failures are reported by the browser runtime's error

--- a/packages/reference/docs/web.md
+++ b/packages/reference/docs/web.md
@@ -140,7 +140,7 @@ same path, configure an app with `ignore_trailing_slash()`:
 ```voyd
 let web_app = app()
   .with(trailing_slash: ignore_trailing_slash())
-  .get("/about", handler: () -> String => "About")
+  .get("/about", handler: () => "About")
 ```
 
 ## Handler Results
@@ -656,7 +656,7 @@ fn health() -> String
 
 let web_app = app()
   .get("/health", handler: health)
-  .get("/debug", handler: (ctx: Context) -> Response =>
+  .get_context("/debug", handler: (ctx) =>
     Response::ok().text(ctx.path())
   )
 ```
@@ -667,12 +667,12 @@ Explicit method names make extracted handler shapes clear:
 let api = app()
   .get_params(
     "/articles/:slug",
-    handler: (params: ArticleParams) -> Response =>
+    handler: (params: ArticleParams) =>
       Response::ok().text(params.slug)
   )
   .get_params_query(
     "/articles/:slug/revisions",
-    handler: (params: ArticleParams, query: SearchQuery) -> Response =>
+    handler: (params: ArticleParams, query: SearchQuery) =>
       revisions(params.slug, query.page)
   )
 ```
@@ -683,7 +683,7 @@ For a reusable subrouter, create `router::Router` and mount it:
 use pkg::web::router
 
 let api = router::Router::init()
-  .get("/health", handler: () -> String => "ok")
+  .get("/health", handler: () => "ok")
 
 let web_app = app().mount("/api", api)
 ```
@@ -693,14 +693,14 @@ through free helpers:
 
 ```voyd
 let web_app = build_app do(base):
-  let with_health = get_context(base, "/health") do(_ctx: Context):
+  let with_health = get_context(base, "/health") do(_ctx):
     "ok"
 
   post(
     with_health,
     "/echo",
     body: text_body(),
-    handler: (input: String) -> Response => Response::ok().text(input)
+    handler: (input: String) => Response::ok().text(input)
   )
 ```
 
@@ -722,7 +722,7 @@ use std::string::type::String
 use std::test::assertions::all
 
 fn test_app() -> App
-  app().get("/health", handler: () -> String => "ok")
+  app().get("/health", handler: () => "ok")
 
 fn request(path: String) -> IncomingRequest
   IncomingRequest {

--- a/packages/reference/docs/web.md
+++ b/packages/reference/docs/web.md
@@ -4,14 +4,61 @@ order: 9
 
 # Web
 
-The `pkg::web` package is Voyd's HTTP application framework. It builds on
-`std::http` and gives you routing, middleware, typed request extraction,
-response conversion, static-file middleware, and server-side HTML helpers.
+`pkg::web` is Voyd's HTTP application framework. It provides routing,
+middleware, typed request data, response conversion, static files, and
+server-rendered VX pages.
 
-Use the web framework when you want to write HTTP handlers as ordinary Voyd
-functions that return ordinary values. The framework owns the route table and
-request pipeline; `std::http` still owns the underlying request and response
-types.
+Use it for JSON APIs, server-rendered sites, or applications that combine an
+HTTP server with an interactive VX client.
+
+## Start A Web Project
+
+Install the Voyd CLI and scaffold the Web starter:
+
+```bash
+npm install -g @voyd-lang/cli
+voyd bootstrap my-site --template web-ssr
+cd my-site
+npm install
+npm run dev
+```
+
+This is the recommended starting point for both APIs and server-rendered sites
+because it includes the Node host and development workflow. For an API, keep
+`src/main.voyd` and remove the client and hydration code you do not need. For an
+interactive site, use the complete starter.
+
+The generated project includes the Web package, VX server rendering and
+hydration, Vite, Tailwind CSS, and static assets. Its main files are:
+
+- `src/main.voyd`: the HTTP server, routes, server data, and rendered pages.
+- `src/client.voyd`: the VX application that runs after hydration.
+- `src/client.ts`: loads the client Wasm module and hydrates the page.
+- `public/`: files served directly by the application.
+- `scripts/dev.mjs`: rebuilds the client and restarts the server in development.
+- `scripts/serve.mjs`: compiles and runs the server.
+
+Useful commands are:
+
+```bash
+npm run dev          # rebuild and restart while editing
+npm run voyd:check   # compile-check the Voyd server and client
+npm run build        # build production client assets and check Voyd
+npm start            # run the server
+```
+
+The generated host reads `PORT` or `VOYD_WEB_PORT` and `HOST` or
+`VOYD_WEB_HOST`. Production platforms usually require binding all interfaces:
+
+```bash
+npm run build
+HOST=0.0.0.0 PORT=8080 npm start
+```
+
+## A Minimal Server
+
+Replace the generated `src/main.voyd` with a small server while learning the
+framework:
 
 ```voyd
 use pkg::web::all
@@ -21,84 +68,60 @@ use std::result::types::all
 use std::task
 
 pub fn main(): (server::HttpServer, task::TaskRuntime) -> Result<Unit, HostError>
-  serve(port: 3000) routes():
+  serve(port: 3000, host: "127.0.0.1") routes():
+    get("/") do:
+      "Hello from Voyd"
+
     get("/health") do:
-      "ok"
+      Response::ok().text("ok")
 ```
 
-Most applications should import `pkg::web::all`. Larger packages can import
-from the narrower modules:
+`serve` uses `std::http::server`, so the entrypoint lists the server and task
+runtime effects. Any effects used by your handlers also remain visible in the
+entrypoint's effect row.
 
-- `pkg::web::router` for `App`, `Router`, `Context`, middleware, and serving.
-- `pkg::web::routes` for builder-style route helper functions.
-- `pkg::web::extract` for body, auth, params, query, headers, and rejections.
-- `pkg::web::response` for `IntoResponse`, `to_response`, and response helpers.
-- `pkg::web::html` for VX server rendering.
-- `pkg::web::static_files` for `serve_dir`.
+Most applications should import `pkg::web::all`. For tighter imports, the public
+modules are `router`, `routes`, `extract`, `response`, `html`, `middleware`, and
+`static_files`.
 
 ## Routes
 
-Routes are declared inside `serve(...) routes():` or inside `build_app do(...)`.
-Use HTTP verb helpers for common routes and `route(..., method:)` when the
-method is dynamic or uncommon.
+Use `get`, `post`, `put`, `patch`, and `delete` for common methods. Use `route`
+when the method is dynamic or less common:
 
 ```voyd
 use pkg::web::all
 use std::http::Method
-use std::error::HostError
-use std::http::server
-use std::result::types::all
-use std::task
 
-pub fn main(): (server::HttpServer, task::TaskRuntime) -> Result<Unit, HostError>
-  serve(port: 3000, host: "127.0.0.1", shutdown_timeout: 250) routes():
-    get("/health") do:
-      "ok"
+serve(port: 3000) routes():
+  get("/articles") do:
+    list_articles()
 
-    post("/events") do(ctx: Context):
-      ctx
-      status(code: 202, reason: "Accepted").empty()
+  post("/articles") do(ctx: Context):
+    create_article(ctx)
 
-    route("/resource", method: Method::Delete {}) do:
-      Response::ok().text("deleted")
+  route("/events", method: Method::Delete {}) do:
+    Response::ok().text("deleted")
 ```
 
-Path segments that begin with `:` are path parameters.
+Path segments beginning with `:` are parameters:
 
 ```voyd
-use pkg::web::all
-use std::error::HostError
-use std::http::server
-use std::result::types::all
 use std::string::type::String
-use std::task
 
-type UserParams = {
-  id: String
+type ArticleParams = {
+  slug: String
 }
 
-pub fn main(): (server::HttpServer, task::TaskRuntime) -> Result<Unit, HostError>
-  serve(port: 3000) routes():
-    get("/users/:id") do(params: UserParams):
-      params.id
-```
-
-Static routes are preferred over parameterized routes when both match. For
-example, `/users/new` wins over `/users/:id` even if the parameterized route was
-registered first.
-
-```voyd
 serve(port: 3000) routes():
-  get("/users/:id") do(params: UserParams):
-    Response::ok().text(params.id)
-
-  get("/users/new") do:
-    Response::ok().text("new")
+  get("/articles/:slug") do(params: ArticleParams):
+    find_article(params.slug)
 ```
 
-Group related routes with a prefix. Middleware adopted before a group applies
-inside the group; middleware adopted inside the group stays scoped to that
-group.
+Static routes take precedence over parameter routes, so `/articles/new` wins
+over `/articles/:slug` regardless of registration order.
+
+Group routes under a shared prefix:
 
 ```voyd
 serve(port: 3000) routes():
@@ -106,28 +129,42 @@ serve(port: 3000) routes():
     get("/health") do:
       "ok"
 
-    group("/users") routes():
-      get("/:id") do(params: UserParams):
-        params.id
+    group("/articles") routes():
+      get("/:slug") do(params: ArticleParams):
+        find_article(params.slug)
 ```
 
-## Handlers
+Trailing slashes are strict by default. To treat `/about` and `/about/` as the
+same path, configure an app with `ignore_trailing_slash()`:
 
-Handlers return values. They do not receive a mutable response writer. The
-framework converts supported values with `IntoResponse`.
+```voyd
+let web_app = app()
+  .with(trailing_slash: ignore_trailing_slash())
+  .get("/about", handler: () -> String => "About")
+```
+
+## Handler Results
+
+Handlers return values; they do not write to a mutable response object. Web
+converts supported values through `IntoResponse`:
 
 ```voyd
 get("/text") do:
   "hello"
 
-get("/raw") do:
-  Response::ok().text("already a response")
-
 get("/created") do:
   (Status::created(), "created")
+
+get("/custom") do:
+  Response::created()
+    .with(headers: Headers::empty().append(
+      header: "location",
+      value: "/articles/first"
+    ))
+    .text("created")
 ```
 
-Useful return shapes include:
+Supported result shapes include:
 
 - `Response`, returned unchanged.
 - `String` and `StringSlice`, returned as `200 OK` text.
@@ -135,93 +172,63 @@ Useful return shapes include:
 - `JsonValue`, returned as `200 OK` JSON.
 - `(Status, String)`, `(Status, StringSlice)`, `(Status, Bytes)`, and
   `(Status, JsonValue)`.
-- `Result<T, E>` when both `T` and `E` can become a response.
+- `Result<T, E>` when both branches can become a response.
 - `Option<T>`, where `None` becomes `404 Not Found`.
 
+Return a typed DTO as JSON with `json_dto`:
+
 ```voyd
-use pkg::web::all
-use std::json::{ JsonBool, JsonValue }
-use std::optional::types::all
-use std::result::types::all
-use std::string::type::String
+type ArticleSummary = {
+  slug: String,
+  title: String
+}
 
-fn feature_flag() -> JsonValue
-  JsonBool { value: true }
-
-fn find_name(id: String) -> Option<String>
-  if id.equals("1") then:
-    Some<String> { value: "Ada" }
-  else:
-    None {}
-
-fn create_name(name: String) -> Result<(Status, String), Rejection>
-  if name.is_empty() then:
-    Err<Rejection> { error: Rejection::bad_request("missing name") }
-  else:
-    Ok<(Status, String)> { value: (Status::created(), name) }
-
-serve(port: 3000) routes():
-  get("/flag") do:
-    feature_flag()
-
-  get("/users/:id") do(params: UserParams):
-    find_name(params.id)
-
-  post("/users", body: text_body()) do(input: String):
-    create_name(input)
+get("/api/articles/:slug") do(params: ArticleParams):
+  json_dto<ArticleSummary>({
+    slug: params.slug,
+    title: "A Voyd article"
+  })
 ```
 
-Use `response_json(...)` when you want to create a JSON response explicitly.
-The shorter `json()` name is reserved in `pkg::web::all` for the JSON body
-policy, so `response_json(...)` is the clearest root-level response helper.
+Use `response_dto_json(Response::created(), value:)` to choose the status,
+`result_dto_json` for a `Result`, and `option_dto_json` when absence should be a
+404. Use `response_json(value)` for an existing `JsonValue`; the root-level
+`json()` name is reserved for the JSON request-body policy.
+
+## Typed Request Data
+
+The route DSL chooses extractors from handler parameter names:
+
+- `params: T` decodes path parameters.
+- `query: T` decodes query parameters.
+- `headers: T` decodes request headers.
+- `cookies: T` decodes cookies.
+- `ctx: Context` provides the complete request context.
+
+Extractor parameters must use a supported order. You can request `params`,
+`headers`, or `cookies` alone; `params` plus `query`; `params` plus `headers`;
+`query` plus `headers`; or `params`, `query`, and `headers`. Any of these shapes
+can add a final `ctx`. A query-only handler must include that final context:
 
 ```voyd
-let value: JsonValue = JsonBool { value: true }
-let response = response_json(value)
+type SearchFilter = {
+  exact: bool
+}
+
+get("/search") do(query: SearchFilter, ctx: Context):
+  ctx
+  if query.exact then: "exact" else: "fuzzy"
 ```
 
-## Context
+For another combination, accept `ctx` and read the value dynamically, or use an
+explicit builder helper from [Composing Applications](#composing-applications).
 
-Request handlers can ask for `ctx: Context` when they need the raw request,
-headers, path values, query values, or explicit rejection handling.
-
-```voyd
-get("/inspect/:id") do(ctx: Context):
-  let id = ctx.param("id") ?? "missing"
-  let mode = ctx.query_value("mode") ?? "default"
-  Response::ok().text(id.concat(":").concat(mode))
-```
-
-Common `Context` methods:
-
-- `ctx.method()` returns the request `Method`.
-- `ctx.path()` returns the request path.
-- `ctx.header(name)` returns an optional header value.
-- `ctx.param(name)` returns an optional path parameter.
-- `ctx.query()` returns all parsed query parameters.
-- `ctx.query_value(name)` returns one query value.
-- `ctx.body_bytes()` returns the raw request body bytes.
-- `ctx.text()` reads the request body as text.
-- `ctx.json()` reads the request body as `JsonValue`.
-- `ctx.reject(rejection)` runs the current rejection handler.
-
-## Params, Query, And Headers
-
-The DSL uses handler parameter names to decide which extractor to use:
-
-- `params: T` decodes path parameters into `T`.
-- `query: T` decodes the query string into `T`.
-- `headers: T` decodes request headers into `T`.
-- `ctx: Context` passes the full request context.
-
-Use structural types for request-shaped data.
+Use structural records for request-shaped data. Start with the common case of
+path and query parameters:
 
 ```voyd
-use pkg::web::all
-use std::string::type::String
-
 type SearchParams = {
-  org: String
+  organization: String
 }
 
 type SearchQuery = {
@@ -230,66 +237,84 @@ type SearchQuery = {
   exact: bool
 }
 
+serve(port: 3000) routes():
+  get("/orgs/:organization/search") do(
+    params: SearchParams,
+    query: SearchQuery
+  ):
+    Response::ok().text(
+      params.organization
+        .concat(":")
+        .concat(query.q)
+    )
+```
+
+Ask for typed headers or cookies only on routes that need them:
+
+```voyd
 type RequestHeaders = {
   authorization: String
 }
 
-serve(port: 3000) routes():
-  get("/orgs/:org/search") do(
-    params: SearchParams,
-    query: SearchQuery,
-    headers: RequestHeaders,
-    ctx: Context
-  ):
-    let request_id = ctx.header("x-request-id") ?? "missing"
-    Response::ok().text(
-      params.org
-        .concat(":")
-        .concat(query.q)
-        .concat(":")
-        .concat(headers.authorization)
-        .concat(":")
-        .concat(request_id)
-    )
+get("/account") do(headers: RequestHeaders):
+  Response::ok().text(headers.authorization)
 ```
-
-Path params and headers decode as strings. Query values decode booleans from
-`true` and `false`, integers from canonical integer strings, and all other
-values as strings.
-
-Use the explicit `route_*` helpers in builder-style code when the parameter
-shape cannot be inferred from a free route helper name.
 
 ```voyd
-let app = build_app do(base):
-  route_query_context(base, "/search", method: Method::Get {}) do(
-    query: SearchQuery,
-    _ctx: Context
-  ):
-    if query.exact then:
-      Response::ok().text("exact")
-    else:
-      Response::ok().text("fuzzy")
+type SessionCookies = {
+  session: String
+}
+
+get("/session") do(cookies: SessionCookies):
+  Response::ok().text(cookies.session)
 ```
+
+Path parameters, headers, and cookies decode as strings. Query values decode
+`true` and `false` as booleans, canonical integer strings as integers, and other
+values as strings. Missing required fields or incompatible field types produce a
+`400 Bad Request`. Make a field optional when the request may omit it.
+
+### Request Context
+
+Use `Context` when you need dynamic access or the raw request:
+
+```voyd
+get("/inspect/:id") do(ctx: Context):
+  let id = ctx.param("id") ?? "missing"
+  let mode = ctx.query_value("mode") ?? "default"
+  let session = ctx.cookie("session") ?? "anonymous"
+  Response::ok().text(id.concat(":").concat(mode).concat(":").concat(session))
+```
+
+The most useful methods are:
+
+- `method()` and `path()`.
+- `header(name)`, `param(name)`, `query_value(name)`, and `cookie(name)`.
+- `query()` and `cookies()` for all parsed values.
+- `body_bytes()`, `text()`, and `json()` for direct body access.
+- `reject(rejection)` to send a value through the current rejection handler.
+
+Prefer typed parameters when the request shape is fixed. Use `Context` for
+dynamic data or framework-level code.
 
 ## Request Bodies
 
-Body policies are explicit route labels. Use `json_body()` for typed JSON,
-`text_body()` for text, and `bytes()` for raw bytes.
+Declare a body policy on the route:
 
 ```voyd
-use pkg::web::all
 use std::bytes::Bytes
-use std::string::type::String
 
-type CreateUser = {
-  name: String,
-  active: bool
+type CreateArticle = {
+  title: String,
+  published: bool
 }
 
 serve(port: 3000) routes():
-  post("/users", body: json_body()) do(input: CreateUser):
-    Response::created().text(input.name)
+  post("/api/articles", body: json_body()) do(input: CreateArticle):
+    response_dto_json(
+      Response::created(),
+      value: { title: input.title, published: input.published }
+    )
 
   post("/echo", body: text_body()) do(input: String):
     Response::ok().text(input)
@@ -299,246 +324,335 @@ serve(port: 3000) routes():
 ```
 
 `json_body()` accepts `application/json` and media types ending in `+json`.
-When the content type is not JSON, the route rejects with `415 Unsupported
-Media Type`. Invalid body text or invalid JSON rejects with `400 Bad Request`.
+Invalid JSON or text produces `400 Bad Request`; an unsupported JSON content
+type produces `415 Unsupported Media Type`.
 
-The concise aliases `json()` and `text()` are also available for body policies,
-but `json_body()` and `text_body()` read better in route declarations because
-`json` and `text` are common response concepts too.
-
-## Auth
-
-Auth is also an explicit route label. The default `required_session()` and
-`optional_session()` policies read the `authorization` header.
+Limit a route body independently of the server-wide limit:
 
 ```voyd
-use pkg::web::all
-use std::optional::types::all
-use std::string::type::String
-
-serve(port: 3000) routes():
-  get("/me", auth: required_session()) do(session: String):
-    Response::ok().text(session)
-
-  get("/maybe-me", auth: optional_session()) do(session: Option<String>):
-    match(session)
-      Some<String> { value }:
-        Response::ok().text(value)
-      None:
-        Response::unauthorized().empty()
+post(
+  "/api/articles",
+  body: json_body(),
+  limit: body_limit(64 * 1024)
+) do(input: CreateArticle):
+  json_dto<CreateArticle>(input)
 ```
 
-Use a custom `AuthPolicy<T>` when your application has a typed session value.
-The extractor can perform effects because `AuthExtractor<T>` has an open effect
-row.
+The `json()` and `text()` aliases also create body policies. The longer names
+are usually clearer in a route declaration.
+
+### HTML Forms
+
+A normal `POST` form sends an `application/x-www-form-urlencoded` body. Read it
+as text and use `parse_query` to decode field names, percent escapes, and `+`
+spaces:
 
 ```voyd
-use pkg::web::all
+use std::msgpack::MsgPack
+use std::optional::types::all
+use std::string::type::String
+use std::vx::all
+
+fn NewArticleForm() -> Html<MsgPack>
+  <form method="post" action="/articles">
+    <label for="title">Title</label>
+    <input id="title" name="title" required />
+    <button type="submit">Create article</button>
+  </form>
+
+post("/articles", body: text_body()) do(input: String):
+  match(parse_query(input).get("title"))
+    Some<String> { value }:
+      Response::created().text(value)
+    None:
+      Response::bad_request().text("title is required")
+```
+
+For a form with `method="get"`, use the normal typed `query: T` extractor.
+Validate required fields and application rules in the handler even when the HTML
+form also uses browser validation.
+
+## Authentication
+
+The built-in session policies read the `authorization` header:
+
+```voyd
+use std::optional::types::all
+
+serve(port: 3000) routes():
+  get("/account", auth: required_session()) do(session: String):
+    Response::ok().text(session)
+
+  get("/welcome", auth: optional_session()) do(session: Option<String>):
+    match(session)
+      Some<String> { value }:
+        Response::ok().text("Welcome, ".concat(value))
+      None:
+        Response::ok().text("Welcome")
+```
+
+For a real application, create an `AuthPolicy<T>` that validates a token or
+loads a typed session:
+
+```voyd
 use std::http::IncomingRequest
 use std::result::types::all
-use std::string::type::String
 
 obj Session {
   api user_id: String,
   api role: String
 }
 
-fn extract_session(request: IncomingRequest) -> Result<Session, Rejection>
+fn authenticate(request: IncomingRequest) -> Result<Session, Rejection>
   match(request.header("authorization"))
     Some<String> { value }:
-      Ok<Session> {
-        value: Session { user_id: value, role: "member" }
-      }
+      lookup_session(value)
     None:
-      Err<Rejection> { error: Rejection::unauthorized("missing auth") }
+      Err<Rejection> {
+        error: Rejection::unauthorized("missing authorization")
+      }
 
 serve(port: 3000) routes():
   get(
     "/account",
-    auth: required_session<Session>(extract: extract_session)
+    auth: required_session<Session>(extract: authenticate)
   ) do(session: Session):
     Response::ok().text(session.user_id)
 ```
 
+An auth extractor can perform effects, so it may call a database or another
+service. Return `Rejection::unauthorized` for missing or invalid credentials and
+`Rejection::forbidden` when the caller is authenticated but lacks permission.
+
 ## Middleware
 
-Middleware receives a `Context` and `next`. It returns a `Response`. Call
-`next(ctx)` to continue to the next middleware or the matched route handler, or
-return a response early.
+Middleware receives `Context` and `Next`. Call `next(ctx)` to continue, or
+return a response early:
 
 ```voyd
-use pkg::web::all
-use std::http::Response
 use std::optional::types::all
-use std::string::type::String
 
 fn require_request_id(ctx: Context, next: Next) -> Response
   match(ctx.header("x-request-id"))
     Some<String>:
       next(ctx)
     None:
-      Response::bad_request().text("missing request id")
+      Response::bad_request().text("missing x-request-id")
 
 serve(port: 3000) routes():
   adopt(require_request_id)
 
+  get("/work") do:
+    "accepted"
+```
+
+Middleware is applied in registration order. An `adopt` affects routes declared
+after it, including routes inside later groups. Middleware adopted inside a
+group stays in that group.
+
+The package includes `request_id_required`, which rejects requests without an
+`x-request-id` header.
+
+## Errors And Rejections
+
+Web distinguishes route failures from request-data failures:
+
+- An unknown path uses the not-found handler.
+- A known path with the wrong method uses the method-not-allowed handler.
+- Invalid params, query, headers, cookies, bodies, or auth produce `Rejection`.
+- A timed-out route returns `504 Gateway Timeout`.
+
+Customize those responses at the application boundary:
+
+```voyd
+serve(port: 3000) routes():
+  not_found() do(_ctx: Context):
+    Response::not_found().text("Page not found")
+
+  method_not_allowed() do(_ctx: Context):
+    Response::method_not_allowed().text("Method not allowed")
+
+  on_rejection() do(rejection: Rejection, _ctx: Context):
+    response_dto_json(
+      Response::new(status: rejection.status),
+      value: { error: rejection.message }
+    )
+```
+
+Returning `Result<T, Rejection>` directly converts the rejection to its default
+status and text response. To pass application validation through a customized
+`on_rejection` handler, accept `Context` and call `ctx.reject(error)`:
+
+```voyd
+fn validate(input: CreateArticle) -> Result<CreateArticle, Rejection>
+  if input.title.is_empty() then:
+    Err<Rejection> {
+      error: Rejection::bad_request("title is required")
+    }
+  else:
+    Ok<CreateArticle> { value: input }
+
+post("/articles", body: json_body()) do(input: CreateArticle, ctx: Context):
+  match(validate(input))
+    Ok<CreateArticle> { value }:
+      response_dto_json(Response::created(), value: value)
+    Err<Rejection> { error }:
+      ctx.reject(error)
+```
+
+Available rejection constructors include `bad_request`, `not_found`,
+`payload_too_large`, `unsupported_media_type`, `unauthorized`, and `forbidden`.
+
+## Timeouts And Server Limits
+
+Set a route timeout for handlers that perform external work:
+
+```voyd
+get("/reports/daily", timeout: timeout_millis(2000)) do:
+  build_daily_report()
+```
+
+You can combine `timeout:`, `body:`, `limit:`, and `auth:` on the same route.
+
+Server options protect the entire process:
+
+```voyd
+serve(
+  port: 3000,
+  host: "0.0.0.0",
+  shutdown_timeout: 30000,
+  max_body_bytes: 1024 * 1024,
+  max_pending_requests: 128
+) routes():
   get("/health") do:
     "ok"
 ```
 
-Middleware is ordered by registration. Middleware adopted before a route applies
-to that route. Middleware adopted later does not affect earlier routes.
+- `max_body_bytes` caps request bodies before route handling.
+- `max_pending_requests` limits queued detached request tasks.
+- `shutdown_timeout` sets how many milliseconds the host waits for a request
+  handler to produce a response. A host timeout becomes a `500` response.
 
-```voyd
-serve(port: 3000) routes():
-  get("/public") do:
-    "public"
-
-  adopt(require_request_id)
-
-  get("/private") do:
-    "private"
-```
-
-The package includes `request_id_required`, which rejects requests that do not
-include `x-request-id`.
-
-```voyd
-serve(port: 3000) routes():
-  adopt(request_id_required)
-  get("/work") do:
-    Response::ok().empty()
-```
-
-## Errors And Rejections
-
-Route matching failures and extractor failures are handled separately.
-
-- No matching path returns the not-found handler.
-- A matching path with the wrong method returns the method-not-allowed handler.
-- Body, auth, params, query, and header extraction failures produce a
-  `Rejection`.
-- `on_error` and `on_rejection` both install an `ErrorHandler`.
-
-```voyd
-serve(port: 3000) routes():
-  not_found() do(ctx: Context):
-    ctx
-    Response::not_found().text("custom 404")
-
-  method_not_allowed() do(ctx: Context):
-    ctx
-    Response::method_not_allowed().text("custom method")
-
-  on_rejection() do(rejection: Rejection, ctx: Context):
-    ctx
-    Response::new(status: rejection.status).text(rejection.message)
-
-  post("/json", body: json_body()) do(input: CreateUser):
-    Response::ok().text(input.name)
-```
-
-Return `Result<T, Rejection>` from handlers when normal application validation
-should use the same response shape as extraction failures.
-
-```voyd
-fn validate_name(input: CreateUser) -> Result<CreateUser, Rejection>
-  if input.name.is_empty() then:
-    Err<Rejection> { error: Rejection::bad_request("name is required") }
-  else:
-    Ok<CreateUser> { value: input }
-
-post("/users", body: json_body()) do(input: CreateUser):
-  match(validate_name(input))
-    Ok<CreateUser> { value }:
-      Response::created().text(value.name)
-    Err<Rejection> { error }:
-      error
-```
+Choose limits for the largest legitimate request your application accepts, then
+use smaller route body limits where possible.
 
 ## Static Files
 
-Use `serve_dir(root)` as middleware. It serves `GET` and `HEAD`, prevents
-`..` path traversal, serves `index.html` for `/`, and falls through to `next`
-when the file is missing or cannot be read.
+Mount a directory as middleware:
 
 ```voyd
-use pkg::web::all
-
 serve(port: 3000) routes():
-  adopt(serve_dir("./public"))
-
   get("/api/health") do:
     "ok"
+
+  adopt(serve_dir("./public"))
 ```
 
-Static files infer common content types for `.html`, `.css`, `.js`, `.json`,
-`.png`, `.jpg`, `.jpeg`, and `.svg`. Other files use
+`serve_dir` handles `GET` and `HEAD`, blocks `..` traversal, serves `index.html`
+for `/`, and calls the next handler when a file is absent. It recognizes common
+HTML, CSS, JavaScript, JSON, PNG, JPEG, and SVG content types; other files use
 `application/octet-stream`.
 
-Place static middleware before dynamic fallback routes when files should win.
-Place it after API routes when the API should win.
+Registration order determines precedence. Put API routes before static
+middleware when API paths should win. Put a final parameterized page route after
+static middleware so existing assets win over the fallback.
+
+## Server-Rendered VX
+
+`pkg::web::html` converts `Html<Msg>` into an HTML response:
 
 ```voyd
-serve(port: 3000) routes():
-  get("/api/health") do:
-    "ok"
-
-  adopt(serve_dir("./public"))
-
-  get("/:slug") do(params: PageParams):
-    render_page(params.slug)
-```
-
-## HTML Responses
-
-`pkg::web::html` renders `std::vx` HTML values to strings for server-side
-responses. Use `html_response` or the `html` alias to attach
-`text/html; charset=utf-8`.
-
-```voyd
-use pkg::web::all
 use std::vx::all
 
 fn home() -> Response
   html_response(
     Response::ok(),
     <main>
-      <h1>Voyd</h1>
-      <p>Hello from the server.</p>
+      <h1>Voyd Journal</h1>
+      <p>Rendered on the server.</p>
     </main>
   )
-
-serve(port: 3000) routes():
-  get("/") do:
-    home()
 ```
 
-Use `render(...)` when you need the HTML string and `document(...)` when you
-want a complete document string with `<!doctype html>`.
+Use `render(view)` when you need an HTML fragment as a string. Use
+`document(view)` for a full string beginning with `<!doctype html>`.
+
+### Hydrate An Interactive Page
+
+Render the initial model, target selector, and client entry together:
 
 ```voyd
-let body = render(<span>Saved</span>)
-let full = document(
-  <html>
-    <body>
-      <h1>Saved</h1>
-    </body>
-  </html>
-)
+fn article_page(model: Model) -> Response
+  html_response(
+    Response::ok(),
+    view: <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Voyd Journal</title>
+        <link rel="stylesheet" href="/assets/client.css" />
+      </head>
+      <body>
+        <div id="app">{view(model)}</div>
+      </body>
+    </html>,
+    hydrate: hydrate(
+      target: "#app",
+      entry: "/assets/client.js",
+      model: model
+    )
+  )
 ```
 
-## Builder API
+The helper safely serializes the model into an `application/json` script and
+adds the module entry. The hydration model must be boundary-safe and must match
+the model expected by the client VX app.
 
-The route DSL is the default surface for applications. The builder API is useful
-for generated routes, package-level composition, and tests.
+In the client entry, read that model and hydrate instead of mounting a new tree:
+
+```ts
+import { createVoydHost } from "@voyd-lang/sdk/js-host";
+import { createVoydVxAppRuntime, hydrateVxApp } from "@voyd-lang/vx-dom/browser";
+import wasmUrl from "./generated/client.wasm?url";
+
+const data = document.querySelector<HTMLScriptElement>("[data-voyd-hydration]");
+const selector = data?.dataset.voydHydration;
+const container = selector ? document.querySelector(selector) : null;
+
+if (!data || !container) throw new Error("Missing hydration data");
+
+const wasm = new Uint8Array(await (await fetch(wasmUrl)).arrayBuffer());
+const host = await createVoydHost({
+  wasm,
+  bufferSize: 1024 * 1024,
+  defaultAdapters: { runtime: "browser" },
+});
+const app = createVoydVxAppRuntime({
+  host,
+  initialModel: JSON.parse(data.textContent ?? "null"),
+});
+const mounted = await hydrateVxApp({ container, app });
+```
+
+The server view and client `view` must produce the same initial tree. Browser
+commands and subscriptions begin after hydration. The `web-ssr` starter contains
+the complete build and host wiring, so it is the best starting point for this
+architecture.
+
+## Composing Applications
+
+Choose the smallest composition API that fits:
+
+- Use the route DSL shown throughout this guide for normal application routes.
+- Use `App` methods when routes are generated or assembled conditionally.
+- Use `Router` for a reusable group that will be mounted under a prefix.
+- Use free builder helpers only when a callback must thread an `AppBuild` value.
+
+The `App` method API is also convenient in direct handler tests:
 
 ```voyd
-use pkg::web::all
-use std::http::Response
-
-fn health() -> Response
-  Response::ok().text("ok")
+fn health() -> String
+  "ok"
 
 let web_app = app()
   .get("/health", handler: health)
@@ -547,151 +661,105 @@ let web_app = app()
   )
 ```
 
-Use explicit builder method names for extracted handler shapes. The names make
-the extracted data visible and avoid ambiguous same-name overloads for inline
-lambdas.
+Explicit method names make extracted handler shapes clear:
 
 ```voyd
-let web_app = app()
-  .get_params("/users/:id", handler: (params: UserParams) -> Response =>
-    Response::ok().text(params.id)
+let api = app()
+  .get_params(
+    "/articles/:slug",
+    handler: (params: ArticleParams) -> Response =>
+      Response::ok().text(params.slug)
   )
   .get_params_query(
-    "/users/:id/activity",
-    handler: (params: UserParams, query: UserQuery) -> Response =>
-      let verbose = if query.verbose then: "true" else: "false"
-      Response::ok().text(params.id.concat(":").concat(verbose))
+    "/articles/:slug/revisions",
+    handler: (params: ArticleParams, query: SearchQuery) -> Response =>
+      revisions(params.slug, query.page)
   )
 ```
 
-`build_app` gives builder helpers a threaded `AppBuild` value.
+For a reusable subrouter, create `router::Router` and mount it:
+
+```voyd
+use pkg::web::router
+
+let api = router::Router::init()
+  .get("/health", handler: () -> String => "ok")
+
+let web_app = app().mount("/api", api)
+```
+
+For advanced callback-based composition, `build_app` threads an `AppBuild`
+through free helpers:
 
 ```voyd
 let web_app = build_app do(base):
   let with_health = get_context(base, "/health") do(_ctx: Context):
-    Response::ok().text("ok")
-
-  let with_item = get(with_health, "/items/:id") do(params: UserParams):
-    Response::ok().text(params.id)
+    "ok"
 
   post(
-    with_item,
+    with_health,
     "/echo",
     body: text_body(),
     handler: (input: String) -> Response => Response::ok().text(input)
   )
 ```
 
-`Router` wraps an `App` for reusable subrouters. Import the module when you need
-the constructor, then call `router::Router::init()`.
+Serve an existing `App` with `serve(web_app, port: 3000)` or
+`serve_app(web_app, port: 3000)`. Use `serve_build` when you want builder-style
+composition and server options in one call.
+
+## Testing A Web App
+
+Build an `App` without opening a socket, then call `app.handle(request)` with an
+`IncomingRequest`. This is the fastest way to test routing, extraction,
+middleware, authentication policies, and response conversion.
 
 ```voyd
 use pkg::web::all
-use pkg::web::router
+use std::http::{ Body, Headers, IncomingRequest, Method }
+use std::optional::types::all
+use std::string::type::String
+use std::test::assertions::all
 
-let api = router::Router::init()
-  .get("/health", handler: () -> Response =>
-    Response::ok().text("router")
-  )
+fn test_app() -> App
+  app().get("/health", handler: () -> String => "ok")
 
-let web_app = app().mount("/api", api)
+fn request(path: String) -> IncomingRequest
+  IncomingRequest {
+    method: Method::Get {},
+    path: path,
+    query: None {},
+    headers: Headers::empty(),
+    body: Body::empty()
+  }
+
+test "health route succeeds":
+  let response = test_app().handle(request("/health"))
+  assert(response.status.code(), eq: 200)
 ```
 
-The package root reserves `pkg::web::router` for the module path, so there is no
-root-level `web::router()` constructor. This keeps imports predictable when a
-module and function would otherwise share the same package-boundary name.
+Run project tests with:
 
-## Serving
-
-Use `serve(...) routes():` for the shortest application entrypoint.
-
-```voyd
-use pkg::web::all
-use std::error::HostError
-use std::http::server
-use std::result::types::all
-use std::task
-
-pub fn main(): (server::HttpServer, task::TaskRuntime) -> Result<Unit, HostError>
-  serve(port: 3000) routes():
-    get("/health") do:
-      "ok"
+```bash
+npx voyd test ./src
 ```
 
-Use `serve(app, port:)` or `serve_app(...)` when you already have an `App`.
+Add integration tests around the running host for behavior that depends on
+network adapters, filesystem-backed static files, shutdown, or the combined SSR
+and hydration flow. Keep application validation and data transformation in
+ordinary functions so they can be tested directly.
 
-```voyd
-use pkg::web::all
-use std::error::HostError
-use std::http::server
-use std::result::types::all
-use std::task
+## Production Checklist
 
-fn make_app() -> App
-  app().get("/health", handler: () -> Response =>
-    Response::ok().text("ok")
-  )
+Before deploying:
 
-pub fn main(): (server::HttpServer, task::TaskRuntime) -> Result<Unit, HostError>
-  serve(make_app(), port: 3000)
-```
-
-Use `serve_build(...)` when you want build-style composition and server options
-in one call.
-
-```voyd
-use pkg::web::all
-use std::error::HostError
-use std::http::server
-use std::result::types::all
-use std::task
-
-pub fn main(): (server::HttpServer, task::TaskRuntime) -> Result<Unit, HostError>
-  serve_build(port: 3000, host: "127.0.0.1") do(base):
-    get_context(base, "/health") do(_ctx: Context):
-      "ok"
-```
-
-`serve` is backed by `std::http::server`, so the surrounding function must
-provide the server and task-runtime effects required by that package.
-Application-specific effects used by handlers also remain visible in the
-entrypoint effect row.
-
-## Developer Notes
-
-The web package intentionally keeps a split between data and behavior:
-
-- Structural records model request data such as params, query, headers, and JSON
-  DTO bodies.
-- Nominal objects model behavior and policies such as `App`, `Router`,
-  `Context`, `JsonBody`, `TextBody`, `RequiredSession`, and `AuthPolicy<T>`.
-- Traits are implemented for nominal policy and response types. Do not rely on
-  applying traits to structural DTOs.
-
-Route registration stores erased `Handler`, `Middleware`, and `ErrorHandler`
-function values internally, but the public route helpers keep typed handler
-parameters long enough to derive extraction before wrapping the handler.
-
-When adding a new extractor family:
-
-- Add a nominal policy type when extraction carries behavior.
-- Keep route labels explicit for behavior-changing policy, such as `body:` and
-  `auth:`.
-- Prefer structural input records for decoded request data.
-- Add both DSL helpers and builder/helper mirrors when the shape is useful in
-  generated or composed code.
-- Keep route helper names explicit when inline lambda overload resolution would
-  otherwise be ambiguous.
-
-When adding a new response type:
-
-- Implement or reuse `IntoResponse<T>`.
-- Add `to_response(...)` overloads for common tuple, result, or option shapes
-  only when they improve call-site clarity.
-- Keep response helpers in `pkg::web::response`, and re-export root-level names
-  from `pkg::web` only when they do not conflict with common policy names.
-
-The framework should not hide effects in ambient state. Handler, middleware,
-auth, and body extraction callbacks use open effect rows where appropriate, and
-serving exposes the effects required by `std::http::server` and the application
-code it runs.
+- Bind to the host and port provided by your environment.
+- Set global and route-specific body limits.
+- Add timeouts around slow external work.
+- Validate authentication server-side; never trust hydrated client state for
+  authorization.
+- Return generic client errors while logging actionable server details.
+- Serve immutable assets with cache-friendly names and HTTPS.
+- Keep the generated `SIGINT` and `SIGTERM` handling, and design request work to
+  tolerate interruption during shutdown.
+- Monitor rejection rates, handler failures, latency, and pending requests.


### PR DESCRIPTION
## Summary

- rewrite the VX reference as a user-first guide from scaffolding through state, views, commands, subscriptions, routing, composition, testing, and browser-host integration
- rewrite the Web reference around real application workflows including APIs, request extraction, forms, authentication, errors, SSR/hydration, deployment, testing, and production concerns
- remove contributor-facing and Voyd implementation notes from both pages
- replace incomplete or misleading examples with source-verified, task-oriented samples

## Why

The previous pages mixed user documentation with framework-development notes, buried the getting-started path, and cataloged internals before showing developers how to build an application. These revisions organize both references around the developer journey while retaining advanced capabilities.

## User impact

Developers can now start from the shipped templates and follow a concise path from installation to production-oriented VX and Web applications. The guides explicitly document framework constraints such as supported route extractor combinations, boundary-safe VX data, request limits, runtime error hooks, and shutdown behavior.

## Validation

- `npm run build --workspace @voyd-lang/reference`
- `git diff --check`
- editor review loop completed with clean final passes:
  - style: 9.5/10
  - accuracy: 10/10
  - completeness: 9/10

Tests were not run because the changes are documentation-only.