### PR TITLE
Fix and audit Voyd syntax highlighting

### DIFF
--- a/apps/vscode/scripts/test-grammar.mjs
+++ b/apps/vscode/scripts/test-grammar.mjs
@@ -81,6 +81,11 @@ assert(
   clausePattern.patterns?.some((pattern) => pattern.include === "#keywords"),
   "Clause-style calls should parse keywords between argument lists and the final colon",
 );
+const clauseIncludes = clausePattern.patterns?.map((pattern) => pattern.include) ?? [];
+assert(
+  clauseIncludes.indexOf("#type-arguments") < clauseIncludes.indexOf("#keywords"),
+  "Clause-style calls should parse type arguments before keyword operators",
+);
 
 const clauseRegex = new RegExp(clausePattern.begin, "g");
 const regexMatches = (line) => [...line.matchAll(clauseRegex)].map((match) => match[0]);

--- a/apps/vscode/scripts/test-grammar.mjs
+++ b/apps/vscode/scripts/test-grammar.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const grammarPath = path.resolve(__dirname, "../syntaxes/voyd.tmLanguage.json");
 const grammar = JSON.parse(fs.readFileSync(grammarPath, "utf8"));
+const functionDefinitionPattern = grammar.repository["function-definition"];
 const functionCallPatterns = grammar.repository["function-call"]?.patterns ?? [];
 const clausePattern = functionCallPatterns.find(
   (pattern) => pattern.name === "meta.function-call.operator-word.voyd"
@@ -20,12 +21,65 @@ const constantPattern = grammar.repository.constants?.patterns?.find(
 const openEffectRowPattern = grammar.repository.keywords?.patterns?.find(
   (pattern) => pattern.name === "keyword.other.effect-row.voyd"
 );
+const controlKeywordPattern = grammar.repository.keywords?.patterns?.find(
+  (pattern) => pattern.name === "keyword.control.voyd"
+);
+const declarationKeywordPatterns = grammar.repository.keywords?.patterns?.filter(
+  (pattern) =>
+    pattern.name === "keyword.other.voyd" || pattern.name === "storage.type.voyd",
+);
+const builtinTypePattern = grammar.repository.keywords?.patterns?.find(
+  (pattern) => pattern.name === "entity.name.type.voyd",
+);
+const operatorPatterns = grammar.repository.keywords?.patterns?.filter((pattern) =>
+  pattern.name?.startsWith("keyword.operator"),
+);
+const attributePattern = grammar.repository.attributes;
+const namespacePattern = grammar.repository.identifiers?.patterns?.find(
+  (pattern) => pattern.name === "variable.language.voyd",
+);
+const numericPattern = grammar.repository.constants?.patterns?.find(
+  (pattern) => pattern.name === "constant.numeric.voyd",
+);
+
+const matchesEntirePattern = (pattern, value) =>
+  new RegExp(`^(?:${pattern.match})$`).test(value);
+
+const assertMatchesAny = (patterns, values, message) =>
+  values.forEach((value) =>
+    assert(
+      patterns.some((pattern) => matchesEntirePattern(pattern, value)),
+      `${message}: ${value}`,
+    ),
+  );
+
+assert(functionDefinitionPattern, "Expected function definition grammar pattern");
+assert.equal(
+  functionDefinitionPattern.captures?.["2"]?.name,
+  "entity.name.function.voyd",
+  "Function declaration names should use the function entity scope",
+);
+["fn add(a: i32)", "fn id<T>(value: T)", "fn '+'(a: i32, b: i32)"].forEach(
+  (declaration) =>
+    assert(
+      new RegExp(functionDefinitionPattern.match).test(declaration),
+      `Expected function declaration to be highlighted: ${declaration}`,
+    ),
+);
+assert(
+  !new RegExp(functionDefinitionPattern.match).test("fn(i32) -> i32"),
+  "Function types should not be mistaken for function declarations",
+);
 
 assert(clausePattern, "Expected clause-call grammar pattern to exist");
 assert.equal(
   clausePattern.beginCaptures?.["1"]?.name,
   "entity.name.function.voyd",
   "Clause-style calls should be highlighted as function names"
+);
+assert(
+  clausePattern.patterns?.some((pattern) => pattern.include === "#keywords"),
+  "Clause-style calls should parse keywords between argument lists and the final colon",
 );
 
 const clauseRegex = new RegExp(clausePattern.begin, "g");
@@ -74,6 +128,171 @@ assert(
   !openEffectRowRegex.test("let open = 1"),
   "Expected ordinary identifiers named open to avoid effect-row highlighting"
 );
+
+assert(controlKeywordPattern, "Expected control keyword grammar pattern to exist");
+assertMatchesAny(
+  [controlKeywordPattern],
+  [
+    "if",
+    "then",
+    "else",
+    "elif",
+    "while",
+    "for",
+    "match",
+    "return",
+    "break",
+    "continue",
+    "do",
+    "tail",
+    "resume",
+    "try",
+    "try open",
+  ],
+  "Expected current control syntax to be highlighted",
+);
+
+assert(declarationKeywordPatterns?.length, "Expected declaration keyword patterns");
+assertMatchesAny(
+  declarationKeywordPatterns,
+  [
+    "use",
+    "pub",
+    "mod",
+    "impl",
+    "api",
+    "pri",
+    "fn",
+    "type",
+    "obj",
+    "val",
+    "trait",
+    "let",
+    "var",
+    "macro",
+    "macro_let",
+    "eff",
+    "test",
+    "enum",
+  ],
+  "Expected current declaration syntax to be highlighted",
+);
+["where", "union", "global"].forEach((word) =>
+  assert(
+    !declarationKeywordPatterns.some((pattern) => matchesEntirePattern(pattern, word)),
+    `Expected stale keyword '${word}' to remain an ordinary identifier`,
+  ),
+);
+
+assert(builtinTypePattern, "Expected built-in type grammar pattern to exist");
+assertMatchesAny(
+  [builtinTypePattern],
+  ["i32", "i64", "f32", "f64", "bool", "void"],
+  "Expected current built-in types to be highlighted",
+);
+["voyd", "string"].forEach((word) =>
+  assert(
+    !matchesEntirePattern(builtinTypePattern, word),
+    `Expected stale built-in type '${word}' to remain an ordinary identifier`,
+  ),
+);
+
+assert(operatorPatterns?.length, "Expected operator grammar patterns");
+assertMatchesAny(
+  operatorPatterns,
+  [
+    "+",
+    "-",
+    "*",
+    "/",
+    "%",
+    "^",
+    "==",
+    "!=",
+    "<",
+    ">",
+    "<=",
+    ">=",
+    ".",
+    "?.",
+    "|>",
+    "<|",
+    "|",
+    "&",
+    "=",
+    "+=",
+    "-=",
+    "*=",
+    "/=",
+    "->",
+    "=>",
+    ":",
+    "?:",
+    ":=",
+    "::",
+    ";",
+    "??",
+    "..",
+    "..=",
+    "..<",
+    "and",
+    "or",
+    "xor",
+    "as",
+    "is",
+    "is_subtype_of",
+    "in",
+    "has_trait",
+    "#",
+    "!",
+    "@",
+    "~",
+    "not",
+    "...",
+  ],
+  "Expected parser operators to be highlighted without whitespace requirements",
+);
+["extends", "final"].forEach((word) =>
+  assert(
+    !operatorPatterns.some((pattern) => matchesEntirePattern(pattern, word)),
+    `Expected stale operator '${word}' to remain an ordinary identifier`,
+  ),
+);
+
+assert(attributePattern, "Expected compiler attribute grammar pattern to exist");
+["boundary", "compiler_contract", "effect", "external", "intrinsic", "intrinsic_type", "serializer"].forEach(
+  (attribute) =>
+    assert(
+      matchesEntirePattern(attributePattern, `@${attribute}`),
+      `Expected @${attribute} to be highlighted as an attribute`,
+    ),
+);
+
+assert(namespacePattern, "Expected module namespace grammar pattern to exist");
+assertMatchesAny(
+  [namespacePattern],
+  ["self", "super", "src", "std", "pkg"],
+  "Expected module root namespaces to be highlighted",
+);
+
+assert(numericPattern, "Expected numeric literal grammar pattern to exist");
+assertMatchesAny(
+  [numericPattern],
+  ["42", "-1", "1.5", "2e10", "3.0E-2", "7i64", "1.25f32"],
+  "Expected current numeric literal forms to be highlighted",
+);
+
+[grammar.patterns, grammar.repository.expression?.patterns].forEach((patterns) => {
+  const includes = patterns?.map((pattern) => pattern.include) ?? [];
+  assert(
+    includes.indexOf("#function-definition") < includes.indexOf("#keywords"),
+    "Function definitions must take precedence over the standalone fn keyword",
+  );
+  assert(
+    includes.indexOf("#comment") < includes.indexOf("#keywords"),
+    "Comments must take precedence over the division operator",
+  );
+});
 
 const interpolationRegex = new RegExp(interpolationPattern.begin, "g");
 assert(

--- a/packages/lib/assets/voyd.tmLanguage.json
+++ b/packages/lib/assets/voyd.tmLanguage.json
@@ -3,13 +3,14 @@
   "name": "Voyd",
   "patterns": [
     { "include": "#jsx" },
+    { "include": "#comment" },
+    { "include": "#constants" },
+    { "include": "#attributes" },
+    { "include": "#function-definition" },
     { "include": "#keywords" },
     { "include": "#type-definition" },
-    { "include": "#constants" },
     { "include": "#types" },
-    { "include": "#function-definition" },
     { "include": "#function-call" },
-    { "include": "#comment" },
     { "include": "#identifiers" },
     { "include": "#paren-expression" }
   ],
@@ -17,39 +18,45 @@
     "expression": {
       "patterns": [
         { "include": "#jsx" },
+        { "include": "#comment" },
+        { "include": "#constants" },
+        { "include": "#attributes" },
+        { "include": "#function-definition" },
         { "include": "#keywords" },
         { "include": "#type-definition" },
-        { "include": "#constants" },
         { "include": "#types" },
-        { "include": "#function-definition" },
         { "include": "#function-call" },
-        { "include": "#comment" },
         { "include": "#identifiers" },
         { "include": "#paren-expression" }
       ]
     },
     "comment": {
-      "begin": "//",
-      "end": "\n",
-      "name": "comment.line.double-slash"
-    },
-    "function-definition": {
-      "name": "entity.name.function",
-      "begin": "fn ",
-      "end": "\\(",
-      "beginCaptures": {
-        "0": { "name": "keyword" }
-      },
-      "endCaptures": {
-        "0": { "name": "punctuation.paren.open" }
-      },
-      "contentName": "meta.function",
       "patterns": [
         {
-          "name": "constant",
-          "match": "[^\\s\\.]+"
+          "name": "comment.line.documentation.voyd",
+          "match": "(?:///|//!).*$"
+        },
+        {
+          "name": "comment.line.double-slash.voyd",
+          "match": "//.*$"
         }
       ]
+    },
+    "attributes": {
+      "name": "meta.annotation.voyd",
+      "match": "(@)\\s*(boundary|compiler_contract|effect|external|intrinsic|intrinsic_type|serializer)\\b",
+      "captures": {
+        "1": { "name": "punctuation.definition.annotation.voyd" },
+        "2": { "name": "entity.name.function.attribute.voyd" }
+      }
+    },
+    "function-definition": {
+      "name": "meta.function.definition.voyd",
+      "match": "\\b(fn)\\s+('[^'\\n]+'|[A-Za-z_][\\w]*)(?=\\s*(?:<[^\\n()]*>)?\\s*\\()",
+      "captures": {
+        "1": { "name": "storage.type.voyd" },
+        "2": { "name": "entity.name.function.voyd" }
+      }
     },
     "type-definition": {
       "name": "meta.type-definition.voyd",
@@ -114,6 +121,7 @@
           },
           "end": "(?=\\s*:)",
           "patterns": [
+            { "include": "#keywords" },
             { "include": "#type-arguments" },
             {
               "begin": "\\(",
@@ -178,7 +186,7 @@
       "patterns": [
         {
           "name": "keyword.control.voyd",
-          "match": "\\b(if|then|else|elif|while|for|return|break|do|tail|resume|try open|try)\\b"
+          "match": "\\b(if|then|else|elif|while|for|match|return|break|continue|do|tail|resume|try open|try)\\b"
         },
         {
           "name": "keyword.other.effect-row.voyd",
@@ -186,35 +194,35 @@
         },
         {
           "name": "keyword.other.voyd",
-          "match": "\\b(use|pub|where|mod|impl|api|pri)\\b"
+          "match": "\\b(use|pub|mod|impl|api|pri)\\b"
         },
         {
           "name": "storage.type.voyd",
-          "match": "\\b(fn|type|obj|val|trait|union|let|var|global|macro|eff)\\b"
+          "match": "\\b(fn|type|obj|val|trait|let|var|macro|macro_let|eff|test|enum)\\b"
         },
         {
           "name": "entity.name.type.voyd",
-          "match": "\\b(i32|f32|f64|i64|bool|voyd|void|string)\\b"
+          "match": "\\b(i32|i64|f32|f64|bool|void)\\b"
         },
         {
           "name": "keyword.operator.voyd",
-          "match": "\\s(\\?|\\.|&|\\*\\*\\*|->|=>|\\||::|:)/\\s"
+          "match": "(?:\\.\\.\\.|\\.\\.=|\\.\\.<|\\.\\.|\\?\\.|\\?\\?|\\|>|<\\||->|=>|::|\\?:|[?.&|:;~@#])"
         },
         {
           "name": "keyword.operator.assignment.voyd",
-          "match": "\\s(=|\\+=|-=|\\*=|\\/=|:=)\\s"
+          "match": "(?:\\+=|-=|\\*=|/=|:=|(?<!=)=(?!=|>))"
         },
         {
           "name": "keyword.operator.logical.voyd",
-          "match": "\\s(==|>=|<=|<|>|and|or|xor|not)\\s"
+          "match": "(?:==|!=|>=|<=|(?<![.<>=])<(?![|<=])|(?<![-=])>(?![=>])|\\b(?:and|or|xor|not)\\b|!)"
         },
         {
           "name": "keyword.operator.word.voyd",
-          "match": "\\s(extends|is|is_subtype_of|has_trait|as|in|final)\\s"
+          "match": "\\b(?:is_subtype_of|has_trait|as|in|is)\\b"
         },
         {
           "name": "keyword.operator.arithmetic.voyd",
-          "match": "\\s(\\+|\\-|\\\\|\\*|%|^)\\s"
+          "match": "(?:\\+|-|\\*|/|%|\\^)"
         }
       ]
     },
@@ -222,7 +230,7 @@
       "patterns": [
         {
           "name": "variable.language.voyd",
-          "match": "(self|std|src)"
+          "match": "\\b(self|super|src|std|pkg)\\b"
         },
         {
           "name": "variable.name.voyd",
@@ -239,7 +247,7 @@
       "patterns": [
         {
           "name": "constant.numeric.voyd",
-          "match": "[+-]?\\d+(\\.\\d+$)?"
+          "match": "(?<![\\w.])[+-]?\\d+(?:\\.\\d+)?(?:[Ee][+-]?\\d+|(?:i|f)(?:32|64)?)?\\b"
         },
         {
           "name": "constant.language.voyd",

--- a/packages/lib/assets/voyd.tmLanguage.json
+++ b/packages/lib/assets/voyd.tmLanguage.json
@@ -121,8 +121,8 @@
           },
           "end": "(?=\\s*:)",
           "patterns": [
-            { "include": "#keywords" },
             { "include": "#type-arguments" },
+            { "include": "#keywords" },
             {
               "begin": "\\(",
               "beginCaptures": {


### PR DESCRIPTION
## Summary

- highlight trailing callback `do` clauses after parenthesized calls
- audit the TextMate grammar against the current parser and documented language surface
- add current control/declaration keywords, module roots, compiler attributes, operators, numeric literals, and documentation comments
- remove stale keyword, operator, and built-in type spellings
- prevent function-definition highlighting from leaking into the rest of a file
- expand grammar regression coverage for the audited syntax

## Root cause

The clause-style function-call region begins at the initial call and remains active through the final colon. Its nested patterns handled type arguments and parenthesized expressions but did not include keyword rules, so `do` between argument lists was left unscoped. The existing function-definition begin/end rule also allowed a child match to consume the opening parenthesis, preventing the region from closing and leaking its scope into later lines.

## Impact

Voyd source now receives consistent highlighting for trailing callbacks and the current language surface in both the VS Code extension and other consumers of `@voyd-lang/lib`'s grammar asset. Function declarations, comments, and following expressions no longer inherit an unterminated function scope.

## Validation

- `npm --prefix apps/vscode test`
- real TextMate tokenization assertions with Shiki for the reported example and representative audited syntax
- `npm run typecheck`
- `npm run test:audit`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm --prefix apps/vscode run package`
- correctness review completed with no remaining findings