### PR TITLE
V-188: Recompute dependencies after macro expansion

### DIFF
--- a/packages/compiler/src/__tests__/macro-expansion.test.ts
+++ b/packages/compiler/src/__tests__/macro-expansion.test.ts
@@ -205,6 +205,44 @@ pub macro declare_helper()
     expect((instance.exports.main as () => number)()).toBe(42);
   });
 
+  it("re-expands importers when generated re-exports add macros", async () => {
+    const root = resolve("/proj/src");
+    const mainPath = `${root}${sep}main.voyd`;
+    const brokerPath = `${root}${sep}broker.voyd`;
+    const macrosPath = `${root}${sep}generated_macros.voyd`;
+    const host = createMemoryHost({
+      [mainPath]: `
+use src::broker::all
+
+declare_helper()
+
+pub fn main() -> f64
+  helper()
+`,
+      [brokerPath]: `
+macro import_generated_macros()
+  syntax_template (pub use src::generated_macros::all)
+
+import_generated_macros()
+`,
+      [macrosPath]: `
+pub macro declare_helper()
+  syntax_template (fn helper() -> f64
+    42.0)
+`,
+    });
+
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: mainPath,
+        roots: { src: root },
+        host,
+      }),
+    );
+    const instance = getWasmInstance(result.wasm!);
+    expect((instance.exports.main as () => number)()).toBe(42);
+  });
+
   it("preserves literal numeric types when splicing macro arguments", async () => {
     const root = resolve("/proj/src");
     const mainPath = `${root}${sep}main.voyd`;

--- a/packages/compiler/src/__tests__/macro-expansion.test.ts
+++ b/packages/compiler/src/__tests__/macro-expansion.test.ts
@@ -325,6 +325,46 @@ pub macro declare_helper()
     expect((instance.exports.main as () => number)()).toBe(42);
   });
 
+  it("re-expands when a generated use changes visibility", async () => {
+    const root = resolve("/proj/src");
+    const mainPath = `${root}${sep}main.voyd`;
+    const brokerPath = `${root}${sep}broker.voyd`;
+    const macrosPath = `${root}${sep}generated_macros.voyd`;
+    const host = createMemoryHost({
+      [mainPath]: `
+use src::broker::all
+
+declare_helper()
+
+pub fn main() -> f64
+  helper()
+`,
+      [brokerPath]: `
+use src::generated_macros::all
+
+macro export_generated_macros()
+  syntax_template (pub use src::generated_macros::all)
+
+export_generated_macros()
+`,
+      [macrosPath]: `
+pub macro declare_helper()
+  syntax_template (fn helper() -> f64
+    42.0)
+`,
+    });
+
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: mainPath,
+        roots: { src: root },
+        host,
+      }),
+    );
+    const instance = getWasmInstance(result.wasm!);
+    expect((instance.exports.main as () => number)()).toBe(42);
+  });
+
   it("preserves literal numeric types when splicing macro arguments", async () => {
     const root = resolve("/proj/src");
     const mainPath = `${root}${sep}main.voyd`;

--- a/packages/compiler/src/__tests__/macro-expansion.test.ts
+++ b/packages/compiler/src/__tests__/macro-expansion.test.ts
@@ -243,6 +243,88 @@ pub macro declare_helper()
     expect((instance.exports.main as () => number)()).toBe(42);
   });
 
+  it("rebuilds exported macro scopes after generated imports load", async () => {
+    const root = resolve("/proj/src");
+    const mainPath = `${root}${sep}main.voyd`;
+    const brokerPath = `${root}${sep}broker.voyd`;
+    const macrosPath = `${root}${sep}generated_macros.voyd`;
+    const host = createMemoryHost({
+      [mainPath]: `
+use src::broker::all
+
+declare_helper()
+
+pub fn main() -> f64
+  helper()
+`,
+      [brokerPath]: `
+macro import_generated_macros()
+  syntax_template (use src::generated_macros::all)
+
+import_generated_macros()
+
+pub macro declare_helper()
+  answer()
+`,
+      [macrosPath]: `
+pub macro answer()
+  syntax_template (fn helper() -> f64
+    42.0)
+`,
+    });
+
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: mainPath,
+        roots: { src: root },
+        host,
+      }),
+    );
+    const instance = getWasmInstance(result.wasm!);
+    expect((instance.exports.main as () => number)()).toBe(42);
+  });
+
+  it("resolves generated pkg self uses against generated inline modules", async () => {
+    const root = resolve("/proj/src");
+    const mainPath = `${root}${sep}main.voyd`;
+    const pkgPath = `${root}${sep}pkgs${sep}arith${sep}pkg.voyd`;
+    const macrosPath = `${root}${sep}generated_macros.voyd`;
+    const host = createMemoryHost({
+      [mainPath]: `
+use src::pkgs::arith::pkg::all
+
+declare_helper()
+
+pub fn main() -> f64
+  helper()
+`,
+      [pkgPath]: `
+macro declare_macros_module()
+  emit_many(
+    \`(mod macros (block (pub use src::generated_macros::all))),
+    \`(pub use self::macros::all)
+  )
+
+declare_macros_module()
+`,
+      [macrosPath]: `
+pub macro declare_helper()
+  syntax_template (fn helper() -> f64
+    42.0)
+`,
+    });
+
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: mainPath,
+        roots: { src: root },
+        host,
+      }),
+    );
+    const instance = getWasmInstance(result.wasm!);
+    expect((instance.exports.main as () => number)()).toBe(42);
+  });
+
   it("preserves literal numeric types when splicing macro arguments", async () => {
     const root = resolve("/proj/src");
     const mainPath = `${root}${sep}main.voyd`;

--- a/packages/compiler/src/__tests__/macro-expansion.test.ts
+++ b/packages/compiler/src/__tests__/macro-expansion.test.ts
@@ -172,6 +172,39 @@ pub use self::macros::all
     expect((instance.exports.main as () => number)()).toBe(42);
   });
 
+  it("re-expands modules after generated imports load macros", async () => {
+    const root = resolve("/proj/src");
+    const mainPath = `${root}${sep}main.voyd`;
+    const macrosPath = `${root}${sep}generated_macros.voyd`;
+    const host = createMemoryHost({
+      [mainPath]: `
+macro import_generated_macros()
+  syntax_template (use src::generated_macros::all)
+
+import_generated_macros()
+declare_helper()
+
+pub fn main() -> f64
+  helper()
+`,
+      [macrosPath]: `
+pub macro declare_helper()
+  syntax_template (fn helper() -> f64
+    42.0)
+`,
+    });
+
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: mainPath,
+        roots: { src: root },
+        host,
+      }),
+    );
+    const instance = getWasmInstance(result.wasm!);
+    expect((instance.exports.main as () => number)()).toBe(42);
+  });
+
   it("preserves literal numeric types when splicing macro arguments", async () => {
     const root = resolve("/proj/src");
     const mainPath = `${root}${sep}main.voyd`;

--- a/packages/compiler/src/modules/__tests__/graph.test.ts
+++ b/packages/compiler/src/modules/__tests__/graph.test.ts
@@ -91,6 +91,44 @@ declare_reserved_module()
     );
   });
 
+  it("drops generated inline modules that disappear after re-expansion", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `
+use src::b::all
+
+macro import_c()
+  syntax_template (use src::c::all)
+
+import_c()
+gen()
+use self::old::all
+`,
+      [`${root}${sep}b.voyd`]: `
+pub macro gen()
+  syntax_template (mod old
+    pub fn answer() -> f64
+      1.0)
+`,
+      [`${root}${sep}c.voyd`]: `
+pub macro gen()
+  syntax_template (fn replacement() -> f64
+    2.0)
+`,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    expect(graph.modules.has("src::main::old")).toBe(false);
+    expect(graph.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "MD0001" })]),
+    );
+  });
+
   it("loads dependencies via use statements and auto-discovers submodules", async () => {
     const root = resolve("/proj/src");
     const host = createMemoryHost({

--- a/packages/compiler/src/modules/__tests__/graph.test.ts
+++ b/packages/compiler/src/modules/__tests__/graph.test.ts
@@ -214,6 +214,46 @@ pub macro gen()
     expect(graph.diagnostics).toHaveLength(0);
   });
 
+  it("stabilizes generated macro imports and replaces surface diagnostics", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `
+use src::b::all
+
+gen()
+`,
+      [`${root}${sep}b.voyd`]: `
+pub macro gen()
+  emit_many(
+    \`(use src::c::all),
+    \`(mod all (block))
+  )
+`,
+      [`${root}${sep}c.voyd`]: `
+pub macro gen()
+  syntax_template (fn replacement() -> f64
+    2.0)
+`,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    expect(graph.diagnostics).toHaveLength(0);
+    expect(graph.modules.has("src::main::all")).toBe(false);
+    const functionNames = graph.modules
+      .get("src::main")
+      ?.surface?.items.flatMap((item) =>
+        item.kind === "function"
+          ? [item.declaration.signature.name.value]
+          : [],
+      );
+    expect(functionNames).toContain("replacement");
+  });
+
   it("loads dependencies via use statements and auto-discovers submodules", async () => {
     const root = resolve("/proj/src");
     const host = createMemoryHost({

--- a/packages/compiler/src/modules/__tests__/graph.test.ts
+++ b/packages/compiler/src/modules/__tests__/graph.test.ts
@@ -174,6 +174,46 @@ pub macro gen()
     expect(functionNames).not.toContain("from_b");
   });
 
+  it("prunes transient file modules and removed import diagnostics", async () => {
+    const root = resolve("/proj/src");
+    const badPath = `${root}${sep}bad.voyd`;
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `
+use src::b::all
+
+macro import_c()
+  syntax_template (use src::c::all)
+
+import_c()
+gen()
+`,
+      [`${root}${sep}b.voyd`]: `
+pub macro gen()
+  emit_many(
+    \`(use src::bad::all),
+    \`(use src::missing::all)
+  )
+`,
+      [`${root}${sep}c.voyd`]: `
+pub macro gen()
+  syntax_template (fn replacement() -> f64
+    2.0)
+`,
+      [badPath]: `fn broken() -> i32
+  <div class="open"
+`,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    expect(graph.modules.has("src::bad")).toBe(false);
+    expect(graph.diagnostics).toHaveLength(0);
+  });
+
   it("loads dependencies via use statements and auto-discovers submodules", async () => {
     const root = resolve("/proj/src");
     const host = createMemoryHost({

--- a/packages/compiler/src/modules/__tests__/graph.test.ts
+++ b/packages/compiler/src/modules/__tests__/graph.test.ts
@@ -129,6 +129,51 @@ pub macro gen()
     );
   });
 
+  it("replaces generated inline modules retained after re-expansion", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `
+use src::b::all
+
+macro import_c()
+  syntax_template (use src::c::all)
+
+import_c()
+gen()
+use self::child::all
+`,
+      [`${root}${sep}b.voyd`]: `
+pub macro gen()
+  syntax_template (mod child
+    pub fn from_b() -> f64
+      1.0)
+`,
+      [`${root}${sep}c.voyd`]: `
+pub macro gen()
+  syntax_template (mod child
+    pub fn from_c() -> f64
+      2.0)
+`,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    expect(graph.diagnostics).toHaveLength(0);
+    const functionNames = graph.modules
+      .get("src::main::child")
+      ?.surface?.items.flatMap((item) =>
+        item.kind === "function"
+          ? [item.declaration.signature.name.value]
+          : [],
+      );
+    expect(functionNames).toContain("from_c");
+    expect(functionNames).not.toContain("from_b");
+  });
+
   it("loads dependencies via use statements and auto-discovers submodules", async () => {
     const root = resolve("/proj/src");
     const host = createMemoryHost({

--- a/packages/compiler/src/modules/__tests__/graph.test.ts
+++ b/packages/compiler/src/modules/__tests__/graph.test.ts
@@ -254,6 +254,56 @@ pub macro gen()
     expect(functionNames).toContain("replacement");
   });
 
+  it("re-resolves package-root imports after generated inline modules disappear", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}pkg.voyd`]: `
+use src::b::all
+use self::macros::all
+
+macro import_c()
+  syntax_template (use src::c::all)
+
+import_c()
+gen()
+declare_helper()
+`,
+      [`${root}${sep}b.voyd`]: `
+pub macro gen()
+  syntax_template (mod macros
+    fn placeholder() -> f64
+      1.0)
+`,
+      [`${root}${sep}c.voyd`]: `
+pub macro gen()
+  syntax_template (fn replacement() -> f64
+    2.0)
+`,
+      [`${root}${sep}macros.voyd`]: `
+pub macro declare_helper()
+  syntax_template (fn helper() -> f64
+    3.0)
+`,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}pkg.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    expect(graph.diagnostics).toHaveLength(0);
+    expect(graph.modules.has("src::pkg::macros")).toBe(false);
+    const functionNames = graph.modules
+      .get("src::pkg")
+      ?.surface?.items.flatMap((item) =>
+        item.kind === "function" ? [item.declaration.signature.name.value] : [],
+      );
+    expect(functionNames).toEqual(
+      expect.arrayContaining(["replacement", "helper"]),
+    );
+  });
+
   it("loads dependencies via use statements and auto-discovers submodules", async () => {
     const root = resolve("/proj/src");
     const host = createMemoryHost({

--- a/packages/compiler/src/modules/__tests__/graph.test.ts
+++ b/packages/compiler/src/modules/__tests__/graph.test.ts
@@ -9,6 +9,88 @@ const createMemoryHost = (files: Record<string, string>): ModuleHost =>
   createMemoryModuleHost({ files, pathAdapter: createNodePathAdapter() });
 
 describe("buildModuleGraph", () => {
+  it("loads dependencies introduced by functional macro expansion", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `
+use src::main::generated::all
+
+macro import_helper()
+  syntax_template (use src::helper::all)
+
+macro declare_generated()
+  syntax_template (mod generated
+    use src::nested::all)
+
+import_helper()
+declare_generated()
+`,
+      [`${root}${sep}helper.voyd`]: `
+macro import_deep()
+  syntax_template (use src::deep::all)
+
+import_deep()
+pub fn helper()
+  1
+`,
+      [`${root}${sep}nested.voyd`]: "pub fn nested()\n  2",
+      [`${root}${sep}deep.voyd`]: "pub fn deep()\n  3",
+      [`${root}${sep}main${sep}generated.voyd`]: `
+use src::orphan::all
+mod stale
+  pub fn from_file()
+    4
+`,
+      [`${root}${sep}orphan.voyd`]: "pub fn orphan()\n  5",
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    expect(graph.diagnostics).toHaveLength(0);
+    expect(Array.from(graph.modules.keys())).toEqual(
+      expect.arrayContaining([
+        "src::main",
+        "src::helper",
+        "src::main::generated",
+        "src::nested",
+        "src::deep",
+      ]),
+    );
+    expect(graph.modules.get("src::main::generated")?.origin.kind).toBe(
+      "inline",
+    );
+    expect(graph.modules.has("src::main::generated::stale")).toBe(false);
+    expect(graph.modules.has("src::orphan")).toBe(false);
+  });
+
+  it("validates inline modules introduced by functional macros", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `
+macro declare_reserved_module()
+  syntax_template (mod all
+    fn value()
+      1)
+
+declare_reserved_module()
+`,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    expect(graph.diagnostics.some((entry) => entry.code === "MD0005")).toBe(
+      true,
+    );
+  });
+
   it("loads dependencies via use statements and auto-discovers submodules", async () => {
     const root = resolve("/proj/src");
     const host = createMemoryHost({

--- a/packages/compiler/src/modules/graph.ts
+++ b/packages/compiler/src/modules/graph.ts
@@ -168,18 +168,42 @@ export const buildModuleGraph = async ({
   const pendingNestedPrefixCounts = new Map<string, number>();
   const noPreludeByModule = new Map<string, boolean>();
   const shadowedModuleFiles = new Set<string>();
-  const collectedUseDependencies = new Map<string, Set<string>>();
+  const collectedUseEntries = new Map<string, Set<string>>();
+  const inlineModuleAstKeys = new Map<string, string>();
   const macroExpander = createModuleMacroExpander();
   const macroDiagnosticsByModule = new Map<string, Diagnostic[]>();
 
-  const useDependencyKeys = (
-    dependencies: readonly ModuleDependency[],
-  ): Set<string> =>
-    new Set(
-      dependencies
-        .filter((dependency) => dependency.kind === "use")
-        .map((dependency) => modulePathToString(dependency.path)),
+  const useEntryKeys = (module: ModuleNode): Set<string> => {
+    const items =
+      module.surface?.items ??
+      module.header?.items ??
+      createModuleHeaderView(module.ast).items;
+    return new Set(
+      items.flatMap((item) =>
+        item.kind === "use"
+          ? item.entries.map((entry) =>
+              JSON.stringify([
+                item.visibility,
+                entry.moduleSegments,
+                entry.path,
+                entry.targetName ?? null,
+                entry.alias ?? null,
+                entry.selectionKind,
+                entry.anchorToSelf ?? false,
+                entry.parentHops ?? 0,
+                entry.hasExplicitPrefix,
+              ]),
+            )
+          : [],
+      ),
     );
+  };
+
+  const setsEqual = (left: ReadonlySet<string>, right: ReadonlySet<string>) =>
+    left.size === right.size && Array.from(left).every((key) => right.has(key));
+
+  const moduleAstKey = (module: ModuleNode): string =>
+    JSON.stringify(module.ast.toJSON());
 
   const addDocDiagnostics = (diagnostics: readonly Diagnostic[]): void => {
     diagnostics.forEach((diagnostic) => {
@@ -219,7 +243,8 @@ export const buildModuleGraph = async ({
     modules.delete(moduleId);
     modulesByPath.delete(modulePathToString(module.path));
     noPreludeByModule.delete(moduleId);
-    collectedUseDependencies.delete(moduleId);
+    collectedUseEntries.delete(moduleId);
+    inlineModuleAstKeys.delete(moduleId);
     updateNestedPrefixCounts({
       counts: moduleNestedPrefixCounts,
       pathKey: modulePathToString(module.path),
@@ -295,10 +320,10 @@ export const buildModuleGraph = async ({
 
   addModuleTree(entryModule, modules, modulesByPath, (module) => {
     noPreludeByModule.set(module.id, entryModule.noPrelude);
-    collectedUseDependencies.set(
-      module.id,
-      useDependencyKeys(module.dependencies),
-    );
+    collectedUseEntries.set(module.id, useEntryKeys(module));
+    if (module.origin.kind === "inline") {
+      inlineModuleAstKeys.set(module.id, moduleAstKey(module));
+    }
     updateNestedPrefixCounts({
       counts: moduleNestedPrefixCounts,
       pathKey: modulePathToString(module.path),
@@ -347,27 +372,37 @@ export const buildModuleGraph = async ({
         break;
       }
 
-      expansion.expandedModuleIds.forEach((moduleId) => {
-        const module = modules.get(moduleId);
-        if (!module) {
+      const refreshedModules = expansion.expandedModuleIds.flatMap(
+        (moduleId) => {
+          const module = modules.get(moduleId);
+          if (!module) {
+            return [];
+          }
+          return [
+            {
+              module,
+              info: collectExpandedModuleInfo({
+                module,
+                host,
+                hasStdPreludeModule,
+                noPrelude: noPreludeByModule.get(module.id) ?? false,
+              }),
+            },
+          ];
+        },
+      );
+      refreshedModules.forEach(({ module, info: refreshed }) => {
+        if (modules.get(module.id) !== module) {
           return;
         }
-
-        const refreshed = collectExpandedModuleInfo({
-          module,
-          host,
-          hasStdPreludeModule,
-          noPrelude: noPreludeByModule.get(module.id) ?? false,
-        });
-        const previousUseDependencies =
-          collectedUseDependencies.get(module.id) ?? new Set<string>();
-        const refreshedUseDependencies = useDependencyKeys(
-          refreshed.dependencies,
+        const previousUseEntries =
+          collectedUseEntries.get(module.id) ?? new Set<string>();
+        const refreshedUseEntries = useEntryKeys(module);
+        const useEntriesChanged = !setsEqual(
+          previousUseEntries,
+          refreshedUseEntries,
         );
-        const introducedUseDependency = Array.from(
-          refreshedUseDependencies,
-        ).some((dependency) => !previousUseDependencies.has(dependency));
-        collectedUseDependencies.set(module.id, refreshedUseDependencies);
+        collectedUseEntries.set(module.id, refreshedUseEntries);
         addDocDiagnostics(
           refreshed.diagnostics.filter(
             (diagnostic) => diagnostic.code === "MD0005",
@@ -380,7 +415,7 @@ export const buildModuleGraph = async ({
           ...refreshed.dependencies,
           ...discoveredSubmodules,
         ];
-        if (introducedUseDependency) {
+        if (useEntriesChanged) {
           macroExpander.invalidate(module.id);
         }
 
@@ -390,22 +425,31 @@ export const buildModuleGraph = async ({
             refreshed.inlineModules.map((inlineModule) => inlineModule.id),
           ),
         });
-        refreshed.inlineModules.forEach((inlineModule) => {
+        const changedInlineModules = refreshed.inlineModules.filter(
+          (inlineModule) => {
+            const existing = modules.get(inlineModule.id);
+            return (
+              !existing ||
+              existing.origin.kind === "file" ||
+              inlineModuleAstKeys.get(existing.id) !==
+                moduleAstKey(inlineModule)
+            );
+          },
+        );
+        changedInlineModules.forEach((inlineModule) => {
           const existing = modules.get(inlineModule.id);
           if (existing?.origin.kind === "file") {
             removeInlineDescendants(existing.id);
           }
         });
-        const newInlineModules = refreshed.inlineModules.filter(
-          (inlineModule) => {
-            const existing = modules.get(inlineModule.id);
-            return !existing || existing.origin.kind === "file";
-          },
-        );
-        newInlineModules.forEach((inlineModule) => {
+        changedInlineModules.forEach((inlineModule) => {
           const existing = modules.get(inlineModule.id);
-          if (existing?.origin.kind === "file") {
+          if (existing) {
             macroExpander.reset(existing.id);
+            macroDiagnosticsByModule.delete(existing.id);
+            missingModules.delete(existing.id);
+          }
+          if (existing?.origin.kind === "file") {
             (existing.sourceFiles ?? [
               { filePath: existing.origin.filePath, source: existing.source },
             ]).forEach(({ filePath }) => shadowedModuleFiles.add(filePath));
@@ -419,10 +463,8 @@ export const buildModuleGraph = async ({
             inlineModule.id,
             noPreludeByModule.get(module.id) ?? false,
           );
-          collectedUseDependencies.set(
-            inlineModule.id,
-            useDependencyKeys(inlineModule.dependencies),
-          );
+          collectedUseEntries.set(inlineModule.id, useEntryKeys(inlineModule));
+          inlineModuleAstKeys.set(inlineModule.id, moduleAstKey(inlineModule));
           if (!existing) {
             updateNestedPrefixCounts({
               counts: moduleNestedPrefixCounts,
@@ -435,7 +477,7 @@ export const buildModuleGraph = async ({
         enqueueDependencies(
           {
             node: module,
-            inlineModules: newInlineModules,
+            inlineModules: changedInlineModules,
           },
           pending,
           (queued) => {
@@ -571,10 +613,10 @@ export const buildModuleGraph = async ({
     }
     addModuleTree(nextModule, modules, modulesByPath, (module) => {
       noPreludeByModule.set(module.id, nextModule.noPrelude);
-      collectedUseDependencies.set(
-        module.id,
-        useDependencyKeys(module.dependencies),
-      );
+      collectedUseEntries.set(module.id, useEntryKeys(module));
+      if (module.origin.kind === "inline") {
+        inlineModuleAstKeys.set(module.id, moduleAstKey(module));
+      }
       updateNestedPrefixCounts({
         counts: moduleNestedPrefixCounts,
         pathKey: modulePathToString(module.path),
@@ -620,7 +662,8 @@ export const buildModuleGraph = async ({
       modules.delete(moduleId);
       modulesByPath.delete(modulePathToString(module.path));
       noPreludeByModule.delete(moduleId);
-      collectedUseDependencies.delete(moduleId);
+      collectedUseEntries.delete(moduleId);
+      inlineModuleAstKeys.delete(moduleId);
       updateNestedPrefixCounts({
         counts: moduleNestedPrefixCounts,
         pathKey: modulePathToString(module.path),

--- a/packages/compiler/src/modules/graph.ts
+++ b/packages/compiler/src/modules/graph.ts
@@ -168,6 +168,16 @@ export const buildModuleGraph = async ({
   const pendingNestedPrefixCounts = new Map<string, number>();
   const noPreludeByModule = new Map<string, boolean>();
   const shadowedModuleFiles = new Set<string>();
+  const collectedUseDependencies = new Map<string, Set<string>>();
+
+  const useDependencyKeys = (
+    dependencies: readonly ModuleDependency[],
+  ): Set<string> =>
+    new Set(
+      dependencies
+        .filter((dependency) => dependency.kind === "use")
+        .map((dependency) => modulePathToString(dependency.path)),
+    );
 
   const addDocDiagnostics = (diagnostics: readonly Diagnostic[]): void => {
     diagnostics.forEach((diagnostic) => {
@@ -196,6 +206,7 @@ export const buildModuleGraph = async ({
       modules.delete(descendant.id);
       modulesByPath.delete(modulePathToString(descendant.path));
       noPreludeByModule.delete(descendant.id);
+      collectedUseDependencies.delete(descendant.id);
       updateNestedPrefixCounts({
         counts: moduleNestedPrefixCounts,
         pathKey: modulePathToString(descendant.path),
@@ -248,6 +259,10 @@ export const buildModuleGraph = async ({
 
   addModuleTree(entryModule, modules, modulesByPath, (module) => {
     noPreludeByModule.set(module.id, entryModule.noPrelude);
+    collectedUseDependencies.set(
+      module.id,
+      useDependencyKeys(module.dependencies),
+    );
     updateNestedPrefixCounts({
       counts: moduleNestedPrefixCounts,
       pathKey: modulePathToString(module.path),
@@ -282,7 +297,7 @@ export const buildModuleGraph = async ({
   };
 
   const macroExpander = createModuleMacroExpander();
-  const macroDiagnostics: Diagnostic[] = [];
+  const macroDiagnosticsByModule = new Map<string, Diagnostic[]>();
   let pendingIndex = 0;
   while (true) {
     if (pendingIndex >= pending.length) {
@@ -291,7 +306,9 @@ export const buildModuleGraph = async ({
         modules,
         diagnostics: [],
       });
-      macroDiagnostics.push(...expansion.diagnostics);
+      expansion.diagnosticsByModule.forEach((diagnostics, moduleId) =>
+        macroDiagnosticsByModule.set(moduleId, diagnostics),
+      );
       if (!expansion.expandedModuleIds.length) {
         break;
       }
@@ -308,6 +325,15 @@ export const buildModuleGraph = async ({
           hasStdPreludeModule,
           noPrelude: noPreludeByModule.get(module.id) ?? false,
         });
+        const previousUseDependencies =
+          collectedUseDependencies.get(module.id) ?? new Set<string>();
+        const refreshedUseDependencies = useDependencyKeys(
+          refreshed.dependencies,
+        );
+        const introducedUseDependency = Array.from(
+          refreshedUseDependencies,
+        ).some((dependency) => !previousUseDependencies.has(dependency));
+        collectedUseDependencies.set(module.id, refreshedUseDependencies);
         addDocDiagnostics(
           refreshed.diagnostics.filter(
             (diagnostic) => diagnostic.code === "MD0005",
@@ -320,6 +346,9 @@ export const buildModuleGraph = async ({
           ...refreshed.dependencies,
           ...discoveredSubmodules,
         ];
+        if (introducedUseDependency) {
+          macroExpander.invalidate(module.id);
+        }
 
         refreshed.inlineModules.forEach((inlineModule) => {
           const existing = modules.get(inlineModule.id);
@@ -336,6 +365,7 @@ export const buildModuleGraph = async ({
         newInlineModules.forEach((inlineModule) => {
           const existing = modules.get(inlineModule.id);
           if (existing?.origin.kind === "file") {
+            macroExpander.reset(existing.id);
             (existing.sourceFiles ?? [
               { filePath: existing.origin.filePath, source: existing.source },
             ]).forEach(({ filePath }) => shadowedModuleFiles.add(filePath));
@@ -348,6 +378,10 @@ export const buildModuleGraph = async ({
           noPreludeByModule.set(
             inlineModule.id,
             noPreludeByModule.get(module.id) ?? false,
+          );
+          collectedUseDependencies.set(
+            inlineModule.id,
+            useDependencyKeys(inlineModule.dependencies),
           );
           if (!existing) {
             updateNestedPrefixCounts({
@@ -497,6 +531,10 @@ export const buildModuleGraph = async ({
     }
     addModuleTree(nextModule, modules, modulesByPath, (module) => {
       noPreludeByModule.set(module.id, nextModule.noPrelude);
+      collectedUseDependencies.set(
+        module.id,
+        useDependencyKeys(module.dependencies),
+      );
       updateNestedPrefixCounts({
         counts: moduleNestedPrefixCounts,
         pathKey: modulePathToString(module.path),
@@ -542,6 +580,7 @@ export const buildModuleGraph = async ({
       modules.delete(moduleId);
       modulesByPath.delete(modulePathToString(module.path));
       noPreludeByModule.delete(moduleId);
+      collectedUseDependencies.delete(moduleId);
       updateNestedPrefixCounts({
         counts: moduleNestedPrefixCounts,
         pathKey: modulePathToString(module.path),
@@ -566,6 +605,9 @@ export const buildModuleGraph = async ({
   const baseDiagnostics = unresolvedModuleDiagnostics.map(
     moduleDiagnosticToDiagnostic,
   );
+  const macroDiagnostics = Array.from(
+    macroDiagnosticsByModule.values(),
+  ).flat();
   return {
     entry: entryModule.node.id,
     modules,

--- a/packages/compiler/src/modules/graph.ts
+++ b/packages/compiler/src/modules/graph.ts
@@ -169,6 +169,8 @@ export const buildModuleGraph = async ({
   const noPreludeByModule = new Map<string, boolean>();
   const shadowedModuleFiles = new Set<string>();
   const collectedUseDependencies = new Map<string, Set<string>>();
+  const macroExpander = createModuleMacroExpander();
+  const macroDiagnosticsByModule = new Map<string, Diagnostic[]>();
 
   const useDependencyKeys = (
     dependencies: readonly ModuleDependency[],
@@ -196,21 +198,55 @@ export const buildModuleGraph = async ({
     });
   };
 
-  const removeInlineDescendants = (parentId: string): void => {
-    const descendants = Array.from(modules.values()).filter(
+  const inlineChildrenFor = (parentId: string): ModuleNode[] =>
+    Array.from(modules.values()).filter(
       (module) =>
         module.origin.kind === "inline" && module.origin.parentId === parentId,
     );
-    descendants.forEach((descendant) => {
-      removeInlineDescendants(descendant.id);
-      modules.delete(descendant.id);
-      modulesByPath.delete(modulePathToString(descendant.path));
-      noPreludeByModule.delete(descendant.id);
-      collectedUseDependencies.delete(descendant.id);
-      updateNestedPrefixCounts({
-        counts: moduleNestedPrefixCounts,
-        pathKey: modulePathToString(descendant.path),
-        delta: -1,
+
+  const removeInlineModuleTree = (moduleId: string): void => {
+    const module = modules.get(moduleId);
+    if (!module || module.origin.kind !== "inline") {
+      return;
+    }
+
+    inlineChildrenFor(moduleId).forEach((child) =>
+      removeInlineModuleTree(child.id),
+    );
+    macroExpander.reset(moduleId);
+    macroDiagnosticsByModule.delete(moduleId);
+    missingModules.delete(moduleId);
+    modules.delete(moduleId);
+    modulesByPath.delete(modulePathToString(module.path));
+    noPreludeByModule.delete(moduleId);
+    collectedUseDependencies.delete(moduleId);
+    updateNestedPrefixCounts({
+      counts: moduleNestedPrefixCounts,
+      pathKey: modulePathToString(module.path),
+      delta: -1,
+    });
+  };
+
+  const removeInlineDescendants = (parentId: string): void =>
+    inlineChildrenFor(parentId).forEach((child) =>
+      removeInlineModuleTree(child.id),
+    );
+
+  const removeMissingInlineDescendants = ({
+    parentId,
+    retainedModuleIds,
+  }: {
+    parentId: string;
+    retainedModuleIds: ReadonlySet<string>;
+  }): void => {
+    inlineChildrenFor(parentId).forEach((child) => {
+      if (!retainedModuleIds.has(child.id)) {
+        removeInlineModuleTree(child.id);
+        return;
+      }
+      removeMissingInlineDescendants({
+        parentId: child.id,
+        retainedModuleIds,
       });
     });
   };
@@ -296,8 +332,6 @@ export const buildModuleGraph = async ({
     return hasNested;
   };
 
-  const macroExpander = createModuleMacroExpander();
-  const macroDiagnosticsByModule = new Map<string, Diagnostic[]>();
   let pendingIndex = 0;
   while (true) {
     if (pendingIndex >= pending.length) {
@@ -350,6 +384,12 @@ export const buildModuleGraph = async ({
           macroExpander.invalidate(module.id);
         }
 
+        removeMissingInlineDescendants({
+          parentId: module.id,
+          retainedModuleIds: new Set(
+            refreshed.inlineModules.map((inlineModule) => inlineModule.id),
+          ),
+        });
         refreshed.inlineModules.forEach((inlineModule) => {
           const existing = modules.get(inlineModule.id);
           if (existing?.origin.kind === "file") {

--- a/packages/compiler/src/modules/graph.ts
+++ b/packages/compiler/src/modules/graph.ts
@@ -168,7 +168,7 @@ export const buildModuleGraph = async ({
   const pendingNestedPrefixCounts = new Map<string, number>();
   const noPreludeByModule = new Map<string, boolean>();
   const inactiveModuleFiles = new Set<string>();
-  const collectedUseEntries = new Map<string, Set<string>>();
+  const collectedMacroScopeKeys = new Map<string, Set<string>>();
   const inlineModuleAstKeys = new Map<string, string>();
   const macroExpander = createModuleMacroExpander();
   const macroDiagnosticsByModule = new Map<string, Diagnostic[]>();
@@ -176,14 +176,17 @@ export const buildModuleGraph = async ({
   const isReplaceableSurfaceDiagnostic = (diagnostic: Diagnostic): boolean =>
     diagnostic.code === "MD0005";
 
-  const useEntryKeys = (module: ModuleNode): Set<string> => {
+  const macroScopeKeys = (module: ModuleNode): Set<string> => {
     const items =
       module.surface?.items ??
       module.header?.items ??
       createModuleHeaderView(module.ast).items;
     return new Set(
-      items.flatMap((item) =>
-        item.kind === "use"
+      items.flatMap((item) => {
+        if (item.kind === "inline-module") {
+          return [`inline-module:${item.declaration.name}`];
+        }
+        return item.kind === "use"
           ? item.entries.map((entry) =>
               JSON.stringify([
                 item.visibility,
@@ -197,8 +200,8 @@ export const buildModuleGraph = async ({
                 entry.hasExplicitPrefix,
               ]),
             )
-          : [],
-      ),
+          : [];
+      }),
     );
   };
 
@@ -250,7 +253,7 @@ export const buildModuleGraph = async ({
     modules.delete(moduleId);
     modulesByPath.delete(modulePathToString(module.path));
     noPreludeByModule.delete(moduleId);
-    collectedUseEntries.delete(moduleId);
+    collectedMacroScopeKeys.delete(moduleId);
     inlineModuleAstKeys.delete(moduleId);
     updateNestedPrefixCounts({
       counts: moduleNestedPrefixCounts,
@@ -327,7 +330,7 @@ export const buildModuleGraph = async ({
 
   addModuleTree(entryModule, modules, modulesByPath, (module) => {
     noPreludeByModule.set(module.id, entryModule.noPrelude);
-    collectedUseEntries.set(module.id, useEntryKeys(module));
+    collectedMacroScopeKeys.set(module.id, macroScopeKeys(module));
     if (module.origin.kind === "inline") {
       inlineModuleAstKeys.set(module.id, moduleAstKey(module));
     }
@@ -402,14 +405,14 @@ export const buildModuleGraph = async ({
         if (modules.get(module.id) !== module) {
           return;
         }
-        const previousUseEntries =
-          collectedUseEntries.get(module.id) ?? new Set<string>();
-        const refreshedUseEntries = useEntryKeys(module);
-        const useEntriesChanged = !setsEqual(
-          previousUseEntries,
-          refreshedUseEntries,
+        const previousMacroScopeKeys =
+          collectedMacroScopeKeys.get(module.id) ?? new Set<string>();
+        const refreshedMacroScopeKeys = macroScopeKeys(module);
+        const macroScopeChanged = !setsEqual(
+          previousMacroScopeKeys,
+          refreshedMacroScopeKeys,
         );
-        collectedUseEntries.set(module.id, refreshedUseEntries);
+        collectedMacroScopeKeys.set(module.id, refreshedMacroScopeKeys);
         surfaceDiagnosticsByModule.set(
           module.id,
           refreshed.diagnostics.filter(isReplaceableSurfaceDiagnostic),
@@ -421,7 +424,7 @@ export const buildModuleGraph = async ({
           ...refreshed.dependencies,
           ...discoveredSubmodules,
         ];
-        if (useEntriesChanged) {
+        if (macroScopeChanged) {
           macroExpander.invalidate(module.id);
         }
 
@@ -470,7 +473,10 @@ export const buildModuleGraph = async ({
             inlineModule.id,
             noPreludeByModule.get(module.id) ?? false,
           );
-          collectedUseEntries.set(inlineModule.id, useEntryKeys(inlineModule));
+          collectedMacroScopeKeys.set(
+            inlineModule.id,
+            macroScopeKeys(inlineModule),
+          );
           inlineModuleAstKeys.set(inlineModule.id, moduleAstKey(inlineModule));
           if (!existing) {
             updateNestedPrefixCounts({
@@ -625,7 +631,7 @@ export const buildModuleGraph = async ({
     }
     addModuleTree(nextModule, modules, modulesByPath, (module) => {
       noPreludeByModule.set(module.id, nextModule.noPrelude);
-      collectedUseEntries.set(module.id, useEntryKeys(module));
+      collectedMacroScopeKeys.set(module.id, macroScopeKeys(module));
       if (module.origin.kind === "inline") {
         inlineModuleAstKeys.set(module.id, moduleAstKey(module));
       }
@@ -678,7 +684,7 @@ export const buildModuleGraph = async ({
     modules.delete(moduleId);
     modulesByPath.delete(modulePathToString(module.path));
     noPreludeByModule.delete(moduleId);
-    collectedUseEntries.delete(moduleId);
+    collectedMacroScopeKeys.delete(moduleId);
     inlineModuleAstKeys.delete(moduleId);
     updateNestedPrefixCounts({
       counts: moduleNestedPrefixCounts,

--- a/packages/compiler/src/modules/graph.ts
+++ b/packages/compiler/src/modules/graph.ts
@@ -172,6 +172,9 @@ export const buildModuleGraph = async ({
   const inlineModuleAstKeys = new Map<string, string>();
   const macroExpander = createModuleMacroExpander();
   const macroDiagnosticsByModule = new Map<string, Diagnostic[]>();
+  const surfaceDiagnosticsByModule = new Map<string, Diagnostic[]>();
+  const isReplaceableSurfaceDiagnostic = (diagnostic: Diagnostic): boolean =>
+    diagnostic.code === "MD0005";
 
   const useEntryKeys = (module: ModuleNode): Set<string> => {
     const items =
@@ -207,6 +210,9 @@ export const buildModuleGraph = async ({
 
   const addDocDiagnostics = (diagnostics: readonly Diagnostic[]): void => {
     diagnostics.forEach((diagnostic) => {
+      if (isReplaceableSurfaceDiagnostic(diagnostic)) {
+        return;
+      }
       const key = [
         diagnostic.code,
         diagnostic.message,
@@ -239,6 +245,7 @@ export const buildModuleGraph = async ({
     );
     macroExpander.reset(moduleId);
     macroDiagnosticsByModule.delete(moduleId);
+    surfaceDiagnosticsByModule.delete(moduleId);
     missingModules.delete(moduleId);
     modules.delete(moduleId);
     modulesByPath.delete(modulePathToString(module.path));
@@ -403,10 +410,9 @@ export const buildModuleGraph = async ({
           refreshedUseEntries,
         );
         collectedUseEntries.set(module.id, refreshedUseEntries);
-        addDocDiagnostics(
-          refreshed.diagnostics.filter(
-            (diagnostic) => diagnostic.code === "MD0005",
-          ),
+        surfaceDiagnosticsByModule.set(
+          module.id,
+          refreshed.diagnostics.filter(isReplaceableSurfaceDiagnostic),
         );
         const discoveredSubmodules = module.dependencies.filter(
           (dependency) => dependency.kind === "export",
@@ -447,6 +453,7 @@ export const buildModuleGraph = async ({
           if (existing) {
             macroExpander.reset(existing.id);
             macroDiagnosticsByModule.delete(existing.id);
+            surfaceDiagnosticsByModule.delete(existing.id);
             missingModules.delete(existing.id);
           }
           if (existing?.origin.kind === "file") {
@@ -666,6 +673,7 @@ export const buildModuleGraph = async ({
     );
     macroExpander.reset(moduleId);
     macroDiagnosticsByModule.delete(moduleId);
+    surfaceDiagnosticsByModule.delete(moduleId);
     missingModules.delete(moduleId);
     modules.delete(moduleId);
     modulesByPath.delete(modulePathToString(module.path));
@@ -715,12 +723,18 @@ export const buildModuleGraph = async ({
   const macroDiagnostics = Array.from(
     macroDiagnosticsByModule.values(),
   ).flat();
+  const surfaceDiagnostics = Array.from(
+    surfaceDiagnosticsByModule.values(),
+  ).flat();
   return {
     entry: entryModule.node.id,
     modules,
     diagnostics: [
       ...baseDiagnostics,
       ...docDiagnostics.filter(
+        (diagnostic) => !inactiveModuleFiles.has(diagnostic.span.file),
+      ),
+      ...surfaceDiagnostics.filter(
         (diagnostic) => !inactiveModuleFiles.has(diagnostic.span.file),
       ),
       ...macroDiagnostics.filter(

--- a/packages/compiler/src/modules/graph.ts
+++ b/packages/compiler/src/modules/graph.ts
@@ -32,7 +32,7 @@ import type {
   ModulePath,
   ModuleRoots,
 } from "./types.js";
-import { expandModuleMacros } from "./macro-expansion.js";
+import { createModuleMacroExpander } from "./macro-expansion.js";
 import type { SourceSpan } from "../semantics/ids.js";
 import {
   incrementCompilerPerfCounter,
@@ -99,6 +99,59 @@ const updateNestedPrefixCounts = ({
   }
 };
 
+const hasAvailableModulePath = ({
+  path,
+  modulesByPath,
+  moduleNestedPrefixCounts,
+}: {
+  path: ModulePath;
+  modulesByPath: ReadonlyMap<string, ModuleNode>;
+  moduleNestedPrefixCounts: ReadonlyMap<string, number>;
+}): boolean => {
+  const pathKey = modulePathToString(path);
+  return (
+    modulesByPath.has(pathKey) ||
+    (moduleNestedPrefixCounts.get(pathKey) ?? 0) > 0
+  );
+};
+
+const reachableModuleIds = ({
+  entry,
+  modules,
+}: {
+  entry: string;
+  modules: ReadonlyMap<string, ModuleNode>;
+}): Set<string> => {
+  const inlineChildren = new Map<string, string[]>();
+  modules.forEach((module) => {
+    if (module.origin.kind !== "inline") {
+      return;
+    }
+    const children = inlineChildren.get(module.origin.parentId) ?? [];
+    children.push(module.id);
+    inlineChildren.set(module.origin.parentId, children);
+  });
+
+  const reachable = new Set<string>();
+  const visit = (moduleId: string): void => {
+    if (reachable.has(moduleId)) {
+      return;
+    }
+    const module = modules.get(moduleId);
+    if (!module) {
+      return;
+    }
+    reachable.add(moduleId);
+    module.dependencies.forEach((dependency) =>
+      visit(modulePathToString(dependency.path)),
+    );
+    inlineChildren.get(moduleId)?.forEach(visit);
+  };
+
+  visit(entry);
+  return reachable;
+};
+
 export const buildModuleGraph = async ({
   entryPath,
   host,
@@ -109,9 +162,47 @@ export const buildModuleGraph = async ({
   const modulesByPath = new Map<string, ModuleNode>();
   const moduleDiagnostics: ModuleDiagnostic[] = [];
   const docDiagnostics: Diagnostic[] = [];
+  const docDiagnosticKeys = new Set<string>();
   const missingModules = new Map<string, Set<string>>();
   const moduleNestedPrefixCounts = new Map<string, number>();
   const pendingNestedPrefixCounts = new Map<string, number>();
+  const noPreludeByModule = new Map<string, boolean>();
+  const shadowedModuleFiles = new Set<string>();
+
+  const addDocDiagnostics = (diagnostics: readonly Diagnostic[]): void => {
+    diagnostics.forEach((diagnostic) => {
+      const key = [
+        diagnostic.code,
+        diagnostic.message,
+        diagnostic.span.file,
+        diagnostic.span.start,
+        diagnostic.span.end,
+      ].join(":");
+      if (docDiagnosticKeys.has(key)) {
+        return;
+      }
+      docDiagnosticKeys.add(key);
+      docDiagnostics.push(diagnostic);
+    });
+  };
+
+  const removeInlineDescendants = (parentId: string): void => {
+    const descendants = Array.from(modules.values()).filter(
+      (module) =>
+        module.origin.kind === "inline" && module.origin.parentId === parentId,
+    );
+    descendants.forEach((descendant) => {
+      removeInlineDescendants(descendant.id);
+      modules.delete(descendant.id);
+      modulesByPath.delete(modulePathToString(descendant.path));
+      noPreludeByModule.delete(descendant.id);
+      updateNestedPrefixCounts({
+        counts: moduleNestedPrefixCounts,
+        pathKey: modulePathToString(descendant.path),
+        delta: -1,
+      });
+    });
+  };
 
   const hasMissingModule = (importer: string, pathKey: string): boolean =>
     missingModules.get(importer)?.has(pathKey) ?? false;
@@ -155,14 +246,15 @@ export const buildModuleGraph = async ({
     hasStdPreludeModule,
   });
 
-  addModuleTree(entryModule, modules, modulesByPath, (module) =>
+  addModuleTree(entryModule, modules, modulesByPath, (module) => {
+    noPreludeByModule.set(module.id, entryModule.noPrelude);
     updateNestedPrefixCounts({
       counts: moduleNestedPrefixCounts,
       pathKey: modulePathToString(module.path),
       delta: 1,
-    }),
-  );
-  docDiagnostics.push(...entryModule.diagnostics);
+    });
+  });
+  addDocDiagnostics(entryModule.diagnostics);
 
   const pending: PendingDependency[] = [];
   enqueueDependencies(entryModule, pending, (queued) => {
@@ -189,8 +281,104 @@ export const buildModuleGraph = async ({
     return hasNested;
   };
 
+  const macroExpander = createModuleMacroExpander();
+  const macroDiagnostics: Diagnostic[] = [];
   let pendingIndex = 0;
-  while (pendingIndex < pending.length) {
+  while (true) {
+    if (pendingIndex >= pending.length) {
+      const expansion = macroExpander.expand({
+        entry: entryModule.node.id,
+        modules,
+        diagnostics: [],
+      });
+      macroDiagnostics.push(...expansion.diagnostics);
+      if (!expansion.expandedModuleIds.length) {
+        break;
+      }
+
+      expansion.expandedModuleIds.forEach((moduleId) => {
+        const module = modules.get(moduleId);
+        if (!module) {
+          return;
+        }
+
+        const refreshed = collectExpandedModuleInfo({
+          module,
+          host,
+          hasStdPreludeModule,
+          noPrelude: noPreludeByModule.get(module.id) ?? false,
+        });
+        addDocDiagnostics(
+          refreshed.diagnostics.filter(
+            (diagnostic) => diagnostic.code === "MD0005",
+          ),
+        );
+        const discoveredSubmodules = module.dependencies.filter(
+          (dependency) => dependency.kind === "export",
+        );
+        module.dependencies = [
+          ...refreshed.dependencies,
+          ...discoveredSubmodules,
+        ];
+
+        refreshed.inlineModules.forEach((inlineModule) => {
+          const existing = modules.get(inlineModule.id);
+          if (existing?.origin.kind === "file") {
+            removeInlineDescendants(existing.id);
+          }
+        });
+        const newInlineModules = refreshed.inlineModules.filter(
+          (inlineModule) => {
+            const existing = modules.get(inlineModule.id);
+            return !existing || existing.origin.kind === "file";
+          },
+        );
+        newInlineModules.forEach((inlineModule) => {
+          const existing = modules.get(inlineModule.id);
+          if (existing?.origin.kind === "file") {
+            (existing.sourceFiles ?? [
+              { filePath: existing.origin.filePath, source: existing.source },
+            ]).forEach(({ filePath }) => shadowedModuleFiles.add(filePath));
+          }
+          modules.set(inlineModule.id, inlineModule);
+          modulesByPath.set(
+            modulePathToString(inlineModule.path),
+            inlineModule,
+          );
+          noPreludeByModule.set(
+            inlineModule.id,
+            noPreludeByModule.get(module.id) ?? false,
+          );
+          if (!existing) {
+            updateNestedPrefixCounts({
+              counts: moduleNestedPrefixCounts,
+              pathKey: modulePathToString(inlineModule.path),
+              delta: 1,
+            });
+          }
+        });
+
+        enqueueDependencies(
+          {
+            node: module,
+            inlineModules: newInlineModules,
+          },
+          pending,
+          (queued) => {
+            if (COMPILER_PERF_ENABLED) {
+              incrementCompilerPerfCounter("graph.pending.enqueued");
+            }
+            updateNestedPrefixCounts({
+              counts: pendingNestedPrefixCounts,
+              pathKey: modulePathToString(queued.dependency.path),
+              delta: 1,
+            });
+          },
+        );
+      });
+      continue;
+    }
+
     const nextPending = pending[pendingIndex];
     pendingIndex += 1;
     if (!nextPending) {
@@ -210,10 +398,10 @@ export const buildModuleGraph = async ({
     const importerLabel = importerFilePath ?? importerId;
     const requestedPath = dependency.path;
     const requestedKey = modulePathToString(requestedPath);
-    if (hasMissingModule(importerId, requestedKey)) {
+    if (modulesByPath.has(requestedKey)) {
       continue;
     }
-    if (modulesByPath.has(requestedKey)) {
+    if (hasMissingModule(importerId, requestedKey)) {
       continue;
     }
 
@@ -307,14 +495,15 @@ export const buildModuleGraph = async ({
       addMissingModule(importerId, requestedKey);
       continue;
     }
-    addModuleTree(nextModule, modules, modulesByPath, (module) =>
+    addModuleTree(nextModule, modules, modulesByPath, (module) => {
+      noPreludeByModule.set(module.id, nextModule.noPrelude);
       updateNestedPrefixCounts({
         counts: moduleNestedPrefixCounts,
         pathKey: modulePathToString(module.path),
         delta: 1,
-      }),
-    );
-    docDiagnostics.push(...nextModule.diagnostics);
+      });
+    });
+    addDocDiagnostics(nextModule.diagnostics);
     enqueueDependencies(nextModule, pending, (queued) => {
       if (COMPILER_PERF_ENABLED) {
         incrementCompilerPerfCounter("graph.pending.enqueued");
@@ -338,16 +527,57 @@ export const buildModuleGraph = async ({
     }
   }
 
-  const baseDiagnostics = moduleDiagnostics.map(moduleDiagnosticToDiagnostic);
-  const graph = {
+  if (shadowedModuleFiles.size) {
+    const reachable = reachableModuleIds({
+      entry: entryModule.node.id,
+      modules,
+    });
+    modules.forEach((module, moduleId) => {
+      if (reachable.has(moduleId)) {
+        return;
+      }
+      module.sourceFiles?.forEach(({ filePath }) =>
+        shadowedModuleFiles.add(filePath),
+      );
+      modules.delete(moduleId);
+      modulesByPath.delete(modulePathToString(module.path));
+      noPreludeByModule.delete(moduleId);
+      updateNestedPrefixCounts({
+        counts: moduleNestedPrefixCounts,
+        pathKey: modulePathToString(module.path),
+        delta: -1,
+      });
+    });
+  }
+
+  const unresolvedModuleDiagnostics = moduleDiagnostics.filter(
+    (diagnostic) =>
+      !(
+        diagnostic.importerFilePath &&
+        shadowedModuleFiles.has(diagnostic.importerFilePath)
+      ) &&
+      (diagnostic.kind !== "missing-module" ||
+        !hasAvailableModulePath({
+          path: diagnostic.requested,
+          modulesByPath,
+          moduleNestedPrefixCounts,
+        })),
+  );
+  const baseDiagnostics = unresolvedModuleDiagnostics.map(
+    moduleDiagnosticToDiagnostic,
+  );
+  return {
     entry: entryModule.node.id,
     modules,
-    diagnostics: [...baseDiagnostics, ...docDiagnostics],
-  };
-  const macroDiagnostics = expandModuleMacros(graph);
-  return {
-    ...graph,
-    diagnostics: [...baseDiagnostics, ...docDiagnostics, ...macroDiagnostics],
+    diagnostics: [
+      ...baseDiagnostics,
+      ...docDiagnostics.filter(
+        (diagnostic) => !shadowedModuleFiles.has(diagnostic.span.file),
+      ),
+      ...macroDiagnostics.filter(
+        (diagnostic) => !shadowedModuleFiles.has(diagnostic.span.file),
+      ),
+    ],
   };
 };
 
@@ -366,7 +596,7 @@ const addModuleTree = (
 };
 
 const enqueueDependencies = (
-  loaded: LoadedModule,
+  loaded: Pick<LoadedModule, "node" | "inlineModules">,
   queue: PendingDependency[],
   onQueued?: (queued: PendingDependency) => void,
 ) => {
@@ -377,6 +607,9 @@ const enqueueDependencies = (
       : module.origin.span?.file;
   modules.forEach((module) =>
     module.dependencies.forEach((dependency) => {
+      if (dependency.kind === "export" && !module.surface) {
+        return;
+      }
       const queued: PendingDependency = {
         dependency,
         importerId: module.id,
@@ -392,6 +625,7 @@ type LoadedModule = {
   node: ModuleNode;
   inlineModules: ModuleNode[];
   diagnostics: readonly Diagnostic[];
+  noPrelude: boolean;
 };
 
 const parseModuleAst = ({
@@ -573,6 +807,7 @@ const loadFileModule = async ({
     node,
     inlineModules: info.inlineModules,
     diagnostics: [...parseDiagnostics, ...info.diagnostics],
+    noPrelude,
   };
 };
 
@@ -739,6 +974,44 @@ const collectModuleInfo = ({
     docs: collectedDocs.documentation,
     diagnostics,
   };
+};
+
+const collectExpandedModuleInfo = ({
+  module,
+  host,
+  hasStdPreludeModule,
+  noPrelude,
+}: {
+  module: ModuleNode;
+  host: ModuleHost;
+  hasStdPreludeModule: boolean;
+  noPrelude: boolean;
+}): ModuleInfo => {
+  const sourceFiles = module.sourceFiles ?? [
+    {
+      filePath:
+        module.origin.kind === "file"
+          ? module.origin.filePath
+          : (module.origin.span?.file ?? module.id),
+      source: module.source,
+    },
+  ];
+  const sourceByFile = new Map(
+    sourceFiles.map(({ filePath, source }) => [filePath, source]),
+  );
+
+  return collectModuleInfo({
+    modulePath: module.path,
+    ast: module.ast,
+    sourceByFile,
+    sourcePackageRoot: module.sourcePackageRoot,
+    moduleIsPackageRoot:
+      module.origin.kind === "file" &&
+      host.path.basename(module.origin.filePath, VOYD_EXTENSION) === "pkg",
+    moduleRange: { start: 0, end: module.source.length },
+    hasStdPreludeModule,
+    noPrelude,
+  });
 };
 
 type InlineModuleTree = {

--- a/packages/compiler/src/modules/graph.ts
+++ b/packages/compiler/src/modules/graph.ts
@@ -167,7 +167,7 @@ export const buildModuleGraph = async ({
   const moduleNestedPrefixCounts = new Map<string, number>();
   const pendingNestedPrefixCounts = new Map<string, number>();
   const noPreludeByModule = new Map<string, boolean>();
-  const shadowedModuleFiles = new Set<string>();
+  const inactiveModuleFiles = new Set<string>();
   const collectedUseEntries = new Map<string, Set<string>>();
   const inlineModuleAstKeys = new Map<string, string>();
   const macroExpander = createModuleMacroExpander();
@@ -452,7 +452,7 @@ export const buildModuleGraph = async ({
           if (existing?.origin.kind === "file") {
             (existing.sourceFiles ?? [
               { filePath: existing.origin.filePath, source: existing.source },
-            ]).forEach(({ filePath }) => shadowedModuleFiles.add(filePath));
+            ]).forEach(({ filePath }) => inactiveModuleFiles.add(filePath));
           }
           modules.set(inlineModule.id, inlineModule);
           modulesByPath.set(
@@ -529,6 +529,7 @@ export const buildModuleGraph = async ({
         kind: "io-error",
         message: formatErrorMessage(error),
         requested: requestedPath,
+        importerId,
         importer: importerLabel,
         importerFilePath,
         span: dependency.span,
@@ -541,6 +542,7 @@ export const buildModuleGraph = async ({
       moduleDiagnostics.push({
         kind: "missing-module",
         requested: requestedPath,
+        importerId,
         importer: importerLabel,
         importerFilePath,
         span: dependency.span,
@@ -568,6 +570,7 @@ export const buildModuleGraph = async ({
         kind: "reserved-module-segment",
         segment: reservedSegment,
         requested: resolvedModulePath,
+        importerId,
         importer: importerLabel,
         importerFilePath,
         span: dependency.span ?? { file: resolvedPath, start: 0, end: 0 },
@@ -582,6 +585,7 @@ export const buildModuleGraph = async ({
       moduleDiagnostics.push({
         kind: "missing-module",
         requested: requestedPath,
+        importerId,
         importer: importerLabel,
         importerFilePath,
         span: dependency.span,
@@ -604,6 +608,7 @@ export const buildModuleGraph = async ({
         kind: "io-error",
         message: formatErrorMessage(error),
         requested: requestedPath,
+        importerId,
         importer: importerLabel,
         importerFilePath,
         span: dependency.span,
@@ -639,6 +644,7 @@ export const buildModuleGraph = async ({
       moduleDiagnostics.push({
         kind: "missing-module",
         requested: requestedPath,
+        importerId,
         importer: importerLabel,
         importerFilePath,
         span: dependency.span,
@@ -647,36 +653,54 @@ export const buildModuleGraph = async ({
     }
   }
 
-  if (shadowedModuleFiles.size) {
-    const reachable = reachableModuleIds({
-      entry: entryModule.node.id,
-      modules,
+  const reachable = reachableModuleIds({
+    entry: entryModule.node.id,
+    modules,
+  });
+  modules.forEach((module, moduleId) => {
+    if (reachable.has(moduleId)) {
+      return;
+    }
+    module.sourceFiles?.forEach(({ filePath }) =>
+      inactiveModuleFiles.add(filePath),
+    );
+    macroExpander.reset(moduleId);
+    macroDiagnosticsByModule.delete(moduleId);
+    missingModules.delete(moduleId);
+    modules.delete(moduleId);
+    modulesByPath.delete(modulePathToString(module.path));
+    noPreludeByModule.delete(moduleId);
+    collectedUseEntries.delete(moduleId);
+    inlineModuleAstKeys.delete(moduleId);
+    updateNestedPrefixCounts({
+      counts: moduleNestedPrefixCounts,
+      pathKey: modulePathToString(module.path),
+      delta: -1,
     });
-    modules.forEach((module, moduleId) => {
-      if (reachable.has(moduleId)) {
-        return;
-      }
-      module.sourceFiles?.forEach(({ filePath }) =>
-        shadowedModuleFiles.add(filePath),
-      );
-      modules.delete(moduleId);
-      modulesByPath.delete(modulePathToString(module.path));
-      noPreludeByModule.delete(moduleId);
-      collectedUseEntries.delete(moduleId);
-      inlineModuleAstKeys.delete(moduleId);
-      updateNestedPrefixCounts({
-        counts: moduleNestedPrefixCounts,
-        pathKey: modulePathToString(module.path),
-        delta: -1,
-      });
-    });
-  }
+  });
+
+  const diagnosticIsStillRequested = (
+    diagnostic: ModuleDiagnostic,
+  ): boolean => {
+    if (!diagnostic.importerId) {
+      return true;
+    }
+    const importer = modules.get(diagnostic.importerId);
+    if (!importer) {
+      return false;
+    }
+    const requestedId = modulePathToString(diagnostic.requested);
+    return importer.dependencies.some(
+      (dependency) => modulePathToString(dependency.path) === requestedId,
+    );
+  };
 
   const unresolvedModuleDiagnostics = moduleDiagnostics.filter(
     (diagnostic) =>
+      diagnosticIsStillRequested(diagnostic) &&
       !(
         diagnostic.importerFilePath &&
-        shadowedModuleFiles.has(diagnostic.importerFilePath)
+        inactiveModuleFiles.has(diagnostic.importerFilePath)
       ) &&
       (diagnostic.kind !== "missing-module" ||
         !hasAvailableModulePath({
@@ -697,10 +721,10 @@ export const buildModuleGraph = async ({
     diagnostics: [
       ...baseDiagnostics,
       ...docDiagnostics.filter(
-        (diagnostic) => !shadowedModuleFiles.has(diagnostic.span.file),
+        (diagnostic) => !inactiveModuleFiles.has(diagnostic.span.file),
       ),
       ...macroDiagnostics.filter(
-        (diagnostic) => !shadowedModuleFiles.has(diagnostic.span.file),
+        (diagnostic) => !inactiveModuleFiles.has(diagnostic.span.file),
       ),
     ],
   };

--- a/packages/compiler/src/modules/macro-expansion.ts
+++ b/packages/compiler/src/modules/macro-expansion.ts
@@ -40,9 +40,8 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
   const sourceAstByModule = new Map<string, Form>();
   const scopeUseEntriesByModule = new Map<
     string,
-    Map<string, UseEntryWithVisibility>
+    Map<string, MacroScopeUseEntry>
   >();
-  const scopeInlineModuleNamesByModule = new Map<string, Set<string>>();
   const invalidatedModules = new Map<string, number>();
   const processedInvalidationByModule = new Map<string, number>();
   let nextInvalidationGeneration = 0;
@@ -58,7 +57,6 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
       exportsByModule.delete(moduleId);
       sourceAstByModule.delete(moduleId);
       scopeUseEntriesByModule.delete(moduleId);
-      scopeInlineModuleNamesByModule.delete(moduleId);
     },
     expand: (graph) => {
       const diagnostics: Diagnostic[] = [];
@@ -88,20 +86,18 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
         // Keep that discovery monotonic, while the surface below remains the
         // replaceable output of only the latest expansion.
         const headerItems = requireModuleHeader(module).items;
+        const currentInlineModuleNames = collectInlineModuleNames(
+          module.surface?.items ?? headerItems,
+        );
         const scopeUseEntries = mergeScopeUseEntries({
           moduleId: id,
           entries: collectUseEntries(headerItems),
+          inlineModuleNames: currentInlineModuleNames,
           scopeUseEntriesByModule,
-        });
-        const scopeInlineModuleNames = mergeScopeInlineModuleNames({
-          moduleId: id,
-          names: collectInlineModuleNames(headerItems),
-          scopeInlineModuleNamesByModule,
         });
         const importedMacros = collectMacroImports({
           module,
           entries: scopeUseEntries,
-          inlineModuleNames: scopeInlineModuleNames,
           exportsByModule,
         });
         const scope = new MacroScope();
@@ -143,12 +139,8 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
         mergeScopeUseEntries({
           moduleId: id,
           entries: surfaceUseEntries,
+          inlineModuleNames: surfaceInlineModuleNames,
           scopeUseEntriesByModule,
-        });
-        mergeScopeInlineModuleNames({
-          moduleId: id,
-          names: surfaceInlineModuleNames,
-          scopeInlineModuleNamesByModule,
         });
         const localExports = indexExports(functionalResult.exports);
         const exportedMacros = collectMacroReexports({
@@ -196,6 +188,10 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
 type MacroExportTable = Map<string, MacroDefinition>;
 type UseEntryWithVisibility = NormalizedUseEntry & {
   visibility: "module" | "pub";
+};
+type MacroScopeUseEntry = {
+  entry: UseEntryWithVisibility;
+  inlineModuleNames: ReadonlySet<string>;
 };
 
 const haveSameMacroExportNames = (
@@ -316,18 +312,16 @@ const collectInlineModuleNames = (
 const collectMacroImports = ({
   module,
   entries,
-  inlineModuleNames,
   exportsByModule,
 }: {
   module: ModuleNode;
-  entries: UseEntryWithVisibility[];
-  inlineModuleNames: ReadonlySet<string>;
+  entries: MacroScopeUseEntry[];
   exportsByModule: Map<string, MacroExportTable>;
 }): Map<string, MacroDefinition> => {
   const imports = new Map<string, MacroDefinition>();
   const moduleIsPackageRoot =
     module.origin.kind === "file" && module.path.segments.at(-1) === "pkg";
-  entries.forEach((entry) => {
+  entries.forEach(({ entry, inlineModuleNames }) => {
     if (!entry.hasExplicitPrefix) {
       return;
     }
@@ -481,37 +475,22 @@ const collectUseEntries = (
 const mergeScopeUseEntries = ({
   moduleId,
   entries,
+  inlineModuleNames,
   scopeUseEntriesByModule,
 }: {
   moduleId: string;
   entries: readonly UseEntryWithVisibility[];
-  scopeUseEntriesByModule: Map<
-    string,
-    Map<string, UseEntryWithVisibility>
-  >;
-}): UseEntryWithVisibility[] => {
+  inlineModuleNames: ReadonlySet<string>;
+  scopeUseEntriesByModule: Map<string, Map<string, MacroScopeUseEntry>>;
+}): MacroScopeUseEntry[] => {
   const scopeEntries =
     scopeUseEntriesByModule.get(moduleId) ??
-    new Map<string, UseEntryWithVisibility>();
-  entries.forEach((entry) => scopeEntries.set(useEntryKey(entry), entry));
+    new Map<string, MacroScopeUseEntry>();
+  entries.forEach((entry) =>
+    scopeEntries.set(useEntryKey(entry), { entry, inlineModuleNames }),
+  );
   scopeUseEntriesByModule.set(moduleId, scopeEntries);
   return Array.from(scopeEntries.values());
-};
-
-const mergeScopeInlineModuleNames = ({
-  moduleId,
-  names,
-  scopeInlineModuleNamesByModule,
-}: {
-  moduleId: string;
-  names: ReadonlySet<string>;
-  scopeInlineModuleNamesByModule: Map<string, Set<string>>;
-}): ReadonlySet<string> => {
-  const scopeNames =
-    scopeInlineModuleNamesByModule.get(moduleId) ?? new Set<string>();
-  names.forEach((name) => scopeNames.add(name));
-  scopeInlineModuleNamesByModule.set(moduleId, scopeNames);
-  return scopeNames;
 };
 
 const useEntryKey = (entry: UseEntryWithVisibility): string =>

--- a/packages/compiler/src/modules/macro-expansion.ts
+++ b/packages/compiler/src/modules/macro-expansion.ts
@@ -34,13 +34,21 @@ export type ModuleMacroExpander = {
 
 export const createModuleMacroExpander = (): ModuleMacroExpander => {
   const exportsByModule = new Map<string, MacroExportTable>();
-  const invalidatedModules = new Set<string>();
+  const sourceAstByModule = new Map<string, Form>();
+  const invalidatedModules = new Map<string, number>();
+  const processedInvalidationByModule = new Map<string, number>();
+  let nextInvalidationGeneration = 0;
 
   return {
-    invalidate: (moduleId) => invalidatedModules.add(moduleId),
+    invalidate: (moduleId) => {
+      nextInvalidationGeneration += 1;
+      invalidatedModules.set(moduleId, nextInvalidationGeneration);
+    },
     reset: (moduleId) => {
       invalidatedModules.delete(moduleId);
+      processedInvalidationByModule.delete(moduleId);
       exportsByModule.delete(moduleId);
+      sourceAstByModule.delete(moduleId);
     },
     expand: (graph) => {
       const diagnostics: Diagnostic[] = [];
@@ -49,12 +57,22 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
 
       sortModules(graph).forEach((id) => {
         const module = graph.modules.get(id);
-        const isInvalidated = invalidatedModules.has(id);
+        const invalidationGeneration = invalidatedModules.get(id);
+        const isInvalidated = invalidationGeneration !== undefined;
         if (!module || (module.surface && !isInvalidated)) {
           return;
         }
         invalidatedModules.delete(id);
+        if (isInvalidated) {
+          processedInvalidationByModule.set(id, invalidationGeneration);
+        }
         const moduleDiagnostics: Diagnostic[] = [];
+        const sourceAst = sourceAstByModule.get(id);
+        if (sourceAst && isInvalidated) {
+          module.ast = sourceAst.clone();
+        } else if (!sourceAst) {
+          sourceAstByModule.set(id, module.ast.clone());
+        }
 
         const useEntries = collectUseEntries(module);
         const importedMacros = collectMacroImports({
@@ -95,13 +113,6 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
           );
         });
         const localExports = indexExports(functionalResult.exports);
-        if (isInvalidated) {
-          exportsByModule.get(id)?.forEach((macro, name) => {
-            if (!localExports.has(name)) {
-              localExports.set(name, macro);
-            }
-          });
-        }
         const exportedMacros = collectMacroReexports({
           module,
           entries: useEntries,
@@ -111,11 +122,26 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
         const previousExports = exportsByModule.get(id);
         module.macroExports = Array.from(exportedMacros.keys());
         exportsByModule.set(id, exportedMacros);
-        if (!haveSameMacroExportNames(previousExports, exportedMacros)) {
+        const exportNamesChanged = !haveSameMacroExportNames(
+          previousExports,
+          exportedMacros,
+        );
+        const rebuiltExportDefinitions =
+          isInvalidated &&
+          ((previousExports?.size ?? 0) > 0 || exportedMacros.size > 0);
+        const propagationGeneration = rebuiltExportDefinitions
+          ? invalidationGeneration
+          : exportNamesChanged
+            ? ++nextInvalidationGeneration
+            : undefined;
+        if (propagationGeneration !== undefined) {
+          processedInvalidationByModule.set(id, propagationGeneration);
           invalidateMacroImporters({
             graph,
             exportedModuleId: id,
             invalidatedModules,
+            processedInvalidationByModule,
+            invalidationGeneration: propagationGeneration,
           });
         }
         diagnostics.push(...moduleDiagnostics);
@@ -144,10 +170,14 @@ const invalidateMacroImporters = ({
   graph,
   exportedModuleId,
   invalidatedModules,
+  processedInvalidationByModule,
+  invalidationGeneration,
 }: {
   graph: ModuleGraph;
   exportedModuleId: string;
-  invalidatedModules: Set<string>;
+  invalidatedModules: Map<string, number>;
+  processedInvalidationByModule: Map<string, number>;
+  invalidationGeneration: number;
 }): void => {
   graph.modules.forEach((module) => {
     if (!module.surface) {
@@ -159,8 +189,16 @@ const invalidateMacroImporters = ({
         dependency.kind === "use" &&
         modulePathToString(dependency.path) === exportedModuleId,
     );
-    if (importsChangedModule) {
-      invalidatedModules.add(module.id);
+    const alreadyProcessed =
+      (processedInvalidationByModule.get(module.id) ?? -1) >=
+      invalidationGeneration;
+    if (!importsChangedModule || alreadyProcessed) {
+      return;
+    }
+
+    const pendingGeneration = invalidatedModules.get(module.id) ?? -1;
+    if (pendingGeneration < invalidationGeneration) {
+      invalidatedModules.set(module.id, invalidationGeneration);
     }
   });
 };
@@ -227,8 +265,9 @@ const indexExports = (exports: MacroDefinition[]): MacroExportTable => {
 };
 
 const inlineModuleNamesFor = (module: ModuleNode): Set<string> => {
+  const items = module.surface?.items ?? requireModuleHeader(module).items;
   return new Set(
-    requireModuleHeader(module).items.flatMap((item) =>
+    items.flatMap((item) =>
       item.kind === "inline-module" ? [item.declaration.name] : [],
     ),
   );

--- a/packages/compiler/src/modules/macro-expansion.ts
+++ b/packages/compiler/src/modules/macro-expansion.ts
@@ -16,7 +16,10 @@ import {
   serializerAttributeMacro,
   stripSerializerAttributeForms,
 } from "../parser/syntax-macros/serializer-attribute.js";
-import { createSurfaceModuleView } from "../parser/surface/index.js";
+import {
+  createSurfaceModuleView,
+  type SurfaceModuleItem,
+} from "../parser/surface/index.js";
 import { requireModuleHeader } from "./views.js";
 
 export const expandModuleMacros = (graph: ModuleGraph): Diagnostic[] =>
@@ -35,6 +38,11 @@ export type ModuleMacroExpander = {
 export const createModuleMacroExpander = (): ModuleMacroExpander => {
   const exportsByModule = new Map<string, MacroExportTable>();
   const sourceAstByModule = new Map<string, Form>();
+  const scopeUseEntriesByModule = new Map<
+    string,
+    Map<string, UseEntryWithVisibility>
+  >();
+  const scopeInlineModuleNamesByModule = new Map<string, Set<string>>();
   const invalidatedModules = new Map<string, number>();
   const processedInvalidationByModule = new Map<string, number>();
   let nextInvalidationGeneration = 0;
@@ -49,6 +57,8 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
       processedInvalidationByModule.delete(moduleId);
       exportsByModule.delete(moduleId);
       sourceAstByModule.delete(moduleId);
+      scopeUseEntriesByModule.delete(moduleId);
+      scopeInlineModuleNamesByModule.delete(moduleId);
     },
     expand: (graph) => {
       const diagnostics: Diagnostic[] = [];
@@ -74,10 +84,24 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
           sourceAstByModule.set(id, module.ast.clone());
         }
 
-        const useEntries = collectUseEntries(module);
+        // Imports exposed by expansion are discovery inputs on later passes.
+        // Keep that discovery monotonic, while the surface below remains the
+        // replaceable output of only the latest expansion.
+        const headerItems = requireModuleHeader(module).items;
+        const scopeUseEntries = mergeScopeUseEntries({
+          moduleId: id,
+          entries: collectUseEntries(headerItems),
+          scopeUseEntriesByModule,
+        });
+        const scopeInlineModuleNames = mergeScopeInlineModuleNames({
+          moduleId: id,
+          names: collectInlineModuleNames(headerItems),
+          scopeInlineModuleNamesByModule,
+        });
         const importedMacros = collectMacroImports({
           module,
-          entries: useEntries,
+          entries: scopeUseEntries,
+          inlineModuleNames: scopeInlineModuleNames,
           exportsByModule,
         });
         const scope = new MacroScope();
@@ -112,10 +136,25 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
             }),
           );
         });
+        const surfaceUseEntries = collectUseEntries(module.surface.items);
+        const surfaceInlineModuleNames = collectInlineModuleNames(
+          module.surface.items,
+        );
+        mergeScopeUseEntries({
+          moduleId: id,
+          entries: surfaceUseEntries,
+          scopeUseEntriesByModule,
+        });
+        mergeScopeInlineModuleNames({
+          moduleId: id,
+          names: surfaceInlineModuleNames,
+          scopeInlineModuleNamesByModule,
+        });
         const localExports = indexExports(functionalResult.exports);
         const exportedMacros = collectMacroReexports({
           module,
-          entries: useEntries,
+          entries: surfaceUseEntries,
+          inlineModuleNames: surfaceInlineModuleNames,
           exportsByModule,
           localExports,
         });
@@ -264,8 +303,9 @@ const indexExports = (exports: MacroDefinition[]): MacroExportTable => {
   return table;
 };
 
-const inlineModuleNamesFor = (module: ModuleNode): Set<string> => {
-  const items = module.surface?.items ?? requireModuleHeader(module).items;
+const collectInlineModuleNames = (
+  items: readonly SurfaceModuleItem[],
+): Set<string> => {
   return new Set(
     items.flatMap((item) =>
       item.kind === "inline-module" ? [item.declaration.name] : [],
@@ -276,16 +316,17 @@ const inlineModuleNamesFor = (module: ModuleNode): Set<string> => {
 const collectMacroImports = ({
   module,
   entries,
+  inlineModuleNames,
   exportsByModule,
 }: {
   module: ModuleNode;
   entries: UseEntryWithVisibility[];
+  inlineModuleNames: ReadonlySet<string>;
   exportsByModule: Map<string, MacroExportTable>;
 }): Map<string, MacroDefinition> => {
   const imports = new Map<string, MacroDefinition>();
   const moduleIsPackageRoot =
     module.origin.kind === "file" && module.path.segments.at(-1) === "pkg";
-  const inlineModuleNames = inlineModuleNamesFor(module);
   entries.forEach((entry) => {
     if (!entry.hasExplicitPrefix) {
       return;
@@ -345,19 +386,19 @@ const collectMacroImports = ({
 const collectMacroReexports = ({
   module,
   entries,
+  inlineModuleNames,
   exportsByModule,
   localExports,
 }: {
   module: ModuleNode;
   entries: UseEntryWithVisibility[];
+  inlineModuleNames: ReadonlySet<string>;
   exportsByModule: Map<string, MacroExportTable>;
   localExports: MacroExportTable;
 }): MacroExportTable => {
   const exports = new Map(localExports);
   const moduleIsPackageRoot =
     module.origin.kind === "file" && module.path.segments.at(-1) === "pkg";
-  const inlineModuleNames = inlineModuleNamesFor(module);
-
   entries
     .filter((entry) => entry.visibility === "pub")
     .forEach((entry) => {
@@ -424,8 +465,9 @@ const collectMacroReexports = ({
   return exports;
 };
 
-const collectUseEntries = (module: ModuleNode): UseEntryWithVisibility[] => {
-  const items = module.surface?.items ?? requireModuleHeader(module).items;
+const collectUseEntries = (
+  items: readonly SurfaceModuleItem[],
+): UseEntryWithVisibility[] => {
   return items.flatMap((item) =>
     item.kind === "use"
       ? item.entries.map((entry) => ({
@@ -435,6 +477,55 @@ const collectUseEntries = (module: ModuleNode): UseEntryWithVisibility[] => {
       : [],
   );
 };
+
+const mergeScopeUseEntries = ({
+  moduleId,
+  entries,
+  scopeUseEntriesByModule,
+}: {
+  moduleId: string;
+  entries: readonly UseEntryWithVisibility[];
+  scopeUseEntriesByModule: Map<
+    string,
+    Map<string, UseEntryWithVisibility>
+  >;
+}): UseEntryWithVisibility[] => {
+  const scopeEntries =
+    scopeUseEntriesByModule.get(moduleId) ??
+    new Map<string, UseEntryWithVisibility>();
+  entries.forEach((entry) => scopeEntries.set(useEntryKey(entry), entry));
+  scopeUseEntriesByModule.set(moduleId, scopeEntries);
+  return Array.from(scopeEntries.values());
+};
+
+const mergeScopeInlineModuleNames = ({
+  moduleId,
+  names,
+  scopeInlineModuleNamesByModule,
+}: {
+  moduleId: string;
+  names: ReadonlySet<string>;
+  scopeInlineModuleNamesByModule: Map<string, Set<string>>;
+}): ReadonlySet<string> => {
+  const scopeNames =
+    scopeInlineModuleNamesByModule.get(moduleId) ?? new Set<string>();
+  names.forEach((name) => scopeNames.add(name));
+  scopeInlineModuleNamesByModule.set(moduleId, scopeNames);
+  return scopeNames;
+};
+
+const useEntryKey = (entry: UseEntryWithVisibility): string =>
+  JSON.stringify([
+    entry.visibility,
+    entry.moduleSegments,
+    entry.path,
+    entry.targetName ?? null,
+    entry.alias ?? null,
+    entry.selectionKind,
+    entry.anchorToSelf ?? false,
+    entry.parentHops ?? 0,
+    entry.hasExplicitPrefix,
+  ]);
 
 const cloneMacroWithAlias = (
   macro: MacroDefinition,

--- a/packages/compiler/src/modules/macro-expansion.ts
+++ b/packages/compiler/src/modules/macro-expansion.ts
@@ -23,25 +23,38 @@ export const expandModuleMacros = (graph: ModuleGraph): Diagnostic[] =>
   createModuleMacroExpander().expand(graph).diagnostics;
 
 export type ModuleMacroExpander = {
+  invalidate(moduleId: string): void;
+  reset(moduleId: string): void;
   expand(graph: ModuleGraph): {
     diagnostics: Diagnostic[];
+    diagnosticsByModule: ReadonlyMap<string, Diagnostic[]>;
     expandedModuleIds: string[];
   };
 };
 
 export const createModuleMacroExpander = (): ModuleMacroExpander => {
   const exportsByModule = new Map<string, MacroExportTable>();
+  const invalidatedModules = new Set<string>();
 
   return {
+    invalidate: (moduleId) => invalidatedModules.add(moduleId),
+    reset: (moduleId) => {
+      invalidatedModules.delete(moduleId);
+      exportsByModule.delete(moduleId);
+    },
     expand: (graph) => {
       const diagnostics: Diagnostic[] = [];
+      const diagnosticsByModule = new Map<string, Diagnostic[]>();
       const expandedModuleIds: string[] = [];
 
       sortModules(graph).forEach((id) => {
         const module = graph.modules.get(id);
-        if (!module || module.surface) {
+        const isInvalidated = invalidatedModules.has(id);
+        if (!module || (module.surface && !isInvalidated)) {
           return;
         }
+        invalidatedModules.delete(id);
+        const moduleDiagnostics: Diagnostic[] = [];
 
         const useEntries = collectUseEntries(module);
         const importedMacros = collectMacroImports({
@@ -57,16 +70,19 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
           strictMacroSignatures: true,
           onError: (error) =>
             reportMacroExpansionError({
-              diagnostics,
+              diagnostics: moduleDiagnostics,
               macroName: "functionalMacroExpander",
               error,
               fallbackSyntax: module.ast,
             }),
         });
-        module.ast = applyPostSyntaxMacros(functionalResult.form, diagnostics);
+        module.ast = applyPostSyntaxMacros(
+          functionalResult.form,
+          moduleDiagnostics,
+        );
         module.surface = createSurfaceModuleView(module.ast);
         module.surface.issues.forEach((issue) => {
-          diagnostics.push(
+          moduleDiagnostics.push(
             diagnosticFromCode({
               code: "MD0002",
               params: {
@@ -79,6 +95,13 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
           );
         });
         const localExports = indexExports(functionalResult.exports);
+        if (isInvalidated) {
+          exportsByModule.get(id)?.forEach((macro, name) => {
+            if (!localExports.has(name)) {
+              localExports.set(name, macro);
+            }
+          });
+        }
         const exportedMacros = collectMacroReexports({
           module,
           entries: useEntries,
@@ -87,10 +110,12 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
         });
         module.macroExports = Array.from(exportedMacros.keys());
         exportsByModule.set(id, exportedMacros);
+        diagnostics.push(...moduleDiagnostics);
+        diagnosticsByModule.set(id, moduleDiagnostics);
         expandedModuleIds.push(id);
       });
 
-      return { diagnostics, expandedModuleIds };
+      return { diagnostics, diagnosticsByModule, expandedModuleIds };
     },
   };
 };
@@ -320,8 +345,9 @@ const collectMacroReexports = ({
   return exports;
 };
 
-const collectUseEntries = (module: ModuleNode): UseEntryWithVisibility[] =>
-  requireModuleHeader(module).items.flatMap((item) =>
+const collectUseEntries = (module: ModuleNode): UseEntryWithVisibility[] => {
+  const items = module.surface?.items ?? requireModuleHeader(module).items;
+  return items.flatMap((item) =>
     item.kind === "use"
       ? item.entries.map((entry) => ({
           ...entry,
@@ -329,6 +355,7 @@ const collectUseEntries = (module: ModuleNode): UseEntryWithVisibility[] =>
         }))
       : [],
   );
+};
 
 const cloneMacroWithAlias = (
   macro: MacroDefinition,

--- a/packages/compiler/src/modules/macro-expansion.ts
+++ b/packages/compiler/src/modules/macro-expansion.ts
@@ -108,8 +108,16 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
           exportsByModule,
           localExports,
         });
+        const previousExports = exportsByModule.get(id);
         module.macroExports = Array.from(exportedMacros.keys());
         exportsByModule.set(id, exportedMacros);
+        if (!haveSameMacroExportNames(previousExports, exportedMacros)) {
+          invalidateMacroImporters({
+            graph,
+            exportedModuleId: id,
+            invalidatedModules,
+          });
+        }
         diagnostics.push(...moduleDiagnostics);
         diagnosticsByModule.set(id, moduleDiagnostics);
         expandedModuleIds.push(id);
@@ -123,6 +131,38 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
 type MacroExportTable = Map<string, MacroDefinition>;
 type UseEntryWithVisibility = NormalizedUseEntry & {
   visibility: "module" | "pub";
+};
+
+const haveSameMacroExportNames = (
+  previous: MacroExportTable | undefined,
+  current: MacroExportTable,
+): boolean =>
+  (previous?.size ?? 0) === current.size &&
+  Array.from(current.keys()).every((name) => previous?.has(name));
+
+const invalidateMacroImporters = ({
+  graph,
+  exportedModuleId,
+  invalidatedModules,
+}: {
+  graph: ModuleGraph;
+  exportedModuleId: string;
+  invalidatedModules: Set<string>;
+}): void => {
+  graph.modules.forEach((module) => {
+    if (!module.surface) {
+      return;
+    }
+
+    const importsChangedModule = module.dependencies.some(
+      (dependency) =>
+        dependency.kind === "use" &&
+        modulePathToString(dependency.path) === exportedModuleId,
+    );
+    if (importsChangedModule) {
+      invalidatedModules.add(module.id);
+    }
+  });
 };
 
 const applyPostSyntaxMacros = (form: Form, diagnostics: Diagnostic[]): Form => {

--- a/packages/compiler/src/modules/macro-expansion.ts
+++ b/packages/compiler/src/modules/macro-expansion.ts
@@ -19,65 +19,80 @@ import {
 import { createSurfaceModuleView } from "../parser/surface/index.js";
 import { requireModuleHeader } from "./views.js";
 
-export const expandModuleMacros = (graph: ModuleGraph): Diagnostic[] => {
-  const order = sortModules(graph);
+export const expandModuleMacros = (graph: ModuleGraph): Diagnostic[] =>
+  createModuleMacroExpander().expand(graph).diagnostics;
+
+export type ModuleMacroExpander = {
+  expand(graph: ModuleGraph): {
+    diagnostics: Diagnostic[];
+    expandedModuleIds: string[];
+  };
+};
+
+export const createModuleMacroExpander = (): ModuleMacroExpander => {
   const exportsByModule = new Map<string, MacroExportTable>();
-  const diagnostics: Diagnostic[] = [];
 
-  order.forEach((id) => {
-    const module = graph.modules.get(id);
-    if (!module) {
-      return;
-    }
+  return {
+    expand: (graph) => {
+      const diagnostics: Diagnostic[] = [];
+      const expandedModuleIds: string[] = [];
 
-    const useEntries = collectUseEntries(module);
-    const importedMacros = collectMacroImports({
-      module,
-      entries: useEntries,
-      exportsByModule,
-    });
-    const scope = new MacroScope();
-    importedMacros.forEach((macro) => scope.defineMacro(macro));
+      sortModules(graph).forEach((id) => {
+        const module = graph.modules.get(id);
+        if (!module || module.surface) {
+          return;
+        }
 
-    const functionalResult = expandFunctionalMacros(module.ast, {
-      scope,
-      strictMacroSignatures: true,
-      onError: (error) =>
-        reportMacroExpansionError({
-          diagnostics,
-          macroName: "functionalMacroExpander",
-          error,
-          fallbackSyntax: module.ast,
-        }),
-    });
-    module.ast = applyPostSyntaxMacros(functionalResult.form, diagnostics);
-    module.surface = createSurfaceModuleView(module.ast);
-    module.surface.issues.forEach((issue) => {
-      diagnostics.push(
-        diagnosticFromCode({
-          code: "MD0002",
-          params: {
-            kind: "load-failed",
-            requested: module.id,
-            errorMessage: issue.message,
-          },
-          span: issue.span,
-        }),
-      );
-    });
-    const { exports } = functionalResult;
-    const localExports = indexExports(exports);
-    const exportedMacros = collectMacroReexports({
-      module,
-      entries: useEntries,
-      exportsByModule,
-      localExports,
-    });
-    module.macroExports = Array.from(exportedMacros.keys());
-    exportsByModule.set(id, exportedMacros);
-  });
+        const useEntries = collectUseEntries(module);
+        const importedMacros = collectMacroImports({
+          module,
+          entries: useEntries,
+          exportsByModule,
+        });
+        const scope = new MacroScope();
+        importedMacros.forEach((macro) => scope.defineMacro(macro));
 
-  return diagnostics;
+        const functionalResult = expandFunctionalMacros(module.ast, {
+          scope,
+          strictMacroSignatures: true,
+          onError: (error) =>
+            reportMacroExpansionError({
+              diagnostics,
+              macroName: "functionalMacroExpander",
+              error,
+              fallbackSyntax: module.ast,
+            }),
+        });
+        module.ast = applyPostSyntaxMacros(functionalResult.form, diagnostics);
+        module.surface = createSurfaceModuleView(module.ast);
+        module.surface.issues.forEach((issue) => {
+          diagnostics.push(
+            diagnosticFromCode({
+              code: "MD0002",
+              params: {
+                kind: "load-failed",
+                requested: module.id,
+                errorMessage: issue.message,
+              },
+              span: issue.span,
+            }),
+          );
+        });
+        const localExports = indexExports(functionalResult.exports);
+        const exportedMacros = collectMacroReexports({
+          module,
+          entries: useEntries,
+          exportsByModule,
+          localExports,
+        });
+        module.macroExports = Array.from(exportedMacros.keys());
+        exportsByModule.set(id, exportedMacros);
+        expandedModuleIds.push(id);
+      });
+
+      return { diagnostics, expandedModuleIds };
+    },
+  };
 };
 
 type MacroExportTable = Map<string, MacroDefinition>;

--- a/packages/compiler/src/modules/types.ts
+++ b/packages/compiler/src/modules/types.ts
@@ -94,30 +94,30 @@ export interface ModuleNode {
   macroExports?: readonly string[];
 }
 
-export type ModuleDiagnostic =
-  | {
-      kind: "missing-module";
-      requested: ModulePath;
-      importer?: string;
-      importerFilePath?: string;
-      span?: SourceSpan;
-    }
-  | {
-      kind: "io-error";
-      message: string;
-      requested: ModulePath;
-      importer?: string;
-      importerFilePath?: string;
-      span?: SourceSpan;
-    }
-  | {
-      kind: "reserved-module-segment";
-      segment: string;
-      requested: ModulePath;
-      importer?: string;
-      importerFilePath?: string;
-      span?: SourceSpan;
-    };
+type ModuleDiagnosticContext = {
+  importerId?: string;
+  importer?: string;
+  importerFilePath?: string;
+  span?: SourceSpan;
+};
+
+export type ModuleDiagnostic = ModuleDiagnosticContext &
+  (
+    | {
+        kind: "missing-module";
+        requested: ModulePath;
+      }
+    | {
+        kind: "io-error";
+        message: string;
+        requested: ModulePath;
+      }
+    | {
+        kind: "reserved-module-segment";
+        segment: string;
+        requested: ModulePath;
+      }
+  );
 
 export interface ModuleGraph {
   entry: string;

--- a/packages/compiler/src/semantics/binding/binders/module.ts
+++ b/packages/compiler/src/semantics/binding/binders/module.ts
@@ -486,9 +486,7 @@ const isStdSubmoduleModuleId = (moduleId: string): boolean =>
 
 const inlineModuleNamesFor = (ctx: BindingContext): Set<string> =>
   new Set(
-    (
-      ctx.module.header?.items ?? requireModuleSurface(ctx.module).items
-    ).flatMap((item) =>
+    requireModuleSurface(ctx.module).items.flatMap((item) =>
       item.kind === "inline-module" ? [item.declaration.name] : [],
     ),
   );


### PR DESCRIPTION
## Summary

- build the module graph to a fixed point across functional macro expansion and dependency loading
- recollect macro-generated `use` dependencies and inline `mod` declarations while preserving inline-module precedence
- reconcile stale diagnostics and prune modules reachable only through shadowed file modules
- add regressions for multi-round generated imports, inline modules, file collisions, stale descendants, and structural diagnostics

## Root cause

The graph previously finished loading dependencies before `expandModuleMacros` mutated module ASTs. Any `use` or `mod` introduced by a functional macro therefore never participated in dependency discovery.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run test:audit`
- repeated correctness review loop — clean

Linear: https://linear.app/voyd-lang/issue/V-188/recompute-deps-after-macro-expansion