### PR TITLE
Clean up web templates and SSR hydration

### DIFF
--- a/apps/cli/src/__tests__/bootstrap.test.ts
+++ b/apps/cli/src/__tests__/bootstrap.test.ts
@@ -13,7 +13,9 @@ const expectCompileSuccess = (
   result: CompileResult,
 ): Extract<CompileResult, { success: true }> => {
   if (!result.success) {
-    throw new Error(result.diagnostics.map((diagnostic) => diagnostic.message).join("\n"));
+    throw new Error(result.diagnostics
+      .map((diagnostic) => `${diagnostic.span.file}: ${diagnostic.message}`)
+      .join("\n"));
   }
   expect(result.success).toBe(true);
   return result;
@@ -32,6 +34,9 @@ describe("runBootstrap", () => {
       expect(result.targetDir).toBe(target);
       expect(result.files).toContain("index.html");
       expect(result.files).toContain("src/main.voyd");
+      expect(result.files).toContain("src/app/model.voyd");
+      expect(result.files).toContain("src/app/update.voyd");
+      expect(result.files).toContain("src/app/ui.voyd");
       expect(result.nextSteps).toEqual(["npm install", "npm run dev"]);
 
       const packageJson = JSON.parse(
@@ -44,14 +49,25 @@ describe("runBootstrap", () => {
       };
       expect(packageJson.name).toBe("my-app");
       expect(packageJson.scripts.dev).toBe("vite");
-      expect(packageJson.scripts.build).toBe("vite build");
+      expect(packageJson.scripts.build).toBe("npm run typecheck && vite build");
+      expect(packageJson.scripts.typecheck).toBe("npm run voyd:build && tsc --noEmit");
       expect(packageJson.dependencies["@voyd-lang/vx-dom"]).toMatch(/^\^/);
       expect(packageJson.devDependencies.tailwindcss).toBe("^4.3.0");
       expect(packageJson.devDependencies["@tailwindcss/vite"]).toBe("^4.3.0");
 
+      const tsConfig = await readFile(resolve(target, "tsconfig.json"), "utf8");
+      expect(tsConfig).not.toContain('"node"');
+
       const viteConfig = await readFile(resolve(target, "vite.config.mjs"), "utf8");
       expect(viteConfig).toContain("compileVoyd");
       expect(viteConfig).toContain('server.watcher.add("src")');
+      expect(viteConfig).toContain("while (completedCompilation < requestedCompilation)");
+      expect(viteConfig).toContain("if (await compileLatest())");
+      expect(viteConfig).toContain('includes("/src/generated/")');
+
+      const compileScript = await readFile(resolve(target, "scripts/compile-voyd.mjs"), "utf8");
+      expect(compileScript).toContain('resolve(rootDir, "src/generated/.staging")');
+      expect(compileScript).toContain("promoteGeneratedFiles");
 
       const css = await readFile(resolve(target, "src/style.css"), "utf8");
       expect(css).toContain('@import "tailwindcss";');
@@ -62,12 +78,25 @@ describe("runBootstrap", () => {
       expect(mainTs).toContain('from "./generated/main.wasm?url"');
 
       const mainVoyd = await readFile(resolve(target, "src/main.voyd"), "utf8");
-      expect(mainVoyd).toContain("pub fn init() -> Model");
-      expect(mainVoyd).toContain('class="min-h-screen');
+      expect(mainVoyd).toContain("program({ init: initial_model, step: step, view })");
+      expect(mainVoyd).not.toContain('class="min-h-screen');
+
+      const appView = await readFile(resolve(target, "src/app/ui.voyd"), "utf8");
+      expect(appView).toContain('class="min-h-screen');
+      expect(appView).toContain("to_string(model.count)");
+
+      expectCompileSuccess(await createSdk().compile({
+        entryPath: resolve(target, "src/main.voyd"),
+        optimize: true,
+        roots: {
+          src: resolve(target, "src"),
+          pkgDirs: [resolve(repoRoot, "packages")],
+        },
+      }));
     } finally {
       await rm(root, { recursive: true, force: true });
     }
-  });
+  }, 120_000);
 
   it("scaffolds the web-ssr starter", async () => {
     const root = await createTempDir();
@@ -81,6 +110,8 @@ describe("runBootstrap", () => {
       expect(result.targetDir).toBe(target);
       expect(result.files).toContain("src/main.voyd");
       expect(result.files).toContain("src/client.ts");
+      expect(result.files).toContain("src/app/ui.voyd");
+      expect(result.files).toContain("src/server/page.voyd");
       expect(result.files).toContain("data/articles/home.md");
       expect(result.nextSteps).toEqual(["npm install", "npm run dev"]);
 
@@ -94,7 +125,9 @@ describe("runBootstrap", () => {
       };
       expect(packageJson.name).toBe("mini-wiki");
       expect(packageJson.scripts.dev).toBe("node scripts/dev.mjs");
-      expect(packageJson.scripts.build).toBe("vite build && node scripts/check-voyd.mjs");
+      expect(packageJson.scripts.build).toBe(
+        "npm run typecheck && vite build && node scripts/check-voyd.mjs",
+      );
       expect(packageJson.dependencies["@voyd-lang/web"]).toMatch(/^\^/);
       expect(packageJson.dependencies["@voyd-lang/vx-dom"]).toMatch(/^\^/);
       expect(packageJson.devDependencies["@voyd-lang/cli"]).toMatch(/^\^/);
@@ -105,48 +138,85 @@ describe("runBootstrap", () => {
       expect(serverScript).toContain("serveWebApp");
       expect(serverScript).toContain("bufferSize: 1024 * 1024");
       expect(serverScript).toContain("optimize = true");
-      expect(serverScript).toContain("await waitForShutdown");
       expect(serverScript).toContain('process.once("SIGINT"');
+      expect(serverScript).toContain("app.closed.then");
+      expect(serverScript).toContain("Voyd server stopped unexpectedly");
 
       const readme = await readFile(resolve(target, "README.md"), "utf8");
       expect(readme).toContain("npm run dev");
-      expect(readme).toContain("data/articles");
-      expect(readme).toContain("max_body_bytes");
+      expect(readme).toContain("src/app");
+      expect(readme).toContain("render identically");
 
       const gitignore = await readFile(resolve(target, ".gitignore"), "utf8");
       expect(gitignore).toContain("data/articles/*.md");
       expect(gitignore).toContain("!data/articles/home.md");
       expect(gitignore).toContain("src/generated");
+      expect(gitignore).toContain(".voyd-dev");
 
       const devScript = await readFile(resolve(target, "scripts/dev.mjs"), "utf8");
-      expect(devScript).toContain("watchTree(sourceDir)");
-      expect(devScript).toContain('filePath.endsWith("client.voyd")');
-      expect(devScript).toContain('filePath.endsWith(".voyd")');
-      expect(devScript).toContain("queueBuild();");
-      expect(devScript).toContain("queueRestart();");
+      expect(devScript).toContain("watchSource(sourceDir");
+      expect(devScript.indexOf("watchSource(sourceDir")).toBeLessThan(
+        devScript.indexOf("await queueRebuild({ failFast: true })"),
+      );
+      expect(devScript).toContain("/\\.(voyd|ts|css)$/");
+      expect(devScript).toContain("void queueRebuild()");
+      expect(devScript).toContain("while (rebuildRequested)");
+      expect(devScript).toContain("await checkServer({ optimize: false })");
+      expect(devScript.indexOf("await checkServer")).toBeLessThan(
+        devScript.indexOf('await run("vite"'),
+      );
+      expect(devScript.indexOf('await run("vite"')).toBeLessThan(
+        devScript.lastIndexOf("await checkServer"),
+      );
+      expect(devScript.lastIndexOf("await checkServer")).toBeLessThan(
+        devScript.indexOf('await app.close("restart")'),
+      );
+      expect(devScript).toContain('"--outDir", stagedPublicDir');
+      expect(devScript).toContain("await promoteAssets()");
+      expect(devScript).toContain('resolve(rootDir, "public/assets")');
+      expect(devScript).not.toContain('rename(livePublicDir');
+
+      const watchScript = await readFile(resolve(target, "scripts/watch-source.mjs"), "utf8");
+      expect(watchScript).toContain("reconcileWatchers");
+      expect(watchScript).toContain("onChange();");
+      expect(watchScript).toContain('watcher.on("error"');
+      expect(watchScript).toContain("scheduleWatchRetry");
 
       const checkScript = await readFile(resolve(target, "scripts/check-voyd.mjs"), "utf8");
       expect(checkScript).toContain("optimize: true");
-      expect(checkScript).toContain("compileClientVoyd");
+      expect(checkScript).toContain("compileClient");
 
       const viteConfig = await readFile(resolve(target, "vite.config.mjs"), "utf8");
-      expect(viteConfig).toContain("compileClientVoyd");
+      expect(viteConfig).toContain("compileClient");
       expect(viteConfig).toContain('entryFileNames: "assets/client.js"');
       expect(viteConfig).toContain('assetFileNames: "assets/[name][extname]"');
 
       const clientTs = await readFile(resolve(target, "src/client.ts"), "utf8");
       expect(clientTs).toContain("createVoydHost");
       expect(clientTs).toContain("hydrateVxApp");
+      expect(clientTs).toContain('readVoydHydrationRoot("article-editor")');
+      expect(clientTs).toContain("onHydrationMismatch");
+      expect(clientTs).toContain('import.meta.env.MODE === "development"');
       expect(clientTs).toContain("./generated/client.wasm?url");
+      expect(clientTs).toContain("hydration.container.prepend(notice)");
+      expect(clientTs).not.toContain("hydration.container.textContent =");
 
       const clientVoyd = await readFile(resolve(target, "src/client.voyd"), "utf8");
-      expect(clientVoyd).toContain("pub fn app() -> Program<ClientArticle, Msg>");
-      expect(clientVoyd).toContain("on_input={(event: InputEvent) -> Msg");
-      expect(clientVoyd).toContain("state_kind: String");
-      expect(clientVoyd).toContain("Cmd<Msg>::task");
-      expect(clientVoyd).toContain("work: () -> i32 => save_article");
-      expect(clientVoyd).toContain("on_click={Msg::Save {}}");
-      expect(clientVoyd).toContain("http_client::post");
+      expect(clientVoyd).toContain("pub fn app() -> Program<Model, Msg>");
+      expect(clientVoyd).toContain("src::app::ui::view");
+      expect(clientVoyd).not.toContain("obj Model");
+
+      const sharedView = await readFile(resolve(target, "src/app/ui.voyd"), "utf8");
+      expect(sharedView).toContain("on_submit={on_submit_with(");
+      expect(sharedView).toContain("attrs.push(event_payload_handler<InputEvent, Msg>(");
+      expect(sharedView).toContain("pub fn static_view(model: Model)");
+      expect(sharedView).toContain("editor(model, interactive: false)");
+      expect(sharedView).toContain('type="submit" disabled={model.saving}');
+
+      const pageVoyd = await readFile(resolve(target, "src/server/page.voyd"), "utf8");
+      expect(pageVoyd).toContain("src::app::ui::static_view");
+      expect(pageVoyd).toContain('<div id="article-editor">{static_view(model)}</div>');
+      expect(pageVoyd).toContain('id: "article-editor"');
 
       const css = await readFile(resolve(target, "src/style.css"), "utf8");
       expect(css).toContain('@import "tailwindcss";');
@@ -155,24 +225,28 @@ describe("runBootstrap", () => {
       const mainVoyd = await readFile(resolve(target, "src/main.voyd"), "utf8");
       expect(mainVoyd).toContain("pub fn main(): (server::HttpServer");
       expect(mainVoyd).toContain("tasks::TaskRuntime");
-      expect(mainVoyd).toContain("serve(port: app_port(), host: app_host()");
       expect(mainVoyd).toContain("max_body_bytes: 65536");
       expect(mainVoyd).toContain('adopt(serve_dir("./public"))');
       expect(mainVoyd).not.toContain('"/api/articles"');
       expect(mainVoyd).toContain('get("/wiki") do(ctx: Context):');
       expect(mainVoyd).toContain('post("/wiki/:slug/body") do(ctx: Context):');
       expect(mainVoyd).toContain('post("/wiki/:slug") do(ctx: Context):');
-      expect(mainVoyd).toContain("request_text_body(ctx)");
-      expect(mainVoyd).toContain('form_article_body(request_text_body(ctx))');
-      expect(mainVoyd).toContain('parse_query(input).get("body".as_slice())');
-      expect(mainVoyd).toContain("write_file_string(article_path(slug), body)");
-      expect(mainVoyd).toContain("fn is_slug_rune(rune: i32) -> bool");
-      expect(mainVoyd).toContain("not is_slug_rune(rune)");
-      expect(mainVoyd).toContain("state_kind: String");
-      expect(mainVoyd).toContain("{article.state_message}");
-      expect(mainVoyd).not.toContain('>Saved</span>');
-      expect(mainVoyd).toContain('href="/assets/client.css"');
-      expect(mainVoyd).toContain("document<MsgPack, ClientArticle>");
+      expect(mainVoyd).toContain("save_form_response(ctx)");
+      expect(mainVoyd).toContain("Response::bad_request().text(error.message)");
+      expect(mainVoyd).toContain('invalid_request("invalid article slug")');
+      expect(mainVoyd).toContain('invalid_request("missing body form field")');
+      expect(mainVoyd).not.toContain('class="min-h-screen');
+
+      const articlesVoyd = await readFile(resolve(target, "src/server/articles.voyd"), "utf8");
+      expect(articlesVoyd).toContain("request_body(ctx: Context) -> Result<String, HttpError>");
+      expect(articlesVoyd).toContain("article_slug_from(ctx: Context) -> Option<String>");
+      expect(articlesVoyd).toContain("form_body(input: String) -> Option<String>");
+      expect(articlesVoyd).not.toContain("Err:\n      String::init()");
+
+      const voydSources = await Promise.all(result.files
+        .filter((file) => file.endsWith(".voyd"))
+        .map((file) => readFile(resolve(target, file), "utf8")));
+      expect(voydSources.join("\n")).not.toContain(".as_slice().to_string()");
 
       const sdk = createSdk();
       expectCompileSuccess(

--- a/apps/cli/src/__tests__/bootstrap.test.ts
+++ b/apps/cli/src/__tests__/bootstrap.test.ts
@@ -2,24 +2,10 @@ import { existsSync } from "node:fs";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
-import { createSdk, type CompileResult } from "@voyd-lang/sdk";
 import { describe, expect, it, vi } from "vitest";
 import { printBootstrapResult, runBootstrap } from "../bootstrap/index.js";
 
 const createTempDir = () => mkdtemp(resolve(tmpdir(), "voyd-bootstrap-"));
-const repoRoot = resolve(import.meta.dirname, "../../../..");
-
-const expectCompileSuccess = (
-  result: CompileResult,
-): Extract<CompileResult, { success: true }> => {
-  if (!result.success) {
-    throw new Error(result.diagnostics
-      .map((diagnostic) => `${diagnostic.span.file}: ${diagnostic.message}`)
-      .join("\n"));
-  }
-  expect(result.success).toBe(true);
-  return result;
-};
 
 describe("runBootstrap", () => {
   it("scaffolds the vx-spa starter", async () => {
@@ -84,15 +70,6 @@ describe("runBootstrap", () => {
       const appView = await readFile(resolve(target, "src/app/ui.voyd"), "utf8");
       expect(appView).toContain('class="min-h-screen');
       expect(appView).toContain("to_string(model.count)");
-
-      expectCompileSuccess(await createSdk().compile({
-        entryPath: resolve(target, "src/main.voyd"),
-        optimize: true,
-        roots: {
-          src: resolve(target, "src"),
-          pkgDirs: [resolve(repoRoot, "packages")],
-        },
-      }));
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -247,28 +224,6 @@ describe("runBootstrap", () => {
         .filter((file) => file.endsWith(".voyd"))
         .map((file) => readFile(resolve(target, file), "utf8")));
       expect(voydSources.join("\n")).not.toContain(".as_slice().to_string()");
-
-      const sdk = createSdk();
-      expectCompileSuccess(
-        await sdk.compile({
-          entryPath: resolve(target, "src/main.voyd"),
-          optimize: true,
-          roots: {
-            src: resolve(target, "src"),
-            pkgDirs: [resolve(repoRoot, "packages")],
-          },
-        }),
-      );
-      expectCompileSuccess(
-        await sdk.compile({
-          entryPath: resolve(target, "src/client.voyd"),
-          optimize: true,
-          roots: {
-            src: resolve(target, "src"),
-            pkgDirs: [resolve(repoRoot, "packages")],
-          },
-        }),
-      );
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/apps/cli/src/__tests__/cli-e2e.test.ts
+++ b/apps/cli/src/__tests__/cli-e2e.test.ts
@@ -36,7 +36,7 @@ const compileBootstrapEntry = async ({
 }): Promise<void> => {
   expectCompileSuccess(await sdk.compile({
     entryPath: resolve(target, "src", entry),
-    optimize: false,
+    optimize: true,
     roots: {
       src: resolve(target, "src"),
       pkgDirs: [resolve(repoRoot, "packages")],

--- a/apps/cli/src/__tests__/cli-e2e.test.ts
+++ b/apps/cli/src/__tests__/cli-e2e.test.ts
@@ -5,14 +5,44 @@ import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { createSdk, type CompileResult } from "@voyd-lang/sdk";
 
 const testDir = fileURLToPath(new URL(".", import.meta.url));
 const repoRoot = resolve(testDir, "../../../../");
 const tsxPath = resolve(repoRoot, "node_modules/.bin/tsx");
 const distCliPath = resolve(repoRoot, "apps/cli/dist/cli-dev.js");
 const CLI_E2E_TIMEOUT_MS = 60_000;
+const BOOTSTRAP_E2E_TIMEOUT_MS = 300_000;
 const cliE2eRuntime =
   process.env.VOYD_CLI_E2E_RUNTIME === "dist" ? "dist" : "source";
+const sdk = createSdk();
+
+const expectCompileSuccess = (result: CompileResult): void => {
+  if (result.success) {
+    return;
+  }
+
+  throw new Error(result.diagnostics
+    .map((diagnostic) => `${diagnostic.span.file}: ${diagnostic.message}`)
+    .join("\n"));
+};
+
+const compileBootstrapEntry = async ({
+  target,
+  entry,
+}: {
+  target: string;
+  entry: string;
+}): Promise<void> => {
+  expectCompileSuccess(await sdk.compile({
+    entryPath: resolve(target, "src", entry),
+    optimize: false,
+    roots: {
+      src: resolve(target, "src"),
+      pkgDirs: [resolve(repoRoot, "packages")],
+    },
+  }));
+};
 
 const writePackageFixture = async (packageSrcRoot: string): Promise<void> => {
   await mkdir(packageSrcRoot, { recursive: true });
@@ -613,8 +643,8 @@ describe("voyd cli docs command", { timeout: CLI_E2E_TIMEOUT_MS }, () => {
   });
 });
 
-describe("voyd cli bootstrap command", { timeout: CLI_E2E_TIMEOUT_MS }, () => {
-  // Bootstrap file contents are covered by bootstrap unit tests. CLI e2e validates command wiring and exit/reporting.
+describe("voyd cli bootstrap command", () => {
+  // Unit tests own scaffold contents. E2E proves CLI wiring and that each generated Voyd entry compiles.
   it("scaffolds a vx-spa project", async () => {
     assertCliRunnerAvailable();
 
@@ -631,11 +661,40 @@ describe("voyd cli bootstrap command", { timeout: CLI_E2E_TIMEOUT_MS }, () => {
       const packageJson = JSON.parse(
         await readFile(resolve(root, "demo-app", "package.json"), "utf8"),
       ) as { scripts: Record<string, string> };
-      expect(packageJson.scripts.build).toBe("vite build");
+      expect(packageJson.scripts.build).toBe("npm run typecheck && vite build");
+      await compileBootstrapEntry({
+        target: resolve(root, "demo-app"),
+        entry: "main.voyd",
+      });
     } finally {
       await rm(root, { recursive: true, force: true });
     }
-  });
+  }, BOOTSTRAP_E2E_TIMEOUT_MS);
+
+  it("scaffolds a compilable web-ssr project", async () => {
+    assertCliRunnerAvailable();
+
+    const root = await createFixture();
+    const target = resolve(root, "demo-app");
+    try {
+      const result = runCli(root, [
+        "bootstrap",
+        "demo-app",
+        "--template",
+        "web-ssr",
+      ]);
+      const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+      if (result.status !== 0) {
+        throw new Error(`voyd bootstrap failed: ${output}`);
+      }
+
+      expect(output).toContain("Created web-ssr project");
+      await compileBootstrapEntry({ target, entry: "main.voyd" });
+      await compileBootstrapEntry({ target, entry: "client.voyd" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, BOOTSTRAP_E2E_TIMEOUT_MS);
 });
 
 describe("voyd cli diagnostics output", { timeout: CLI_E2E_TIMEOUT_MS }, () => {

--- a/apps/cli/src/bootstrap/loaders/vx-spa.ts
+++ b/apps/cli/src/bootstrap/loaders/vx-spa.ts
@@ -6,103 +6,75 @@ export const vxSpaLoader: BootstrapLoader = {
   plan: ({ packageName, voydVersion }): BootstrapPlan => ({
     template: "vx-spa",
     files: [
-      {
-        path: "index.html",
-        content: indexHtml,
-      },
-      {
-        path: "package.json",
-        content: `${JSON.stringify(
-          {
-            name: packageName,
-            private: true,
-            type: "module",
-            scripts: {
-              dev: "vite",
-              build: "vite build",
-              preview: "vite preview",
-              "voyd:build": "node scripts/compile-voyd.mjs",
-              typecheck: "tsc --noEmit",
-            },
-            dependencies: {
-              "@voyd-lang/sdk": `^${voydVersion}`,
-              "@voyd-lang/vx-dom": `^${voydVersion}`,
-            },
-            devDependencies: {
-              "@tailwindcss/vite": "^4.3.0",
-              "@voyd-lang/cli": `^${voydVersion}`,
-              tailwindcss: "^4.3.0",
-              typescript: "^5.8.3",
-              vite: "^8.0.0",
-            },
-          },
-          null,
-          2,
-        )}\n`,
-      },
-      {
-        path: "vite.config.mjs",
-        content: viteConfig,
-      },
-      {
-        path: "tsconfig.json",
-        content: `${JSON.stringify(
-          {
-            compilerOptions: {
-              target: "ES2022",
-              useDefineForClassFields: true,
-              module: "ESNext",
-              lib: ["ES2022", "DOM", "DOM.Iterable"],
-              types: ["vite/client", "node"],
-              skipLibCheck: true,
-              moduleResolution: "bundler",
-              customConditions: ["development"],
-              allowImportingTsExtensions: true,
-              isolatedModules: true,
-              moduleDetection: "force",
-              noEmit: true,
-              strict: true,
-            },
-            include: ["src"],
-          },
-          null,
-          2,
-        )}\n`,
-      },
-      {
-        path: ".gitignore",
-        content: gitIgnore,
-      },
-      {
-        path: "scripts/compile-voyd.mjs",
-        content: compileVoydScript,
-      },
-      {
-        path: "src/main.ts",
-        content: mainTs,
-      },
-      {
-        path: "src/main.voyd",
-        content: mainVoyd,
-      },
-      {
-        path: "src/style.css",
-        content: styleCss,
-      },
+      { path: "index.html", content: indexHtml },
+      { path: "package.json", content: packageJson(packageName, voydVersion) },
+      { path: "vite.config.mjs", content: viteConfig },
+      { path: "tsconfig.json", content: tsConfig },
+      { path: ".gitignore", content: gitIgnore },
+      { path: "scripts/compile-voyd.mjs", content: compileVoydScript },
+      { path: "scripts/run-voyd.mjs", content: runVoydScript },
+      { path: "src/main.ts", content: mainTs },
+      { path: "src/main.voyd", content: mainVoyd },
+      { path: "src/app.voyd", content: appModuleVoyd },
+      { path: "src/app/model.voyd", content: modelVoyd },
+      { path: "src/app/update.voyd", content: updateVoyd },
+      { path: "src/app/ui.voyd", content: viewVoyd },
+      { path: "src/style.css", content: styleCss },
     ],
-    nextSteps: [
-      "npm install",
-      "npm run dev",
-    ],
+    nextSteps: ["npm install", "npm run dev"],
   }),
 };
+
+const packageJson = (packageName: string, voydVersion: string): string =>
+  `${JSON.stringify({
+    name: packageName,
+    private: true,
+    type: "module",
+    scripts: {
+      dev: "vite",
+      build: "npm run typecheck && vite build",
+      preview: "vite preview",
+      "voyd:build": "node scripts/compile-voyd.mjs",
+      typecheck: "npm run voyd:build && tsc --noEmit",
+    },
+    dependencies: {
+      "@voyd-lang/sdk": `^${voydVersion}`,
+      "@voyd-lang/vx-dom": `^${voydVersion}`,
+    },
+    devDependencies: {
+      "@tailwindcss/vite": "^4.3.0",
+      "@voyd-lang/cli": `^${voydVersion}`,
+      tailwindcss: "^4.3.0",
+      typescript: "^5.8.3",
+      vite: "^8.0.0",
+    },
+  }, null, 2)}\n`;
+
+const tsConfig = `${JSON.stringify({
+  compilerOptions: {
+    target: "ES2022",
+    useDefineForClassFields: true,
+    module: "ESNext",
+    lib: ["ES2022", "DOM", "DOM.Iterable"],
+    types: ["vite/client"],
+    skipLibCheck: true,
+    moduleResolution: "bundler",
+    customConditions: ["development"],
+    allowImportingTsExtensions: true,
+    isolatedModules: true,
+    moduleDetection: "force",
+    noEmit: true,
+    strict: true,
+  },
+  include: ["src"],
+}, null, 2)}\n`;
 
 const indexHtml = `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="color-scheme" content="light dark" />
+    <meta name="color-scheme" content="dark" />
     <title>Voyd VX App</title>
   </head>
   <body>
@@ -116,19 +88,35 @@ const viteConfig = `import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 import { compileVoyd } from "./scripts/compile-voyd.mjs";
 
+let requestedCompilation = 0;
+let completedCompilation = 0;
+let compilationQueue = Promise.resolve();
+
+async function compileLatest() {
+  const request = ++requestedCompilation;
+  compilationQueue = compilationQueue.catch(() => undefined).then(async () => {
+    while (completedCompilation < requestedCompilation) {
+      const compiling = requestedCompilation;
+      await compileVoyd();
+      completedCompilation = compiling;
+    }
+  });
+  await compilationQueue;
+  return request === requestedCompilation;
+}
+
 const voyd = () => ({
   name: "voyd",
   async buildStart() {
-    await compileVoyd();
+    await compileLatest();
   },
   configureServer(server) {
     server.watcher.add("src");
   },
-  async handleHotUpdate(ctx) {
-    if (!ctx.file.endsWith(".voyd")) return;
-
-    await compileVoyd();
-    ctx.server.ws.send({ type: "full-reload" });
+  async handleHotUpdate({ file, server }) {
+    if (file.replaceAll("\\\\", "/").includes("/src/generated/")) return [];
+    if (!file.endsWith(".voyd")) return;
+    if (await compileLatest()) server.ws.send({ type: "full-reload" });
     return [];
   },
 });
@@ -138,32 +126,13 @@ export default defineConfig({
 });
 `;
 
-const compileVoydScript = `import { spawn } from "node:child_process";
-import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+const runVoydScript = `import { spawn } from "node:child_process";
 
-const rootDir = resolve(fileURLToPath(new URL("..", import.meta.url)));
-const entryPath = resolve(rootDir, "src/main.voyd");
-const outPath = resolve(rootDir, "src/generated/main.wasm");
-const adaptersPath = resolve(rootDir, "src/generated/voyd-adapters.ts");
-
-export async function compileVoyd({ verbose = true } = {}) {
-  await mkdir(dirname(outPath), { recursive: true });
-  const wasm = await runVoyd(["--emit-wasm", "--opt", entryPath]);
-  await writeFile(outPath, wasm);
-  await runVoyd(["generate", "registry", entryPath, "--out", adaptersPath]);
-  if (verbose) {
-    console.log(\`compiled \${entryPath} -> \${outPath}\`);
-  }
-}
-
-function runVoyd(args) {
+export function runVoyd(args, { cwd }) {
   const command = process.platform === "win32" ? "voyd.cmd" : "voyd";
-
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
-      cwd: rootDir,
+      cwd,
       stdio: ["ignore", "pipe", "pipe"],
     });
     const stdout = [];
@@ -171,23 +140,73 @@ function runVoyd(args) {
 
     child.stdout.on("data", (chunk) => stdout.push(chunk));
     child.stderr.on("data", (chunk) => stderr.push(chunk));
-    child.on("error", (error) => {
-      if (error && error.code === "ENOENT") {
-        reject(new Error("Unable to find the voyd CLI. Run npm install before starting the app."));
-        return;
-      }
-      reject(error);
-    });
+    child.on("error", (error) => reject(missingCliError(error)));
     child.on("close", (code) => {
       if (code === 0) {
         resolve(Buffer.concat(stdout));
         return;
       }
-
-      const output = Buffer.concat(stderr).toString("utf8").trim();
-      reject(new Error(output || \`voyd exited with status \${code}\`));
+      reject(new Error(Buffer.concat(stderr).toString("utf8").trim() ||
+        "voyd exited with status " + code));
     });
   });
+}
+
+function missingCliError(error) {
+  return error?.code === "ENOENT"
+    ? new Error("Unable to find the voyd CLI. Run npm install before starting the app.")
+    : error;
+}
+`;
+
+const compileVoydScript = `import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { runVoyd } from "./run-voyd.mjs";
+
+const rootDir = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const entryPath = resolve(rootDir, "src/main.voyd");
+const outPath = resolve(rootDir, "src/generated/main.wasm");
+const adaptersPath = resolve(rootDir, "src/generated/voyd-adapters.ts");
+const stagingDir = resolve(rootDir, "src/generated/.staging");
+const previousDir = resolve(rootDir, "src/generated/.previous");
+
+export async function compileVoyd({ verbose = true } = {}) {
+  await rm(stagingDir, { recursive: true, force: true });
+  await mkdir(stagingDir, { recursive: true });
+  const stagedWasm = resolve(stagingDir, "main.wasm");
+  const stagedAdapters = resolve(stagingDir, "voyd-adapters.ts");
+  await writeFile(stagedWasm, await runVoyd(["--emit-wasm", "--opt", entryPath], { cwd: rootDir }));
+  await runVoyd(["generate", "registry", entryPath, "--out", stagedAdapters], { cwd: rootDir });
+  await promoteGeneratedFiles([
+    { staged: stagedWasm, live: outPath, previous: resolve(previousDir, "main.wasm") },
+    { staged: stagedAdapters, live: adaptersPath, previous: resolve(previousDir, "voyd-adapters.ts") },
+  ]);
+  if (verbose) console.log("compiled " + entryPath + " -> " + outPath);
+}
+
+async function promoteGeneratedFiles(files) {
+  await rm(previousDir, { recursive: true, force: true });
+  await mkdir(previousDir, { recursive: true });
+  const backedUp = [];
+  try {
+    for (const file of files) {
+      try {
+        await rename(file.live, file.previous);
+        backedUp.push(file);
+      } catch (error) {
+        if (error?.code !== "ENOENT") throw error;
+      }
+    }
+    for (const file of files) await rename(file.staged, file.live);
+  } catch (error) {
+    await Promise.all(files.map((file) => rm(file.live, { force: true })));
+    await Promise.all(backedUp.map((file) => rename(file.previous, file.live)));
+    throw error;
+  } finally {
+    await rm(stagingDir, { recursive: true, force: true });
+    await rm(previousDir, { recursive: true, force: true });
+  }
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
@@ -202,11 +221,9 @@ import { adapters } from "./generated/voyd-adapters";
 import "./style.css";
 
 const root = document.getElementById("root");
-if (!root) {
-  throw new Error("Missing #root element");
-}
+if (!root) throw new Error("Missing #root element");
 
-const start = async () => {
+async function start() {
   const wasm = new Uint8Array(await (await fetch(wasmUrl)).arrayBuffer());
   const host = await createVoydHost({
     wasm,
@@ -215,97 +232,115 @@ const start = async () => {
   });
   const app = createVoydVxAppRuntime({ host });
   const mounted = await mountVxApp({ container: root, app });
-
   import.meta.hot?.dispose(() => mounted.dispose());
-};
+}
 
-start().catch((reason) => {
-  console.error(reason);
-  root.textContent = reason instanceof Error ? reason.message : String(reason);
+start().catch((error) => {
+  console.error(error);
+  root.textContent = error instanceof Error ? error.message : String(error);
 });
 `;
 
-const mainVoyd = `use std::enums::{ enum }
-use std::string::type::String
+const mainVoyd = `use src::app::model::{ Model, initial_model }
+use src::app::update::{ Msg, step }
+use src::app::ui::view
 use std::vx::all
 
-obj Model {
+pub fn app() -> Program<Model, Msg>
+  program({ init: initial_model, step: step, view })
+`;
+
+const appModuleVoyd = `pub self::model
+pub self::update
+pub self::ui
+`;
+
+const modelVoyd = `use std::string::type::String
+
+pub obj Model {
   count: i32,
   title: String
 }
 
-enum Msg
+pub fn initial_model() -> Model
+  Model { count: 0, title: "Voyd VX" }
+
+pub fn with_count(model: Model, count: i32) -> Model
+  Model { count: count, title: model.title }
+
+pub fn with_title(model: Model, title: String) -> Model
+  Model { count: model.count, title: title }
+`;
+
+const updateVoyd = `use super::model::{ Model, with_count, with_title }
+use std::enums::{ enum }
+use std::string::type::String
+use std::vx::{ Program, next }
+
+pub enum Msg
   Increment
   Decrement
   Rename { value: String }
 
-pub fn app() -> Program<Model, Msg>
-  program<Model, Msg>(
-    init: init,
-    step: step,
-    view: view
-  )
-
-pub fn init() -> Model
-  Model {
-    count: 0,
-    title: "Voyd VX"
-  }
-
 pub fn step(model: Model, message: Msg) -> Program<Model, Msg>
   match(message)
     Msg::Increment:
-      next(Model { count: model.count + 1, title: model.title })
+      next(with_count(model, model.count + 1))
     Msg::Decrement:
-      next(Model { count: model.count - 1, title: model.title })
+      next(with_count(model, model.count - 1))
     Msg::Rename { value }:
-      next(Model { count: model.count, title: value })
+      next(with_title(model, value))
+`;
+
+const viewVoyd = `use super::model::Model
+use super::update::Msg
+use std::number::cast::to_string
+use std::string::type::String
+use std::vx::all
 
 pub fn view(model: Model) -> Html<Msg>
   <main class="min-h-screen bg-slate-950 px-6 py-12 text-slate-100">
     <section class="mx-auto flex max-w-3xl flex-col gap-8">
       <header class="space-y-3">
         <p class="text-sm font-semibold uppercase tracking-wide text-cyan-300">Voyd VX</p>
-        <h1 class="text-4xl font-bold text-white">Production starter</h1>
+        <h1 class="text-4xl font-bold text-white">A clean place to start</h1>
         <p class="max-w-2xl text-lg text-slate-300">
-          Edit <code class="rounded bg-slate-800 px-2 py-1 text-cyan-200">src/main.voyd</code> and Vite will rebuild the WebAssembly module.
+          Application state, updates, and views live in focused modules under <code class="rounded bg-slate-800 px-2 py-1 text-cyan-200">src/app</code>.
         </p>
       </header>
-
-      <div class="rounded-lg border border-slate-800 bg-slate-900 p-6 shadow-xl shadow-cyan-950/30">
-        <label class="block text-sm font-medium text-slate-300" for="title">App title</label>
-        <input
-          id="title"
-          class="mt-2 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-white outline-none ring-cyan-400 transition focus:ring-2"
-          value={model.title}
-          on_input={(event: InputEvent) -> Msg => Msg::Rename { value: event.value }}
-        />
-
-        <div class="mt-6 flex items-center gap-4">
-          <button class="rounded-md bg-slate-800 px-4 py-2 font-semibold text-white transition hover:bg-slate-700" on_click={Msg::Decrement {}}>
-            -
-          </button>
-          <p class="min-w-24 text-center text-3xl font-bold text-cyan-200">{count_label(model.count)}</p>
-          <button class="rounded-md bg-cyan-400 px-4 py-2 font-semibold text-slate-950 transition hover:bg-cyan-300" on_click={Msg::Increment {}}>
-            +
-          </button>
-        </div>
-
-        <p class="mt-6 text-slate-300">{model.title}</p>
-      </div>
+      <Counter model={model} />
     </section>
   </main>
 
-fn count_label(value: i32) -> String
-  if
-    value == -3: "-3"
-    value == -2: "-2"
-    value == -1: "-1"
-    value == 0: "0"
-    value == 1: "1"
-    value == 2: "2"
-    value == 3: "3"
-    else: "many"
+fn Counter({ model: Model }) -> Html<Msg>
+  <div class="rounded-lg border border-slate-800 bg-slate-900 p-6 shadow-xl shadow-cyan-950/30">
+    <TitleField title={model.title} />
+    <div class="mt-6 flex items-center gap-4">
+      <CounterButton label="−" message={Msg::Decrement {}} />
+      <p class="min-w-24 text-center text-3xl font-bold text-cyan-200">{to_string(model.count)}</p>
+      <CounterButton label="+" message={Msg::Increment {}} />
+    </div>
+    <p class="mt-6 text-slate-300">{model.title}</p>
+  </div>
+
+fn TitleField({ title: String }) -> Html<Msg>
+  <label class="block text-sm font-medium text-slate-300">
+    App title
+    <input
+      class="mt-2 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-white outline-none ring-cyan-400 transition focus:ring-2"
+      value={title}
+      on_input={(event: InputEvent) -> Msg => Msg::Rename { value: event.value }}
+    />
+  </label>
+
+fn CounterButton({ label: String, message: Msg }) -> Html<Msg>
+  <button
+    class="rounded-md bg-cyan-400 px-4 py-2 font-semibold text-slate-950 transition hover:bg-cyan-300"
+    type="button"
+    on_click={message}
+  >
+    {label}
+  </button>
 `;
 
 const styleCss = `@import "tailwindcss";
@@ -313,9 +348,7 @@ const styleCss = `@import "tailwindcss";
 @source "./**/*.voyd";
 
 :root {
-  font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
   color: #e2e8f0;
   background: #020617;
 }

--- a/apps/cli/src/bootstrap/loaders/web-ssr.ts
+++ b/apps/cli/src/bootstrap/loaders/web-ssr.ts
@@ -6,143 +6,98 @@ export const webSsrLoader: BootstrapLoader = {
   plan: ({ packageName, voydVersion }): BootstrapPlan => ({
     template: "web-ssr",
     files: [
-      {
-        path: "package.json",
-        content: `${JSON.stringify(
-          {
-            name: packageName,
-            private: true,
-            type: "module",
-            scripts: {
-              dev: "node scripts/dev.mjs",
-              build: "vite build && node scripts/check-voyd.mjs",
-              start: "node scripts/serve.mjs",
-              "voyd:check": "node scripts/check-voyd.mjs",
-              typecheck: "tsc --noEmit",
-            },
-            dependencies: {
-              "@voyd-lang/sdk": `^${voydVersion}`,
-              "@voyd-lang/vx-dom": `^${voydVersion}`,
-              "@voyd-lang/web": `^${voydVersion}`,
-            },
-            devDependencies: {
-              "@tailwindcss/vite": "^4.3.0",
-              "@types/node": "^22.5.1",
-              "@voyd-lang/cli": `^${voydVersion}`,
-              tailwindcss: "^4.3.0",
-              typescript: "^5.8.3",
-              vite: "^8.0.0",
-            },
-          },
-          null,
-          2,
-        )}\n`,
-      },
-      {
-        path: "vite.config.mjs",
-        content: viteConfig,
-      },
-      {
-        path: "tsconfig.json",
-        content: `${JSON.stringify(
-          {
-            compilerOptions: {
-              target: "ES2022",
-              module: "ESNext",
-              lib: ["ES2022", "DOM", "DOM.Iterable"],
-              types: ["node", "vite/client"],
-              skipLibCheck: true,
-              moduleResolution: "bundler",
-              allowImportingTsExtensions: true,
-              isolatedModules: true,
-              moduleDetection: "force",
-              noEmit: true,
-              strict: true,
-            },
-            include: ["scripts", "src"],
-          },
-          null,
-          2,
-        )}\n`,
-      },
-      {
-        path: ".gitignore",
-        content: gitIgnore,
-      },
-      {
-        path: "README.md",
-        content: readme(packageName),
-      },
-      {
-        path: "scripts/check-voyd.mjs",
-        content: checkVoydScript,
-      },
-      {
-        path: "scripts/compile-client-voyd.mjs",
-        content: compileClientVoydScript,
-      },
-      {
-        path: "scripts/dev.mjs",
-        content: devScript,
-      },
-      {
-        path: "scripts/serve.mjs",
-        content: serveScript,
-      },
-      {
-        path: "src/client.ts",
-        content: clientTs,
-      },
-      {
-        path: "src/client.voyd",
-        content: clientVoyd,
-      },
-      {
-        path: "src/main.voyd",
-        content: mainVoyd,
-      },
-      {
-        path: "src/style.css",
-        content: styleCss,
-      },
-      {
-        path: "data/articles/home.md",
-        content: homeArticle,
-      },
-      {
-        path: "data/articles/voyd.md",
-        content: voydArticle,
-      },
-      {
-        path: "data/articles/webassembly.md",
-        content: webassemblyArticle,
-      },
-      {
-        path: "public/.gitkeep",
-        content: "",
-      },
+      { path: "package.json", content: packageJson(packageName, voydVersion) },
+      { path: "vite.config.mjs", content: viteConfig },
+      { path: "tsconfig.json", content: tsConfig },
+      { path: ".gitignore", content: gitIgnore },
+      { path: "README.md", content: readme(packageName) },
+      { path: "scripts/run-voyd.mjs", content: runVoydScript },
+      { path: "scripts/compile-client.mjs", content: compileClientScript },
+      { path: "scripts/check-voyd.mjs", content: checkVoydScript },
+      { path: "scripts/serve.mjs", content: serveScript },
+      { path: "scripts/watch-source.mjs", content: watchSourceScript },
+      { path: "scripts/dev.mjs", content: devScript },
+      { path: "src/client.ts", content: clientTs },
+      { path: "src/client.voyd", content: clientVoyd },
+      { path: "src/main.voyd", content: mainVoyd },
+      { path: "src/app.voyd", content: appModuleVoyd },
+      { path: "src/app/model.voyd", content: modelVoyd },
+      { path: "src/app/update.voyd", content: updateVoyd },
+      { path: "src/app/ui.voyd", content: viewVoyd },
+      { path: "src/server.voyd", content: serverModuleVoyd },
+      { path: "src/server/articles.voyd", content: articlesVoyd },
+      { path: "src/server/page.voyd", content: pageVoyd },
+      { path: "src/style.css", content: styleCss },
+      { path: "data/articles/home.md", content: homeArticle },
+      { path: "data/articles/voyd.md", content: voydArticle },
+      { path: "data/articles/webassembly.md", content: webassemblyArticle },
+      { path: "public/.gitkeep", content: "" },
     ],
     nextSteps: ["npm install", "npm run dev"],
   }),
 };
 
+const packageJson = (packageName: string, voydVersion: string): string =>
+  `${JSON.stringify({
+    name: packageName,
+    private: true,
+    type: "module",
+    scripts: {
+      dev: "node scripts/dev.mjs",
+      build: "npm run typecheck && vite build && node scripts/check-voyd.mjs",
+      start: "node scripts/serve.mjs",
+      "voyd:check": "node scripts/check-voyd.mjs",
+      typecheck: "tsc --noEmit",
+    },
+    dependencies: {
+      "@voyd-lang/sdk": `^${voydVersion}`,
+      "@voyd-lang/vx-dom": `^${voydVersion}`,
+      "@voyd-lang/web": `^${voydVersion}`,
+    },
+    devDependencies: {
+      "@tailwindcss/vite": "^4.3.0",
+      "@types/node": "^22.5.1",
+      "@voyd-lang/cli": `^${voydVersion}`,
+      tailwindcss: "^4.3.0",
+      typescript: "^5.8.3",
+      vite: "^8.0.0",
+    },
+  }, null, 2)}\n`;
+
+const tsConfig = `${JSON.stringify({
+  compilerOptions: {
+    target: "ES2022",
+    module: "ESNext",
+    lib: ["ES2022", "DOM", "DOM.Iterable"],
+    types: ["node", "vite/client"],
+    skipLibCheck: true,
+    moduleResolution: "bundler",
+    customConditions: ["development"],
+    allowImportingTsExtensions: true,
+    isolatedModules: true,
+    moduleDetection: "force",
+    noEmit: true,
+    strict: true,
+  },
+  include: ["src"],
+}, null, 2)}\n`;
+
 const viteConfig = `import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
-import { compileClientVoyd } from "./scripts/compile-client-voyd.mjs";
+import { compileClient } from "./scripts/compile-client.mjs";
 
 const voydClient = () => ({
   name: "voyd-client",
   async buildStart() {
-    await compileClientVoyd();
+    await compileClient();
   },
   configureServer(server) {
-    server.watcher.add("src/client.voyd");
+    server.watcher.add("src");
   },
-  async handleHotUpdate(ctx) {
-    if (!ctx.file.endsWith("client.voyd")) return;
-
-    await compileClientVoyd();
-    ctx.server.ws.send({ type: "full-reload" });
+  async handleHotUpdate({ file, server }) {
+    if (!file.endsWith(".voyd")) return;
+    await compileClient();
+    server.ws.send({ type: "full-reload" });
     return [];
   },
 });
@@ -153,7 +108,6 @@ export default defineConfig({
   build: {
     outDir: "public",
     emptyOutDir: false,
-    manifest: false,
     rollupOptions: {
       input: "src/client.ts",
       output: {
@@ -165,64 +119,13 @@ export default defineConfig({
 });
 `;
 
-const checkVoydScript = `import { createSdk } from "@voyd-lang/sdk";
-import { resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { compileClientVoyd } from "./compile-client-voyd.mjs";
+const runVoydScript = `import { spawn } from "node:child_process";
 
-const rootDir = resolve(fileURLToPath(new URL("..", import.meta.url)));
-const entryPath = resolve(rootDir, "src/main.voyd");
-const sdk = createSdk();
-const result = await sdk.compile({
-  entryPath,
-  optimize: true,
-  runtimeDiagnostics: true,
-});
-
-if (!result.success) {
-  console.error(formatDiagnostics(result.diagnostics));
-  process.exit(1);
-}
-
-await compileClientVoyd();
-console.log("Voyd server compiled successfully.");
-
-function formatDiagnostics(diagnostics) {
-  return diagnostics
-    .map((diagnostic) => {
-      const location = diagnostic.location
-        ? \`\${diagnostic.location.filePath}:\${diagnostic.location.start.line}:\${diagnostic.location.start.column}\`
-        : diagnostic.file ?? "voyd";
-      return \`\${location} \${diagnostic.severity}: \${diagnostic.message}\`;
-    })
-    .join("\\n");
-}
-`;
-
-const compileClientVoydScript = `import { spawn } from "node:child_process";
-import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
-
-const rootDir = resolve(fileURLToPath(new URL("..", import.meta.url)));
-const entryPath = resolve(rootDir, "src/client.voyd");
-const outPath = resolve(rootDir, "src/generated/client.wasm");
-
-export async function compileClientVoyd({ verbose = true } = {}) {
-  await mkdir(dirname(outPath), { recursive: true });
-  const wasm = await runVoyd(["--emit-wasm", "--opt", entryPath]);
-  await writeFile(outPath, wasm);
-  if (verbose) {
-    console.log(\`compiled \${entryPath} -> \${outPath}\`);
-  }
-}
-
-function runVoyd(args) {
+export function runVoyd(args, { cwd }) {
   const command = process.platform === "win32" ? "voyd.cmd" : "voyd";
-
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
-      cwd: rootDir,
+      cwd,
       stdio: ["ignore", "pipe", "pipe"],
     });
     const stdout = [];
@@ -230,27 +133,70 @@ function runVoyd(args) {
 
     child.stdout.on("data", (chunk) => stdout.push(chunk));
     child.stderr.on("data", (chunk) => stderr.push(chunk));
-    child.on("error", (error) => {
-      if (error && error.code === "ENOENT") {
-        reject(new Error("Unable to find the voyd CLI. Run npm install before starting the app."));
-        return;
-      }
-      reject(error);
-    });
+    child.on("error", (error) => reject(missingCliError(error)));
     child.on("close", (code) => {
       if (code === 0) {
         resolve(Buffer.concat(stdout));
         return;
       }
-
-      const output = Buffer.concat(stderr).toString("utf8").trim();
-      reject(new Error(output || \`voyd exited with status \${code}\`));
+      reject(new Error(Buffer.concat(stderr).toString("utf8").trim() ||
+        "voyd exited with status " + code));
     });
   });
 }
 
+function missingCliError(error) {
+  return error?.code === "ENOENT"
+    ? new Error("Unable to find the voyd CLI. Run npm install before starting the app.")
+    : error;
+}
+`;
+
+const compileClientScript = `import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { runVoyd } from "./run-voyd.mjs";
+
+const rootDir = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const entryPath = resolve(rootDir, "src/client.voyd");
+const outPath = resolve(rootDir, "src/generated/client.wasm");
+
+export async function compileClient({ verbose = true } = {}) {
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, await runVoyd(["--emit-wasm", "--opt", entryPath], { cwd: rootDir }));
+  if (verbose) console.log("compiled " + entryPath + " -> " + outPath);
+}
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  await compileClientVoyd();
+  await compileClient();
+}
+`;
+
+const checkVoydScript = `import { createSdk } from "@voyd-lang/sdk";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { compileClient } from "./compile-client.mjs";
+
+const rootDir = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const result = await createSdk().compile({
+  entryPath: resolve(rootDir, "src/main.voyd"),
+  optimize: true,
+  runtimeDiagnostics: true,
+});
+
+if (!result.success) {
+  console.error(result.diagnostics.map(formatDiagnostic).join("\\n"));
+  process.exit(1);
+}
+
+await compileClient();
+console.log("Voyd server and client compiled successfully.");
+
+function formatDiagnostic(diagnostic) {
+  const location = diagnostic.location
+    ? diagnostic.location.filePath + ":" + diagnostic.location.start.line + ":" + diagnostic.location.start.column
+    : diagnostic.file ?? "voyd";
+  return location + " " + diagnostic.severity + ": " + diagnostic.message;
 }
 `;
 
@@ -267,8 +213,7 @@ export async function serve({
   port = readPort(),
   optimize = true,
 } = {}) {
-  const sdk = createSdk();
-  const result = await sdk.serveWebApp({
+  const result = await createSdk().serveWebApp({
     entryPath,
     host,
     port,
@@ -279,339 +224,333 @@ export async function serve({
       defaultAdapters: { runtime: "node" },
     },
   });
-
   if (!result.success) {
-    throw new Error(formatDiagnostics(result.diagnostics));
+    throw new Error(result.diagnostics.map((diagnostic) => diagnostic.message).join("\\n"));
   }
-
   return result;
 }
 
+export async function checkServer({ optimize = false } = {}) {
+  const result = await createSdk().compile({
+    entryPath,
+    optimize,
+    runtimeDiagnostics: true,
+  });
+  if (!result.success) {
+    throw new Error(result.diagnostics.map((diagnostic) => diagnostic.message).join("\\n"));
+  }
+}
+
 function readPort() {
-  const raw = process.env.PORT ?? process.env.VOYD_WEB_PORT ?? "3000";
-  const parsed = Number.parseInt(raw, 10);
+  const parsed = Number.parseInt(process.env.PORT ?? process.env.VOYD_WEB_PORT ?? "3000", 10);
   return Number.isFinite(parsed) ? parsed : 3000;
 }
 
-function formatDiagnostics(diagnostics) {
-  return diagnostics
-    .map((diagnostic) => {
-      const location = diagnostic.location
-        ? \`\${diagnostic.location.filePath}:\${diagnostic.location.start.line}:\${diagnostic.location.start.column}\`
-        : diagnostic.file ?? "voyd";
-      return \`\${location} \${diagnostic.severity}: \${diagnostic.message}\`;
-    })
-    .join("\\n");
-}
-
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  let app;
-  try {
-    app = await serve();
-    console.log(\`Voyd wiki ready at \${app.url}\`);
-  } catch (error) {
-    console.error(error instanceof Error ? error.message : error);
-    process.exit(1);
-  }
-
+  const app = await serve();
+  console.log("Voyd app ready at " + app.url);
   let closing = false;
   const keepAlive = setInterval(() => undefined, 1_000_000_000);
-  app.closed.catch((error) => {
-    if (closing) return;
-    clearInterval(keepAlive);
-    console.error(error instanceof Error ? error.message : error);
-    process.exit(1);
-  });
-
-  await waitForShutdown(async (signal) => {
-    closing = true;
-    clearInterval(keepAlive);
-    await app.close(signal).catch(() => undefined);
-  });
-}
-
-function waitForShutdown(close) {
-  return new Promise((resolve) => {
-    let closing = false;
-    const shutdown = (signal) => {
+  const shutdown = new Promise((resolveShutdown) => {
+    const close = (signal) => {
       if (closing) return;
       closing = true;
-      void close(signal).finally(resolve);
+      clearInterval(keepAlive);
+      void app.close(signal).finally(resolveShutdown);
     };
-    process.once("SIGINT", () => shutdown("SIGINT"));
-    process.once("SIGTERM", () => shutdown("SIGTERM"));
+    process.once("SIGINT", () => close("SIGINT"));
+    process.once("SIGTERM", () => close("SIGTERM"));
   });
+  const unexpectedClose = app.closed.then(
+    () => {
+      if (!closing) throw new Error("Voyd server stopped unexpectedly");
+    },
+    (error) => {
+      if (!closing) throw error;
+    },
+  );
+  try {
+    await Promise.race([shutdown, unexpectedClose]);
+  } finally {
+    clearInterval(keepAlive);
+  }
 }
 `;
 
-const devScript = `import { spawn } from "node:child_process";
-import { readdirSync, statSync, watch } from "node:fs";
-import { join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { serve } from "./serve.mjs";
+const watchSourceScript = `import { readdirSync, statSync, watch } from "node:fs";
+import { join } from "node:path";
 
-const rootDir = resolve(fileURLToPath(new URL("..", import.meta.url)));
-const sourceDir = resolve(rootDir, "src");
-const port = Number.parseInt(process.env.PORT ?? process.env.VOYD_WEB_PORT ?? "3000", 10);
-
-let app;
-let building = false;
-let restarting = false;
-let buildQueued = false;
-let restartQueued = false;
-
-await buildClient();
-await restartServer();
-
-const watcher = watchSource();
-
-function queueBuild() {
-  buildQueued = true;
-  if (building) return;
-  setTimeout(() => void buildClient(), 75);
-}
-
-function queueRestart() {
-  restartQueued = true;
-  if (restarting) return;
-  setTimeout(() => void restartServer(), 75);
-}
-
-async function buildClient() {
-  if (building) return;
-  buildQueued = false;
-  building = true;
-  try {
-    await run("vite", ["build", "--mode", "development"]);
-  } catch (error) {
-    console.error(error instanceof Error ? error.message : error);
-  } finally {
-    building = false;
-    if (buildQueued) {
-      setTimeout(() => void buildClient(), 75);
-    }
-  }
-}
-
-async function restartServer() {
-  if (restarting) return;
-  if (!restartQueued && app) return;
-  restartQueued = false;
-  restarting = true;
-  try {
-    if (app) {
-      await app.close("restart").catch(() => undefined);
-    }
-    app = await serve({
-      port: Number.isFinite(port) ? port : 3000,
-      optimize: process.env.NODE_ENV === "production",
-    });
-    console.log(\`Voyd wiki ready at \${app.url}\`);
-  } catch (error) {
-    console.error(error instanceof Error ? error.message : error);
-  } finally {
-    restarting = false;
-    if (restartQueued) {
-      setTimeout(() => void restartServer(), 75);
-    }
-  }
-}
-
-async function shutdown() {
-  watcher?.close();
-  if (app) {
-    await app.close("shutdown").catch(() => undefined);
-  }
-  process.exit(0);
-}
-
-process.once("SIGINT", shutdown);
-process.once("SIGTERM", shutdown);
-
-function run(name, args) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command(name), args, {
-      cwd: rootDir,
-      stdio: "inherit",
-    });
-    child.once("error", reject);
-    child.once("exit", (code) => {
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      reject(new Error(\`\${name} \${args.join(" ")} exited with code \${code}\`));
-    });
-  });
-}
-
-function watchSource() {
+export function watchSource(root, onChange) {
   const watchers = new Map();
-
-  const watchTree = (dir) => {
-    watchDir(dir);
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      if (entry.isDirectory()) {
-        watchTree(join(dir, entry.name));
-      }
+  const retryAttempts = new Map();
+  const retryTimers = new Map();
+  let closed = false;
+  const watchTree = (directory) => {
+    if (closed || !isDirectory(directory)) return;
+    watchDirectory(directory);
+    let entries;
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch (error) {
+      scheduleWatchRetry(directory, error);
+      return;
+    }
+    entries
+      .filter((entry) => entry.isDirectory())
+      .forEach((entry) => watchTree(join(directory, entry.name)));
+  };
+  const watchDirectory = (directory) => {
+    if (closed || watchers.has(directory)) return;
+    try {
+      const watcher = watch(directory, (_event, filename) => {
+        retryAttempts.delete(directory);
+        if (!filename) {
+          reconcileWatchers();
+          onChange();
+          return;
+        }
+        const path = join(directory, filename.toString());
+        if (isDirectory(path)) {
+          watchTree(path);
+          onChange();
+          return;
+        }
+        reconcileWatchers();
+        onChange(path);
+      });
+      watchers.set(directory, watcher);
+      watcher.on("error", (error) => handleWatcherError(directory, watcher, error));
+    } catch (error) {
+      scheduleWatchRetry(directory, error);
     }
   };
-
-  const watchDir = (dir) => {
-    if (watchers.has(dir)) return;
-    const sourceWatcher = watch(dir, { persistent: true }, (_event, filename) => {
-      if (!filename) {
-        queueBuild();
-        queueRestart();
-        return;
-      }
-
-      const filePath = join(dir, filename.toString());
-      if (isDirectory(filePath)) {
-        watchTree(filePath);
-        return;
-      }
-      handleSourceChange(filePath);
-    });
-    sourceWatcher.on("error", (error) => {
-      console.error(\`Source file watching stopped: \${error instanceof Error ? error.message : error}\`);
-    });
-    watchers.set(dir, sourceWatcher);
+  const handleWatcherError = (directory, watcher, error) => {
+    console.error("Source watcher failed for " + directory, error);
+    watcher.close();
+    if (watchers.get(directory) === watcher) watchers.delete(directory);
+    scheduleWatchRetry(directory);
+    onChange();
   };
-
-  try {
-    watchTree(sourceDir);
-  } catch (error) {
-    console.error(\`Source file watching unavailable: \${error instanceof Error ? error.message : error}\`);
-    return undefined;
-  }
-  return {
-    close() {
-      for (const sourceWatcher of watchers.values()) {
-        sourceWatcher.close();
-      }
-      watchers.clear();
-    },
+  const scheduleWatchRetry = (directory, error) => {
+    if (closed || retryTimers.has(directory)) return;
+    const attempt = retryAttempts.get(directory) ?? 0;
+    if (error && attempt === 0) {
+      console.error("Unable to watch source directory " + directory, error);
+    }
+    retryAttempts.set(directory, attempt + 1);
+    const timer = setTimeout(() => {
+      retryTimers.delete(directory);
+      if (isDirectory(directory)) watchDirectory(directory);
+      reconcileWatchers();
+    }, Math.min(100 * (2 ** attempt), 5000));
+    retryTimers.set(directory, timer);
+  };
+  const reconcileWatchers = () => {
+    if (closed) return;
+    watchers.forEach((watcher, directory) => {
+      if (isDirectory(directory)) return;
+      watcher.close();
+      watchers.delete(directory);
+    });
+    watchTree(root);
+  };
+  watchTree(root);
+  return () => {
+    closed = true;
+    watchers.forEach((watcher) => watcher.close());
+    retryTimers.forEach((timer) => clearTimeout(timer));
+    watchers.clear();
+    retryAttempts.clear();
+    retryTimers.clear();
   };
 }
 
-function handleSourceChange(filePath) {
-  if (filePath.endsWith("client.voyd")) {
-    queueBuild();
-    return;
-  }
-  if (filePath.endsWith(".voyd")) {
-    queueBuild();
-    queueRestart();
-    return;
-  }
-  if (filePath.endsWith(".css") || filePath.endsWith(".ts")) {
-    queueBuild();
-  }
-}
-
-function isDirectory(filePath) {
+function isDirectory(path) {
   try {
-    return statSync(filePath).isDirectory();
+    return statSync(path).isDirectory();
   } catch {
     return false;
   }
 }
+`;
 
-function command(name) {
-  return process.platform === "win32" ? \`\${name}.cmd\` : name;
+const devScript = `import { rename, rm } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { checkServer, serve } from "./serve.mjs";
+import { watchSource } from "./watch-source.mjs";
+
+const rootDir = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const sourceDir = resolve(rootDir, "src");
+const stagedPublicDir = resolve(rootDir, ".voyd-dev/public");
+const liveAssetsDir = resolve(rootDir, "public/assets");
+const previousAssetsDir = resolve(rootDir, ".voyd-dev/previous-assets");
+let app;
+let rebuilding = false;
+let rebuildRequested = false;
+
+const stopWatching = watchSource(sourceDir, (file) => {
+  if (file && !/\\.(voyd|ts|css)$/.test(file)) return;
+  void queueRebuild();
+});
+await queueRebuild({ failFast: true });
+
+async function queueRebuild({ failFast = false } = {}) {
+  rebuildRequested = true;
+  if (rebuilding) return;
+  rebuilding = true;
+  try {
+    while (rebuildRequested) {
+      rebuildRequested = false;
+      try {
+        await rebuild();
+      } catch (error) {
+        if (failFast) throw error;
+        console.error(error);
+      }
+    }
+  } finally {
+    rebuilding = false;
+  }
 }
+
+async function rebuild() {
+  await checkServer({ optimize: false });
+  await rm(stagedPublicDir, { recursive: true, force: true });
+  await run("vite", [
+    "build",
+    "--mode", "development",
+    "--outDir", stagedPublicDir,
+    "--emptyOutDir",
+  ]);
+  await checkServer({ optimize: false });
+  if (app) await app.close("restart").catch(() => undefined);
+  const nextApp = await serve({ optimize: false });
+  try {
+    await promoteAssets();
+  } catch (error) {
+    await nextApp.close("asset-promotion-failed").catch(() => undefined);
+    throw error;
+  }
+  app = nextApp;
+  console.log("Voyd app ready at " + app.url);
+}
+
+async function promoteAssets() {
+  const stagedAssetsDir = resolve(stagedPublicDir, "assets");
+  await rm(previousAssetsDir, { recursive: true, force: true });
+  await rename(liveAssetsDir, previousAssetsDir).catch((error) => {
+    if (error?.code !== "ENOENT") throw error;
+  });
+  try {
+    await rename(stagedAssetsDir, liveAssetsDir);
+  } catch (error) {
+    await rename(previousAssetsDir, liveAssetsDir).catch(() => undefined);
+    throw error;
+  }
+  await rm(previousAssetsDir, { recursive: true, force: true });
+  await rm(stagedPublicDir, { recursive: true, force: true });
+}
+
+function run(name, args) {
+  const command = process.platform === "win32" ? name + ".cmd" : name;
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(command, args, { cwd: rootDir, stdio: "inherit" });
+    child.once("error", reject);
+    child.once("exit", (code) => code === 0
+      ? resolveRun()
+      : reject(new Error(name + " exited with code " + code)));
+  });
+}
+
+async function shutdown() {
+  stopWatching();
+  if (app) await app.close("shutdown").catch(() => undefined);
+}
+
+process.once("SIGINT", () => void shutdown().finally(() => process.exit(0)));
+process.once("SIGTERM", () => void shutdown().finally(() => process.exit(0)));
 `;
 
 const clientTs = `import { createVoydHost } from "@voyd-lang/sdk/js-host";
-import { createVoydVxAppRuntime, hydrateVxApp } from "@voyd-lang/vx-dom/browser";
+import {
+  createVoydVxAppRuntime,
+  hydrateVxApp,
+  readVoydHydrationRoot,
+} from "@voyd-lang/vx-dom/browser";
 import wasmUrl from "./generated/client.wasm?url";
 import "./style.css";
 
-const hydration = document.querySelector<HTMLScriptElement>("[data-voyd-hydration]");
-const targetSelector = hydration?.dataset.voydHydration;
-const target = targetSelector ? document.querySelector(targetSelector) : undefined;
+const hydration = readVoydHydrationRoot("article-editor");
 
-if (!hydration || !target) {
-  throw new Error("Mini Voydpedia hydration target was not found.");
-}
-
-const initialModel = JSON.parse(hydration.textContent ?? "null") as unknown;
-
-const start = async () => {
+async function start() {
   const wasm = new Uint8Array(await (await fetch(wasmUrl)).arrayBuffer());
   const host = await createVoydHost({
     wasm,
     bufferSize: 1024 * 1024,
     defaultAdapters: { runtime: "browser" },
   });
-  const app = createVoydVxAppRuntime({ host, initialModel });
-  const mounted = await hydrateVxApp({ container: target, app });
-
+  const app = createVoydVxAppRuntime({ host, initialModel: hydration.model });
+  const mounted = await hydrateVxApp({
+    container: hydration.container,
+    app,
+    onHydrationMismatch: import.meta.env.MODE === "development"
+      ? (mismatch) => console.warn("Voyd hydration mismatch", mismatch)
+      : undefined,
+  });
   import.meta.hot?.dispose(() => mounted.dispose());
-};
+}
 
-start().catch((reason) => {
-  console.error(reason);
-  target.textContent = reason instanceof Error ? reason.message : String(reason);
+start().catch((error) => {
+  console.error(error);
+  const notice = document.createElement("p");
+  notice.setAttribute("role", "alert");
+  notice.className = "m-5 rounded-md border border-rose-300 bg-rose-50 p-3 text-sm text-rose-800";
+  notice.textContent = "Interactive features could not start. You can still edit and submit this form.";
+  hydration.container.prepend(notice);
 });
 `;
 
-const mainVoyd = `use pkg::web::all
+const mainVoyd = `use src::server::articles::{
+  article_slug_from,
+  form_body,
+  load_article,
+  request_body,
+  save_article
+}
+use src::server::page::article_page
+use pkg::web::all
 use std::env::self as env
 use std::error::{ HostError, IoError }
 use std::fs::self as fs
-use std::fs::{ read_string as read_file_string, write_string as write_file_string }
-use std::http::server
-use std::msgpack::MsgPack
-use std::optional::types::all
-use std::path::Path
+use std::http::{ HttpError, server }
 use std::result::types::all
-use std::string::type::String
 use std::task::self as tasks
-use std::vx::all
-
-type ArticleParams = {
-  slug: String
-}
-
-type Article = {
-  slug: String,
-  title: String,
-  body: String,
-  state_kind: String,
-  state_message: String
-}
-
-obj ClientArticle {
-  slug: String,
-  title: String,
-  body: String,
-  saved_body: String,
-  state_kind: String,
-  state_message: String,
-  preview_open: bool,
-  save_count: i32
-}
 
 pub fn main(): (server::HttpServer, tasks::TaskRuntime, env::Env, fs::Fs) -> i32
-  let result = serve(port: app_port(), host: app_host(), shutdown_timeout: 30000, max_body_bytes: 65536) routes():
+  let result = serve(
+    port: app_port(),
+    host: app_host(),
+    shutdown_timeout: 30000,
+    max_body_bytes: 65536
+  ) routes():
     adopt(serve_dir("./public"))
 
     get("/") do:
       article_page(load_article("home"))
 
     get("/wiki") do(ctx: Context):
-      article_page(load_article(article_slug_from(ctx)))
+      article_response(ctx)
 
     get("/wiki/:slug") do(ctx: Context):
-      article_page(load_article(article_slug_from(ctx)))
+      article_response(ctx)
 
     post("/wiki/:slug/body") do(ctx: Context):
-      save_article_body(request_text_body(ctx), article_slug_from(ctx))
+      save_body_response(ctx)
 
     post("/wiki/:slug") do(ctx: Context):
-      save_article(form_article_body(request_text_body(ctx)), article_slug_from(ctx))
+      save_form_response(ctx)
 
   match(result)
     Ok<Unit>:
@@ -619,412 +558,274 @@ pub fn main(): (server::HttpServer, tasks::TaskRuntime, env::Env, fs::Fs) -> i32
     Err<HostError> { error }:
       -error.code
 
-fn app_port(): env::Env -> i32
-  match(env::get_int("VOYD_WEB_PORT".as_slice()))
-    Some<i32> { value }:
-      value
+fn save_body_response(ctx: Context): fs::Fs -> Response
+  match(article_slug_from(ctx))
+    Some<String> { value: slug }:
+      match(request_body(ctx))
+        Ok<String> { value }:
+          saved_body_response(slug: slug, body: value)
+        Err<HttpError> { error }:
+          Response::bad_request().text(error.message)
     None:
-      3000
+      invalid_request("invalid article slug")
+
+fn saved_body_response({ slug: String, body: String }): fs::Fs -> Response
+  match(save_article(slug: slug, body: body))
+    Ok:
+      Response::ok().text("saved")
+    Err<IoError> { error }:
+      Response::internal_server_error().text(error.message)
+
+fn save_form_response(ctx: Context): fs::Fs -> Response
+  match(article_slug_from(ctx))
+    Some<String> { value: slug }:
+      match(request_body(ctx))
+        Ok<String> { value }:
+          match(form_body(value))
+            Some<String> { value: body }:
+              saved_form_response(slug: slug, body: body)
+            None:
+              invalid_request("missing body form field")
+        Err<HttpError> { error }:
+          Response::bad_request().text(error.message)
+    None:
+      invalid_request("invalid article slug")
+
+fn saved_form_response({ slug: String, body: String }): fs::Fs -> Response
+  match(save_article(slug: slug, body: body))
+    Ok { value }:
+      article_page(value)
+    Err<IoError> { error }:
+      Response::internal_server_error().text(error.message)
+
+fn article_response(ctx: Context): fs::Fs -> Response
+  match(article_slug_from(ctx))
+    Some<String> { value }:
+      article_page(load_article(value))
+    None:
+      invalid_request("invalid article slug")
+
+fn invalid_request(message: String) -> Response
+  Response::bad_request().text(message)
+
+fn app_port(): env::Env -> i32
+  env::get_int("VOYD_WEB_PORT") ?? 3000
 
 fn app_host(): env::Env -> String
-  match(env::get("VOYD_WEB_HOST".as_slice()))
-    Some<String> { value }:
-      value
-    None:
-      "127.0.0.1".as_slice().to_string()
-
-fn load_article(slug: String): fs::Fs -> Article
-  let clean = safe_slug(slug)
-  match(read_file_string(article_path(clean)))
-    Ok<String> { value }:
-      {
-        slug: clean,
-        title: title_for(clean),
-        body: value,
-        state_kind: "saved".as_slice().to_string(),
-        state_message: "Saved".as_slice().to_string()
-      }
-    Err<IoError>:
-      {
-        slug: clean,
-        title: title_for(clean),
-        body: "# New article\\n\\nStart writing. Click Save to create the local file.".as_slice().to_string(),
-        state_kind: "unsaved".as_slice().to_string(),
-        state_message: "Unsaved changes".as_slice().to_string()
-      }
-
-fn article_slug_from(ctx: Context) -> String
-  safe_slug(ctx.param("slug".as_slice()) ?? ctx.query_value("slug".as_slice()) ?? "home".as_slice().to_string())
-
-fn request_text_body(ctx: Context) -> String
-  match(ctx.request.body.as_text())
-    Ok<String> { value }:
-      value
-    Err:
-      String::init()
-
-fn save_article(body: String, slug: String): fs::Fs -> Response
-  match(write_file_string(article_path(slug), body))
-    Ok<Unit>:
-      article_page({
-        slug: slug,
-        title: title_for(slug),
-        body: body,
-        state_kind: "saved".as_slice().to_string(),
-        state_message: "Saved".as_slice().to_string()
-      })
-    Err<IoError> { error }:
-      Response::internal_server_error().text(error.message)
-
-fn save_article_body(body: String, slug: String): fs::Fs -> Response
-  match(write_file_string(article_path(slug), body))
-    Ok<Unit>:
-      Response::ok()
-        .with(header: "content-type".as_slice(), value: "text/plain; charset=utf-8".as_slice())
-        .text("saved".as_slice())
-    Err<IoError> { error }:
-      Response::internal_server_error().text(error.message)
-
-fn form_article_body(input: String) -> String
-  parse_query(input).get("body".as_slice()) ?? String::init()
-
-fn article_path(slug: String) -> Path
-  Path::new("./data/articles".as_slice()).join(slug.concat(".md".as_slice()))
-
-fn safe_slug(value: String) -> String
-  let lower = value.as_slice().trimmed().to_string().lowered()
-  if lower.is_empty():
-    return "home".as_slice().to_string()
-  if lower.contains(where: (rune: i32) -> bool => not is_slug_rune(rune)):
-    return "home".as_slice().to_string()
-  lower
-
-fn is_slug_rune(rune: i32) -> bool
-  (rune >= 97 and rune <= 122) or (rune >= 48 and rune <= 57) or rune == 45 or rune == 95
-
-fn title_for(slug: String) -> String
-  if slug.equals("home"):
-    "Mini Voydpedia".as_slice().to_string()
-  else:
-    slug
-
-fn article_page(article: Article) -> Response
-  Response::ok()
-    .with(header: "content-type".as_slice(), value: "text/html; charset=utf-8".as_slice())
-    .text(document<MsgPack, ClientArticle>(
-      view: page_view(article),
-      hydrate: hydrate<ClientArticle>(
-        target: "#article-app".as_slice(),
-        entry: "/assets/client.js".as_slice(),
-        model: client_article(article)
-      )
-    ))
-
-fn client_article(article: Article) -> ClientArticle
-  ClientArticle {
-    slug: article.slug,
-    title: article.title,
-    body: article.body,
-    saved_body: article.body,
-    state_kind: article.state_kind,
-    state_message: article.state_message,
-    preview_open: true,
-    save_count: 0
-  }
-
-fn page_view(article: Article) -> Html<MsgPack>
-  <html lang="en">
-    <head>
-      <meta charset="utf-8"></meta>
-      <meta name="viewport" content="width=device-width, initial-scale=1"></meta>
-      <title>{article.title}</title>
-      <link rel="stylesheet" href="/assets/client.css"></link>
-    </head>
-    <body class="min-h-screen bg-stone-50 text-zinc-950 antialiased">
-      <main
-        class="grid min-h-screen grid-cols-1 lg:grid-cols-[18rem_minmax(0,1fr)]"
-        data-article-slug={article.slug}
-      >
-        <aside class="border-b border-zinc-200 bg-white px-5 py-6 lg:border-b-0 lg:border-r">
-          <a class="block text-lg font-semibold tracking-tight text-emerald-700" href="/">Mini Voydpedia</a>
-          <nav class="mt-8 grid gap-2 text-sm">
-            <NavLink href="/" label="Home" active={article.slug.equals("home")} />
-            <NavLink href="/wiki/voyd" label="Voyd" active={article.slug.equals("voyd")} />
-            <NavLink href="/wiki/webassembly" label="WebAssembly" active={article.slug.equals("webassembly")} />
-          </nav>
-          <form class="mt-8 flex gap-2" action="/wiki" method="get">
-            <input
-              class="min-w-0 flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm outline-none focus:border-emerald-600"
-              name="slug"
-              placeholder="article-slug"
-            ></input>
-            <button class="rounded-md bg-zinc-950 px-3 py-2 text-sm font-medium text-white" type="submit">Open</button>
-          </form>
-        </aside>
-        <div id="article-app">
-          <ArticleEditor article={article} />
-        </div>
-      </main>
-    </body>
-  </html>
-
-fn ArticleEditor({ article: Article }) -> Html<MsgPack>
-  <form class="mx-auto flex w-full max-w-5xl flex-col px-5 py-8 lg:px-10" action={article_form_action(article.slug)} method="post">
-    <header class="flex flex-col gap-4 border-b border-zinc-200 pb-6 md:flex-row md:items-end md:justify-between">
-      <div>
-        <p class="text-sm font-medium uppercase tracking-wide text-emerald-700">Local file article</p>
-        <h1 class="mt-2 text-4xl font-semibold tracking-tight text-zinc-950">{article.title}</h1>
-        <p class="mt-3 max-w-2xl text-zinc-600">
-          Server-rendered by Voyd and hydrated by a Voyd client module. Saved as <code class="rounded bg-zinc-100 px-1.5 py-0.5 text-zinc-800">data/articles/{article.slug}.md</code>.
-        </p>
-      </div>
-      <div class="flex flex-wrap items-center gap-3">
-        <span class={status_class(article.state_kind)}>{article.state_message}</span>
-        <button
-          class="rounded-md bg-emerald-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-800"
-          type="submit"
-        >
-          Save
-        </button>
-      </div>
-    </header>
-    <label class="mt-8 flex min-h-[32rem] flex-1 flex-col">
-      <span class="mb-3 text-sm font-medium text-zinc-700">Article body</span>
-      <textarea
-        class="min-h-[32rem] flex-1 resize-y rounded-md border border-zinc-300 bg-white p-5 font-mono text-sm leading-7 text-zinc-900 outline-none shadow-sm focus:border-emerald-600 focus:ring-2 focus:ring-emerald-100"
-        name="body"
-        spellcheck="true"
-      >{article.body}</textarea>
-    </label>
-  </form>
-
-fn NavLink({ href: String, label: String, active: bool }) -> Html<MsgPack>
-  <a class={nav_class(active)} href={href}>
-    {label}
-  </a>
-
-fn nav_class(active: bool) -> String
-  if active:
-    "rounded-md bg-emerald-50 px-3 py-2 font-medium text-emerald-800".as_slice().to_string()
-  else:
-    "rounded-md px-3 py-2 text-zinc-600 hover:bg-zinc-100 hover:text-zinc-950".as_slice().to_string()
-
-fn article_form_action(slug: String) -> String
-  "/wiki/".as_slice().to_string().concat(slug)
-
-fn status_class(state_kind: String) -> String
-  if state_is(state_kind, "saved".as_slice().to_string()):
-    return "rounded-full bg-emerald-100 px-3 py-1 text-sm font-medium text-emerald-800".as_slice().to_string()
-  if state_is(state_kind, "saving".as_slice().to_string()):
-    return "rounded-full bg-sky-100 px-3 py-1 text-sm font-medium text-sky-800".as_slice().to_string()
-  if state_is(state_kind, "failed".as_slice().to_string()):
-    return "rounded-full bg-rose-100 px-3 py-1 text-sm font-medium text-rose-800".as_slice().to_string()
-  "rounded-full bg-amber-100 px-3 py-1 text-sm font-medium text-amber-800".as_slice().to_string()
-
-fn state_is(kind: String, expected: String) -> bool
-  kind.equals(expected)
+  env::get("VOYD_WEB_HOST") ?? "127.0.0.1"
 `;
 
-const clientVoyd = `use std::array::Array
+const clientVoyd = `use src::app::model::{ Model, empty_model }
+use src::app::update::{ Msg, step }
+use src::app::ui::view
+use std::vx::all
+
+pub fn app() -> Program<Model, Msg>
+  program({ init: empty_model, step: step, view })
+`;
+
+const appModuleVoyd = `pub self::model
+pub self::update
+pub self::ui
+`;
+
+const modelVoyd = `use std::string::type::String
+
+pub obj Model {
+  slug: String,
+  title: String,
+  body: String,
+  saved_body: String,
+  preview_open: bool,
+  save_count: i32,
+  saving: bool,
+  save_failed: bool
+}
+
+pub fn initial_model({ slug: String, title: String, body: String }) -> Model
+  Model {
+    slug: slug,
+    title: title,
+    body: body,
+    saved_body: body,
+    preview_open: true,
+    save_count: 0,
+    saving: false,
+    save_failed: false
+  }
+
+pub fn empty_model() -> Model
+  initial_model(slug: "home", title: "Mini Voydpedia", body: String::init())
+
+pub fn with_body(model: Model, body: String) -> Model
+  copy(model, body: body)
+
+pub fn reset(model: Model) -> Model
+  copy(model, body: model.saved_body, save_failed: false)
+
+pub fn toggle_preview(model: Model) -> Model
+  copy(model, preview_open: not model.preview_open)
+
+pub fn start_saving(model: Model) -> Model
+  copy(model, saving: true, save_failed: false)
+
+pub fn finish_saving(model: Model, succeeded: bool) -> Model
+  copy(
+    model,
+    saved_body: if succeeded then: model.body else: model.saved_body,
+    save_count: if succeeded then: model.save_count + 1 else: model.save_count,
+    saving: false,
+    save_failed: not succeeded
+  )
+
+pub fn is_dirty(model: Model) -> bool
+  not (model.body == model.saved_body)
+
+pub fn can_save(model: Model) -> bool
+  is_dirty(model) and not model.saving
+
+fn copy(model: Model, {
+  body?: String,
+  saved_body?: String,
+  preview_open?: bool,
+  save_count?: i32,
+  saving?: bool,
+  save_failed?: bool
+}) -> Model
+  Model {
+    slug: model.slug,
+    title: model.title,
+    body: body ?? model.body,
+    saved_body: saved_body ?? model.saved_body,
+    preview_open: preview_open ?? model.preview_open,
+    save_count: save_count ?? model.save_count,
+    saving: saving ?? model.saving,
+    save_failed: save_failed ?? model.save_failed
+  }
+`;
+
+const updateVoyd = `use super::model::{
+  Model,
+  can_save,
+  finish_saving,
+  reset,
+  start_saving,
+  toggle_preview,
+  with_body
+}
 use std::enums::{ enum }
 use std::error::HostError
 use std::http::{ Body, Response }
 use std::http::client::self as http_client
-use std::msgpack::MsgPack
-use std::number::cast::to_string
 use std::result::types::all
 use std::string::type::String
 use std::task::self as tasks
 use std::vx::all
 
-obj ClientArticle {
-  slug: String,
-  title: String,
-  body: String,
-  saved_body: String,
-  state_kind: String,
-  state_message: String,
-  preview_open: bool,
-  save_count: i32
-}
-
-enum Msg
+pub enum Msg
   Edit { value: String }
   Save
-  SaveFinished { code: i32 }
+  SaveFinished { succeeded: bool }
   Reset
   TogglePreview
 
-pub fn app() -> Program<ClientArticle, Msg>
-  program({ init, step, view })
-
-fn init() -> ClientArticle
-  ClientArticle {
-    slug: "home",
-    title: "Mini Voydpedia",
-    body: String::init(),
-    saved_body: String::init(),
-    state_kind: "saved",
-    state_message: "Saved",
-    preview_open: true,
-    save_count: 0
-  }
-
-fn step(model: ClientArticle, message: Msg): (http_client::HttpClient, tasks::TaskRuntime) -> Program<ClientArticle, Msg>
+pub fn step(
+  model: Model,
+  message: Msg
+): (http_client::HttpClient, tasks::TaskRuntime) -> Program<Model, Msg>
   match(message)
     Msg::Edit { value }:
-      next(ClientArticle {
-        slug: model.slug,
-        title: model.title,
-        body: value,
-        saved_body: model.saved_body,
-        state_kind: state_kind_for_body(value, model.saved_body),
-        state_message: state_message_for_body(value, model.saved_body),
-        preview_open: model.preview_open,
-        save_count: model.save_count
-      })
+      next(with_body(model, value))
     Msg::Reset:
-      next(ClientArticle {
-        slug: model.slug,
-        title: model.title,
-        body: model.saved_body,
-        saved_body: model.saved_body,
-        state_kind: "saved",
-        state_message: "Saved",
-        preview_open: model.preview_open,
-        save_count: model.save_count
-      })
+      next(reset(model))
     Msg::TogglePreview:
-      next(ClientArticle {
-        slug: model.slug,
-        title: model.title,
-        body: model.body,
-        saved_body: model.saved_body,
-        state_kind: model.state_kind,
-        state_message: model.state_message,
-        preview_open: not model.preview_open,
-        save_count: model.save_count
-      })
+      next(toggle_preview(model))
     Msg::Save:
-      if is_saving(model) or not is_dirty(model):
-        return next(model)
-      program<ClientArticle, Msg>(
-        model: ClientArticle {
-          slug: model.slug,
-          title: model.title,
-          body: model.body,
-          saved_body: model.saved_body,
-          state_kind: "saving",
-          state_message: "Saving...",
-          preview_open: model.preview_open,
-          save_count: model.save_count
-        },
-        commands: Cmd<Msg>::task(
-          work: () -> i32 => save_article(model.slug, model.body),
-          handler: (code: i32) -> Msg => Msg::SaveFinished { code: code }
-        )
-      )
-    Msg::SaveFinished { code }:
-      if code == 1:
-        return next(ClientArticle {
-          slug: model.slug,
-          title: model.title,
-          body: model.body,
-          saved_body: model.body,
-          state_kind: "saved",
-          state_message: "Saved",
-          preview_open: model.preview_open,
-          save_count: model.save_count + 1
-        })
-      next(ClientArticle {
-        slug: model.slug,
-        title: model.title,
-        body: model.body,
-        saved_body: model.saved_body,
-        state_kind: "failed",
-        state_message: "Save failed",
-        preview_open: model.preview_open,
-        save_count: model.save_count
-      })
+      save(model)
+    Msg::SaveFinished { succeeded }:
+      next(finish_saving(model, succeeded))
 
-fn view(model: ClientArticle) -> Html<Msg>
+fn save(model: Model): (http_client::HttpClient, tasks::TaskRuntime) -> Program<Model, Msg>
+  if not can_save(model):
+    return next(model)
+  program<Model, Msg>(
+    model: start_saving(model),
+    commands: Cmd<Msg>::task(
+      work: () -> bool => save_article(slug: model.slug, body: model.body),
+      handler: (succeeded: bool) -> Msg => Msg::SaveFinished { succeeded: succeeded }
+    )
+  )
+
+fn save_article({ slug: String, body: String }): http_client::HttpClient -> bool
+  let response: Result<Response, HostError> = http_client::post(
+    url: "/wiki/".concat(slug).concat("/body"),
+    body: Body::text(body)
+  )
+  match(response)
+    Ok<Response> { value }:
+      value.is_success()
+    Err<HostError>:
+      false
+`;
+
+const viewVoyd = `use super::model::{ Model, can_save, is_dirty }
+use super::update::Msg
+use std::array::Array
+use std::msgpack::MsgPack
+use std::number::cast::to_string
+use std::string::type::String
+use std::vx::all
+
+pub fn view(model: Model) -> Html<Msg>
+  editor(model, interactive: true)
+
+pub fn static_view(model: Model) -> Html<Msg>
+  editor(model, interactive: false)
+
+fn editor(model: Model, { interactive: bool }) -> Html<Msg>
   <form
     class="mx-auto flex w-full max-w-5xl flex-col px-5 py-8 lg:px-10"
-    action={article_form_action(model.slug)}
+    action={"/wiki/".concat(model.slug)}
     method="post"
+    on_submit={on_submit_with(
+      options: EventOptions {
+        prevent_default: true,
+        stop_propagation: false,
+        capture: false,
+        passive: false
+      },
+      message: Msg::Save {}
+    )}
   >
-    <header class="flex flex-col gap-4 border-b border-zinc-200 pb-6 md:flex-row md:items-end md:justify-between">
-      <div>
-        <p class="text-sm font-medium uppercase tracking-wide text-emerald-700">Local file article</p>
-        <h1 class="mt-2 text-4xl font-semibold tracking-tight text-zinc-950">{model.title}</h1>
-        <p class="mt-3 max-w-2xl text-zinc-600">
-          Server-rendered by Voyd and hydrated by a Voyd client module. Saved as <code class="rounded bg-zinc-100 px-1.5 py-0.5 text-zinc-800">data/articles/{model.slug}.md</code>.
-        </p>
-      </div>
-      <div class="flex flex-wrap items-center gap-3">
-        <span class={status_class(model)}>{status_label(model)}</span>
-        <button
-          class="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-semibold text-zinc-800 shadow-sm transition hover:bg-zinc-50 disabled:cursor-not-allowed disabled:text-zinc-400"
-          type="button"
-          disabled={not can_save_or_reset(model)}
-          on_click={Msg::Reset {}}
-        >
-          Reset
-        </button>
-        <button
-          class="rounded-md border border-emerald-700 bg-white px-4 py-2 text-sm font-semibold text-emerald-800 shadow-sm transition hover:bg-emerald-50"
-          type="button"
-          disabled={is_saving(model)}
-          on_click={Msg::TogglePreview {}}
-        >
-          {preview_button_label(model)}
-        </button>
-        <button
-          class="rounded-md bg-emerald-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
-          type="button"
-          disabled={not can_save_or_reset(model)}
-          on_click={Msg::Save {}}
-        >
-          {save_button_label(model)}
-        </button>
-      </div>
-    </header>
-    <section class="grid gap-4 border-b border-zinc-200 py-4 text-sm text-zinc-600 sm:grid-cols-4">
-      <Stat label="Words" value={to_string(word_count(model.body))} />
-      <Stat label="Characters" value={to_string(model.body.byte_len())} />
-      <Stat label="Local state" value={dirty_label(model)} />
-      <Stat label="Client saves" value={to_string(model.save_count)} />
-    </section>
+    <EditorHeader model={model} />
+    <EditorStats model={model} />
     <div class={editor_grid_class(model)}>
-      <label class="mt-8 flex min-h-[32rem] flex-1 flex-col">
-        <span class="mb-3 text-sm font-medium text-zinc-700">Article body</span>
-        <textarea
-          class="min-h-[32rem] flex-1 resize-y rounded-md border border-zinc-300 bg-white p-5 font-mono text-sm leading-7 text-zinc-900 outline-none shadow-sm focus:border-emerald-600 focus:ring-2 focus:ring-emerald-100"
-          name="body"
-          spellcheck="true"
-          value={model.body}
-          disabled={is_saving(model)}
-          on_input={(event: InputEvent) -> Msg => Msg::Edit { value: event.value }}
-        >{model.body}</textarea>
-      </label>
+      <BodyEditor model={model} interactive={interactive} />
       <Preview model={model} />
     </div>
   </form>
 
-fn Preview({ model: ClientArticle }) -> Html<Msg>
-  if model.preview_open:
-    <aside class="mt-8 rounded-md border border-zinc-200 bg-white p-5 shadow-sm">
-      <div class="flex items-center justify-between border-b border-zinc-200 pb-3">
-        <h2 class="text-sm font-semibold uppercase tracking-wide text-zinc-500">Live preview</h2>
-        <span class="text-xs font-medium text-emerald-700">Voyd client state</span>
-      </div>
-      <article class="prose mt-5 max-w-none text-zinc-800">
-        <h3 class="text-2xl font-semibold text-zinc-950">{model.title}</h3>
-        <pre class="whitespace-pre-wrap rounded-md bg-zinc-50 p-4 text-sm leading-7 text-zinc-800">{model.body}</pre>
-      </article>
-    </aside>
-  else:
-    fragment(Array<MsgPack>::init())
+fn EditorHeader({ model: Model }) -> Html<Msg>
+  <header class="flex flex-col gap-4 border-b border-zinc-200 pb-6 md:flex-row md:items-end md:justify-between">
+    <div>
+      <p class="text-sm font-medium uppercase tracking-wide text-emerald-700">Local file article</p>
+      <h1 class="mt-2 text-4xl font-semibold tracking-tight">{model.title}</h1>
+      <p class="mt-3 max-w-2xl text-zinc-600">Rendered once by the server, then hydrated from the same Voyd view.</p>
+    </div>
+    <div class="flex flex-wrap items-center gap-3">
+      <span class={status_class(model)}>{status_label(model)}</span>
+      <button class="rounded-md border border-zinc-300 bg-white px-4 py-2 font-semibold" type="button" disabled={not can_save(model)} on_click={Msg::Reset {}}>Reset</button>
+      <button class="rounded-md border border-emerald-700 bg-white px-4 py-2 font-semibold text-emerald-800" type="button" disabled={model.saving} on_click={Msg::TogglePreview {}}>{preview_label(model)}</button>
+      <button class="rounded-md bg-emerald-700 px-4 py-2 font-semibold text-white disabled:bg-zinc-400" type="submit" disabled={model.saving}>{save_label(model)}</button>
+    </div>
+  </header>
+
+fn EditorStats({ model: Model }) -> Html<Msg>
+  <section class="grid gap-4 border-b border-zinc-200 py-4 text-sm text-zinc-600 sm:grid-cols-3">
+    <Stat label="Characters" value={to_string(model.body.byte_len())} />
+    <Stat label="Local state" value={dirty_label(model)} />
+    <Stat label="Client saves" value={to_string(model.save_count)} />
+  </section>
 
 fn Stat({ label: String, value: String }) -> Html<Msg>
   <div class="rounded-md border border-zinc-200 bg-white px-3 py-2">
@@ -1032,108 +833,205 @@ fn Stat({ label: String, value: String }) -> Html<Msg>
     <div class="mt-1 font-semibold text-zinc-950">{value}</div>
   </div>
 
-fn save_article(slug: String, body: String): http_client::HttpClient -> i32
-  let result: Result<Response, HostError> = http_client::post(url: article_body_action(slug), body: Body::text(body))
-  match(result)
-    Ok<Response> { value }:
-      if value.is_success():
-        1
-      else:
-        0
-    Err<HostError>:
-      0
+fn BodyEditor({ model: Model, interactive: bool }) -> Html<Msg>
+  <label class="mt-8 flex min-h-[32rem] flex-1 flex-col">
+    <span class="mb-3 text-sm font-medium text-zinc-700">Article body</span>
+    {BodyTextarea(model: model, interactive: interactive)}
+  </label>
 
+fn BodyTextarea({ model: Model, interactive: bool }) -> Html<Msg>
+  let ~attrs = [
+    class("min-h-[32rem] flex-1 resize-y rounded-md border border-zinc-300 bg-white p-5 font-mono text-sm leading-7 outline-none focus:border-emerald-600"),
+    attr(name: "name", value: "body"),
+    attr(name: "spellcheck", value: "true"),
+    value(model.body),
+    disabled(model.saving)
+  ]
+  if interactive:
+    attrs.push(event_payload_handler<InputEvent, Msg>(
+      name: "input",
+      handler: (event: InputEvent) -> Msg => Msg::Edit { value: event.value }
+    ))
+  element(tag: "textarea", attrs: attrs, children: [text(model.body)])
 
-fn article_form_action(slug: String) -> String
-  "/wiki/".as_slice().to_string().concat(slug)
-
-fn article_body_action(slug: String) -> String
-  article_form_action(slug).concat("/body".as_slice())
-
-fn is_dirty(model: ClientArticle) -> bool
-  not (model.body == model.saved_body)
-
-fn can_save_or_reset(model: ClientArticle) -> bool
-  is_dirty(model) and not is_saving(model)
-
-fn is_saving(model: ClientArticle) -> bool
-  state_is(model.state_kind, "saving")
-
-fn state_kind_for_body(body: String, saved_body: String) -> String
-  if body == saved_body:
-    "saved"
+fn Preview({ model: Model }) -> Html<Msg>
+  if model.preview_open:
+    <aside class="mt-8 rounded-md border border-zinc-200 bg-white p-5 shadow-sm">
+      <p class="text-xs font-medium uppercase tracking-wide text-emerald-700">Live preview</p>
+      <h2 class="mt-3 text-2xl font-semibold">{model.title}</h2>
+      <pre class="mt-4 whitespace-pre-wrap rounded-md bg-zinc-50 p-4 text-sm leading-7">{model.body}</pre>
+    </aside>
   else:
-    "unsaved"
+    fragment(Array<MsgPack>::init())
 
-fn state_message_for_body(body: String, saved_body: String) -> String
-  if body == saved_body:
-    "Saved"
-  else:
-    "Unsaved changes"
-
-fn dirty_label(model: ClientArticle) -> String
-  if state_is(model.state_kind, "saving"):
-    return "Saving"
-  if state_is(model.state_kind, "failed"):
+fn status_label(model: Model) -> String
+  if model.saving:
+    return "Saving..."
+  if model.save_failed:
     return "Save failed"
   if is_dirty(model):
-    "Unsaved"
-  else:
-    "Saved"
+    return "Unsaved changes"
+  "Saved"
 
-fn status_label(model: ClientArticle) -> String
-  model.state_message
-
-fn status_class(model: ClientArticle) -> String
-  if state_is(model.state_kind, "saved"):
-    return "rounded-full bg-emerald-100 px-3 py-1 text-sm font-medium text-emerald-800"
-  if state_is(model.state_kind, "saving"):
-    return "rounded-full bg-sky-100 px-3 py-1 text-sm font-medium text-sky-800"
-  if state_is(model.state_kind, "failed"):
+fn status_class(model: Model) -> String
+  if model.save_failed:
     return "rounded-full bg-rose-100 px-3 py-1 text-sm font-medium text-rose-800"
-  "rounded-full bg-amber-100 px-3 py-1 text-sm font-medium text-amber-800"
+  if model.saving:
+    return "rounded-full bg-sky-100 px-3 py-1 text-sm font-medium text-sky-800"
+  if is_dirty(model):
+    return "rounded-full bg-amber-100 px-3 py-1 text-sm font-medium text-amber-800"
+  "rounded-full bg-emerald-100 px-3 py-1 text-sm font-medium text-emerald-800"
 
-fn preview_button_label(model: ClientArticle) -> String
-  if model.preview_open:
-    "Hide preview"
-  else:
-    "Show preview"
+fn dirty_label(model: Model) -> String
+  if is_dirty(model) then: "Unsaved" else: "Saved"
 
-fn save_button_label(model: ClientArticle) -> String
-  if is_saving(model):
-    "Saving..."
-  else:
-    "Save"
+fn preview_label(model: Model) -> String
+  if model.preview_open then: "Hide preview" else: "Show preview"
 
-fn state_is(kind: String, expected: String) -> bool
-  kind.equals(expected)
+fn save_label(model: Model) -> String
+  if model.saving then: "Saving..." else: "Save"
 
-fn editor_grid_class(model: ClientArticle) -> String
+fn editor_grid_class(model: Model) -> String
   if model.preview_open:
     "grid gap-6 lg:grid-cols-[minmax(0,1fr)_22rem]"
   else:
     "grid gap-6"
+`;
 
-fn word_count(value: String) -> i32
-  var count = 0
-  var in_word = false
-  var index = 0
-  while index < value.byte_len():
-    match(value.get_byte(index))
-      Some<i32> { value: byte }:
-        if is_space(byte):
-          in_word = false
-        else:
-          if not in_word:
-            count = count + 1
-            in_word = true
-      None:
-        void
-    index = index + 1
-  count
+const articlesVoyd = `use pkg::web::{ Context, parse_query }
+use std::error::IoError
+use std::fs::self as fs
+use std::fs::{ read_string, write_string }
+use std::http::HttpError
+use std::optional::types::all
+use std::path::Path
+use std::result::types::all
+use std::string::type::String
 
-fn is_space(byte: i32) -> bool
-  byte == 9 or byte == 10 or byte == 13 or byte == 32
+pub type Article = {
+  slug: String,
+  title: String,
+  body: String
+}
+
+pub fn load_article(slug: String): fs::Fs -> Article
+  let clean = canonical_slug(slug)
+  match(read_string(article_path(clean)))
+    Ok<String> { value }:
+      article(clean, value)
+    Err<IoError>:
+      article(clean, "# New article\\n\\nStart writing, then click Save.")
+
+pub fn save_article({ slug: String, body: String }): fs::Fs -> Result<Article, IoError>
+  match(write_string(article_path(slug), body))
+    Ok<Unit>:
+      Ok<Article> { value: article(slug, body) }
+    Err<IoError> { error }:
+      Err<IoError> { error: error }
+
+pub fn article_slug_from(ctx: Context) -> Option<String>
+  match(ctx.param("slug"))
+    Some<String> { value }:
+      valid_slug(value)
+    None:
+      match(ctx.query_value("slug"))
+        Some<String> { value }:
+          valid_slug(value)
+        None:
+          Some<String> { value: "home" }
+
+pub fn request_body(ctx: Context) -> Result<String, HttpError>
+  ctx.request.body.as_text()
+
+pub fn form_body(input: String) -> Option<String>
+  parse_query(input).get("body")
+
+fn article(slug: String, body: String) -> Article
+  { slug: slug, title: title_for(slug), body: body }
+
+fn article_path(slug: String) -> Path
+  Path::new("./data/articles").join(canonical_slug(slug).concat(".md"))
+
+fn canonical_slug(value: String) -> String
+  valid_slug(value) ?? "home"
+
+fn valid_slug(value: String) -> Option<String>
+  let slug = value.trimmed().lowered()
+  if slug.is_empty() or slug.contains(where: (rune: i32) -> bool => not is_slug_rune(rune)):
+    return None {}
+  Some<String> { value: slug }
+
+fn is_slug_rune(rune: i32) -> bool
+  (rune >= 97 and rune <= 122) or (rune >= 48 and rune <= 57) or rune == 45 or rune == 95
+
+fn title_for(slug: String) -> String
+  if slug == "home" then: "Mini Voydpedia" else: slug
+`;
+
+const pageVoyd = `use super::articles::Article
+use src::app::model::{ Model, initial_model }
+use src::app::update::Msg
+use src::app::ui::static_view
+use pkg::web::{ Response, document, hydrate_named }
+use std::string::type::String
+use std::vx::all
+
+pub fn article_page(article: Article) -> Response
+  let model = initial_model(slug: article.slug, title: article.title, body: article.body)
+  Response::ok()
+    .with(header: "content-type", value: "text/html; charset=utf-8")
+    .text(document<Msg, Model>(
+      view: page_view(model),
+      hydrate: hydrate_named<Model>(
+        id: "article-editor",
+        target: "#article-editor",
+        entry: "/assets/client.js",
+        model: model
+      )
+    ))
+
+fn page_view(model: Model) -> Html<Msg>
+  <html lang="en">
+    <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <title>{model.title}</title>
+      <link rel="stylesheet" href="/assets/client.css" />
+    </head>
+    <body class="min-h-screen bg-stone-50 text-zinc-950 antialiased">
+      <main class="grid min-h-screen grid-cols-1 lg:grid-cols-[18rem_minmax(0,1fr)]">
+        <Sidebar active_slug={model.slug} />
+        <div id="article-editor">{static_view(model)}</div>
+      </main>
+    </body>
+  </html>
+
+fn Sidebar({ active_slug: String }) -> Html<Msg>
+  <aside class="border-b border-zinc-200 bg-white px-5 py-6 lg:border-b-0 lg:border-r">
+    <a class="block text-lg font-semibold text-emerald-700" href="/">Mini Voydpedia</a>
+    <nav class="mt-8 grid gap-2 text-sm">
+      <NavLink href="/" label="Home" active={active_slug == "home"} />
+      <NavLink href="/wiki/voyd" label="Voyd" active={active_slug == "voyd"} />
+      <NavLink href="/wiki/webassembly" label="WebAssembly" active={active_slug == "webassembly"} />
+    </nav>
+    <form class="mt-8 flex gap-2" action="/wiki" method="get">
+      <input class="min-w-0 flex-1 rounded-md border border-zinc-300 px-3 py-2" name="slug" placeholder="article-slug" />
+      <button class="rounded-md bg-zinc-950 px-3 py-2 text-white" type="submit">Open</button>
+    </form>
+  </aside>
+
+fn NavLink({ href: String, label: String, active: bool }) -> Html<Msg>
+  <a class={nav_class(active)} href={href}>{label}</a>
+
+fn nav_class(active: bool) -> String
+  if active:
+    "rounded-md bg-emerald-50 px-3 py-2 font-medium text-emerald-800"
+  else:
+    "rounded-md px-3 py-2 text-zinc-600 hover:bg-zinc-100"
+`;
+
+const serverModuleVoyd = `pub self::articles
+pub self::page
 `;
 
 const styleCss = `@import "tailwindcss";
@@ -1141,9 +1039,7 @@ const styleCss = `@import "tailwindcss";
 @source "./**/*.voyd";
 
 :root {
-  font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
 }
 
 body {
@@ -1160,29 +1056,24 @@ textarea {
 
 const homeArticle = `# Mini Voydpedia
 
-This tiny wiki is rendered on the server by Voyd and styled with Tailwind.
-
-Edit this article, click Save, and inspect data/articles/home.md. The page is
-just a local file, so it is easy to seed, diff, back up, or delete.
+This article editor is rendered on the server and hydrated in the browser from
+the same shared Voyd view.
 `;
 
 const voydArticle = `# Voyd
 
-Voyd is a programming language that compiles to WebAssembly. This app uses the
-Voyd web framework to route HTTP requests, render HTML, and write articles
-through std::fs.
+Voyd is a programming language that compiles to WebAssembly.
 `;
 
 const webassemblyArticle = `# WebAssembly
 
-WebAssembly is the portable compilation target that runs this server. The
-JavaScript host starts the Voyd module and provides filesystem and HTTP server
-capabilities.
+WebAssembly is the portable compilation target used by the server and browser.
 `;
 
 const gitIgnore = `node_modules
 public/assets
 src/generated
+.voyd-dev
 dist
 .turbo
 .DS_Store
@@ -1194,33 +1085,29 @@ data/articles/*.md
 
 const readme = (packageName: string) => `# ${packageName}
 
-Mini Voydpedia is a server-rendered Voyd app with a hydrated Voyd client module
-and Tailwind assets built by Vite. Articles are local markdown files in
-\`data/articles\`, so edits are easy to diff, seed, back up, or delete.
+This is a server-rendered Voyd application with a hydrated VX editor.
 
-The browser TypeScript entrypoint only loads the compiled Voyd client wasm and
-hydrates the server-rendered form. Routing, article lookup, rendering, client
-editor state, client save behavior, and filesystem writes all live in Voyd:
-\`src/main.voyd\` for the server and \`src/client.voyd\` for the browser.
+## Architecture
 
-## Scripts
+- \`src/main.voyd\` owns HTTP routes and server startup.
+- \`src/server\` owns persistence and the server-rendered document shell.
+- \`src/app\` owns the shared model, update logic, and exact markup. Its
+  \`static_view\` omits retained browser handlers while sharing the same editor
+  implementation as the interactive \`view\`.
+- \`src/client.voyd\` is the browser Program entrypoint.
+- \`src/client.ts\` is the generic Wasm hydration bridge.
 
-- \`npm run dev\` builds the client assets, starts the Voyd SSR server, rebuilds
-  assets when \`src/client.voyd\`, \`src/**/*.ts\`, or \`src/**/*.css\` changes,
-  and restarts the server when other \`src/**/*.voyd\` files change.
-- \`npm run build\` builds the Tailwind/client assets into \`public/assets\` and
-  checks the Voyd server and client with optimized compilation.
-- \`npm start\` runs the production-style SSR server.
-- \`npm run voyd:check\` compiles the Voyd server and browser module.
-- \`npm run typecheck\` checks the TypeScript helper scripts and wasm hydration
-  entrypoint.
+Code inside \`#article-editor\` must render identically on the server and client.
+The development bridge reports hydration differences without preventing recovery.
 
-## Configuration
+## Commands
 
-- \`PORT\` or \`VOYD_WEB_PORT\` changes the server port. The default is \`3000\`.
-- \`HOST\` or \`VOYD_WEB_HOST\` changes the bind host. The default is
-  \`127.0.0.1\`.
+- \`npm run dev\` rebuilds both Wasm entrypoints and restarts the server when
+  Voyd, TypeScript, or CSS sources change.
+- \`npm run build\` builds browser assets and compile-checks both entrypoints.
+- \`npm start\` runs the production server.
+- \`npm run voyd:check\` compile-checks the server and browser modules.
+- \`npm run typecheck\` checks the TypeScript bridge.
 
-Article form posts accept request bodies up to 64 KiB by default. Adjust
-\`max_body_bytes\` in \`src/main.voyd\` if your app needs larger edits.
+Set \`HOST\`/\`VOYD_WEB_HOST\` and \`PORT\`/\`VOYD_WEB_PORT\` to configure the listener.
 `;

--- a/packages/reference/docs/vx.md
+++ b/packages/reference/docs/vx.md
@@ -27,7 +27,10 @@ npm run dev
 The starter includes Vite, Tailwind CSS, Voyd compilation, the JavaScript host,
 and the VX browser runtime. Its main files are:
 
-- `src/main.voyd`: your model, messages, application logic, and views.
+- `src/app/model.voyd`: model definitions and initial state.
+- `src/app/update.voyd`: messages and transitions.
+- `src/app/ui.voyd`: views and components.
+- `src/main.voyd`: the small `Program` composition entrypoint.
 - `src/main.ts`: loads the compiled Wasm module and mounts the app.
 - `src/style.css`: global styles and Tailwind configuration.
 - `scripts/compile-voyd.mjs`: compiles Voyd and generates host adapters.
@@ -262,8 +265,23 @@ style(name: "display", value: "grid")
 styles([("display", "grid"), ("gap", "0.5rem")])
 ```
 
+These form properties have stable server representations on the elements where
+HTML defines matching behavior: `value` on `input` and `textarea`, `checked` on
+`input`, and `disabled` on disableable form controls. A controlled `textarea`
+must render the same value as its text child. In particular, `value` on `select`
+is browser-only because HTML derives its initial selection from `selected`
+options. Other `prop` names remain available for browser-only views, but the SSR
+renderers reject combinations that would emit different server semantics. Use
+`attr` for ordinary HTML attributes. Structured style values are single
+declaration values and reject semicolons, exclamation marks, and control
+characters; use classes for more complex styling.
+
 HTML syntax is preferred. `text`, `fragment`, `html_element`, and `element` are
-available for helpers that build trees dynamically.
+available for helpers that build trees dynamically. Dynamic HTML tag names must
+be lowercase, as must names passed to `attr`; use the canonical `class` name
+rather than DOM spellings such as `className`. Void elements such as `input`, `img`, and `br` cannot have
+children; VX rejects those trees before rendering so browser and server output
+cannot diverge.
 
 ## Events And Forms
 
@@ -635,10 +653,16 @@ browser:
 voyd bootstrap my-site --template web-ssr
 ```
 
-The server sends a complete document, the initial model, and a client entry URL.
-The browser creates the same VX application with that model and calls
-`hydrateVxApp`, preserving the server-rendered DOM. See [Web](./web.md) for the
-complete server and hydration workflow.
+The shared `src/app` code owns the model, transitions, and exact markup. Its
+`static_view` omits retained browser callback descriptors while calling the same
+internal view implementation as the interactive `view`; this prevents
+server-request callback leaks without duplicating UI. The server wraps that
+markup in the document shell and sends its initial model plus a structured
+hydration root. The browser creates the same VX
+application with that model and calls `hydrateVxApp`, preserving matching DOM
+and reporting mismatches in development. Server-only routes and persistence stay
+under `src/server`; Wasm loading stays in the TypeScript bridge. See
+[Web](./web.md) for the complete server and hydration workflow.
 
 ## Browser Runtime Integration
 

--- a/packages/reference/docs/web.md
+++ b/packages/reference/docs/web.md
@@ -29,13 +29,18 @@ because it includes the Node host and development workflow. For an API, keep
 interactive site, use the complete starter.
 
 The generated project includes the Web package, VX server rendering and
-hydration, Vite, Tailwind CSS, and static assets. Its main files are:
+hydration, Vite, Tailwind CSS, and static assets. It separates code by runtime
+boundary:
 
-- `src/main.voyd`: the HTTP server, routes, server data, and rendered pages.
-- `src/client.voyd`: the VX application that runs after hydration.
-- `src/client.ts`: loads the client Wasm module and hydrates the page.
+- `src/app/`: the shared model, update logic, and exact interactive view used
+  by both server rendering and browser hydration.
+- `src/server/`: persistence and the server-only document shell.
+- `src/main.voyd`: the small HTTP routing and server-startup entrypoint.
+- `src/client.voyd`: the small browser `Program` entrypoint.
+- `src/client.ts`: the generic Wasm and hydration bridge.
 - `public/`: files served directly by the application.
-- `scripts/dev.mjs`: rebuilds the client and restarts the server in development.
+- `scripts/dev.mjs`: rebuilds both entrypoints and restarts the server when
+  shared source changes.
 - `scripts/serve.mjs`: compiles and runs the server.
 
 Useful commands are:
@@ -579,7 +584,8 @@ Use `render(view)` when you need an HTML fragment as a string. Use
 
 ### Hydrate An Interactive Page
 
-Render the initial model, target selector, and client entry together:
+Render the initial model, stable root id, target selector, and client entry
+together:
 
 ```voyd
 fn article_page(model: Model) -> Response
@@ -593,10 +599,11 @@ fn article_page(model: Model) -> Response
         <link rel="stylesheet" href="/assets/client.css" />
       </head>
       <body>
-        <div id="app">{view(model)}</div>
+        <div id="app">{static_view(model)}</div>
       </body>
     </html>,
-    hydrate: hydrate(
+    hydrate: hydrate_named(
+      id: "article-editor",
       target: "#app",
       entry: "/assets/client.js",
       model: model
@@ -604,22 +611,47 @@ fn article_page(model: Model) -> Response
   )
 ```
 
-The helper safely serializes the model into an `application/json` script and
-adds the module entry. The hydration model must be boundary-safe and must match
-the model expected by the client VX app.
+The helper safely serializes the model into an `application/json` script inside
+the document body and adds the module entry. Serialization failure stops the
+response instead of silently replacing the model. The hydration model must be
+boundary-safe and must match the model expected by the client VX app. Use a
+unique `id` for each interactive root; one document may contain several roots.
+Call `append_hydration` for each additional model when a page has more than one
+interactive region:
+
+```voyd
+let with_editor = append_hydration(
+  document(page),
+  hydrate_named(
+    id: "editor",
+    target: "#editor",
+    entry: "/assets/editor.js",
+    model: editor_model
+  )
+)
+let complete = append_hydration(
+  with_editor,
+  hydrate_named(
+    id: "presence",
+    target: "#presence",
+    entry: "/assets/presence.js",
+    model: presence_model
+  )
+)
+```
 
 In the client entry, read that model and hydrate instead of mounting a new tree:
 
 ```ts
 import { createVoydHost } from "@voyd-lang/sdk/js-host";
-import { createVoydVxAppRuntime, hydrateVxApp } from "@voyd-lang/vx-dom/browser";
+import {
+  createVoydVxAppRuntime,
+  hydrateVxApp,
+  readVoydHydrationRoot,
+} from "@voyd-lang/vx-dom/browser";
 import wasmUrl from "./generated/client.wasm?url";
 
-const data = document.querySelector<HTMLScriptElement>("[data-voyd-hydration]");
-const selector = data?.dataset.voydHydration;
-const container = selector ? document.querySelector(selector) : null;
-
-if (!data || !container) throw new Error("Missing hydration data");
+const hydration = readVoydHydrationRoot("article-editor");
 
 const wasm = new Uint8Array(await (await fetch(wasmUrl)).arrayBuffer());
 const host = await createVoydHost({
@@ -629,15 +661,51 @@ const host = await createVoydHost({
 });
 const app = createVoydVxAppRuntime({
   host,
-  initialModel: JSON.parse(data.textContent ?? "null"),
+  initialModel: hydration.model,
 });
-const mounted = await hydrateVxApp({ container, app });
+const mounted = await hydrateVxApp({
+  container: hydration.container,
+  app,
+  onHydrationMismatch: import.meta.env.MODE === "development"
+    ? (mismatch) => console.warn("Voyd hydration mismatch", mismatch)
+    : undefined,
+});
 ```
 
-The server view and client `view` must produce the same initial tree. Browser
-commands and subscriptions begin after hydration. The `web-ssr` starter contains
-the complete build and host wiring, so it is the best starting point for this
-architecture.
+The element selected by `target` is the render container. Its server-rendered
+children and the client `view` must produce the same initial markup; share an
+internal view function rather than maintaining server and client copies. The
+server variant should omit retained callback event descriptors, which are not
+part of HTML and would otherwise remain in a long-running server host. The
+starter's `static_view` and `view` call the same internal editor with server or
+browser event wiring. Hydration preserves
+matching DOM, reports drift through `onHydrationMismatch`, and repairs mismatches
+so the application can continue.
+
+By default a `Program` adopts the server model without rerunning `init`. Provide
+a `hydrate` lifecycle callback when the browser must start a command from that
+model. Subscriptions are synchronized after hydration:
+
+```voyd
+pub fn app() -> Program<Model, Msg>
+  program({ init, hydrate, step, view, subscriptions })
+
+fn hydrate(model: Model) -> Program<Model, Msg>
+  next(model: model, cmd: reconnect(model))
+```
+
+A `map_model` program needs mappings in both directions to hydrate a parent
+snapshot. Use the labeled overload so the runtime can recover the child model:
+
+```voyd
+map_model(
+  program: child_program,
+  map: (child) => AppModel { child: child },
+  hydrate: (parent) => parent.child
+)
+```
+
+The `web-ssr` starter contains the complete shared-view, build, and host wiring.
 
 ## Composing Applications
 

--- a/packages/std/src/vx.test.voyd
+++ b/packages/std/src/vx.test.voyd
@@ -635,6 +635,20 @@ test "vx program map helpers encode retained mappers":
     Err:
       assert(false, eq: true)
 
+  let hydratable_model = map_model(
+    program: step,
+    map: (model: TypedVxTestModel) -> ParentVxTestModel =>
+      ParentVxTestModel { child: model },
+    hydrate: (model: ParentVxTestModel) -> TypedVxTestModel => model.child
+  )
+  match(msgpack::unpack_map(hydratable_model.payload))
+    Ok<Dict<String, MsgPack>> { value }:
+      assert_string_field(value, "kind", "program_map_model")
+      assert_payload_has_field(hydratable_model.payload, "handlerId")
+      assert_payload_has_field(hydratable_model.payload, "hydrateHandlerId")
+    Err:
+      assert(false, eq: true)
+
   let typed_message = map_message(
     step,
     (message: TypedVxTestMsg) -> MsgPack => msgpack::make_string("parent")

--- a/packages/std/src/vx.voyd
+++ b/packages/std/src/vx.voyd
@@ -2048,12 +2048,15 @@ pub fn next<Model, Msg>({ model: Model, cmd: Cmd<Msg> }) -> Program<Model, Msg>
 /// Lifts a child program result through a retained model mapper.
 pub fn map_model<Model, NextModel, Msg>({
   program: Program<Model, Msg>,
-  handler_id: i32
+  handler_id: i32,
+  hydrate_handler_id?: i32
 }) -> Program<NextModel, Msg>
   let ~out = Dict<String, MsgPack>::init()
   out.set("kind", "program_map_model")
   out.set("child", program.payload)
   out.set("handlerId", msgpack::make_i32(handler_id))
+  if hydrate_handler_id is Some:
+    out.set("hydrateHandlerId", msgpack::make_i32(hydrate_handler_id.value))
   Program<NextModel, Msg> { payload: msgpack::make_map(out) }
 
 /// Lifts a child program result through a typed model mapper.
@@ -2064,6 +2067,19 @@ pub fn map_model<Model, NextModel, Msg>(
   map_model<Model, NextModel, Msg>(
     program: program,
     handler_id: retain_program_callback_id(handler)
+  )
+
+/// Lifts a child program through model mappers in both runtime directions.
+/// The hydrate mapper is required when the mapped program adopts an SSR model.
+pub fn map_model<Model, NextModel, Msg>({
+  program: Program<Model, Msg>,
+  map: fn(Model) -> NextModel,
+  hydrate: fn(NextModel) -> Model
+}) -> Program<NextModel, Msg>
+  map_model<Model, NextModel, Msg>(
+    program: program,
+    handler_id: retain_program_callback_id(map),
+    hydrate_handler_id: retain_program_callback_id(hydrate)
   )
 
 /// Lifts a child program result through a retained message mapper.
@@ -2089,12 +2105,14 @@ pub fn map_message<Model, ChildMsg, ParentMsg>(
 
 pub fn program<Model, Msg>({
   init: fn() : (open) -> Model,
+  hydrate: fn(Model) : (open) -> Program<Model, Msg> = ((model: Model) : (open) -> Program<Model, Msg>) => next(model),
   step: fn(Model, Msg) : (open) -> Program<Model, Msg>,
   view: fn(Model) : (open) -> Html<Msg>,
   subscriptions: fn(Model) : (open) -> Sub<Msg> = ((_model: Model) : (open) -> Sub<Msg>) => Sub<Msg>::none()
 }) -> Program<Model, Msg>
   program_handlers<Model, Msg>(
     init_id: retain_program_callback_id(init),
+    hydrate_id: retain_program_callback_id(hydrate),
     step_id: retain_program_callback_id(step),
     view_id: retain_program_callback_id(view),
     subscriptions_id: retain_program_callback_id(subscriptions)
@@ -2102,12 +2120,14 @@ pub fn program<Model, Msg>({
 
 pub fn program<Model, Msg>({
   init: fn() : (open) -> Program<Model, Msg>,
+  hydrate: fn(Model) : (open) -> Program<Model, Msg> = ((model: Model) : (open) -> Program<Model, Msg>) => next(model),
   step: fn(Model, Msg) : (open) -> Program<Model, Msg>,
   view: fn(Model) : (open) -> Html<Msg>,
   subscriptions: fn(Model) : (open) -> Sub<Msg> = ((_model: Model) : (open) -> Sub<Msg>) => Sub<Msg>::none()
 }) -> Program<Model, Msg>
   program_handlers<Model, Msg>(
     init_id: retain_program_callback_id(init),
+    hydrate_id: retain_program_callback_id(hydrate),
     step_id: retain_program_callback_id(step),
     view_id: retain_program_callback_id(view),
     subscriptions_id: retain_program_callback_id(subscriptions)
@@ -2115,6 +2135,7 @@ pub fn program<Model, Msg>({
 
 fn program_handlers<Model, Msg>({
   init_id: i32,
+  hydrate_id: i32,
   step_id: i32,
   view_id: i32,
   subscriptions_id?: i32
@@ -2122,6 +2143,7 @@ fn program_handlers<Model, Msg>({
   let ~out = Dict<String, MsgPack>::init()
   out.set("kind", "program")
   out.set("initHandlerId", msgpack::make_i32(init_id))
+  out.set("hydrateHandlerId", msgpack::make_i32(hydrate_id))
   out.set("stepHandlerId", msgpack::make_i32(step_id))
   out.set("viewHandlerId", msgpack::make_i32(view_id))
   if subscriptions_id is Some:

--- a/packages/vx-dom/src/__tests__/app-runtime.test.ts
+++ b/packages/vx-dom/src/__tests__/app-runtime.test.ts
@@ -299,6 +299,43 @@ describe("createVoydVxAppRuntime", () => {
     });
   });
 
+  it("runs the program hydration lifecycle with the server model", async () => {
+    const retainedDispatch = vi.fn(async (id: number, payload: unknown) => {
+      if (id === 1) throw new Error("init must not run during hydration");
+      if (id === 2) return payload;
+      if (id === 3) return textFrame(`View: ${String(payload)}`);
+      if (id === 4) {
+        return {
+          $vx: "runtime_result",
+          model: Number(payload) + 1,
+          commands: { type: "cmd", kind: "message", value: "hydrated" },
+        };
+      }
+      throw new Error(`unexpected retained handler ${id}`);
+    });
+    const host = fakeHost({
+      app: async () => ({
+        kind: "program",
+        initHandlerId: 1,
+        hydrateHandlerId: 4,
+        stepHandlerId: 2,
+        viewHandlerId: 3,
+      }),
+    });
+    host.hasExport = (entryName) => entryName === "app";
+    host.retainedCallbacks = { dispatch: retainedDispatch };
+    const app = createVoydVxAppRuntime({ host, initialModel: 5 });
+
+    await expect(app.init?.()).resolves.toEqual({
+      frame: textFrame("View: 6"),
+      commands: { type: "cmd", kind: "message", value: "hydrated" },
+      subscriptions: undefined,
+      snapshot: 6,
+    });
+    expect(retainedDispatch).toHaveBeenCalledWith(4, 5);
+    expect(retainedDispatch).not.toHaveBeenCalledWith(1, expect.anything());
+  });
+
   it("maps program descriptors for model snapshots and outward messages", async () => {
     const retainedDispatch = vi.fn(async (id: number, payload: unknown) => {
       if (id === 1) return { count: 1 };
@@ -406,9 +443,9 @@ describe("createVoydVxAppRuntime", () => {
     expect(retainedDispatch).toHaveBeenCalledWith(31, { count: 2 });
   });
 
-  it("does not hydrate mapped-model descriptors with parent-shaped snapshots", async () => {
+  it("hydrates mapped-model descriptors through an explicit reverse mapper", async () => {
     const retainedDispatch = vi.fn(async (id: number, payload: unknown) => {
-      if (id === 1) return { count: 1 };
+      if (id === 1) throw new Error("init must not run during hydration");
       if (id === 2) {
         const [current] = payload as unknown[];
         return {
@@ -418,12 +455,14 @@ describe("createVoydVxAppRuntime", () => {
       }
       if (id === 3) return textFrame(`Child: ${String((payload as { count: number }).count)}`);
       if (id === 31) return { parent: payload };
+      if (id === 32) return (payload as { parent: unknown }).parent;
       throw new Error(`unexpected retained handler ${id}`);
     });
     const host = fakeHost({
       app: async () => ({
         kind: "program_map_model",
         handlerId: 31,
+        hydrateHandlerId: 32,
         child: {
           kind: "program",
           initHandlerId: 1,
@@ -440,15 +479,40 @@ describe("createVoydVxAppRuntime", () => {
     });
 
     await expect(app.init?.()).resolves.toMatchObject({
-      frame: textFrame("Child: 1"),
-      snapshot: { parent: { count: 1 } },
+      frame: textFrame("Child: 99"),
+      snapshot: { parent: { count: 99 } },
     });
     await expect(app.dispatch({ kind: "msgpack", value: "tick" })).resolves.toMatchObject({
-      frame: textFrame("Child: 2"),
-      snapshot: { parent: { count: 2 } },
+      frame: textFrame("Child: 100"),
+      snapshot: { parent: { count: 100 } },
     });
-    expect(retainedDispatch).toHaveBeenCalledWith(3, { count: 1 });
-    expect(retainedDispatch).toHaveBeenCalledWith(2, [{ count: 1 }, "tick"]);
+    expect(retainedDispatch).toHaveBeenCalledWith(32, { parent: { count: 99 } });
+    expect(retainedDispatch).toHaveBeenCalledWith(2, [{ count: 99 }, "tick"]);
+  });
+
+  it("rejects SSR hydration for mapped models without a reverse mapper", async () => {
+    const host = fakeHost({
+      app: async () => ({
+        kind: "program_map_model",
+        handlerId: 31,
+        child: {
+          kind: "program",
+          initHandlerId: 1,
+          stepHandlerId: 2,
+          viewHandlerId: 3,
+        },
+      }),
+    });
+    host.hasExport = (entryName) => entryName === "app";
+    host.retainedCallbacks = { dispatch: vi.fn(async () => undefined) };
+    const app = createVoydVxAppRuntime({
+      host,
+      initialModel: { parent: { count: 99 } },
+    });
+
+    await expect(app.init?.()).rejects.toThrow(
+      "mapped-model programs require a hydrate mapper",
+    );
   });
 
   it("keeps repeated component state call-site occurrences in distinct slots", async () => {

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -1,7 +1,13 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createVxDomRenderer, hydrateVxApp, mountVxApp } from "../browser.js";
+import {
+  createVxDomRenderer,
+  hydrateVxApp,
+  mountVxApp,
+  readVoydHydrationRoot,
+  readVoydHydrationRoots,
+} from "../browser.js";
 import type {
   NormalizedEventPayload,
   VNode,
@@ -136,11 +142,12 @@ describe("vx-dom browser renderer", () => {
     expect(dispatch).toHaveBeenLastCalledWith(2, expect.objectContaining({ kind: "mouse" }));
   });
 
-  it("does not release outer mapped event handler ids when mapped views are removed", () => {
+  it("does not release caller-owned mapped event handler ids when views are removed", () => {
     const dispatch = vi.fn<RetainedDispatch>();
+    const dispatchMapped = vi.fn(async () => undefined);
     const releaseMany = vi.fn<(ids: Iterable<number>) => void>();
     const renderer = createVxDomRenderer(container, {
-      handlers: { dispatch, releaseMany },
+      handlers: { dispatch, dispatchMapped, releaseMany },
     });
 
     renderer.render({
@@ -155,8 +162,24 @@ describe("vx-dom browser renderer", () => {
 
     expect(releaseMany).toHaveBeenCalledWith([1]);
 
+    renderer.render({
+      version: 1,
+      root: {
+        kind: "map",
+        handlerId: 9,
+        child: buttonNode(3),
+      },
+    });
+    container.querySelector("button")!.click();
+    expect(dispatchMapped).toHaveBeenCalledWith(
+      3,
+      expect.objectContaining({ kind: "mouse" }),
+      [9],
+    );
+    expect(releaseMany.mock.calls.flatMap(([ids]) => Array.from(ids))).not.toContain(9);
+
     renderer.dispose();
-    expect(releaseMany).toHaveBeenLastCalledWith(new Set([2]));
+    expect(releaseMany).toHaveBeenLastCalledWith(new Set([3]));
   });
 
   it("hydrates matching DOM, attaches listeners, and disposes cleanly", () => {
@@ -191,6 +214,278 @@ describe("vx-dom browser renderer", () => {
     renderer.dispose();
     expect(container.innerHTML).toBe("");
     expect(releaseMany).toHaveBeenLastCalledWith(new Set([7]));
+  });
+
+  it("preserves exactly matching server DOM without reporting a mismatch", () => {
+    const onHydrationMismatch = vi.fn();
+    container.innerHTML = `<button class="live" style="background: blue">Save</button>`;
+    const serverButton = container.querySelector("button");
+    const renderer = createVxDomRenderer(container, { onHydrationMismatch });
+
+    renderer.hydrate(frame({
+      ...buttonNode(7),
+      attrs: { class: "live" },
+      styles: { background: "blue" },
+    }));
+
+    expect(container.querySelector("button")).toBe(serverButton);
+    expect(onHydrationMismatch).not.toHaveBeenCalled();
+  });
+
+  it("preserves matching inline style attributes during hydration", () => {
+    const onHydrationMismatch = vi.fn();
+    container.innerHTML = `<button style="color: red">Save</button>`;
+    const renderer = createVxDomRenderer(container, { onHydrationMismatch });
+
+    renderer.hydrate(frame({
+      ...buttonNode(7),
+      attrs: { style: "color: red" },
+    }));
+
+    expect(container.querySelector("button")?.style.color).toBe("red");
+    expect(onHydrationMismatch).not.toHaveBeenCalled();
+  });
+
+  it("preserves serialized form property attributes and reset defaults", () => {
+    const onHydrationMismatch = vi.fn();
+    container.innerHTML = `<form><input checked type="checkbox" value="Draft"></form>`;
+    const renderer = createVxDomRenderer(container, { onHydrationMismatch });
+
+    renderer.hydrate(frame({
+      kind: "element",
+      tag: "form",
+      children: [{
+        kind: "element",
+        tag: "input",
+        attrs: { type: "checkbox" },
+        props: { checked: true, value: "Draft" },
+      }],
+    }));
+
+    const input = container.querySelector("input")!;
+    expect(input.getAttribute("value")).toBe("Draft");
+    expect(input.hasAttribute("checked")).toBe(true);
+    expect(input.defaultValue).toBe("Draft");
+    expect(input.defaultChecked).toBe(true);
+    expect(onHydrationMismatch).not.toHaveBeenCalled();
+  });
+
+  it("preserves and reconciles textarea edits made before hydration", async () => {
+    container.innerHTML = `<textarea>Server draft</textarea>`;
+    const textarea = container.querySelector("textarea")!;
+    textarea.value = "User draft";
+    const dispatch = vi.fn(async () => undefined);
+    const bubbledInput = vi.fn();
+    container.addEventListener("input", bubbledInput);
+    const renderer = createVxDomRenderer(container, { handlers: { dispatch } });
+
+    renderer.hydrate(frame({
+      kind: "element",
+      tag: "textarea",
+      props: { value: "Server draft" },
+      events: [{ kind: "event", event: "input", handlerId: 7 }],
+      children: [{ kind: "text", value: "Server draft" }],
+    }));
+
+    expect(textarea.value).toBe("User draft");
+    expect(bubbledInput).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(dispatch).toHaveBeenCalledWith(
+        7,
+        expect.objectContaining({ kind: "input", value: "User draft" }),
+      );
+    });
+  });
+
+  it("defers dirty-control reconciliation until hydration commands finish", async () => {
+    container.innerHTML = `<textarea>Server draft</textarea>`;
+    container.querySelector("textarea")!.value = "User draft";
+    let finishCommand: (() => void) | undefined;
+    const command = new Promise<void>((resolve) => {
+      finishCommand = resolve;
+    });
+    const dispatch = vi.fn(async () => frame({ kind: "fragment", children: [] }));
+    const app: VxAppRuntime = {
+      init: () => ({
+        frame: frame({
+          kind: "element",
+          tag: "textarea",
+          props: { value: "Server draft" },
+          events: [{ kind: "event", event: "input", handlerId: 7 }],
+          children: [{ kind: "text", value: "Server draft" }],
+        }),
+        commands: { type: "cmd", kind: "wait" },
+      }),
+      render: () => frame({ kind: "fragment", children: [] }),
+      dispatch,
+    };
+
+    const mounting = hydrateVxApp({
+      container,
+      app,
+      runtimeHost: {
+        commands: {
+          wait: async () => {
+            await command;
+            container.querySelector("textarea")!.value = "Command draft";
+          },
+        },
+      },
+    });
+    await nextTurn();
+    expect(dispatch).not.toHaveBeenCalled();
+
+    finishCommand?.();
+    await mounting;
+    await vi.waitFor(() => expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "event",
+        handlerId: 7,
+        payload: expect.objectContaining({ value: "User draft" }),
+      }),
+    ));
+  });
+
+  it("releases newly retained handlers when hydration throws", () => {
+    container.innerHTML = `<button class="server">Save</button>`;
+    const releaseMany = vi.fn();
+    const renderer = createVxDomRenderer(container, {
+      handlers: { dispatch: vi.fn(async () => undefined), releaseMany },
+      onHydrationMismatch: () => {
+        throw new Error("mismatch callback failed");
+      },
+    });
+
+    expect(() => renderer.hydrate({
+      version: 1,
+      root: {
+        kind: "map",
+        handlerId: 9,
+        child: { ...buttonNode(7), attrs: { class: "client" } },
+      },
+    })).toThrow("mismatch callback failed");
+    expect(releaseMany).toHaveBeenCalledWith([7]);
+  });
+
+  it("uses structured styles consistently across hydration and updates", () => {
+    const onHydrationMismatch = vi.fn();
+    container.innerHTML = `<button style="display: grid">Save</button>`;
+    const renderer = createVxDomRenderer(container, { onHydrationMismatch });
+
+    renderer.hydrate(frame({
+      ...buttonNode(7),
+      attrs: { style: "color: red" },
+      styles: { display: "grid" },
+    }));
+
+    const button = container.querySelector("button")!;
+    expect(button.style.display).toBe("grid");
+    expect(button.style.color).toBe("");
+    expect(onHydrationMismatch).not.toHaveBeenCalled();
+
+    renderer.render(frame({
+      ...buttonNode(7),
+      attrs: { style: "color: red" },
+    }));
+
+    expect(button.style.display).toBe("");
+    expect(button.style.color).toBe("red");
+
+  });
+
+  it("restores live form state after overriding properties are removed", () => {
+    const renderer = createVxDomRenderer(container);
+
+    renderer.render(frame({
+      kind: "element",
+      tag: "input",
+      attrs: { checked: true, type: "checkbox", value: "fallback" },
+      props: { checked: false, value: "controlled" },
+    }));
+    const input = container.querySelector("input")!;
+    expect(input.checked).toBe(false);
+    expect(input.value).toBe("controlled");
+
+    renderer.render(frame({
+      kind: "element",
+      tag: "input",
+      attrs: { checked: true, type: "checkbox", value: "fallback" },
+    }));
+
+    expect(input.checked).toBe(true);
+    expect(input.value).toBe("fallback");
+  });
+
+  it("preserves carriage returns encoded by the server renderer", () => {
+    const onHydrationMismatch = vi.fn();
+    container.innerHTML = "<p>A&#13;\nB</p>";
+    const paragraph = container.querySelector("p");
+    const renderer = createVxDomRenderer(container, { onHydrationMismatch });
+
+    renderer.hydrate(frame({
+      kind: "element",
+      tag: "p",
+      children: [{ kind: "text", value: "A\r\nB" }],
+    }));
+
+    expect(container.querySelector("p")).toBe(paragraph);
+    expect(paragraph?.textContent).toBe("A\r\nB");
+    expect(onHydrationMismatch).not.toHaveBeenCalled();
+  });
+
+  it("reports hydration drift while recovering the DOM", () => {
+    const onHydrationMismatch = vi.fn();
+    container.innerHTML = `<section class="stale"><span>Server</span></section>`;
+    const renderer = createVxDomRenderer(container, { onHydrationMismatch });
+
+    renderer.hydrate(frame({
+      kind: "element",
+      tag: "main",
+      attrs: { class: "live" },
+      children: [{ kind: "text", value: "Client" }],
+    }));
+
+    expect(container.innerHTML).toBe(`<main class="live">Client</main>`);
+    expect(onHydrationMismatch).toHaveBeenCalledWith(expect.objectContaining({
+      path: "root",
+      reason: "tag",
+      expected: "main",
+      actual: "section",
+    }));
+  });
+
+  it("reads multiple structured hydration roots by stable id", () => {
+    container.innerHTML = `
+      <main id="first"></main>
+      <aside id="second"></aside>
+      <script type="application/json" data-voyd-hydration-id="primary" data-voyd-hydration="#first" data-voyd-entry="/first.js">{"count":1}</script>
+      <script type="application/json" data-voyd-hydration-id="secondary" data-voyd-hydration="#second" data-voyd-entry="/second.js">{"count":2}</script>
+    `;
+
+    const roots = readVoydHydrationRoots(container);
+
+    expect(roots.map(({ id, selector, entry, model }) => ({
+      id,
+      selector,
+      entry,
+      model,
+    }))).toEqual([
+      { id: "primary", selector: "#first", entry: "/first.js", model: { count: 1 } },
+      { id: "secondary", selector: "#second", entry: "/second.js", model: { count: 2 } },
+    ]);
+    expect(readVoydHydrationRoot("secondary", container).container).toBe(
+      container.querySelector("#second"),
+    );
+  });
+
+  it("reads one hydration root without parsing unrelated islands", () => {
+    container.innerHTML = `
+      <main id="valid"></main>
+      <script type="application/json" data-voyd-hydration-id="valid" data-voyd-hydration="#valid">{"count":1}</script>
+      <script type="application/json" data-voyd-hydration-id="broken" data-voyd-hydration="#missing">not-json</script>
+    `;
+
+    expect(readVoydHydrationRoot("valid", container).model).toEqual({ count: 1 });
   });
 
   it("hydrates mapped event handler ids from serialized frames", () => {
@@ -622,6 +917,69 @@ describe("vx-dom browser renderer", () => {
       expect.any(Error),
       expect.objectContaining({ phase: "commands" }),
     );
+  });
+
+  it("leaves server DOM progressive when hydration initialization fails", async () => {
+    container.innerHTML = `<form><button type="submit">Save</button></form>`;
+    const serverForm = container.querySelector("form")!;
+    const releaseMany = vi.fn<(ids: Iterable<number>) => void>();
+    const disposeApp = vi.fn();
+    const disposeSubscription = vi.fn();
+    let commandSignal: AbortSignal | undefined;
+    const app: VxAppRuntime = {
+      retainedCallbacks: { releaseMany },
+      init: () => ({
+        frame: frame({
+          kind: "element",
+          tag: "form",
+          events: [{
+            kind: "event",
+            event: "submit",
+            handlerId: 30,
+            options: { preventDefault: true },
+          }],
+          attrs: { class: "hydrating" },
+          children: [{
+            kind: "element",
+            tag: "button",
+            attrs: { type: "submit", disabled: true },
+            children: [{ kind: "text", value: "Starting" }],
+          }],
+        }),
+        subscriptions: { type: "sub", kind: "timer", key: "main" },
+        commands: { type: "cmd", kind: "fail" },
+      }),
+      render: () => frame({ kind: "fragment", children: [] }),
+      dispatch: () => frame({ kind: "fragment", children: [] }),
+      dispose: disposeApp,
+    };
+
+    await expect(hydrateVxApp({
+      container,
+      app,
+      runtimeHost: {
+        commands: {
+          fail: (_command, context) => {
+            commandSignal = context.signal;
+            throw new Error("initial command failed");
+          },
+        },
+        subscriptions: { timer: () => disposeSubscription },
+      },
+    })).rejects.toThrow("initial command failed");
+    await nextTurn();
+
+    const submit = new SubmitEvent("submit", { bubbles: true, cancelable: true });
+    expect(container.querySelector("form")).toBe(serverForm);
+    expect(serverForm.className).toBe("");
+    expect(serverForm.querySelector("button")?.disabled).toBe(false);
+    expect(serverForm.querySelector("button")?.textContent).toBe("Save");
+    expect(serverForm.dispatchEvent(submit)).toBe(true);
+    expect(submit.defaultPrevented).toBe(false);
+    expect(commandSignal?.aborted).toBe(true);
+    expect(disposeSubscription).toHaveBeenCalledOnce();
+    expect(disposeApp).toHaveBeenCalledOnce();
+    expect(releaseMany).toHaveBeenCalledWith([30]);
   });
 
   it("reports command diagnostics for malformed map and delay envelopes", async () => {

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -346,11 +346,12 @@ describe("vx-dom browser renderer", () => {
     ));
   });
 
-  it("releases newly retained handlers when hydration throws", () => {
-    container.innerHTML = `<button class="server">Save</button>`;
+  it("detaches partial listeners and releases handlers when hydration throws", () => {
+    container.innerHTML = `<button><span>Save</span></button>`;
+    const dispatch = vi.fn(async () => undefined);
     const releaseMany = vi.fn();
     const renderer = createVxDomRenderer(container, {
-      handlers: { dispatch: vi.fn(async () => undefined), releaseMany },
+      handlers: { dispatch, releaseMany },
       onHydrationMismatch: () => {
         throw new Error("mismatch callback failed");
       },
@@ -361,10 +362,13 @@ describe("vx-dom browser renderer", () => {
       root: {
         kind: "map",
         handlerId: 9,
-        child: { ...buttonNode(7), attrs: { class: "client" } },
+        child: buttonNode(7),
       },
     })).toThrow("mismatch callback failed");
     expect(releaseMany).toHaveBeenCalledWith([7]);
+    container.querySelector("button")!.click();
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(renderer.getSnapshot()).toBeUndefined();
   });
 
   it("uses structured styles consistently across hydration and updates", () => {

--- a/packages/vx-dom/src/__tests__/normalize.test.ts
+++ b/packages/vx-dom/src/__tests__/normalize.test.ts
@@ -40,6 +40,18 @@ describe("vx-dom VNode normalization", () => {
     })).toThrow("invalid VX frame at root.tag");
     expect(() => normalizeRenderFrame({
       version: 1,
+      root: { kind: "element", tag: "SCRIPT" },
+    })).toThrow("invalid HTML tag name at root.tag");
+    expect(() => normalizeRenderFrame({
+      version: 1,
+      root: {
+        kind: "element",
+        tag: "input",
+        children: [{ kind: "text", value: "not allowed" }],
+      },
+    })).toThrow("void element at root cannot have children");
+    expect(() => normalizeRenderFrame({
+      version: 1,
       root: {
         kind: "element",
         tag: "button",
@@ -51,9 +63,59 @@ describe("vx-dom VNode normalization", () => {
       root: {
         kind: "element",
         tag: "button",
+        attrs: { className: "primary" },
+      },
+    })).toThrow("invalid HTML attribute name at root.attrs.className");
+    expect(normalizeRenderFrame({
+      version: 1,
+      root: {
+        kind: "element",
+        tag: "div",
+        props: { textContent: "unsafe" },
+      },
+    }).root).toMatchObject({ props: { textContent: "unsafe" } });
+    expect(() => normalizeRenderFrame({
+      version: 1,
+      root: {
+        kind: "element",
+        tag: "input",
+        props: { checked: 1 },
+      },
+    })).toThrow("invalid DOM property value at root.props.checked");
+    expect(() => normalizeRenderFrame({
+      version: 1,
+      root: {
+        kind: "element",
+        tag: "div",
+        styles: { color: "red; display: none" },
+      },
+    })).toThrow("invalid CSS property value at root.styles.color");
+    expect(() => normalizeRenderFrame({
+      version: 1,
+      root: {
+        kind: "element",
+        tag: "button",
         events: [{ kind: "event", event: "click" }],
       },
     })).toThrow("expected handlerId or message");
+  });
+
+  it("validates ordinary unversioned VX elements with the shared SSR rules", () => {
+    expect(() => normalizeRenderFrame({
+      kind: "element",
+      tag: "div",
+      attrs: { "bad attr": "x" },
+    })).toThrow("invalid HTML attribute name at element.attrs.bad attr");
+    expect(() => normalizeRenderFrame({
+      kind: "element",
+      tag: "input",
+      props: { checked: 1 },
+    })).toThrow("invalid DOM property value at element.props.checked");
+    expect(() => normalizeRenderFrame({
+      kind: "element",
+      tag: "div",
+      styles: { color: "red; display: none" },
+    })).toThrow("invalid CSS property value at element.styles.color");
   });
 
   it("unwraps mapped HTML nodes for DOM rendering", () => {

--- a/packages/vx-dom/src/__tests__/server.test.ts
+++ b/packages/vx-dom/src/__tests__/server.test.ts
@@ -39,10 +39,137 @@ describe("vx-dom server renderer", () => {
     expect(result.html).toBe(`<main role="main"><h1>Wiki</h1></main>`);
   });
 
+  it("encodes carriage returns so HTML parsing preserves exact text and attributes", async () => {
+    const result = await renderVxToString({
+      frame: {
+        version: 1,
+        root: {
+          kind: "element",
+          tag: "p",
+          attrs: { title: "A\r\nB" },
+          children: [{ kind: "text", value: "A\r\nB" }],
+        },
+      },
+    });
+
+    expect(result.html).toBe(`<p title="A&#13;\nB">A&#13;\nB</p>`);
+  });
+
+  it("preserves leading newlines in parser-sensitive elements", async () => {
+    const result = await renderVxToString({
+      frame: {
+        version: 1,
+        root: {
+          kind: "element",
+          tag: "pre",
+          children: [{ kind: "text", value: "\nLeading" }],
+        },
+      },
+    });
+
+    expect(result.html).toBe("<pre>\n\nLeading</pre>");
+  });
+
+  it("serializes controlled textarea values as matching text content", async () => {
+    const result = await renderVxToString({
+      frame: {
+        version: 1,
+        root: {
+          kind: "element",
+          tag: "textarea",
+          props: { value: "Draft" },
+          children: [{ kind: "text", value: "Draft" }],
+        },
+      },
+    });
+
+    expect(result.html).toBe("<textarea>Draft</textarea>");
+  });
+
+  it("rejects form properties without a stable SSR representation", async () => {
+    await expect(renderVxToString({
+      frame: {
+        version: 1,
+        root: {
+          kind: "element",
+          tag: "select",
+          props: { value: "draft" },
+        },
+      },
+    })).rejects.toThrow("property value has no stable SSR representation on <select>");
+
+    await expect(renderVxToString({
+      frame: {
+        version: 1,
+        root: {
+          kind: "element",
+          tag: "textarea",
+          props: { value: "Draft" },
+          children: [{ kind: "text", value: "Other" }],
+        },
+      },
+    })).rejects.toThrow("textarea value must match its text children");
+  });
+
+  it("renders raw-text element children without entity decoding drift", async () => {
+    const result = await renderVxToString({
+      frame: {
+        version: 1,
+        root: {
+          kind: "fragment",
+          children: [
+            {
+              kind: "element",
+              tag: "style",
+              children: [{ kind: "text", value: "a > b { color: red }" }],
+            },
+            {
+              kind: "element",
+              tag: "script",
+              children: [{ kind: "text", value: "if (a < b) value = '&'" }],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.html).toBe(
+      "<style>a > b { color: red }</style><script>if (a < b) value = '&'</script>",
+    );
+  });
+
+  it("rejects raw text that can terminate its containing element", async () => {
+    await expect(renderVxToString({
+      frame: {
+        version: 1,
+        root: {
+          kind: "element",
+          tag: "script",
+          children: [{ kind: "text", value: "</SCRIPT><p>unsafe</p>" }],
+        },
+      },
+    })).rejects.toThrow("script text contains its closing delimiter");
+  });
+
   it("rejects invalid SSR tag, attribute, and style names", async () => {
     await expect(renderVxToString({
       frame: { version: 1, root: { kind: "element", tag: "script>alert(1)</script" } },
     })).rejects.toThrow("invalid HTML tag name");
+
+    await expect(renderVxToString({
+      frame: { version: 1, root: { kind: "element", tag: "INPUT" } },
+    })).rejects.toThrow("invalid HTML tag name");
+
+    await expect(renderVxToString({
+      frame: {
+        version: 1,
+        root: {
+          kind: "element",
+          tag: "input",
+          children: [{ kind: "text", value: "not allowed" }],
+        },
+      },
+    })).rejects.toThrow("void element at root cannot have children");
 
     await expect(renderVxToString({
       frame: {
@@ -65,6 +192,28 @@ describe("vx-dom server renderer", () => {
         },
       },
     })).rejects.toThrow("invalid CSS property name");
+
+    await expect(renderVxToString({
+      frame: {
+        version: 1,
+        root: {
+          kind: "element",
+          tag: "div",
+          props: { innerHTML: "<img src=x onerror=alert(1)>" },
+        },
+      },
+    })).rejects.toThrow("unsupported DOM property");
+
+    await expect(renderVxToString({
+      frame: {
+        version: 1,
+        root: {
+          kind: "element",
+          tag: "div",
+          styles: { color: "red; display: none" },
+        },
+      },
+    })).rejects.toThrow("invalid CSS property value");
   });
 
   it("allows vendor-prefixed and custom CSS property names", async () => {

--- a/packages/vx-dom/src/app-runtime.ts
+++ b/packages/vx-dom/src/app-runtime.ts
@@ -49,12 +49,14 @@ type RuntimeResult = Record<string, unknown> & {
 type ProgramDescriptor = {
   kind: "program";
   initHandlerId: number;
+  hydrateHandlerId?: number;
   stepHandlerId: number;
   viewHandlerId: number;
   subscriptionsHandlerId?: number;
 } | {
   kind: "program_map_model";
   handlerId: number;
+  hydrateHandlerId?: number;
   child: ProgramDescriptor;
 } | {
   kind: "program_map_message";
@@ -66,7 +68,7 @@ type TaskObserver = (taskId: number) => Promise<unknown>;
 type RetainedDispatch = (handlerId: number, payload: unknown) => Promise<unknown>;
 
 type ProgramDescriptorRunner = {
-  hydrate(model: unknown): boolean;
+  hydrate(model: unknown): Promise<RuntimeResult>;
   init(): Promise<RuntimeResult>;
   step(message: VxRuntimeMessage): Promise<RuntimeResult>;
   view(): Promise<unknown>;
@@ -203,8 +205,8 @@ export function createVoydVxAppRuntime(
     retainedCallbacks: options.host.retainedCallbacks,
     init: async () => {
       const descriptor = await readProgramRunner();
-      if (initialized && descriptor?.hydrate(model)) {
-        const result = runtimeResult({ model });
+      if (initialized && descriptor) {
+        const result = await descriptor.hydrate(model);
         return toRuntimeStep(result, true);
       }
       const result = initialized
@@ -336,7 +338,15 @@ function createProgramDescriptorRunner({
       return copyTaskObserver(result, { ...result, model: mappedModel }) as RuntimeResult;
     };
     return {
-      hydrate: () => false,
+      hydrate: async (model) => {
+        if (descriptor.hydrateHandlerId === undefined) {
+          throw new Error(
+            "vx-dom: mapped-model programs require a hydrate mapper to adopt an SSR model",
+          );
+        }
+        const childModel = await dispatch(descriptor.hydrateHandlerId, model);
+        return mapModel(await child.hydrate(childModel));
+      },
       init: async () => mapModel(await child.init()),
       step: async (message) => mapModel(await child.step(message)),
       view: () => child.view(),
@@ -370,7 +380,9 @@ function createProgramDescriptorRunner({
           : {}),
       }) as RuntimeResult;
     return {
-      hydrate: (model) => child.hydrate(model),
+      hydrate: async (model) => {
+        return mapMessages(await child.hydrate(model));
+      },
       init: async () => mapMessages(await child.init()),
       step: async (message) => {
         const childMessage =
@@ -422,10 +434,16 @@ function createProgramDescriptorRunner({
     adoptResult(await resolveProgramResultMaps(result, dispatch), adoptPlainModel);
 
   return {
-    hydrate: (nextModel) => {
+    hydrate: async (nextModel) => {
       model = nextModel;
       initialized = true;
-      return true;
+      if (descriptor.hydrateHandlerId === undefined) {
+        return runtimeResult({ model: nextModel });
+      }
+      return adoptLifecycleResult(
+        await dispatch(descriptor.hydrateHandlerId, nextModel),
+        true,
+      );
     },
     init: async () =>
       adoptLifecycleResult(await dispatch(descriptor.initHandlerId, undefined), true),
@@ -625,9 +643,13 @@ function isRecord(input: unknown): input is Record<PropertyKey, unknown> {
 function parseProgramDescriptor(input: unknown): ProgramDescriptor {
   const kind = readField(input, "kind");
   if (kind === "program_map_model" || kind === "program_map_message") {
+    const hydrateHandlerId = kind === "program_map_model"
+      ? readOptionalNumberField(input, "hydrateHandlerId")
+      : undefined;
     return {
       kind,
       handlerId: readNumberField(input, "handlerId"),
+      ...(hydrateHandlerId !== undefined ? { hydrateHandlerId } : {}),
       child: parseProgramDescriptor(readField(input, "child")),
     };
   }
@@ -636,6 +658,7 @@ function parseProgramDescriptor(input: unknown): ProgramDescriptor {
     throw new Error("vx-dom: app export did not return a VX program descriptor");
   }
   const initHandlerId = readNumberField(input, "initHandlerId");
+  const hydrateHandlerId = readOptionalNumberField(input, "hydrateHandlerId");
   const stepHandlerId = readNumberField(input, "stepHandlerId");
   const viewHandlerId = readNumberField(input, "viewHandlerId");
   const subscriptionsHandlerId = readOptionalNumberField(
@@ -645,6 +668,7 @@ function parseProgramDescriptor(input: unknown): ProgramDescriptor {
   return {
     kind: "program",
     initHandlerId,
+    ...(hydrateHandlerId !== undefined ? { hydrateHandlerId } : {}),
     stepHandlerId,
     viewHandlerId,
     ...(subscriptionsHandlerId !== undefined ? { subscriptionsHandlerId } : {}),

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -8,6 +8,7 @@ import {
 import type {
   CallOptions,
   EventDescriptor,
+  NormalizedEventPayload,
   RetainedEventHandlerRegistry,
   VNode,
   VxAppRuntime,
@@ -60,9 +61,28 @@ export type RenderOptions = {
   handlers?: RetainedEventHandlerRegistry;
 };
 
+export type HydrationMismatch = {
+  path: string;
+  reason: "node-kind" | "tag" | "text" | "attributes" | "children";
+  expected: unknown;
+  actual: unknown;
+};
+
+export type HydrationMismatchHandler = (mismatch: HydrationMismatch) => void;
+
+export type VoydHydrationRoot = {
+  id: string;
+  selector: string;
+  entry: string;
+  model: unknown;
+  container: Element;
+  script: HTMLScriptElement;
+};
+
 export type VxDomRenderer = {
   render(input: unknown): void;
   hydrate(input: unknown): void;
+  detach(): void;
   dispose(): void;
   getSnapshot(): VxRenderFrame | undefined;
 };
@@ -87,8 +107,71 @@ export type MountVxAppOptions = {
   app?: VxAppRuntime;
   runtimeHost?: VxRuntimeHostOptions;
   onError?: VxRuntimeErrorHandler;
+  onHydrationMismatch?: HydrationMismatchHandler;
   dispatch?: (message: VxMessage) => Promise<void> | void;
 };
+
+export function readVoydHydrationRoots(
+  scope: ParentNode = document,
+): VoydHydrationRoot[] {
+  return Array.from(
+    scope.querySelectorAll<HTMLScriptElement>(
+      'script[type="application/json"][data-voyd-hydration]',
+    ),
+  ).map((script) => hydrationRootFrom(script, scope));
+}
+
+export function readVoydHydrationRoot(
+  id: string,
+  scope: ParentNode = document,
+): VoydHydrationRoot {
+  const script = Array.from(
+    scope.querySelectorAll<HTMLScriptElement>(
+      'script[type="application/json"][data-voyd-hydration]',
+    ),
+  ).find((candidate) =>
+    (candidate.dataset.voydHydrationId ?? candidate.dataset.voydHydration) === id
+  );
+  if (!script) throw new Error(`vx-dom: missing Voyd hydration root ${JSON.stringify(id)}`);
+  return hydrationRootFrom(script, scope);
+}
+
+function hydrationRootFrom(
+  script: HTMLScriptElement,
+  scope: ParentNode,
+): VoydHydrationRoot {
+  const selector = script.dataset.voydHydration;
+  if (!selector) throw new Error("vx-dom: hydration metadata is missing its target selector");
+  const id = script.dataset.voydHydrationId ?? selector;
+  const container = scope.querySelector(selector);
+  if (!container) {
+    throw new Error(
+      `vx-dom: hydration root ${JSON.stringify(id)} cannot find target ${JSON.stringify(selector)}`,
+    );
+  }
+  const entry = script.dataset.voydEntry ?? readAdjacentHydrationEntry(script);
+  try {
+    return {
+      id,
+      selector,
+      entry,
+      model: JSON.parse(script.textContent ?? "null") as unknown,
+      container,
+      script,
+    };
+  } catch (error) {
+    throw new Error(`vx-dom: invalid hydration model for ${JSON.stringify(id)}`, {
+      cause: error,
+    });
+  }
+}
+
+function readAdjacentHydrationEntry(script: HTMLScriptElement): string {
+  const sibling = script.nextElementSibling;
+  return sibling instanceof HTMLScriptElement && sibling.type === "module"
+    ? sibling.src
+    : "";
+}
 
 type ListenerRecord = {
   key: string;
@@ -114,6 +197,7 @@ const mapHandlerIdentityProperty = "__vxMapHandlerIdentity";
 const taskObserverProperty = Symbol.for("voyd.taskObserver");
 const locationChangeEvent = "vxlocationchange";
 const listenerState = new WeakMap<Element, Map<string, ListenerRecord>>();
+const pendingDirtyReconciliations = new WeakMap<Element, { cancelled: boolean }>();
 
 type TaskRunOutcome =
   | { kind: "value"; value: unknown }
@@ -191,10 +275,23 @@ export function renderMsgPackNode(
 
 export function createVxDomRenderer(
   container: Element,
-  options: { handlers?: RetainedEventHandlerRegistry } = {},
+  options: {
+    handlers?: RetainedEventHandlerRegistry;
+    onHydrationMismatch?: HydrationMismatchHandler;
+    deferHydrationReconciliation?: (callback: () => void) => void;
+  } = {},
 ): VxDomRenderer {
   let currentFrame: VxRenderFrame | undefined;
   let retainedHandlers = new Set<number>();
+
+  const releaseHandlers = (handlers: ReadonlySet<number> | number[]) => {
+    if (Array.isArray(handlers) ? handlers.length === 0 : handlers.size === 0) return;
+    if (options.handlers?.releaseMany) {
+      options.handlers.releaseMany(handlers);
+    } else {
+      handlers.forEach((id) => options.handlers?.release?.(id));
+    }
+  };
 
   const releaseRemovedHandlers = (next: Set<number>) => {
     const removed = Array.from(retainedHandlers).filter((id) => !next.has(id));
@@ -202,39 +299,56 @@ export function createVxDomRenderer(
       retainedHandlers = next;
       return;
     }
-    if (options.handlers?.releaseMany) {
-      options.handlers.releaseMany(removed);
-    } else {
-      removed.forEach((id) => options.handlers?.release?.(id));
-    }
+    releaseHandlers(removed);
     retainedHandlers = next;
+  };
+
+  const applyFrame = (
+    nextFrame: VxRenderFrame,
+    updateDom: () => void,
+  ) => {
+    const nextHandlers = collectHandlerIds(nextFrame.root);
+    const introduced = Array.from(nextHandlers).filter((id) => !retainedHandlers.has(id));
+    try {
+      updateDom();
+    } catch (error) {
+      releaseHandlers(introduced);
+      throw error;
+    }
+    releaseRemovedHandlers(nextHandlers);
+    currentFrame = nextFrame;
+  };
+
+  const detach = () => {
+    removeContainerListeners(container);
+    releaseHandlers(retainedHandlers);
+    retainedHandlers = new Set();
+    currentFrame = undefined;
   };
 
   return {
     render(input: unknown) {
       const nextFrame = flattenRenderFrame(normalizeRenderFrame(input));
-      const nextHandlers = collectHandlerIds(nextFrame.root);
-      patchContainer(container, currentFrame?.root, nextFrame.root, options.handlers);
-      releaseRemovedHandlers(nextHandlers);
-      currentFrame = nextFrame;
+      applyFrame(nextFrame, () => {
+        patchContainer(container, currentFrame?.root, nextFrame.root, options.handlers);
+      });
     },
     hydrate(input: unknown) {
       const nextFrame = flattenRenderFrame(normalizeRenderFrame(input));
-      const nextHandlers = collectHandlerIds(nextFrame.root);
-      hydrateContainer(container, nextFrame.root, options.handlers);
-      releaseRemovedHandlers(nextHandlers);
-      currentFrame = nextFrame;
+      applyFrame(nextFrame, () => {
+        hydrateContainer(
+          container,
+          nextFrame.root,
+          options.handlers,
+          options.onHydrationMismatch,
+          options.deferHydrationReconciliation,
+        );
+      });
     },
+    detach,
     dispose() {
-      removeContainerListeners(container);
+      detach();
       container.textContent = "";
-      if (options.handlers?.releaseMany) {
-        options.handlers.releaseMany(retainedHandlers);
-      } else {
-        retainedHandlers.forEach((id) => options.handlers?.release?.(id));
-      }
-      retainedHandlers = new Set();
-      currentFrame = undefined;
     },
     getSnapshot() {
       return currentFrame;
@@ -279,7 +393,11 @@ export async function hydrateVxApp(
 
   const instance = await resolveInstanceForMount(options);
   const exportName = options.exportName ?? "main";
-  const renderer = createVxDomRenderer(options.container, { handlers: options.handlers });
+  const renderer = createVxDomRenderer(options.container, {
+    handlers: options.handlers,
+    onHydrationMismatch: options.onHydrationMismatch,
+  });
+  const domSnapshot = captureContainerSnapshot(options.container);
 
   const readFrame = () => {
     if (options.frame !== undefined) return options.frame;
@@ -292,7 +410,13 @@ export async function hydrateVxApp(
     return callComponentFn(componentFn, callOptions);
   };
 
-  renderer.hydrate(readFrame());
+  try {
+    renderer.hydrate(readFrame());
+  } catch (error) {
+    renderer.detach();
+    restoreContainerSnapshot(options.container, domSnapshot);
+    throw error;
+  }
 
   return {
     dispatch: async (message) => {
@@ -310,6 +434,9 @@ async function mountRuntimeApp(
   mode: "hydrate" | "render",
 ): Promise<MountedVxApp> {
   const app = options.app!;
+  const domSnapshot = mode === "hydrate"
+    ? captureContainerSnapshot(options.container)
+    : undefined;
   let disposed = false;
   let previousSubscriptions: unknown;
   const abortController = new AbortController();
@@ -387,22 +514,25 @@ async function mountRuntimeApp(
   };
   const renderer = createVxDomRenderer(options.container, {
     handlers: runtimeHandlers,
+    onHydrationMismatch: options.onHydrationMismatch,
+    deferHydrationReconciliation: executionContext.deferAfterCommands,
   });
 
   const applyRuntimeStep = async (result: unknown, renderMode: "hydrate" | "render" = "render") => {
     if (disposed) return;
     const step = normalizeRuntimeStep(result);
+    const deferredCallbacks: Array<() => void> = [];
+    afterCommandCallbacks.push(deferredCallbacks);
     try {
       const frame = step.frame ?? (await app.render());
       if (renderMode === "hydrate") renderer.hydrate(frame);
       else renderer.render(frame);
     } catch (error) {
+      afterCommandCallbacks.pop();
       reportError(error, { phase: "render" });
       throw error;
     }
 
-    const deferredCallbacks: Array<() => void> = [];
-    afterCommandCallbacks.push(deferredCallbacks);
     let commandPhaseStarted = false;
     try {
       if (step.subscriptions !== undefined && app.syncSubscriptions) {
@@ -449,6 +579,20 @@ async function mountRuntimeApp(
       : initialHydrationFrame(options) ?? await app.render();
     await applyRuntimeStep(initial, mode);
   } catch (error) {
+    disposed = true;
+    abortController.abort();
+    try {
+      await disposeSubscriptions(activeSubscriptions, retainedHandlerReleaser);
+    } catch (disposeError) {
+      reportError(disposeError, { phase: "dispose" });
+    }
+    renderer.detach();
+    if (domSnapshot) restoreContainerSnapshot(options.container, domSnapshot);
+    try {
+      await app.dispose?.();
+    } catch (disposeError) {
+      reportError(disposeError, { phase: "dispose" });
+    }
     reportError(error, { phase: "init" });
     throw error;
   }
@@ -644,11 +788,66 @@ function applyElementProps(
   oldNode: VxElementNode | undefined,
   newNode: VxElementNode,
   handlers: RetainedEventHandlerRegistry | undefined,
+  preservedProps: ReadonlySet<string> = new Set(),
 ): void {
-  patchAttrs(element, oldNode?.attrs ?? {}, newNode.attrs ?? {});
-  patchStyles(element as HTMLElement, oldNode?.styles ?? {}, newNode.styles ?? {});
-  patchProps(element, oldNode?.props ?? {}, newNode.props ?? {});
+  patchAttrs(element, effectiveAttrs(oldNode), effectiveAttrs(newNode));
+  patchProps(element, effectiveProps(oldNode), effectiveProps(newNode), preservedProps);
+  restoreAttrsOverriddenByRemovedProps(element, oldNode, newNode);
+  if (!usesUnstructuredStyle(newNode)) {
+    patchStyles(element as HTMLElement, oldNode?.styles ?? {}, newNode.styles ?? {});
+  }
   patchEvents(element, oldNode?.events ?? [], newNode.events ?? [], handlers);
+}
+
+function restoreAttrsOverriddenByRemovedProps(
+  element: Element,
+  oldNode: VxElementNode | undefined,
+  newNode: VxElementNode,
+): void {
+  const oldProps = oldNode?.props ?? {};
+  const newProps = newNode.props ?? {};
+  const newAttrs = effectiveAttrs(newNode);
+  Object.keys(oldProps).forEach((key) => {
+    if (key in newProps) return;
+    const attrName = key === "className" ? "class" : key;
+    if (!(attrName in newAttrs)) return;
+    setDomProperty(element, key, newAttrs[attrName]);
+  });
+}
+
+function effectiveAttrs(node: VxElementNode | undefined): Record<string, unknown> {
+  const attrs = { ...(node?.attrs ?? {}) };
+  Object.entries(node?.props ?? {}).forEach(([key, value]) => {
+    const attrName = key === "className" ? "class" : key;
+    if (!node || !serializesPropertyAsAttribute(node.tag, key)) {
+      delete attrs[attrName];
+      return;
+    }
+    if (value == null || value === false) {
+      delete attrs[attrName];
+      return;
+    }
+    attrs[attrName] = value;
+  });
+  if (Object.keys(node?.styles ?? {}).length > 0) delete attrs.style;
+  return attrs;
+}
+
+function serializesPropertyAsAttribute(tag: string, property: string): boolean {
+  if (property === "value") return tag === "input";
+  if (property === "checked") return tag === "input";
+  return property === "disabled";
+}
+
+function effectiveProps(node: VxElementNode | undefined): Record<string, unknown> {
+  const props = { ...(node?.props ?? {}) };
+  if (Object.keys(node?.styles ?? {}).length > 0) delete props.style;
+  return props;
+}
+
+function usesUnstructuredStyle(node: VxElementNode): boolean {
+  const attrs = { ...(node.attrs ?? {}), ...(node.props ?? {}) };
+  return Object.hasOwn(attrs, "style") && Object.keys(node.styles ?? {}).length === 0;
 }
 
 function patchAttrs(
@@ -677,11 +876,13 @@ function patchProps(
   element: Element,
   oldProps: Record<string, unknown>,
   newProps: Record<string, unknown>,
+  preservedProps: ReadonlySet<string> = new Set(),
 ): void {
   Object.keys(oldProps).forEach((key) => {
-    if (!(key in newProps)) setDomProperty(element, key, undefined);
+    if (!(key in newProps) && !preservedProps.has(key)) setDomProperty(element, key, undefined);
   });
   Object.entries(newProps).forEach(([key, value]) => {
+    if (preservedProps.has(key)) return;
     setDomProperty(element, key, value);
   });
 }
@@ -723,45 +924,14 @@ function patchEvents(
     const key = listenerKey(event);
     if (current.has(key)) return;
     const listener: EventListener = (browserEvent) => {
+      const pendingReconciliation = pendingDirtyReconciliations.get(element);
+      if (pendingReconciliation) {
+        pendingReconciliation.cancelled = true;
+        pendingDirtyReconciliations.delete(element);
+      }
       if (event.options?.preventDefault) browserEvent.preventDefault();
       if (event.options?.stopPropagation) browserEvent.stopPropagation();
-      if (typeof event.handlerId === "number") {
-        if (event.mapHandlerIds?.length) {
-          const payload = normalizeBrowserEvent(browserEvent);
-          if (handlers?.dispatchMapped) {
-            settleAsyncDispatch(handlers.dispatchMapped(event.handlerId, payload, event.mapHandlerIds));
-            return;
-          }
-          settleAsyncDispatch(handlers?.dispatchMessage?.(
-            mapDomEventMessage({
-              kind: "event",
-              handlerId: event.handlerId,
-              payload,
-            }, event.mapHandlerIds),
-          ));
-          return;
-        }
-        void Promise.resolve(
-          handlers?.dispatch(event.handlerId, normalizeBrowserEvent(browserEvent)),
-        ).then((message) => {
-          if (message !== undefined) {
-            return handlers?.dispatchMessage?.(
-              event.mapHandlerIds?.length
-                ? mapDomEventMessage(toVxMessage(message), event.mapHandlerIds)
-                : message,
-            );
-          }
-        }).catch(() => undefined);
-        return;
-      }
-      if (Object.hasOwn(event, "message")) {
-        const message = toVxMessage(event.message);
-        settleAsyncDispatch(handlers?.dispatchMessage?.(
-          event.mapHandlerIds?.length
-            ? mapDomEventMessage(message, event.mapHandlerIds)
-            : event.message,
-        ));
-      }
+      dispatchEventDescriptor(event, normalizeBrowserEvent(browserEvent), handlers);
     };
     const options = toListenerOptions(event.options);
     element.addEventListener(event.event, listener, options);
@@ -775,57 +945,307 @@ function patchEvents(
   }
 }
 
+function dispatchEventDescriptor(
+  event: EventDescriptor,
+  payload: NormalizedEventPayload,
+  handlers: RetainedEventHandlerRegistry | undefined,
+): void {
+  if (typeof event.handlerId === "number") {
+    if (event.mapHandlerIds?.length) {
+      if (handlers?.dispatchMapped) {
+        settleAsyncDispatch(handlers.dispatchMapped(event.handlerId, payload, event.mapHandlerIds));
+        return;
+      }
+      settleAsyncDispatch(handlers?.dispatchMessage?.(
+        mapDomEventMessage({ kind: "event", handlerId: event.handlerId, payload }, event.mapHandlerIds),
+      ));
+      return;
+    }
+    void Promise.resolve(handlers?.dispatch(event.handlerId, payload))
+      .then((message) => message === undefined
+        ? undefined
+        : handlers?.dispatchMessage?.(message))
+      .catch(() => undefined);
+    return;
+  }
+  if (!Object.hasOwn(event, "message")) return;
+  const message = toVxMessage(event.message);
+  settleAsyncDispatch(handlers?.dispatchMessage?.(
+    event.mapHandlerIds?.length
+      ? mapDomEventMessage(message, event.mapHandlerIds)
+      : event.message,
+  ));
+}
+
 function hydrateContainer(
   container: Element,
   vnode: VNode,
   handlers: RetainedEventHandlerRegistry | undefined,
+  onMismatch: HydrationMismatchHandler | undefined,
+  deferReconciliation: ((callback: () => void) => void) | undefined,
 ): void {
   if (vnode.kind === "fragment") {
     vnode.children.forEach((child, index) => {
       const domChild = container.childNodes.item(index);
-      if (domChild) hydrateNode(domChild, child, handlers);
-      else container.appendChild(createDom(child, handlers));
+      if (domChild) {
+        hydrateNode(domChild, child, handlers, onMismatch, `root[${index}]`, deferReconciliation);
+        return;
+      }
+      reportHydrationMismatch(onMismatch, {
+        path: `root[${index}]`,
+        reason: "children",
+        expected: describeVNode(child),
+        actual: undefined,
+      });
+      container.appendChild(createDom(child, handlers));
     });
+    reportExtraHydrationChildren(container, vnode.children.length, "root", onMismatch);
     removeExtraChildren(container, vnode.children.length);
     return;
   }
 
   const current = container.firstChild;
   if (!current) {
+    reportHydrationMismatch(onMismatch, {
+      path: "root",
+      reason: "children",
+      expected: describeVNode(vnode),
+      actual: undefined,
+    });
     container.appendChild(createDom(vnode, handlers));
     return;
   }
-  hydrateNode(current, vnode, handlers);
+  hydrateNode(current, vnode, handlers, onMismatch, "root", deferReconciliation);
+  reportExtraHydrationChildren(container, 1, "root", onMismatch);
+  removeExtraChildren(container, 1);
 }
 
 function hydrateNode(
   dom: Node,
   vnode: VNode,
   handlers: RetainedEventHandlerRegistry | undefined,
+  onMismatch: HydrationMismatchHandler | undefined,
+  path: string,
+  deferReconciliation: ((callback: () => void) => void) | undefined,
 ): void {
   if (vnode.kind === "text") {
-    if (dom.textContent !== vnode.value) dom.textContent = vnode.value;
+    if (dom.nodeType !== Node.TEXT_NODE) {
+      reportHydrationMismatch(onMismatch, {
+        path,
+        reason: "node-kind",
+        expected: "text",
+        actual: describeDomNode(dom),
+      });
+      dom.parentNode?.replaceChild(createDom(vnode, handlers), dom);
+      return;
+    }
+    if (dom.textContent !== vnode.value) {
+      reportHydrationMismatch(onMismatch, {
+        path,
+        reason: "text",
+        expected: vnode.value,
+        actual: dom.textContent,
+      });
+      dom.textContent = vnode.value;
+    }
     return;
   }
   if (vnode.kind === "fragment") {
     vnode.children.forEach((child, index) => {
       const domChild = dom.childNodes.item(index);
-      if (domChild) hydrateNode(domChild, child, handlers);
+      if (domChild) {
+        hydrateNode(domChild, child, handlers, onMismatch, `${path}[${index}]`, deferReconciliation);
+      }
     });
+    reportExtraHydrationChildren(dom, vnode.children.length, path, onMismatch);
     removeExtraChildren(dom, vnode.children.length);
     return;
   }
-  if (!(dom instanceof Element) || dom.tagName.toLowerCase() !== vnode.tag) {
+  if (!(dom instanceof Element)) {
+    reportHydrationMismatch(onMismatch, {
+      path,
+      reason: "node-kind",
+      expected: `element:${vnode.tag}`,
+      actual: describeDomNode(dom),
+    });
     dom.parentNode?.replaceChild(createDom(vnode, handlers), dom);
     return;
   }
-  applyElementProps(dom, domElementSnapshot(dom), vnode, handlers);
+  if (dom.tagName.toLowerCase() !== vnode.tag) {
+    reportHydrationMismatch(onMismatch, {
+      path,
+      reason: "tag",
+      expected: vnode.tag,
+      actual: dom.tagName.toLowerCase(),
+    });
+    dom.parentNode?.replaceChild(createDom(vnode, handlers), dom);
+    return;
+  }
+  const dirtyProps = dirtyFormProperties(dom, vnode);
+  reportElementHydrationMismatch(dom, vnode, path, onMismatch);
+  applyElementProps(dom, domElementSnapshot(dom), vnode, handlers, dirtyProps);
   (vnode.children ?? []).forEach((child, index) => {
     const domChild = dom.childNodes.item(index);
-    if (domChild) hydrateNode(domChild, child, handlers);
-    else dom.appendChild(createDom(child, handlers));
+    if (domChild) {
+      hydrateNode(domChild, child, handlers, onMismatch, `${path}.${vnode.tag}[${index}]`, deferReconciliation);
+      return;
+    }
+    reportHydrationMismatch(onMismatch, {
+      path: `${path}.${vnode.tag}[${index}]`,
+      reason: "children",
+      expected: describeVNode(child),
+      actual: undefined,
+    });
+    dom.appendChild(createDom(child, handlers));
   });
+  reportExtraHydrationChildren(dom, vnode.children?.length ?? 0, path, onMismatch);
   removeExtraChildren(dom, vnode.children?.length ?? 0);
+  reconcileDirtyFormControl(dom, vnode, dirtyProps, handlers, deferReconciliation);
+}
+
+function dirtyFormProperties(element: Element, vnode: VxElementNode): Set<string> {
+  const dirty = new Set<string>();
+  const control = element as Element & {
+    value?: unknown;
+    defaultValue?: unknown;
+    checked?: unknown;
+    defaultChecked?: unknown;
+  };
+  if (
+    Object.hasOwn(vnode.props ?? {}, "value") &&
+    "value" in control && "defaultValue" in control &&
+    control.value !== control.defaultValue
+  ) {
+    dirty.add("value");
+  }
+  if (
+    Object.hasOwn(vnode.props ?? {}, "checked") &&
+    "checked" in control && "defaultChecked" in control &&
+    control.checked !== control.defaultChecked
+  ) {
+    dirty.add("checked");
+  }
+  return dirty;
+}
+
+function reconcileDirtyFormControl(
+  element: Element,
+  vnode: VxElementNode,
+  dirtyProps: ReadonlySet<string>,
+  handlers: RetainedEventHandlerRegistry | undefined,
+  deferReconciliation: ((callback: () => void) => void) | undefined,
+): void {
+  if (dirtyProps.size === 0) return;
+  const preferredEvent = dirtyProps.has("checked") ? "change" : "input";
+  const events = vnode.events ?? [];
+  const eventName = events.some((event) => event.event === preferredEvent)
+    ? preferredEvent
+    : preferredEvent === "input" ? "change" : "input";
+  const control = element as Element & { value?: unknown; checked?: unknown };
+  const payload: NormalizedEventPayload = {
+    kind: "input",
+    value: typeof control.value === "string" ? control.value : "",
+    checked: control.checked === true,
+    input_type: "",
+  };
+  const reconcile = () => {
+    events
+      .filter((event) => event.event === eventName)
+      .forEach((event) => dispatchEventDescriptor(event, payload, handlers));
+  };
+  if (!deferReconciliation) {
+    reconcile();
+    return;
+  }
+  const pending = { cancelled: false };
+  pendingDirtyReconciliations.set(element, pending);
+  deferReconciliation(() => {
+    if (pending.cancelled) return;
+    pendingDirtyReconciliations.delete(element);
+    reconcile();
+  });
+}
+
+function reportElementHydrationMismatch(
+  element: Element,
+  vnode: VxElementNode,
+  path: string,
+  onMismatch: HydrationMismatchHandler | undefined,
+): void {
+  if (!onMismatch) return;
+  const actual = {
+    attrs: currentAttrs(element),
+    styles: currentStyles(element),
+  };
+  const expected = {
+    attrs: expectedHydrationAttrs(vnode),
+    styles: expectedStyleText(element, vnode),
+  };
+  if (
+    recordsEqual(actual.attrs, expected.attrs) &&
+    inlineStyleText(element) === expected.styles
+  ) return;
+  reportHydrationMismatch(onMismatch, {
+    path,
+    reason: "attributes",
+    expected,
+    actual,
+  });
+}
+
+function expectedHydrationAttrs(vnode: VxElementNode): Record<string, unknown> {
+  const combined = effectiveAttrs(vnode);
+  return Object.fromEntries(Object.entries(combined).flatMap(([key, value]) => {
+    const name = key === "className" ? "class" : key;
+    if (name === "key" || name === "style" || value == null || value === false) return [];
+    return [[name, value === true ? "" : String(value)]];
+  }));
+}
+
+function recordsEqual(
+  left: Record<string, unknown>,
+  right: Record<string, unknown>,
+): boolean {
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  return leftKeys.length === rightKeys.length &&
+    leftKeys.every((key, index) =>
+      key === rightKeys[index] && String(left[key]) === String(right[key])
+    );
+}
+
+function reportExtraHydrationChildren(
+  parent: Node,
+  expectedLength: number,
+  path: string,
+  onMismatch: HydrationMismatchHandler | undefined,
+): void {
+  if (parent.childNodes.length <= expectedLength) return;
+  reportHydrationMismatch(onMismatch, {
+    path,
+    reason: "children",
+    expected: expectedLength,
+    actual: parent.childNodes.length,
+  });
+}
+
+function reportHydrationMismatch(
+  onMismatch: HydrationMismatchHandler | undefined,
+  mismatch: HydrationMismatch,
+): void {
+  onMismatch?.(mismatch);
+}
+
+function describeVNode(vnode: VNode): string {
+  return vnode.kind === "element" ? `element:${vnode.tag}` : vnode.kind;
+}
+
+function describeDomNode(node: Node): string {
+  return node instanceof Element
+    ? `element:${node.tagName.toLowerCase()}`
+    : node.nodeType === Node.TEXT_NODE
+      ? "text"
+      : `node:${node.nodeType}`;
 }
 
 function domElementSnapshot(element: Element): VxElementNode {
@@ -850,12 +1270,39 @@ function currentAttrs(element: Element): Record<string, unknown> {
 }
 
 function currentStyles(element: Element): Record<string, string> {
-  if (!(element instanceof HTMLElement)) return {};
+  if (!("style" in element)) return {};
+  const declaration = element.style as CSSStyleDeclaration;
   const styles: Record<string, string> = {};
-  Array.from(element.style).forEach((name) => {
-    styles[name] = element.style.getPropertyValue(name);
+  Array.from(declaration).forEach((name) => {
+    styles[name] = declaration.getPropertyValue(name);
   });
   return styles;
+}
+
+function inlineStyleText(element: Element): string {
+  return "style" in element
+    ? (element.style as CSSStyleDeclaration).cssText
+    : "";
+}
+
+function expectedStyleText(
+  element: Element,
+  vnode: VxElementNode,
+): string {
+  const scratch = element.ownerDocument.createElement("div");
+  const attrs = { ...(vnode.attrs ?? {}), ...(vnode.props ?? {}) };
+  const inlineStyle = attrs.style;
+  if (
+    Object.keys(vnode.styles ?? {}).length === 0 &&
+    inlineStyle != null &&
+    inlineStyle !== false
+  ) {
+    scratch.setAttribute("style", String(inlineStyle));
+  }
+  Object.entries(vnode.styles ?? {}).forEach(([name, value]) => {
+    scratch.style.setProperty(name, String(value));
+  });
+  return scratch.style.cssText;
 }
 
 function removeExtraChildren(parent: Node, expectedLength: number): void {
@@ -867,6 +1314,91 @@ function removeExtraChildren(parent: Node, expectedLength: number): void {
 function removeContainerListeners(container: Element): void {
   Array.from(container.querySelectorAll("*")).forEach(removeElementListeners);
   removeElementListeners(container);
+}
+
+function captureContainerSnapshot(container: Element): Element {
+  const snapshot = container.cloneNode(true) as Element;
+  copyLiveFormState(container, snapshot);
+  return snapshot;
+}
+
+function restoreContainerSnapshot(container: Element, snapshot: Element): void {
+  restoreElementSnapshot(container, snapshot);
+}
+
+function copyLiveFormState(source: Element, target: Element): void {
+  copyOwnFormState(source, target);
+  Array.from(source.children).forEach((child, index) => {
+    const targetChild = target.children.item(index);
+    if (targetChild) copyLiveFormState(child, targetChild);
+  });
+}
+
+function copyOwnFormState(source: Element, target: Element): void {
+  const sourceControl = source as Element & {
+    value?: unknown;
+    checked?: unknown;
+    selected?: unknown;
+  };
+  const targetControl = target as Element & {
+    value?: unknown;
+    checked?: unknown;
+    selected?: unknown;
+  };
+  if ("value" in sourceControl && "value" in targetControl) {
+    targetControl.value = sourceControl.value;
+  }
+  if ("checked" in sourceControl && "checked" in targetControl) {
+    targetControl.checked = sourceControl.checked;
+  }
+  if ("selected" in sourceControl && "selected" in targetControl) {
+    targetControl.selected = sourceControl.selected;
+  }
+}
+
+function restoreElementSnapshot(element: Element, snapshot: Element): void {
+  Array.from(element.attributes).forEach((attr) => {
+    if (!snapshot.hasAttribute(attr.name)) element.removeAttribute(attr.name);
+  });
+  Array.from(snapshot.attributes).forEach((attr) => {
+    if (element.getAttribute(attr.name) !== attr.value) element.setAttribute(attr.name, attr.value);
+  });
+  Array.from(snapshot.childNodes).forEach((snapshotChild, index) => {
+    const child = element.childNodes.item(index);
+    if (!child) {
+      element.appendChild(cloneSnapshotNode(snapshotChild));
+      return;
+    }
+    if (!sameDomSnapshotKind(child, snapshotChild)) {
+      element.replaceChild(cloneSnapshotNode(snapshotChild), child);
+      return;
+    }
+    if (child instanceof Element && snapshotChild instanceof Element) {
+      restoreElementSnapshot(child, snapshotChild);
+      return;
+    }
+    if (child.nodeValue !== snapshotChild.nodeValue) child.nodeValue = snapshotChild.nodeValue;
+  });
+  while (element.childNodes.length > snapshot.childNodes.length) {
+    if (element.lastChild) element.removeChild(element.lastChild);
+  }
+  copyOwnFormState(snapshot, element);
+}
+
+function cloneSnapshotNode(node: Node): Node {
+  const clone = node.cloneNode(true);
+  if (node instanceof Element && clone instanceof Element) {
+    copyLiveFormState(node, clone);
+  }
+  return clone;
+}
+
+function sameDomSnapshotKind(left: Node, right: Node): boolean {
+  if (left.nodeType !== right.nodeType) return false;
+  if (left instanceof Element && right instanceof Element) {
+    return left.tagName === right.tagName;
+  }
+  return true;
 }
 
 function removeElementListeners(element: Element): void {

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -335,15 +335,20 @@ export function createVxDomRenderer(
     },
     hydrate(input: unknown) {
       const nextFrame = flattenRenderFrame(normalizeRenderFrame(input));
-      applyFrame(nextFrame, () => {
-        hydrateContainer(
-          container,
-          nextFrame.root,
-          options.handlers,
-          options.onHydrationMismatch,
-          options.deferHydrationReconciliation,
-        );
-      });
+      try {
+        applyFrame(nextFrame, () => {
+          hydrateContainer(
+            container,
+            nextFrame.root,
+            options.handlers,
+            options.onHydrationMismatch,
+            options.deferHydrationReconciliation,
+          );
+        });
+      } catch (error) {
+        detach();
+        throw error;
+      }
     },
     detach,
     dispose() {

--- a/packages/vx-dom/src/index.ts
+++ b/packages/vx-dom/src/index.ts
@@ -15,13 +15,18 @@ export {
   createVxDomRenderer,
   hydrateVxApp,
   mountVxApp,
+  readVoydHydrationRoot,
+  readVoydHydrationRoots,
   render,
   renderMsgPackNode,
 } from "./browser.js";
 export type {
+  HydrationMismatch,
+  HydrationMismatchHandler,
   MountedVxApp,
   MountVxAppOptions,
   RenderOptions,
+  VoydHydrationRoot,
   VxDomRenderer,
 } from "./browser.js";
 export {

--- a/packages/vx-dom/src/normalize.ts
+++ b/packages/vx-dom/src/normalize.ts
@@ -11,6 +11,11 @@ type LegacyElement = {
   children?: unknown[];
 };
 
+const voidTags = new Set([
+  "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta",
+  "param", "source", "track", "wbr",
+]);
+
 export function normalizeRenderFrame(input: unknown): VxRenderFrame {
   const record = toRecord(input);
   if (record && "version" in record) {
@@ -24,13 +29,13 @@ export function normalizeRenderFrame(input: unknown): VxRenderFrame {
 }
 
 export function validateHtmlTagName(value: string, path = "tag"): void {
-  if (!/^[a-zA-Z][a-zA-Z0-9:-]*$/.test(value)) {
+  if (!/^[a-z][a-z0-9:-]*$/.test(value)) {
     throw new Error(`vx-dom: invalid HTML tag name at ${path}: ${JSON.stringify(value)}`);
   }
 }
 
 export function validateHtmlAttributeName(value: string, path = "attribute"): void {
-  if (!/^[^\s"'/>=\u0000-\u001f\u007f]+$/.test(value)) {
+  if (/[A-Z]/.test(value) || !/^[^\s"'/>=\u0000-\u001f\u007f]+$/.test(value)) {
     throw new Error(`vx-dom: invalid HTML attribute name at ${path}: ${JSON.stringify(value)}`);
   }
 }
@@ -38,6 +43,31 @@ export function validateHtmlAttributeName(value: string, path = "attribute"): vo
 export function validateCssPropertyName(value: string, path = "style"): void {
   if (!/^(--[a-zA-Z0-9_-]+|-[a-zA-Z][a-zA-Z0-9-]*|[a-zA-Z][a-zA-Z0-9-]*)$/.test(value)) {
     throw new Error(`vx-dom: invalid CSS property name at ${path}: ${JSON.stringify(value)}`);
+  }
+}
+
+export function validateCssPropertyValue(value: string, path = "style"): void {
+  if (/[;!\u0000-\u001f\u007f]/.test(value)) {
+    throw new Error(`vx-dom: invalid CSS property value at ${path}: ${JSON.stringify(value)}`);
+  }
+}
+
+export function validateDomPropertyName(value: string, path = "property"): void {
+  if (value !== "value" && value !== "checked" && value !== "disabled") {
+    throw new Error(`vx-dom: unsupported DOM property at ${path}: ${JSON.stringify(value)}`);
+  }
+}
+
+export function validateDomPropertyValue(
+  name: string,
+  value: unknown,
+  path = "property",
+): void {
+  const valid = name === "value"
+    ? typeof value === "string" || typeof value === "number"
+    : typeof value === "boolean";
+  if (!valid) {
+    throw new Error(`vx-dom: invalid DOM property value at ${path}: ${JSON.stringify(value)}`);
   }
 }
 
@@ -86,15 +116,18 @@ export function normalizeVNode(input: unknown): VNode {
 
 function normalizeElement(input: Record<string, unknown>): VxElementNode {
   const tag = typeof input.tag === "string" && input.tag ? input.tag : "div";
+  validateHtmlTagName(tag);
+  const children = normalizeChildren(input.children);
+  validateVoidElementChildren(tag, children, "element");
   return {
     kind: "element",
     tag,
     key: optionalString(input.key),
-    attrs: normalizeRecord(input.attrs),
-    props: normalizeRecord(input.props),
-    styles: normalizeStringRecord(input.styles),
+    attrs: normalizeValidatedRecord(input.attrs, "element.attrs", validateHtmlAttributeName),
+    props: normalizeValidatedProps(input.props, "element.props"),
+    styles: normalizeValidatedStyles(input.styles, "element.styles"),
     events: normalizeEvents(input.events),
-    children: normalizeChildren(input.children),
+    children,
   };
 }
 
@@ -103,12 +136,14 @@ function normalizeLegacyElement(input: LegacyElement): VxElementNode {
   const tag = input.name || "div";
   validateHtmlTagName(tag, "legacy.name");
   Object.keys(attributes ?? {}).forEach((key) => validateHtmlAttributeName(key, `legacy.attributes.${key}`));
+  const children = normalizeChildren(input.children);
+  validateVoidElementChildren(tag, children, "legacy element");
   return {
     kind: "element",
     tag,
     key: optionalString(attributes?.key),
     attrs: attributes,
-    children: normalizeChildren(input.children),
+    children,
   };
 }
 
@@ -134,15 +169,6 @@ function normalizeRecord(input: unknown): Record<string, unknown> | undefined {
   const record = toRecord(input);
   if (!record) return undefined;
   const entries = Object.entries(record).filter(([, value]) => value !== undefined);
-  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
-}
-
-function normalizeStringRecord(input: unknown): Record<string, string> | undefined {
-  const record = toRecord(input);
-  if (!record) return undefined;
-  const entries = Object.entries(record)
-    .filter(([, value]) => value != null)
-    .map(([key, value]) => [key, String(value)]);
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
@@ -216,16 +242,32 @@ function normalizeVersionedElement(input: Record<string, unknown>, path: string)
     throw new Error(`vx-dom: invalid VX frame at ${path}.tag: expected non-empty string`);
   }
   validateHtmlTagName(input.tag, `${path}.tag`);
+  const children = normalizeVersionedChildren(input.children, `${path}.children`);
+  validateVoidElementChildren(input.tag, children, path);
   return {
     kind: "element",
     tag: input.tag,
     key: strictOptionalString(input.key, `${path}.key`),
-    attrs: normalizeVersionedRecord(input.attrs, `${path}.attrs`, validateHtmlAttributeName),
-    props: normalizeVersionedRecord(input.props, `${path}.props`),
-    styles: normalizeVersionedStyles(input.styles, `${path}.styles`),
+    attrs: normalizeValidatedRecord(input.attrs, `${path}.attrs`, validateHtmlAttributeName),
+    props: normalizeValidatedProps(input.props, `${path}.props`),
+    styles: normalizeValidatedStyles(input.styles, `${path}.styles`),
     events: normalizeVersionedEvents(input.events, `${path}.events`),
-    children: normalizeVersionedChildren(input.children, `${path}.children`),
+    children,
   };
+}
+
+function normalizeValidatedProps(
+  input: unknown,
+  path: string,
+): Record<string, unknown> | undefined {
+  const props = normalizeValidatedRecord(input, path);
+  if (!props) return undefined;
+  Object.entries(props).forEach(([name, value]) => {
+    if (name === "value" || name === "checked" || name === "disabled") {
+      validateDomPropertyValue(name, value, `${path}.${name}`);
+    }
+  });
+  return props;
 }
 
 function normalizeVersionedChildren(input: unknown, path: string): VNode[] {
@@ -236,7 +278,13 @@ function normalizeVersionedChildren(input: unknown, path: string): VNode[] {
   return input.map((child, index) => normalizeVersionedVNode(child, `${path}[${index}]`));
 }
 
-function normalizeVersionedRecord(
+function validateVoidElementChildren(tag: string, children: VNode[], path: string): void {
+  if (voidTags.has(tag) && children.length > 0) {
+    throw new Error(`vx-dom: void element at ${path} cannot have children`);
+  }
+}
+
+function normalizeValidatedRecord(
   input: unknown,
   path: string,
   validateName?: (name: string, path: string) => void,
@@ -251,13 +299,17 @@ function normalizeVersionedRecord(
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
-function normalizeVersionedStyles(input: unknown, path: string): Record<string, string> | undefined {
+function normalizeValidatedStyles(input: unknown, path: string): Record<string, string> | undefined {
   if (input === undefined) return undefined;
-  const record = normalizeVersionedRecord(input, path, validateCssPropertyName);
+  const record = normalizeValidatedRecord(input, path, validateCssPropertyName);
   if (!record) return undefined;
   const entries = Object.entries(record)
     .filter(([, value]) => value != null)
-    .map(([key, value]) => [key, String(value)]);
+    .map(([key, value]) => {
+      const stringValue = String(value);
+      validateCssPropertyValue(stringValue, `${path}.${key}`);
+      return [key, stringValue];
+    });
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 

--- a/packages/vx-dom/src/server.ts
+++ b/packages/vx-dom/src/server.ts
@@ -2,6 +2,9 @@ import { callComponentFn } from "./memory.js";
 import {
   normalizeRenderFrame,
   validateCssPropertyName,
+  validateCssPropertyValue,
+  validateDomPropertyName,
+  validateDomPropertyValue,
   validateHtmlAttributeName,
   validateHtmlTagName,
 } from "./normalize.js";
@@ -44,6 +47,11 @@ const voidTags = new Set([
   "track",
   "wbr",
 ]);
+const newlineStrippingTags = new Set(["listing", "pre", "textarea"]);
+const rawTextTags = new Set(["script", "style"]);
+const disableableTags = new Set([
+  "button", "fieldset", "input", "optgroup", "option", "select", "textarea",
+]);
 
 export async function renderVxToString(
   options: RenderVxToStringOptions,
@@ -73,25 +81,57 @@ export async function renderVxToString(
 }
 
 export function renderNodeToString(vnode: VNode): string {
-  if (vnode.kind === "text") return escapeText(vnode.value);
-  if (vnode.kind === "fragment") return vnode.children.map(renderNodeToString).join("");
+  return renderNode(vnode);
+}
+
+function renderNode(vnode: VNode, rawTextTag?: string): string {
+  if (vnode.kind === "text") {
+    return rawTextTag ? renderRawText(vnode.value, rawTextTag) : escapeText(vnode.value);
+  }
+  if (vnode.kind === "fragment") {
+    return vnode.children.map((child) => renderNode(child, rawTextTag)).join("");
+  }
+  if (rawTextTag) {
+    throw new Error(`vx-dom/server: ${rawTextTag} elements may only contain text`);
+  }
 
   validateHtmlTagName(vnode.tag, "server.tag");
+  validateTextareaValue(vnode);
   const attrs = renderAttrs(vnode);
   if (voidTags.has(vnode.tag)) return `<${vnode.tag}${attrs}>`;
-  const children = (vnode.children ?? []).map(renderNodeToString).join("");
-  return `<${vnode.tag}${attrs}>${children}</${vnode.tag}>`;
+  const childRawTextTag = rawTextTags.has(vnode.tag) ? vnode.tag : undefined;
+  const children = (vnode.children ?? [])
+    .map((child) => renderNode(child, childRawTextTag))
+    .join("");
+  const leadingNewline = newlineStrippingTags.has(vnode.tag) && children.startsWith("\n")
+    ? "\n"
+    : "";
+  return `<${vnode.tag}${attrs}>${leadingNewline}${children}</${vnode.tag}>`;
+}
+
+function renderRawText(value: string, tag: string): string {
+  if (value.includes("\0") || value.includes("\r")) {
+    throw new Error(`vx-dom/server: ${tag} text contains a character HTML cannot preserve`);
+  }
+  if (value.toLowerCase().includes(`</${tag}`)) {
+    throw new Error(`vx-dom/server: ${tag} text contains its closing delimiter`);
+  }
+  return value;
 }
 
 function renderAttrs(vnode: Extract<VNode, { kind: "element" }>): string {
   const attrs = { ...(vnode.attrs ?? {}) };
   Object.entries(vnode.props ?? {}).forEach(([key, value]) => {
-    if (key === "className") attrs.class = value;
-    else attrs[key] = value;
+    validateDomPropertyName(key, `server.props.${key}`);
+    validateDomPropertyValue(key, value, `server.props.${key}`);
+    validateSsrProperty(vnode.tag, key, value);
+    if (vnode.tag === "textarea" && key === "value") return;
+    attrs[key] = value;
   });
   const style = Object.entries(vnode.styles ?? {})
     .map(([key, value]) => {
       validateCssPropertyName(key, `server.styles.${key}`);
+      validateCssPropertyValue(value, `server.styles.${key}`);
       return `${key}: ${value}`;
     })
     .join("; ");
@@ -107,9 +147,37 @@ function renderAttrs(vnode: Extract<VNode, { kind: "element" }>): string {
     .join("");
 }
 
+function validateSsrProperty(tag: string, property: string, value: unknown): void {
+  if (property === "value" && (tag === "input" || (tag === "textarea" && typeof value === "string"))) {
+    return;
+  }
+  if (property === "checked" && tag === "input") return;
+  if (property === "disabled" && disableableTags.has(tag)) {
+    return;
+  }
+  throw new Error(`vx-dom/server: property ${property} has no stable SSR representation on <${tag}>`);
+}
+
+function validateTextareaValue(vnode: Extract<VNode, { kind: "element" }>): void {
+  if (vnode.tag !== "textarea" || !Object.hasOwn(vnode.props ?? {}, "value")) return;
+  const value = vnode.props?.value;
+  if (typeof value !== "string" || textareaText(vnode.children ?? []) !== value) {
+    throw new Error("vx-dom/server: textarea value must match its text children for hydration");
+  }
+}
+
+function textareaText(children: VNode[]): string {
+  return children.map((child) => {
+    if (child.kind === "text") return child.value;
+    if (child.kind === "fragment") return textareaText(child.children);
+    throw new Error("vx-dom/server: textarea elements may only contain text");
+  }).join("");
+}
+
 function escapeText(value: string): string {
   return value
     .replace(/&/g, "&amp;")
+    .replace(/\r/g, "&#13;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
 }

--- a/packages/web/src/all.voyd
+++ b/packages/web/src/all.voyd
@@ -39,7 +39,7 @@ pub use super::extract::{
   parse_query,
   percent_decode
 }
-pub use super::html::{ Hydration, document, html, html_response, hydrate, render }
+pub use super::html::{ Hydration, append_hydration, document, html, html_response, hydrate, hydrate_named, render }
 pub use super::middleware::request_id_required
 pub use super::response::{
   Body,

--- a/packages/web/src/html.voyd
+++ b/packages/web/src/html.voyd
@@ -2,17 +2,19 @@
 
 use std::array::Array
 use std::dict::Dict
+use std::error::panic
 use std::http::Response
 use std::json::{ JsonError, stringify as stringify_json }
 use std::msgpack::{ MsgPack, MsgPackError }
 use std::msgpack::self as msgpack
 use std::number::cast::to_string
 use std::optional::types::all
-use std::string::type::{ String, StringSlice }
+use std::string::type::{ String, StringIndex, StringSlice }
 use std::vx
 use super::response::dto_json
 
 pub obj Hydration<Model> {
+  api id?: String,
   api target: String,
   api entry: String,
   api model: Model
@@ -25,7 +27,10 @@ pub fn document<Msg>(value: vx::Html<Msg>) -> String
   "<!doctype html>".as_slice().to_string().concat(render<Msg>(value))
 
 pub fn document<Msg, Model>({ view: vx::Html<Msg>, hydrate: Hydration<Model> }) -> String
-  document<Msg>(view).concat(render_hydration<Model>(hydrate))
+  insert_hydration(document<Msg>(view), render_hydration<Model>(hydrate))
+
+pub fn append_hydration<Model>(document: String, hydrate: Hydration<Model>) -> String
+  insert_hydration(document, render_hydration<Model>(hydrate))
 
 pub fn html_response<Msg>(response: Response, value: vx::Html<Msg>) -> Response
   response
@@ -57,6 +62,17 @@ pub fn hydrate<Model>({ target: String, entry: String, model: Model }) -> Hydrat
     model: model
   }
 
+pub fn hydrate_named<Model>({ id: StringSlice, target: StringSlice, entry: StringSlice, model: Model }) -> Hydration<Model>
+  Hydration<Model> {
+    id: id.to_string(),
+    target: target.to_string(),
+    entry: entry.to_string(),
+    model: model
+  }
+
+pub fn hydrate_named<Model>({ id: String, target: String, entry: String, model: Model }) -> Hydration<Model>
+  Hydration<Model> { id: id, target: target, entry: entry, model: model }
+
 fn render_node(value: MsgPack): () -> String
   match(msgpack::unpack_string(value))
     Ok<String> { value }:
@@ -78,6 +94,8 @@ fn render_node(value: MsgPack): () -> String
             return render_element(map)
           if kind.equals("fragment"):
             return render_node_children(map)
+          if kind.equals("map"):
+            return render_mapped_node(map)
           if kind.equals("text"):
             match(read_string(map, "value".as_slice()))
               Some<String> { value }:
@@ -90,15 +108,32 @@ fn render_node(value: MsgPack): () -> String
     Err<MsgPackError>:
       String::init()
 
+fn render_mapped_node(map: Dict<String, MsgPack>) -> String
+  match(map.get("child"))
+    Some<MsgPack> { value }:
+      render_node(value)
+    None:
+      String::init()
+
 fn render_element(map: Dict<String, MsgPack>): () -> String
   let tag = read_string_or(map, "tag".as_slice(), "div".as_slice())
-  let attrs = render_attrs(map)
-  let children = render_node_children(map)
-  "<".as_slice()
+  if not is_valid_tag_name(tag):
+    panic("invalid VX HTML tag: ".concat(tag))
+    return String::init()
+  if is_void_tag(tag) and has_element_children(map):
+    panic("void VX HTML element cannot have children: ".concat(tag))
+    return String::init()
+  let attrs = render_element_attrs(map, tag)
+  let opening = "<".as_slice()
     .to_string()
     .concat(tag)
     .concat(attrs)
     .concat(">".as_slice())
+  if is_void_tag(tag):
+    return opening
+  let children = if is_raw_text_tag(tag.as_slice()) then: render_raw_text_children(map, tag.as_slice()) else: preserve_leading_newline(tag, render_node_children(map))
+  validate_textarea_value(map, tag: tag, children: children)
+  opening
     .concat(children)
     .concat("</".as_slice())
     .concat(tag)
@@ -115,6 +150,17 @@ fn render_node_children(map: Dict<String, MsgPack>): () -> String
     None:
       String::init()
 
+fn has_element_children(map: Dict<String, MsgPack>) -> bool
+  match(map.get("children".as_slice().to_string()))
+    Some<MsgPack> { value }:
+      match(msgpack::unpack_array(value))
+        Ok<Array<MsgPack>> { value }:
+          not value.is_empty()
+        Err<MsgPackError>:
+          false
+    None:
+      false
+
 fn render_children(children: Array<MsgPack>): () -> String
   var out = String::init()
   var index = 0
@@ -127,18 +173,108 @@ fn render_children(children: Array<MsgPack>): () -> String
     index = index + 1
   out
 
-fn render_attrs(map: Dict<String, MsgPack>): () -> String
+fn render_raw_text_children(map: Dict<String, MsgPack>, tag: StringSlice) -> String
+  match(map.get("children"))
+    Some<MsgPack> { value }:
+      match(msgpack::unpack_array(value))
+        Ok<Array<MsgPack>> { value }:
+          render_raw_text_array(value, tag)
+        Err<MsgPackError>:
+          String::init()
+    None:
+      String::init()
+
+fn render_raw_text_array(children: Array<MsgPack>, tag: StringSlice) -> String
   var out = String::init()
-  match(map.get("attrs".as_slice().to_string()))
+  var index = 0
+  while index < children.len():
+    match(children.get(index))
+      Some<MsgPack> { value }:
+        out = out.concat(render_raw_text_node(value, tag))
+      None:
+        void
+    index = index + 1
+  out
+
+fn render_raw_text_node(value: MsgPack, tag: StringSlice): () -> String
+  match(msgpack::unpack_string(value))
+    Ok<String> { value }:
+      return validate_raw_text(value, tag)
+    Err<MsgPackError>:
+      void
+
+  match(msgpack::unpack_array(value))
+    Ok<Array<MsgPack>> { value }:
+      return render_raw_text_array(value, tag)
+    Err<MsgPackError>:
+      void
+
+  match(msgpack::unpack_map(value))
+    Ok<Dict<String, MsgPack>> { value: map }:
+      match(read_string(map, "kind".as_slice()))
+        Some<String> { value: kind }:
+          if kind == "text":
+            return validate_raw_text(
+              read_string_or(map, "value".as_slice(), "".as_slice()),
+              tag
+            )
+          if kind == "fragment":
+            return render_raw_text_children(map, tag)
+          if kind == "map":
+            match(map.get("child"))
+              Some<MsgPack> { value }:
+                return render_raw_text_node(value, tag)
+              None:
+                return String::init()
+          panic("VX raw-text elements may only contain text")
+          String::init()
+        None:
+          String::init()
+    Err<MsgPackError>:
+      String::init()
+
+fn validate_raw_text(value: String, tag: StringSlice) -> String
+  var index = 0
+  while index < value.byte_len():
+    let byte = value.get_byte(index) ?? 0
+    if byte == 0 or byte == 13:
+      panic("VX raw text contains a character HTML cannot preserve")
+    index = index + 1
+  let closing = "</".as_slice().to_string().concat(tag)
+  if value.lowered().contains(closing.as_slice()):
+    panic("VX raw text contains its closing delimiter")
+  value
+
+fn render_element_attrs(map: Dict<String, MsgPack>, tag: String): () -> String
+  let ~attrs = Dict<String, MsgPack>::init()
+  copy_named_values(map, field: "attrs", into: attrs)
+  copy_properties(map, tag: tag, into: attrs)
+  let styles = read_styles(map)
+  if not styles.is_empty():
+    attrs.set("style", styles)
+  render_named_values(attrs)
+
+fn copy_properties(
+  map: Dict<String, MsgPack>,
+  { tag: String, into ~attrs: Dict<String, MsgPack> }
+) -> void
+  match(map.get("props"))
     Some<MsgPack> { value }:
       match(msgpack::unpack_map(value))
-        Ok<Dict<String, MsgPack>> { value: attrs }:
-          let entries = attrs.entries()
+        Ok<Dict<String, MsgPack>> { value: props }:
+          let entries = props.entries()
           var index = 0
           while index < entries.len():
             match(entries.get(index))
               Some<(String, MsgPack)> { value }:
-                out = out.concat(render_attr(value.0, value.1))
+                if not is_supported_property(value.0):
+                  panic("unsupported VX DOM property: ".concat(value.0))
+                if not is_valid_property_value(name: value.0, value: value.1):
+                  panic("invalid VX DOM property value for: ".concat(value.0))
+                if not is_supported_property_for_tag(name: value.0, tag: tag):
+                  panic("VX DOM property has no stable SSR representation on <".concat(tag).concat(">: ").concat(value.0))
+                if not (tag == "textarea" and value.0 == "value"):
+                  attrs.set(value.0, value.1)
               None:
                 void
             index = index + 1
@@ -146,9 +282,46 @@ fn render_attrs(map: Dict<String, MsgPack>): () -> String
           void
     None:
       void
+
+fn copy_named_values(
+  map: Dict<String, MsgPack>,
+  { field: String, into ~attrs: Dict<String, MsgPack> }
+): () -> void
+  match(map.get(field))
+    Some<MsgPack> { value }:
+      match(msgpack::unpack_map(value))
+        Ok<Dict<String, MsgPack>> { value: values }:
+          let entries = values.entries()
+          var index = 0
+          while index < entries.len():
+            match(entries.get(index))
+              Some<(String, MsgPack)> { value }:
+                attrs.set(value.0, value.1)
+              None:
+                void
+            index = index + 1
+        Err<MsgPackError>:
+          void
+    None:
+      void
+
+fn render_named_values(attrs: Dict<String, MsgPack>): () -> String
+  var out = String::init()
+  let entries = attrs.entries()
+  var index = 0
+  while index < entries.len():
+    match(entries.get(index))
+      Some<(String, MsgPack)> { value }:
+        out = out.concat(render_attr(value.0, value.1))
+      None:
+        void
+    index = index + 1
   out
 
 fn render_attr(name: String, value: MsgPack): () -> String
+  if not is_valid_attr_name(name):
+    panic("invalid VX HTML attribute: ".concat(name))
+    return String::init()
   match(msgpack::unpack_bool(value))
     Ok<bool> { value }:
       if value:
@@ -179,6 +352,41 @@ fn render_attr(name: String, value: MsgPack): () -> String
     Err<MsgPackError>:
       String::init()
 
+fn read_styles(map: Dict<String, MsgPack>): () -> String
+  match(map.get("styles"))
+    Some<MsgPack> { value }:
+      match(msgpack::unpack_map(value))
+        Ok<Dict<String, MsgPack>> { value: styles }:
+          render_style_entries(styles)
+        Err<MsgPackError>:
+          String::init()
+    None:
+      String::init()
+
+fn render_style_entries(styles: Dict<String, MsgPack>): () -> String
+  var out = String::init()
+  let entries = styles.entries()
+  var index = 0
+  while index < entries.len():
+    match(entries.get(index))
+      Some<(String, MsgPack)> { value }:
+        let name = value.0
+        if not is_valid_style_name(name):
+          panic("invalid VX CSS property: ".concat(name))
+        match(msgpack::unpack_string(value.1))
+          Ok<String> { value: style_value }:
+            if not is_valid_style_value(style_value):
+              panic("invalid VX CSS property value: ".concat(style_value))
+            if not out.is_empty():
+              out = out.concat("; ")
+            out = out.concat(name).concat(": ").concat(style_value)
+          Err<MsgPackError>:
+            void
+      None:
+        void
+    index = index + 1
+  out
+
 fn read_string(map: Dict<String, MsgPack>, key: StringSlice): () -> Option<String>
   match(map.get(key.to_string()))
     Some<MsgPack> { value }:
@@ -201,21 +409,173 @@ fn render_hydration<Model>(hydrate: Hydration<Model>): () -> String
   let model_json = match(stringify_json(dto_json<Model>(hydrate.model)))
     Ok<String> { value }:
       escape_script_json(value)
-    Err<JsonError>:
-      "null".as_slice().to_string()
-  "<script type=\"application/json\" data-voyd-hydration=\"".as_slice()
+    Err<JsonError> { error }:
+      panic("unable to serialize Voyd hydration model: ".concat(error.message))
+      String::init()
+  "<script type=\"application/json\" data-voyd-hydration-id=\"".as_slice()
     .to_string()
+    .concat(escape_attr((hydrate.id ?? hydrate.target).as_slice()))
+    .concat("\" data-voyd-hydration=\"".as_slice())
     .concat(escape_attr(hydrate.target.as_slice()))
+    .concat("\" data-voyd-entry=\"".as_slice())
+    .concat(escape_attr(hydrate.entry.as_slice()))
     .concat("\">".as_slice())
     .concat(model_json)
     .concat("</script><script type=\"module\" src=\"".as_slice())
     .concat(escape_attr(hydrate.entry.as_slice()))
     .concat("\"></script>".as_slice())
 
+fn insert_hydration(document: String, scripts: String) -> String
+  match(document.reverse_find("</body>".as_slice()))
+    Some<StringIndex> { value }:
+      let offset = value.to_i32()
+      document.slice(bytes: 0, len: offset)
+        .to_string()
+        .concat(scripts)
+        .concat(document.slice(bytes: offset, len: document.byte_len() - offset))
+    None:
+      document.concat(scripts)
+
+fn is_void_tag(tag: String) -> bool
+  tag == "area" or tag == "base" or tag == "br" or tag == "col" or
+    tag == "embed" or tag == "hr" or tag == "img" or tag == "input" or
+    tag == "link" or tag == "meta" or tag == "param" or tag == "source" or
+    tag == "track" or tag == "wbr"
+
+fn is_raw_text_tag(tag: StringSlice) -> bool
+  tag == "script".as_slice() or tag == "style".as_slice()
+
+fn preserve_leading_newline(tag: String, children: String) -> String
+  if (tag == "listing" or tag == "pre" or tag == "textarea") and children.starts_with("\n"):
+    return "\n".as_slice().to_string().concat(children)
+  children
+
+fn is_supported_property(name: String) -> bool
+  name == "value" or name == "checked" or name == "disabled"
+
+fn is_supported_property_for_tag({ name: String, tag: String }) -> bool
+  if name == "value":
+    return tag == "input" or tag == "textarea"
+  if name == "checked":
+    return tag == "input"
+  tag == "button" or tag == "fieldset" or tag == "input" or
+    tag == "optgroup" or tag == "option" or tag == "select" or
+    tag == "textarea"
+
+fn validate_textarea_value(map: Dict<String, MsgPack>, { tag: String, children: String }) -> void
+  if tag == "textarea":
+    match(map.get("props"))
+      Some<MsgPack> { value }:
+        match(msgpack::unpack_map(value))
+          Ok<Dict<String, MsgPack>> { value: props }:
+            match(props.get("value"))
+              Some<MsgPack> { value }:
+                match(msgpack::unpack_string(value))
+                  Ok<String> { value }:
+                    let expected = preserve_leading_newline(tag, escape_text(value.as_slice()))
+                    if children != expected:
+                      panic("textarea value must match its text children for hydration")
+                  Err<MsgPackError>:
+                    panic("textarea value must be a string for server rendering")
+              None:
+                void
+          Err<MsgPackError>:
+            void
+      None:
+        void
+
+fn is_valid_property_value({ name: String, value: MsgPack }) -> bool
+  if name == "value":
+    match(msgpack::unpack_string(value))
+      Ok<String>:
+        return true
+      Err<MsgPackError>:
+        match(msgpack::unpack_i32(value))
+          Ok<i32>:
+            return true
+          Err<MsgPackError>:
+            return false
+  match(msgpack::unpack_bool(value))
+    Ok<bool>:
+      true
+    Err<MsgPackError>:
+      false
+
+fn is_valid_tag_name(name: String) -> bool
+  if name.is_empty() or not is_ascii_lowercase(name.get_byte(0) ?? 0):
+    return false
+  name_bytes_match(name, where: (byte: i32) -> bool =>
+    is_ascii_lowercase(byte) or is_ascii_digit(byte) or byte == 45 or byte == 58
+  )
+
+fn is_valid_attr_name(name: String) -> bool
+  not name.is_empty() and name_bytes_match(name, where: (byte: i32) -> bool =>
+    byte > 31 and byte != 127 and byte != 32 and byte != 34 and byte != 39 and
+      byte != 47 and byte != 61 and byte != 62 and not is_ascii_uppercase(byte)
+  )
+
+fn is_valid_style_name(name: String) -> bool
+  if name.is_empty():
+    return false
+  let first = name.get_byte(0) ?? 0
+  var index = 1
+  var custom = false
+  if first == 45:
+    if name.byte_len() < 2:
+      return false
+    let second = name.get_byte(1) ?? 0
+    if second == 45:
+      if name.byte_len() == 2:
+        return false
+      custom = true
+      index = 2
+    else:
+      if not is_ascii_letter(second):
+        return false
+      index = 2
+  else:
+    if not is_ascii_letter(first):
+      return false
+  while index < name.byte_len():
+    let byte = name.get_byte(index) ?? 0
+    if not (
+      is_ascii_letter(byte) or is_ascii_digit(byte) or byte == 45 or
+        (custom and byte == 95)
+    ):
+      return false
+    index = index + 1
+  true
+
+fn is_valid_style_value(value: String) -> bool
+  name_bytes_match(value, where: (byte: i32) -> bool =>
+    byte > 31 and byte != 33 and byte != 59 and byte != 127
+  )
+
+fn name_bytes_match(name: String, { where predicate: fn(i32) -> bool }) -> bool
+  var index = 0
+  while index < name.byte_len():
+    if not predicate(name.get_byte(index) ?? 0):
+      return false
+    index = index + 1
+  true
+
+fn is_ascii_letter(byte: i32) -> bool
+  (byte >= 65 and byte <= 90) or (byte >= 97 and byte <= 122)
+
+fn is_ascii_lowercase(byte: i32) -> bool
+  byte >= 97 and byte <= 122
+
+fn is_ascii_uppercase(byte: i32) -> bool
+  byte >= 65 and byte <= 90
+
+fn is_ascii_digit(byte: i32) -> bool
+  byte >= 48 and byte <= 57
+
 fn escape_script_json(value: String): () -> String
-  value
-    .replaced(old: "</".as_slice().to_string(), with: "<\\/".as_slice().to_string())
-    .replaced(old: "<!--".as_slice().to_string(), with: "\\u003c!--".as_slice().to_string())
+  value.replaced(
+    old: "<".as_slice().to_string(),
+    with: "\\u003c".as_slice().to_string()
+  )
 
 fn escape_text(value: StringSlice): () -> String
   escape(value, true)
@@ -232,16 +592,19 @@ fn escape(value: StringSlice, text: bool): () -> String
         if byte == 38:
           out = out.concat("&amp;".as_slice())
         else:
-          if byte == 60:
-            out = out.concat("&lt;".as_slice())
+          if byte == 13:
+            out = out.concat("&#13;".as_slice())
           else:
-            if byte == 62:
-              out = out.concat("&gt;".as_slice())
+            if byte == 60:
+              out = out.concat("&lt;".as_slice())
             else:
-              if not text and byte == 34:
-                out = out.concat("&quot;".as_slice())
+              if byte == 62:
+                out = out.concat("&gt;".as_slice())
               else:
-                out = out.concat(value.slice(bytes: index, len: 1))
+                if not text and byte == 34:
+                  out = out.concat("&quot;".as_slice())
+                else:
+                  out = out.concat(value.slice(bytes: index, len: 1))
       None:
         void
     index = index + 1

--- a/packages/web/src/phase2.test.voyd
+++ b/packages/web/src/phase2.test.voyd
@@ -1,5 +1,5 @@
 use src::extract::{ body_limit, extract_query, limit_body, parse_query, required_session, text as text_body_policy }
-use src::html::{ document, hydrate }
+use src::html::{ document, hydrate_named }
 use src::response::{ json_dto, response_dto_json }
 use src::router::{ Context, app }
 use src::routes::{
@@ -758,13 +758,23 @@ test "dto route helpers compose with timeout policies":
 
 test "html document can include hydration model and client entry":
   let page: MsgPack =
-    <main id="app">
-      <h1>Hydrate</h1>
-    </main>
-  let model: TestProfile = { name: "Ada".as_slice().to_string(), active: true }
+    <html>
+      <body>
+        <main id="app">
+          <h1>Hydrate</h1>
+        </main>
+        <aside id="status">Ready</aside>
+        <style>{"body::after { content: '</body>'; }"}</style>
+      </body>
+    </html>
+  let model: TestProfile = {
+    name: "</SCRIPT><script>alert(1)</script>".as_slice().to_string(),
+    active: true
+  }
   let rendered = document<MsgPack, TestProfile>(
     view: page,
-    hydrate: hydrate<TestProfile>(
+    hydrate: hydrate_named<TestProfile>(
+      id: "primary".as_slice(),
       target: "#app".as_slice(),
       entry: "/assets/app.js".as_slice(),
       model: model
@@ -772,6 +782,11 @@ test "html document can include hydration model and client entry":
   )
 
   assert(rendered.contains("<!doctype html>".as_slice()), eq: true)
+  assert(rendered.contains("data-voyd-hydration-id=\"primary\"".as_slice()), eq: true)
   assert(rendered.contains("data-voyd-hydration=\"#app\"".as_slice()), eq: true)
-  assert(rendered.contains("\"name\":\"Ada\"".as_slice()), eq: true)
+  assert(rendered.contains("data-voyd-entry=\"/assets/app.js\"".as_slice()), eq: true)
+  assert(rendered.contains("\\u003c/SCRIPT>".as_slice()), eq: true)
+  assert(rendered.contains("</SCRIPT>".as_slice()), eq: false)
   assert(rendered.contains("src=\"/assets/app.js\"".as_slice()), eq: true)
+  assert(rendered.contains("<style>body::after { content: '</body>'; }</style>".as_slice()), eq: true)
+  assert(rendered.contains("</script></body>".as_slice()), eq: true)

--- a/packages/web/src/pkg.voyd
+++ b/packages/web/src/pkg.voyd
@@ -48,7 +48,7 @@ pub use src::extract::{
   text,
   text_body
 }
-pub use src::html::{ Hydration, document, html_response, hydrate, render }
+pub use src::html::{ Hydration, append_hydration, document, html_response, hydrate, hydrate_named, render }
 pub use src::middleware::request_id_required
 pub use src::response::{
   Body,

--- a/packages/web/src/web.test.voyd
+++ b/packages/web/src/web.test.voyd
@@ -1102,3 +1102,64 @@ test "html rendering turns vx nodes into a text html response":
       assert(value.equals("text/html; charset=utf-8"), eq: true)
     None:
       assert(false, eq: true)
+
+test "html rendering includes props and styles and respects void elements":
+  let input = element(
+    tag: "input",
+    attrs: [
+      value("Draft"),
+      disabled(true),
+      style(name: "display", value: "grid")
+    ],
+    children: Array<MsgPack>::init()
+  )
+
+  let rendered = render<MsgPack>(input)
+  assert(rendered.contains("<input".as_slice()), eq: true)
+  assert(rendered.contains(" value=\"Draft\"".as_slice()), eq: true)
+  assert(rendered.contains(" disabled".as_slice()), eq: true)
+  assert(rendered.contains(" style=\"display: grid\"".as_slice()), eq: true)
+  assert(rendered.contains("</input>".as_slice()), eq: false)
+
+test "html rendering unwraps mapped child views":
+  let child: MsgPack = <p class="child">Mapped child</p>
+  let mapped = map_html<MsgPack, MsgPack>(html: child, handler_id: 7)
+  let rendered = render<MsgPack>(mapped)
+
+  assert(rendered.contains("<p class=\"child\">Mapped child</p>".as_slice()), eq: true)
+
+test "html rendering preserves carriage returns through parsing":
+  let paragraph: MsgPack = <p title={"A\r\nB"}>{"A\r\nB"}</p>
+  let rendered = render<MsgPack>(paragraph)
+
+  assert(rendered.contains("title=\"A&#13;\nB\"".as_slice()), eq: true)
+  assert(rendered.contains(">A&#13;\nB</p>".as_slice()), eq: true)
+
+test "html rendering preserves leading newlines in parser-sensitive elements":
+  let pre = element(
+    tag: "pre",
+    children: [text("\nLeading")]
+  )
+  let textarea = element(
+    tag: "textarea",
+    attrs: [value("\nDraft")],
+    children: [text("\nDraft")]
+  )
+
+  assert(render<MsgPack>(pre).contains("<pre>\n\nLeading</pre>".as_slice()), eq: true)
+  let rendered_textarea = render<MsgPack>(textarea)
+  assert(rendered_textarea.contains(">\n\nDraft</textarea>".as_slice()), eq: true)
+  assert(rendered_textarea.contains(" value=".as_slice()), eq: false)
+
+test "html rendering preserves raw style and script text":
+  let style_node = element(
+    tag: "style",
+    children: [text("a > b { color: red }")]
+  )
+  let script_node = element(
+    tag: "script",
+    children: [text("if (a < b) value = '&'")]
+  )
+
+  assert(render<MsgPack>(style_node).equals("<style>a > b { color: red }</style>"), eq: true)
+  assert(render<MsgPack>(script_node).equals("<script>if (a < b) value = '&'</script>"), eq: true)

--- a/tests/integration/src/vx-dom.test.ts
+++ b/tests/integration/src/vx-dom.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createSdk, type CompileResult } from "@voyd-lang/sdk";
 import { createVoydHost } from "@voyd-lang/sdk/js-host";
 import {
+  createVxDomRenderer,
   createVoydVxAppRuntime,
   mountVxApp,
   renderMsgPackNode,
@@ -71,6 +72,112 @@ const expectCompileSuccess = (
 };
 
 describe("integration: compiled VX DOM rendering", () => {
+  it("hydrates pkg::web output from the same compiled VX tree without replacing DOM", async () => {
+    const result = expectCompileSuccess(await createSdk().compile({
+      source: `
+use pkg::web::{ append_hydration, document, hydrate_named, render }
+use std::array::Array
+use std::msgpack::MsgPack
+use std::vx::all
+
+pub fn tree() -> MsgPack
+  element(
+    tag: "section",
+    attrs: [class("card"), style(name: "display", value: "grid")],
+    children: [
+      element(
+        tag: "input",
+        attrs: [value("Draft"), disabled(true)],
+        children: Array<MsgPack>::init()
+      ),
+      fragment([text("Ready")]),
+      element(
+        tag: "style",
+        children: [text("a > b { color: red }")]
+      )
+    ]
+  )
+
+pub fn html() -> String
+  render<MsgPack>(tree())
+
+pub fn static_event_tree() -> MsgPack
+  let ~attrs = Array<MsgPack>::init()
+  let interactive = false
+  if interactive:
+    attrs.push(event_payload_handler<InputEvent, MsgPack>(
+      name: "input",
+      handler: (event: InputEvent) -> MsgPack => text(event.value)
+    ))
+  element(tag: "textarea", attrs: attrs, children: [text("Draft")])
+
+pub fn invalid_void_html() -> String
+  render<MsgPack>(element(tag: "input", children: [text("not allowed")]))
+
+pub fn uppercase_tag_html() -> String
+  render<MsgPack>(element(tag: "INPUT", children: Array<MsgPack>::init()))
+
+pub fn uppercase_attribute_html() -> String
+  render<MsgPack>(element(
+    tag: "div",
+    attrs: [attr(name: "CLASS", value: "card")],
+    children: Array<MsgPack>::init()
+  ))
+
+pub fn multi_document() -> String
+  let view: MsgPack = <html><body><main id="one">One</main><aside id="two">Two</aside></body></html>
+  let first = append_hydration<i32>(
+    document<MsgPack>(view),
+    hydrate_named<i32>(
+      id: "one".as_slice(),
+      target: "#one".as_slice(),
+      entry: "/one.js".as_slice(),
+      model: 1
+    )
+  )
+  append_hydration<bool>(
+    first,
+    hydrate_named<bool>(
+      id: "two".as_slice(),
+      target: "#two".as_slice(),
+      entry: "/two.js".as_slice(),
+      model: true
+    )
+  )
+`,
+    }));
+    const [tree, html, multiDocument] = await Promise.all([
+      result.run<unknown>({ entryName: "tree" }),
+      result.run<string>({ entryName: "html" }),
+      result.run<string>({ entryName: "multi_document" }),
+    ]);
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    const section = container.querySelector("section");
+    const input = container.querySelector("input");
+    const style = container.querySelector("style");
+    const text = section?.lastChild;
+    const onHydrationMismatch = vi.fn();
+
+    createVxDomRenderer(container, { onHydrationMismatch }).hydrate(tree);
+
+    expect(container.querySelector("section")).toBe(section);
+    expect(container.querySelector("input")).toBe(input);
+    expect(container.querySelector("style")).toBe(style);
+    expect(container.querySelector("section")?.lastChild).toBe(text);
+    expect(style?.textContent).toBe("a > b { color: red }");
+    expect(onHydrationMismatch).not.toHaveBeenCalled();
+    expect(multiDocument).toContain('data-voyd-hydration-id="one"');
+    expect(multiDocument).toContain('data-voyd-hydration-id="two"');
+    await expect(result.run<string>({ entryName: "invalid_void_html" })).rejects.toThrow();
+    await expect(result.run<string>({ entryName: "uppercase_tag_html" })).rejects.toThrow();
+    await expect(result.run<string>({ entryName: "uppercase_attribute_html" })).rejects.toThrow();
+
+    const host = await createVoydHost({ wasm: result.wasm, bufferSize: 256 * 1024 });
+    await host.run("static_event_tree");
+    expect(host.retainedCallbacks.size()).toBe(0);
+  });
+
   it("renders a JS-backed Markdown package as an ordinary VX component", async () => {
     const result = expectCompileSuccess(
       await createSdk().compile({ entryPath: markdownEntryPath }),


### PR DESCRIPTION
## Summary

- reorganize the `vx-spa` and `web-ssr` starters into small, focused shared model/update/view modules with thin client and server entrypoints
- make SSR hydration preserve exact server DOM, support structured multi-root metadata, mapped models, lifecycle state, rollback, and pre-hydration form edits
- harden server rendering parity for attributes, properties, styles, raw-text/void elements, hydration payloads, callback ownership, and multiple hydration roots
- make generated development workflows coalesced and failure-atomic, with staged artifact promotion and resilient source watching
- document the shared/server/client ownership model and SSR/hydration workflow

## Validation

- `npm test`
- `npm run typecheck`
- `npm run test:audit`
- focused CLI bootstrap, vx-dom browser/server/runtime, web, and compiled integration tests
- agentic review loop: implementation gap, architecture, and correctness stages all clean
