### PR TITLE
Add ergonomic enum construction and matching

### DIFF
--- a/packages/compiler/src/__tests__/module-imports.test.ts
+++ b/packages/compiler/src/__tests__/module-imports.test.ts
@@ -1151,6 +1151,45 @@ pub fn main() -> i32
     ).toHaveLength(0);
   });
 
+  it("reports module import collisions with local union member aliases", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}a.voyd`]: `
+pub fn foo() -> i32
+  1
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+obj Apple {}
+obj Banana {}
+type Fruit = Apple | Banana
+
+use Fruit::Apple as A
+use src::a as A
+
+pub fn main() -> i32
+  0
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      combinedDiagnostics.some(
+        (entry) =>
+          entry.code === "BD0001" &&
+          entry.message.includes("Cannot import A as module") &&
+          entry.message.includes("already bound as type"),
+      ),
+      JSON.stringify(combinedDiagnostics),
+    ).toBe(true);
+  });
+
   it("deduplicates the same namespace member across re-export paths", async () => {
     const srcRoot = resolve("/proj/src");
     const host = createMemoryHost({

--- a/packages/compiler/src/__tests__/module-imports.test.ts
+++ b/packages/compiler/src/__tests__/module-imports.test.ts
@@ -820,6 +820,658 @@ pub fn main() -> i32
     expect(importNames.has("Water")).toBe(true);
   });
 
+  it("allows redundant namespace imports for locally declared union members", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}main.voyd`]: `
+obj Apple {}
+obj Banana { age: i32 }
+type Fruit = Apple | Banana
+type Produce = Fruit
+
+use Fruit::{ Apple, Banana }
+use Fruit::Apple
+use Fruit::all
+use Produce::{ Apple, Banana }
+use Produce::Apple
+use Produce::all
+
+pub fn main() -> i32
+  let fruit: Fruit = Banana(age: 7)
+  match(fruit)
+    Apple:
+      0
+    Banana { age }:
+      age
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      combinedDiagnostics,
+      JSON.stringify(combinedDiagnostics),
+    ).toHaveLength(0);
+  });
+
+  it("imports qualified members from a locally declared union alias", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}fruit.voyd`]: `
+pub obj Apple {}
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::fruit
+
+obj Banana {}
+type Fruit = fruit::Apple | Banana
+
+use Fruit::Apple
+
+pub fn main() -> i32
+  let _fruit: Fruit = Apple()
+  0
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      combinedDiagnostics,
+      JSON.stringify(combinedDiagnostics),
+    ).toHaveLength(0);
+  });
+
+  it("fieldwise-constructs module-qualified nominal types and aliases", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}models.voyd`]: `
+pub obj Person { age: i32 }
+pub obj Empty {}
+pub type PersonAlias = Person
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::models
+
+pub fn main() -> i32
+  let person = models::Person(age: 5)
+  let alias = models::PersonAlias(age: 6)
+  let _empty = models::Empty()
+  person.age + alias.age
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      combinedDiagnostics,
+      JSON.stringify(combinedDiagnostics),
+    ).toHaveLength(0);
+  });
+
+  it("imports members through imported union alias chains", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}fruit.voyd`]: `
+pub obj Apple {}
+pub obj Banana {}
+pub type Fruit = Apple | Banana
+pub type Produce = Fruit
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::fruit::{ Produce }
+use Produce::{ Apple, Banana }
+
+pub fn main() -> i32
+  let _first: Produce = Apple()
+  let _second: Produce = Banana()
+  0
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      combinedDiagnostics,
+      JSON.stringify(combinedDiagnostics),
+    ).toHaveLength(0);
+  });
+
+  it("preserves enum namespaces through alias-only re-exports", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}fruit.voyd`]: `
+pub obj Apple {}
+pub obj Banana {}
+pub type Fruit = Apple | Banana
+`,
+      [`${srcRoot}${sep}api.voyd`]: `
+pub use src::fruit::{ Fruit }
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::api::{ Fruit }
+use Fruit::Apple
+
+pub fn main() -> i32
+  let _apple: Fruit = Apple()
+  let _banana: Fruit = Fruit::Banana()
+  0
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      combinedDiagnostics,
+      JSON.stringify(combinedDiagnostics),
+    ).toHaveLength(0);
+  });
+
+  it("preserves imported namespaces for qualified external union members", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}a.voyd`]: `
+pub obj Apple {}
+`,
+      [`${srcRoot}${sep}b.voyd`]: `
+pub obj Banana {}
+`,
+      [`${srcRoot}${sep}fruit.voyd`]: `
+use src::{ a, b }
+pub type Fruit = a::Apple | b::Banana
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::fruit::{ Fruit }
+use Fruit::Apple
+
+pub fn main() -> i32
+  let _apple: Fruit = Apple()
+  let _banana: Fruit = Fruit::Banana()
+  0
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      combinedDiagnostics,
+      JSON.stringify(combinedDiagnostics),
+    ).toHaveLength(0);
+  });
+
+  it("diagnoses ambiguous imported union namespace members", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}a.voyd`]: `
+pub obj Item { a: i32 }
+`,
+      [`${srcRoot}${sep}b.voyd`]: `
+pub obj Item { b: i32 }
+`,
+      [`${srcRoot}${sep}items.voyd`]: `
+use src::{ a, b }
+pub type Both = a::Item | b::Item
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::items::{ Both }
+use Both::Item
+
+pub fn main() -> i32
+  0
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      combinedDiagnostics.some(
+        (entry) =>
+          entry.code === "BD0001" &&
+          entry.message.includes("multiple distinct members named Item"),
+      ),
+      JSON.stringify(combinedDiagnostics),
+    ).toBe(true);
+  });
+
+  it("diagnoses ambiguous same-named local union namespace members", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}a.voyd`]: `
+pub obj Item { a: i32 }
+`,
+      [`${srcRoot}${sep}b.voyd`]: `
+pub obj Item { b: i32 }
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::{ a, b }
+
+type Both = a::Item | b::Item
+use Both::Item
+
+pub fn main() -> i32
+  0
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      combinedDiagnostics.some(
+        (entry) =>
+          entry.code === "BD0001" &&
+          entry.message.includes("multiple distinct members named Item"),
+      ),
+      JSON.stringify(combinedDiagnostics),
+    ).toBe(true);
+  });
+
+  it("deduplicates the same namespace member across re-export paths", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}origin.voyd`]: `
+pub obj Item {}
+`,
+      [`${srcRoot}${sep}a.voyd`]: `
+pub use src::origin::{ Item }
+`,
+      [`${srcRoot}${sep}b.voyd`]: `
+pub use src::origin::{ Item }
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::{ a, b }
+
+type Both = a::Item | b::Item
+use Both::Item
+
+pub fn main() -> i32
+  let _item: Both = Item()
+  0
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      combinedDiagnostics,
+      JSON.stringify(combinedDiagnostics),
+    ).toHaveLength(0);
+  });
+
+  it("infers fieldwise type arguments for imported nominal aliases", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}boxes.voyd`]: `
+pub obj Box<T> { value: T }
+pub type BoxAlias<T> = Box<T>
+pub type BoxAliasChain<T> = BoxAlias<T>
+pub obj Animal { id: i32 }
+pub obj Dog: Animal { id: i32 }
+pub obj AnimalBox<T: Animal> { value: T }
+pub type AnimalBoxAlias<T: Animal> = AnimalBox<T>
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::boxes::{ AnimalBoxAlias, BoxAlias, BoxAliasChain, Dog }
+
+pub fn main() -> i32
+  let box = BoxAlias(value: 3)
+  let chained = BoxAliasChain(value: 2)
+  let constrained = AnimalBoxAlias(value: Dog(id: 4))
+  box.value + chained.value + constrained.value.id
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      combinedDiagnostics,
+      JSON.stringify(combinedDiagnostics),
+    ).toHaveLength(0);
+  });
+
+  it("prefers qualified union members over same-named lexical types", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}fruit.voyd`]: `
+pub obj Apple {}
+pub type Fruit = Apple
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::fruit::{ Fruit }
+
+obj Apple { value: i32 }
+
+pub fn main() -> i32
+  let first: Fruit = Fruit::Apple()
+  let second: Fruit = Fruit::Apple {}
+  0
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      combinedDiagnostics,
+      JSON.stringify(combinedDiagnostics),
+    ).toHaveLength(0);
+  });
+
+  it("does not fieldwise-construct imported types with inaccessible init", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}guarded.voyd`]: `
+pub obj Guarded { value: i32 }
+
+impl Guarded
+  pri fn init({ value: i32 }) -> Guarded
+    Guarded { value: value + 1 }
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::guarded::{ Guarded }
+
+type GuardedAlias = Guarded
+
+pub fn main() -> i32
+  let guarded = Guarded(value: 1)
+  let aliased = GuardedAlias(value: 2)
+  guarded.value + aliased.value
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { semantics, diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(combinedDiagnostics.some((entry) => entry.code === "TY0041")).toBe(
+      true,
+    );
+    expect(
+      Array.from(semantics.get("src::main")?.hir.expressions.values() ?? []).some(
+        (expr) => expr.exprKind === "object-literal" && expr.literalKind === "nominal",
+      ),
+    ).toBe(false);
+  });
+
+  it("infers unqualified imported union members in match patterns", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}fruit.voyd`]: `
+pub obj Apple {}
+pub obj Banana { age: i32 }
+pub type Fruit = Apple | Banana
+pub type BananaAlias = Banana
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::fruit::{ BananaAlias, Fruit }
+
+fn score(fruit: Fruit) -> i32
+  match(fruit)
+    Apple:
+      0
+    Banana { age }:
+      age
+
+pub fn main() -> i32
+  score(BananaAlias(age: 7))
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(combinedDiagnostics, JSON.stringify(combinedDiagnostics)).toHaveLength(0);
+  });
+
+  it("does not infer inaccessible imported union members in match patterns", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}choice.voyd`]: `
+obj Hidden {}
+pub obj Visible {}
+pub type Choice = Hidden | Visible
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::choice::{ Choice }
+
+pub fn score(choice: Choice) -> i32
+  match(choice)
+    Hidden:
+      0
+    Visible:
+      1
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const allDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      allDiagnostics.some(
+        (diagnostic) =>
+          diagnostic.code === "TY0026" && diagnostic.message.includes("Hidden"),
+      ),
+      JSON.stringify(allDiagnostics),
+    ).toBe(true);
+  });
+
+  it("prefers explicitly imported lexical types over contextual match members", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}fruit.voyd`]: `
+pub obj Apple { local: i32 }
+pub type Fruit = Apple
+`,
+      [`${srcRoot}${sep}foreign.voyd`]: `
+pub obj Apple { foreign: i32 }
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::fruit::{ Fruit }
+use src::foreign::{ Apple }
+
+pub fn score(fruit: Fruit) -> i32
+  match(fruit)
+    Apple:
+      1
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const allDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      allDiagnostics.some(
+        (diagnostic) =>
+          diagnostic.code === "TY0002" &&
+          diagnostic.message.includes("does not match discriminant"),
+      ),
+      JSON.stringify(allDiagnostics),
+    ).toBe(true);
+  });
+
+  it("does not override lexical traits during contextual match lookup", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}fruit.voyd`]: `
+pub obj Apple {}
+pub obj Banana {}
+pub type Fruit = Apple | Banana
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::fruit::{ Fruit }
+
+trait Apple
+  fn id(self) -> i32
+
+pub fn score(fruit: Fruit) -> i32
+  match(fruit)
+    Apple:
+      1
+    Banana:
+      2
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const allDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      allDiagnostics.some((diagnostic) => diagnostic.code === "TY0002"),
+      JSON.stringify(allDiagnostics),
+    ).toBe(true);
+  });
+
+  it("resolves explicitly imported aliases before contextual match lookup", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}choice.voyd`]: `
+pub obj Some<T> { value: T }
+pub type Renamed<T> = Some<T>
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::choice::{ Renamed }
+
+pub fn score(choice: Renamed<i32>) -> i32
+  match(choice)
+    Renamed<i32> { value }:
+      value
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      combinedDiagnostics,
+      JSON.stringify(combinedDiagnostics),
+    ).toHaveLength(0);
+  });
+
+  it("uses explicit type arguments for contextual same-head match patterns", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}choice.voyd`]: `
+pub obj Some<T> { value: T }
+pub type Choice = Some<i32> | Some<bool>
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::choice::{ Choice }
+
+pub fn score(choice: Choice) -> i32
+  match(choice)
+    Some<i32> { value }:
+      value
+    Some<bool>:
+      0
+
+pub fn main() -> i32
+  0
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    expect([...graph.diagnostics, ...diagnostics]).toHaveLength(0);
+  });
+
   it("supports generic enum namespace all imports via use Drink::all", async () => {
     const srcRoot = resolve("/proj/src");
     const host = createMemoryHost({
@@ -962,7 +1614,7 @@ pub fn main() -> Drink
     ).toBe(true);
   });
 
-  it("reports missing exports for unresolved enum namespace members", async () => {
+  it("resolves public external members through imported union namespaces", async () => {
     const srcRoot = resolve("/proj/src");
     const host = createMemoryHost({
       [`${srcRoot}${sep}variants.voyd`]: `
@@ -992,13 +1644,9 @@ pub fn main() -> Drink
     const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
 
     expect(
-      combinedDiagnostics.some(
-        (diag) =>
-          diag.code === "BD0001" &&
-          diag.message.includes("src::drinks") &&
-          diag.message.includes("Tea"),
-      ),
-    ).toBe(true);
+      combinedDiagnostics,
+      JSON.stringify(combinedDiagnostics),
+    ).toHaveLength(0);
   });
 
   it("deduplicates repeated grouped-import diagnostics with the same source span", async () => {

--- a/packages/compiler/src/__tests__/module-imports.test.ts
+++ b/packages/compiler/src/__tests__/module-imports.test.ts
@@ -1113,6 +1113,44 @@ pub fn main() -> i32
     ).toBe(true);
   });
 
+  it("supports aliases for local union namespace member imports and re-exports", async () => {
+    const srcRoot = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}fruit.voyd`]: `
+pub obj Apple {}
+pub obj Banana {}
+pub type Fruit = Apple | Banana
+
+use Fruit::Banana as B
+pub use Fruit::Apple as A
+
+pub fn local_alias() -> Fruit
+  B()
+`,
+      [`${srcRoot}${sep}main.voyd`]: `
+use src::fruit::{ A, Fruit, local_alias }
+
+pub fn main() -> i32
+  let _apple: Fruit = A()
+  let _banana: Fruit = local_alias()
+  0
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot },
+      host,
+    });
+
+    const { diagnostics } = analyzeModules({ graph });
+    const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
+    expect(
+      combinedDiagnostics,
+      JSON.stringify(combinedDiagnostics),
+    ).toHaveLength(0);
+  });
+
   it("deduplicates the same namespace member across re-export paths", async () => {
     const srcRoot = resolve("/proj/src");
     const host = createMemoryHost({

--- a/packages/compiler/src/__tests__/module-imports.test.ts
+++ b/packages/compiler/src/__tests__/module-imports.test.ts
@@ -860,22 +860,24 @@ pub fn main() -> i32
     ).toHaveLength(0);
   });
 
-  it("imports qualified members from a locally declared union alias", async () => {
+  it("imports and constructs qualified members from a local union", async () => {
     const srcRoot = resolve("/proj/src");
     const host = createMemoryHost({
       [`${srcRoot}${sep}fruit.voyd`]: `
 pub obj Apple {}
+pub obj Pear {}
 `,
       [`${srcRoot}${sep}main.voyd`]: `
 use src::fruit
 
 obj Banana {}
-type Fruit = fruit::Apple | Banana
+type Fruit = fruit::Apple | fruit::Pear | Banana
 
 use Fruit::Apple
 
 pub fn main() -> i32
   let _fruit: Fruit = Apple()
+  let _qualified: Fruit = Fruit::Pear()
   0
 `,
     });

--- a/packages/compiler/src/__tests__/module-typing.test.ts
+++ b/packages/compiler/src/__tests__/module-typing.test.ts
@@ -784,14 +784,14 @@ pub obj Water {}
 pub type Drink<T> = Coffee<T> | Tea<T> | Water
 
 pub fn make<T>(size: T) -> Drink<T>
-  Drink::Coffee<T> { size }
+  Drink::Coffee<T>(size: size)
 `,
       [`${root}${sep}main.voyd`]: `
 use src::drinks::{ Drink, make }
 
 pub fn main() -> i32
   let brewed: Drink<i32> = make(12)
-  let poured: Drink<i32> = Drink::Coffee<i32> { size: 8 }
+  let poured: Drink<i32> = Drink::Coffee<i32>(size: 8)
   match(brewed)
     Drink::Coffee { size }:
       match(poured)
@@ -814,11 +814,25 @@ pub fn main() -> i32
       host,
     });
 
-    const { diagnostics } = analyzeModules({ graph });
+    const { semantics, diagnostics } = analyzeModules({ graph });
     expect(diagnostics).toHaveLength(0);
     expect(diagnostics.some((diagnostic) => diagnostic.code === "TY9999")).toBe(
       false,
     );
+    const fieldwiseLiterals = Array.from(semantics.values()).flatMap((result) =>
+      Array.from(result.hir.expressions.values()).flatMap((expr) =>
+        expr.exprKind === "object-literal" && expr.literalKind === "nominal"
+          ? [expr]
+          : [],
+      ),
+    );
+    expect(fieldwiseLiterals).toHaveLength(2);
+    fieldwiseLiterals.forEach((literal) => {
+      expect(literal.target?.typeKind).toBe("named");
+      if (literal.target?.typeKind === "named") {
+        expect(literal.target.typeArguments).toHaveLength(1);
+      }
+    });
   });
 
   it("preserves outer generic args for namespaced type members", async () => {

--- a/packages/compiler/src/diagnostics/registry.ts
+++ b/packages/compiler/src/diagnostics/registry.ts
@@ -54,6 +54,11 @@ type DiagnosticParamsMap = {
     | { kind: "missing-export"; moduleId: string; target: string }
     | { kind: "missing-module-identifier" }
     | {
+        kind: "ambiguous-namespace-member";
+        namespace: string;
+        member: string;
+      }
+    | {
         kind: "out-of-scope-export";
         moduleId: string;
         target: string;
@@ -352,6 +357,8 @@ export const diagnosticsRegistry: {
           return `Module ${params.moduleId} does not export ${params.target}`;
         case "missing-module-identifier":
           return "missing module identifier for import";
+        case "ambiguous-namespace-member":
+          return `Cannot import ${params.namespace}::${params.member}; the namespace contains multiple distinct members named ${params.member}`;
         case "out-of-scope-export":
           return `Module ${params.moduleId} export ${params.target} is not visible here (visibility: ${params.visibility})`;
         case "instance-member-import": {
@@ -903,7 +910,7 @@ export const diagnosticsRegistry: {
     hints: [
       {
         message:
-          "Type aliases cannot be constructed as values; for structural aliases use '{ ... }', and for nominal construction use an object type value.",
+          "Types are not values; construct nominal types with 'Type(...)' or 'Type { ... }', and construct structural values with '{ ... }'.",
       },
       {
         message:

--- a/packages/compiler/src/modules/semantic-snapshot.ts
+++ b/packages/compiler/src/modules/semantic-snapshot.ts
@@ -57,6 +57,7 @@ export const cloneSemanticsForTypingState = ({
       callTypeArguments: cloneNestedMap(typing.callTypeArguments),
       callInstanceKeys: cloneNestedMap(typing.callInstanceKeys),
       callTraitDispatches: new Set(typing.callTraitDispatches),
+      sourceImportLocals: new Set(typing.sourceImportLocals),
       functionInstantiationInfo: cloneNestedMap(typing.functionInstantiationInfo),
       functionInstanceExprTypes: cloneNestedMap(typing.functionInstanceExprTypes),
       functionInstanceValueTypes: cloneNestedMap(typing.functionInstanceValueTypes),

--- a/packages/compiler/src/semantics/__tests__/symbol-table.test.ts
+++ b/packages/compiler/src/semantics/__tests__/symbol-table.test.ts
@@ -45,6 +45,7 @@ describe("SymbolTable", () => {
     expect(table.resolve("temp", table.rootScope)).toBeUndefined();
     expect(table.resolve("root", table.rootScope)).toBeDefined();
     expect(table.resolve("alias", table.rootScope)).toBe(root);
+    expect(table.symbolsNamedInScope("alias", table.rootScope)).toEqual([root]);
   });
 
   it("supports kind-aware resolution domains", () => {

--- a/packages/compiler/src/semantics/__tests__/symbol-table.test.ts
+++ b/packages/compiler/src/semantics/__tests__/symbol-table.test.ts
@@ -31,7 +31,12 @@ describe("SymbolTable", () => {
 
   it("restores to a snapshot", () => {
     const table = new SymbolTable({ rootOwner: 0 });
-    table.declare({ name: "root", kind: "module", declaredAt: 1 });
+    const root = table.declare({
+      name: "root",
+      kind: "module",
+      declaredAt: 1,
+    });
+    table.bindAlias({ name: "alias", symbol: root });
     const snap = table.snapshot();
 
     table.declare({ name: "temp", kind: "value", declaredAt: 2 });
@@ -39,6 +44,7 @@ describe("SymbolTable", () => {
 
     expect(table.resolve("temp", table.rootScope)).toBeUndefined();
     expect(table.resolve("root", table.rootScope)).toBeDefined();
+    expect(table.resolve("alias", table.rootScope)).toBe(root);
   });
 
   it("supports kind-aware resolution domains", () => {

--- a/packages/compiler/src/semantics/binder/symbol-table.ts
+++ b/packages/compiler/src/semantics/binder/symbol-table.ts
@@ -1,6 +1,7 @@
 import type { ScopeId, SymbolId } from "../ids.js";
 import type {
   ScopeInfo,
+  SymbolAliasBinding,
   SymbolKind,
   SymbolRecord,
   SymbolTableInit,
@@ -46,6 +47,7 @@ export class SymbolTable {
   private readonly scopeBuckets: ScopeBucket[] = [];
   private readonly symbolRecords: SymbolRecord[] = [];
   private readonly scopeStack: ScopeId[] = [];
+  private readonly aliasBindings: SymbolAliasBinding[] = [];
   readonly rootScope: ScopeId;
 
   constructor(init: SymbolTableInit) {
@@ -122,6 +124,26 @@ export class SymbolTable {
     }
 
     return id;
+  }
+
+  bindAlias(
+    { name, symbol }: Pick<SymbolAliasBinding, "name" | "symbol">,
+    scope: ScopeId = this.currentScope()
+  ): void {
+    if (RESERVED_SYMBOL_NAMES.has(name)) {
+      throw new Error(`cannot declare reserved identifier ${name}`);
+    }
+    if (!this.symbolRecords[symbol]) {
+      throw new Error(`symbol ${symbol} does not exist`);
+    }
+    const bucket = ensureScopeExists(this.scopeBuckets[scope], scope);
+    const hits = bucket.nameIndex.get(name);
+    if (hits) {
+      hits.push(symbol);
+    } else {
+      bucket.nameIndex.set(name, [symbol]);
+    }
+    this.aliasBindings.push({ name, symbol, scope });
   }
 
   getScope(id: ScopeId): Readonly<ScopeInfo> {
@@ -283,6 +305,9 @@ export class SymbolTable {
       nextSymbol: this.nextSymbol,
       scopes: this.scopeBuckets.map((bucket) => cloneScopeInfo(bucket.info)),
       symbols: this.symbolRecords.map(cloneSymbolRecord),
+      ...(this.aliasBindings.length > 0
+        ? { aliases: this.aliasBindings.map((alias) => ({ ...alias })) }
+        : {}),
       payload,
     };
   }
@@ -316,6 +341,21 @@ export class SymbolTable {
       } else {
         bucket.nameIndex.set(record.name, [record.id]);
       }
+    });
+
+    this.aliasBindings.length = 0;
+    (snap.aliases ?? []).forEach((alias) => {
+      const bucket = ensureScopeExists(
+        this.scopeBuckets[alias.scope],
+        alias.scope
+      );
+      const hits = bucket.nameIndex.get(alias.name);
+      if (hits) {
+        hits.push(alias.symbol);
+      } else {
+        bucket.nameIndex.set(alias.name, [alias.symbol]);
+      }
+      this.aliasBindings.push({ ...alias });
     });
 
     this.scopeStack.length = 0;

--- a/packages/compiler/src/semantics/binder/symbol-table.ts
+++ b/packages/compiler/src/semantics/binder/symbol-table.ts
@@ -169,6 +169,11 @@ export class SymbolTable {
     return this.resolveAllInternal(name, fromScope);
   }
 
+  symbolsNamedInScope(name: string, scope: ScopeId): readonly SymbolId[] {
+    const bucket = ensureScopeExists(this.scopeBuckets[scope], scope);
+    return [...(bucket.nameIndex.get(name) ?? [])];
+  }
+
   resolveWhere(
     name: string,
     fromScope: ScopeId,

--- a/packages/compiler/src/semantics/binder/types.ts
+++ b/packages/compiler/src/semantics/binder/types.ts
@@ -56,5 +56,12 @@ export interface SymbolTableSnapshot {
   nextSymbol: SymbolId;
   scopes: readonly ScopeInfo[];
   symbols: readonly SymbolRecord[];
+  aliases?: readonly SymbolAliasBinding[];
   payload?: Record<string, unknown>;
+}
+
+export interface SymbolAliasBinding {
+  name: string;
+  symbol: SymbolId;
+  scope: ScopeId;
 }

--- a/packages/compiler/src/semantics/binding/binders/expressions.ts
+++ b/packages/compiler/src/semantics/binding/binders/expressions.ts
@@ -929,6 +929,14 @@ const ensureEnumNamespaceImport = ({
 }): void => {
   const existing = ctx.staticMethods.get(targetSymbol)?.get(memberName);
   if (existing?.size) {
+    existing.forEach((symbol) =>
+      ensureConstructorImport({
+        targetSymbol: symbol,
+        syntax,
+        scope,
+        ctx,
+      }),
+    );
     return;
   }
 

--- a/packages/compiler/src/semantics/binding/binders/module.ts
+++ b/packages/compiler/src/semantics/binding/binders/module.ts
@@ -46,11 +46,12 @@ import {
   stdPkgExportsFor,
 } from "../export-visibility.js";
 import {
-  enumVariantTypeNamesFromAliasTarget,
+  enumVariantTypeTargetsFromAliasTarget,
   importedSymbolTargetFromMetadata,
 } from "../../enum-namespace.js";
 import { isPackageRootModule } from "../../packages.js";
 import { requireModuleSurface } from "../../../modules/views.js";
+import { resolveNominalTypeSymbol } from "../../nominal-type-target.js";
 
 export const bindModule = (
   surface: SurfaceModuleView,
@@ -340,34 +341,79 @@ const resolveImplicitNamespaceUseEntry = ({
     namespaceRecord.metadata as Record<string, unknown> | undefined,
   );
   if (!importedTarget) {
-    return undefined;
+    return resolveLocalTypeNamespaceUseEntry({
+      namespaceSymbol,
+      entry,
+      decl,
+      ctx,
+    });
   }
 
   const dependency = ctx.dependencies.get(importedTarget.moduleId);
-  const aliasDecl = dependency?.decls.getTypeAlias(importedTarget.symbol);
-  const variantNames = aliasDecl
-    ? enumVariantTypeNamesFromAliasTarget(aliasDecl.target)
-    : undefined;
-  if (!dependency || !variantNames || variantNames.length === 0) {
+  const variantMembers = new Map(
+    Array.from(ctx.staticMethods.get(namespaceSymbol)?.entries() ?? [])
+      .map(([name, symbols]) => [
+        name,
+        new Set(
+          Array.from(symbols).filter((symbol) => {
+            const record = ctx.symbolTable.getSymbol(symbol);
+            const entity = (
+              record.metadata as { entity?: unknown } | undefined
+            )?.entity;
+            return record.kind === "type" && entity === "object";
+          }),
+        ),
+      ] as const)
+      .filter(([, symbols]) => symbols.size > 0),
+  );
+  if (!dependency || variantMembers.size === 0) {
     return undefined;
   }
 
-  const exports = ctx.moduleExports.get(importedTarget.moduleId);
-  if (!exports) {
-    return undefined;
-  }
-
+  let ambiguityReported = false;
   const visibleObjectExportFor = (
     variantName: string,
   ): ModuleExportEntry | undefined => {
-    if (!variantNames.includes(variantName)) {
+    const symbols = variantMembers.get(variantName);
+    if (!symbols) {
       return undefined;
     }
-    const exported = exports.get(variantName);
+    const canonicalCandidates = new Map(
+      Array.from(symbols).map((symbol) => {
+        const canonical = canonicalBindingSymbol({
+          moduleId: ctx.module.id,
+          symbol,
+          binding: ctx,
+        });
+        return [`${canonical.moduleId}:${canonical.symbol}`, canonical] as const;
+      }),
+    );
+    if (canonicalCandidates.size > 1) {
+      ambiguityReported = true;
+      recordImportDiagnostic({
+        params: {
+          kind: "ambiguous-namespace-member",
+          namespace: namespaceRecord.name,
+          member: variantName,
+        },
+        span: entry.span,
+        ctx,
+      });
+      return undefined;
+    }
+    const canonical = Array.from(canonicalCandidates.values())[0];
+    if (!canonical) {
+      return undefined;
+    }
+    const exported = Array.from(
+      ctx.moduleExports.get(canonical.moduleId)?.values() ?? [],
+    ).find((candidate) => candidate.symbol === canonical.symbol);
     if (!exported) {
       return undefined;
     }
-    const exportedRecord = dependency.symbolTable.getSymbol(exported.symbol);
+    const exportedRecord = canonical.binding.symbolTable.getSymbol(
+      canonical.symbol,
+    );
     const metadata = exportedRecord.metadata as { entity?: string } | undefined;
     if (exportedRecord.kind !== "type" || metadata?.entity !== "object") {
       return undefined;
@@ -375,7 +421,7 @@ const resolveImplicitNamespaceUseEntry = ({
     if (
       !canAccessExport({
         exported,
-        moduleId: importedTarget.moduleId,
+        moduleId: canonical.moduleId,
         ctx,
         explicitlyTargetsStdSubmodule,
       })
@@ -387,7 +433,7 @@ const resolveImplicitNamespaceUseEntry = ({
 
   const imports = (() => {
     if (entry.selectionKind === "all") {
-      return variantNames.flatMap((variantName) => {
+      return Array.from(variantMembers.keys()).flatMap((variantName) => {
         const exported = visibleObjectExportFor(variantName);
         if (!exported) {
           return [];
@@ -395,6 +441,7 @@ const resolveImplicitNamespaceUseEntry = ({
         return declareImportedSymbol({
           exported,
           alias: variantName,
+          explicitlyTargetsStdSubmodule,
           ctx,
           declaredAt: decl.form,
           span: entry.span,
@@ -415,6 +462,9 @@ const resolveImplicitNamespaceUseEntry = ({
 
     const exported = visibleObjectExportFor(targetName);
     if (!exported) {
+      if (ambiguityReported) {
+        return [];
+      }
       recordImportDiagnostic({
         params: {
           kind: "missing-export",
@@ -447,6 +497,298 @@ const resolveImplicitNamespaceUseEntry = ({
     alias: entry.alias,
     imports,
   };
+};
+
+const resolveLocalTypeNamespaceUseEntry = ({
+  namespaceSymbol,
+  entry,
+  decl,
+  ctx,
+}: {
+  namespaceSymbol: SymbolId;
+  entry: ParsedUseEntry;
+  decl: ParsedUseDecl;
+  ctx: BindingContext;
+}): BoundUseEntry | undefined => {
+  const namespaceMembers = collectLocalTypeNamespaceMembers({
+    namespaceSymbol,
+    ctx,
+  });
+  if (namespaceMembers.length === 0) {
+    return undefined;
+  }
+
+  let ambiguityReported = false;
+  const localVariant = (name: string): BoundImport | undefined => {
+    const candidates = new Map<string, SymbolId>();
+    namespaceMembers
+      .filter((member) => member.name === name)
+      .forEach((member) => {
+        const key = canonicalBindingSymbolKey({
+          moduleId: ctx.module.id,
+          symbol: member.symbol,
+          binding: ctx,
+        });
+        candidates.set(key, member.symbol);
+      });
+    if (candidates.size === 0) {
+      return undefined;
+    }
+    if (candidates.size > 1) {
+      ambiguityReported = true;
+      recordImportDiagnostic({
+        params: {
+          kind: "ambiguous-namespace-member",
+          namespace: ctx.symbolTable.getSymbol(namespaceSymbol).name,
+          member: name,
+        },
+        span: entry.span,
+        ctx,
+      });
+      return undefined;
+    }
+    const symbol = Array.from(candidates.values())[0]!;
+    const record = ctx.symbolTable.getSymbol(symbol);
+    const metadata = record.metadata as { entity?: unknown } | undefined;
+    if (record.kind !== "type" || metadata?.entity !== "object") {
+      return undefined;
+    }
+    const importedName = entry.alias ?? name;
+    if (importedName !== name) {
+      return undefined;
+    }
+    if (record.scope === ctx.symbolTable.rootScope && record.name === name) {
+      return {
+        name,
+        local: symbol,
+        visibility: decl.visibility,
+        span: entry.span,
+      };
+    }
+
+    const importedTarget = importedSymbolTargetFromMetadata(
+      record.metadata as Record<string, unknown> | undefined,
+    );
+    if (!importedTarget) {
+      return undefined;
+    }
+    const existing = ctx.imports.find(
+      (candidate) =>
+        candidate.name === name &&
+        candidate.target?.moduleId === importedTarget.moduleId &&
+        candidate.target.symbol === importedTarget.symbol &&
+        ctx.symbolTable.getSymbol(candidate.local).scope ===
+          ctx.symbolTable.rootScope,
+    );
+    if (existing) {
+      return {
+        ...existing,
+        visibility: decl.visibility,
+        span: entry.span,
+      };
+    }
+
+    const exported = Array.from(
+      ctx.moduleExports.get(importedTarget.moduleId)?.values() ?? [],
+    ).find(
+      (candidate) =>
+        candidate.symbol === importedTarget.symbol ||
+        candidate.symbols?.includes(importedTarget.symbol),
+    );
+    const explicitlyTargetsStdSubmodule =
+      importedModuleExplicitStdSubmoduleFrom(
+        record.metadata as Record<string, unknown> | undefined,
+      ) ?? false;
+    if (
+      !exported ||
+      !canAccessExport({
+        exported,
+        moduleId: importedTarget.moduleId,
+        ctx,
+        explicitlyTargetsStdSubmodule,
+      })
+    ) {
+      return undefined;
+    }
+    return declareImportedSymbol({
+      exported,
+      alias: name,
+      explicitlyTargetsStdSubmodule,
+      ctx,
+      declaredAt: decl.form,
+      span: entry.span,
+      visibility: decl.visibility,
+    })[0];
+  };
+
+  const imports = (() => {
+    if (entry.selectionKind === "all") {
+      return Array.from(new Set(namespaceMembers.map(({ name }) => name))).flatMap(
+        (name) => {
+          const imported = localVariant(name);
+          return imported ? [imported] : [];
+        },
+      );
+    }
+
+    const targetName = entry.targetName ?? entry.alias;
+    if (!targetName) {
+      return [];
+    }
+    const imported = localVariant(targetName);
+    return imported ? [imported] : [];
+  })();
+
+  if (imports.length === 0) {
+    if (ambiguityReported) {
+      return {
+        path: entry.path,
+        moduleId: ctx.module.id,
+        span: entry.span,
+        selectionKind: entry.selectionKind,
+        targetName: entry.targetName,
+        alias: entry.alias,
+        imports: [],
+      };
+    }
+    return undefined;
+  }
+
+  return {
+    path: entry.path,
+    moduleId: ctx.module.id,
+    span: entry.span,
+    selectionKind: entry.selectionKind,
+    targetName: entry.targetName,
+    alias: entry.alias,
+    imports,
+  };
+};
+
+const collectLocalTypeNamespaceMembers = ({
+  namespaceSymbol,
+  ctx,
+  seen = new Set<SymbolId>(),
+}: {
+  namespaceSymbol: SymbolId;
+  ctx: Pick<
+    BindingContext,
+    "decls" | "symbolTable" | "moduleMembers" | "staticMethods"
+  >;
+  seen?: Set<SymbolId>;
+}): { name: string; symbol: SymbolId }[] => {
+  if (seen.has(namespaceSymbol)) {
+    return [];
+  }
+  const nextSeen = new Set(seen);
+  nextSeen.add(namespaceSymbol);
+
+  const aliasDecl = ctx.decls.getTypeAlias(namespaceSymbol);
+  const targets = aliasDecl
+    ? enumVariantTypeTargetsFromAliasTarget(aliasDecl.target)
+    : undefined;
+  if (targets) {
+    return targets.flatMap((target) => {
+      const symbol = resolveNominalTypeSymbol({
+        target: target.target,
+        scope: ctx.symbolTable.rootScope,
+        symbolTable: ctx.symbolTable,
+        moduleMembers: ctx.moduleMembers,
+      });
+      if (typeof symbol !== "number") {
+        return [];
+      }
+      const record = ctx.symbolTable.getSymbol(symbol);
+      const entity = (record.metadata as { entity?: unknown } | undefined)
+        ?.entity;
+      if (record.kind !== "type") {
+        return [];
+      }
+      if (entity === "object") {
+        return [{ name: target.name, symbol }];
+      }
+      if (entity === "type-alias") {
+        return collectLocalTypeNamespaceMembers({
+          namespaceSymbol: symbol,
+          ctx,
+          seen: nextSeen,
+        });
+      }
+      return [];
+    });
+  }
+
+  const methods = ctx.staticMethods.get(namespaceSymbol);
+  if (!methods) {
+    return [];
+  }
+  return Array.from(methods.entries()).flatMap(([name, symbols]) =>
+    Array.from(symbols).flatMap((symbol) => {
+      const record = ctx.symbolTable.getSymbol(symbol);
+      const entity = (record.metadata as { entity?: unknown } | undefined)
+        ?.entity;
+      return record.kind === "type" && entity === "object"
+        ? [{ name, symbol }]
+        : [];
+    }),
+  );
+};
+
+const canonicalBindingSymbolKey = ({
+  moduleId,
+  symbol,
+  binding,
+}: {
+  moduleId: string;
+  symbol: SymbolId;
+  binding: Pick<BindingContext, "symbolTable" | "dependencies">;
+}): string => {
+  const canonical = canonicalBindingSymbol({ moduleId, symbol, binding });
+  return `${canonical.moduleId}:${canonical.symbol}`;
+};
+
+const canonicalBindingSymbol = ({
+  moduleId,
+  symbol,
+  binding,
+}: {
+  moduleId: string;
+  symbol: SymbolId;
+  binding: Pick<BindingContext, "symbolTable" | "dependencies">;
+}): {
+  moduleId: string;
+  symbol: SymbolId;
+  binding: Pick<BindingContext, "symbolTable" | "dependencies">;
+} => {
+  let currentModuleId = moduleId;
+  let currentSymbol = symbol;
+  let current = binding;
+  const visited = new Set<string>();
+
+  while (true) {
+    const key = `${currentModuleId}:${currentSymbol}`;
+    if (visited.has(key)) {
+      return { moduleId: currentModuleId, symbol: currentSymbol, binding: current };
+    }
+    visited.add(key);
+    const imported = importedSymbolTargetFromMetadata(
+      current.symbolTable.getSymbol(currentSymbol).metadata,
+    );
+    if (!imported) {
+      return { moduleId: currentModuleId, symbol: currentSymbol, binding: current };
+    }
+    const dependency = current.dependencies.get(imported.moduleId);
+    if (!dependency) {
+      return {
+        moduleId: imported.moduleId,
+        symbol: imported.symbol,
+        binding: current,
+      };
+    }
+    currentModuleId = imported.moduleId;
+    currentSymbol = imported.symbol;
+    current = dependency;
+  }
 };
 
 const isStdImportBlocked = ({
@@ -1145,35 +1487,33 @@ const hydrateImportedEnumAliasNamespace = ({
     return;
   }
 
-  const aliasDecl = dependency.decls.getTypeAlias(importedSymbolId);
-  const variantNames = aliasDecl
-    ? enumVariantTypeNamesFromAliasTarget(aliasDecl.target)
-    : undefined;
-  if (!variantNames || variantNames.length === 0) {
-    return;
-  }
-
-  const exports = ctx.moduleExports.get(importedModuleId);
-  if (!exports) {
+  const variantMembers = collectLocalTypeNamespaceMembers({
+    namespaceSymbol: importedSymbolId,
+    ctx: dependency,
+  });
+  if (variantMembers.length === 0) {
     return;
   }
 
   const bucket = ctx.staticMethods.get(namespaceSymbol) ?? new Map();
   let changed = false;
 
-  variantNames.forEach((variantName) => {
-    if (bucket.get(variantName)?.size) {
-      return;
-    }
-
-    const exported = exports.get(variantName);
+  variantMembers.forEach(({ name: variantName, symbol: variantSymbol }) => {
+    const canonical = canonicalBindingSymbol({
+      moduleId: importedModuleId,
+      symbol: variantSymbol,
+      binding: dependency,
+    });
+    const exported = Array.from(
+      ctx.moduleExports.get(canonical.moduleId)?.values() ?? [],
+    ).find((entry) => entry.symbol === canonical.symbol);
     if (!exported) {
       return;
     }
     if (
       !canAccessExport({
         exported,
-        moduleId: importedModuleId,
+        moduleId: canonical.moduleId,
         ctx,
         explicitlyTargetsStdSubmodule,
       })
@@ -1181,7 +1521,9 @@ const hydrateImportedEnumAliasNamespace = ({
       return;
     }
 
-    const exportedRecord = dependency.symbolTable.getSymbol(exported.symbol);
+    const exportedRecord = canonical.binding.symbolTable.getSymbol(
+      canonical.symbol,
+    );
     const metadata = exportedRecord.metadata as { entity?: string } | undefined;
     if (exportedRecord.kind !== "type" || metadata?.entity !== "object") {
       return;
@@ -1189,8 +1531,8 @@ const hydrateImportedEnumAliasNamespace = ({
 
     const existing = ctx.imports.find(
       (entry) =>
-        entry.target?.moduleId === importedModuleId &&
-        entry.target.symbol === exported.symbol,
+        entry.target?.moduleId === canonical.moduleId &&
+        entry.target.symbol === canonical.symbol,
     )?.local;
     const hiddenImportName = `__enum_ns_${implicitEnumNamespaceImportId++}_${variantName}`;
     const local =
@@ -1202,8 +1544,8 @@ const hydrateImportedEnumAliasNamespace = ({
             declaredAt: declaredAt.syntaxId,
             metadata: {
               import: {
-                moduleId: importedModuleId,
-                symbol: exported.symbol,
+                moduleId: canonical.moduleId,
+                symbol: canonical.symbol,
                 explicitlyTargetsStdSubmodule,
               },
               ...(importableMetadataFrom(
@@ -1215,14 +1557,17 @@ const hydrateImportedEnumAliasNamespace = ({
       ctx.imports.push({
         name: hiddenImportName,
         local,
-        target: { moduleId: importedModuleId, symbol: exported.symbol },
+        target: { moduleId: canonical.moduleId, symbol: canonical.symbol },
         visibility: moduleVisibility(),
         span: toSourceSpan(declaredAt),
       });
     }
 
-    bucket.set(variantName, new Set([local]));
-    changed = true;
+    const variants = bucket.get(variantName) ?? new Set<SymbolId>();
+    const sizeBefore = variants.size;
+    variants.add(local);
+    bucket.set(variantName, variants);
+    changed ||= variants.size !== sizeBefore;
   });
 
   if (!changed) {

--- a/packages/compiler/src/semantics/binding/binders/module.ts
+++ b/packages/compiler/src/semantics/binding/binders/module.ts
@@ -554,12 +554,32 @@ const resolveLocalTypeNamespaceUseEntry = ({
       return undefined;
     }
     const importedName = entry.alias ?? name;
-    if (importedName !== name) {
-      return undefined;
-    }
     if (record.scope === ctx.symbolTable.rootScope && record.name === name) {
+      if (importedName !== name) {
+        const importNameCollision = findModuleNamespaceNameCollision({
+          name: importedName,
+          scope: ctx.symbolTable.rootScope,
+          incomingKind: record.kind,
+          ctx,
+        });
+        if (importNameCollision) {
+          recordImportNameConflict({
+            name: importedName,
+            incomingKind: record.kind,
+            existingKind: importNameCollision.kind,
+            span: entry.span,
+            previousSpan: importNameCollision.span,
+            ctx,
+          });
+          return undefined;
+        }
+        ctx.symbolTable.bindAlias(
+          { name: importedName, symbol },
+          ctx.symbolTable.rootScope,
+        );
+      }
       return {
-        name,
+        name: importedName,
         local: symbol,
         visibility: decl.visibility,
         span: entry.span,
@@ -574,7 +594,7 @@ const resolveLocalTypeNamespaceUseEntry = ({
     }
     const existing = ctx.imports.find(
       (candidate) =>
-        candidate.name === name &&
+        candidate.name === importedName &&
         candidate.target?.moduleId === importedTarget.moduleId &&
         candidate.target.symbol === importedTarget.symbol &&
         ctx.symbolTable.getSymbol(candidate.local).scope ===
@@ -612,7 +632,7 @@ const resolveLocalTypeNamespaceUseEntry = ({
     }
     return declareImportedSymbol({
       exported,
-      alias: name,
+      alias: importedName,
       explicitlyTargetsStdSubmodule,
       ctx,
       declaredAt: decl.form,

--- a/packages/compiler/src/semantics/binding/binders/type-alias.ts
+++ b/packages/compiler/src/semantics/binding/binders/type-alias.ts
@@ -19,7 +19,7 @@ import {
 } from "./expressions.js";
 import {
   enumNamespaceMetadataFromAliasTarget,
-  enumVariantTypeNamesFromAliasTarget,
+  enumVariantTypeTargetsFromAliasTarget,
   importedSymbolTargetFromMetadata,
 } from "../../enum-namespace.js";
 import type { SymbolId } from "../../ids.js";
@@ -220,17 +220,17 @@ const seedEnumVariantNamespace = ({
   scope: number;
   ctx: BindingContext;
 }): void => {
-  const variantNames = enumVariantTypeNamesFromAliasTarget(target);
-  if (!variantNames) {
+  const variants = enumVariantTypeTargetsFromAliasTarget(target);
+  if (!variants) {
     return;
   }
 
   const bucket = ctx.staticMethods.get(aliasSymbol) ?? new Map();
   let seeded = false;
 
-  variantNames.forEach((variantName) => {
+  variants.forEach((variant) => {
     const variantSymbol = resolveObjectTypeSymbol({
-      name: variantName,
+      target: variant.target,
       scope,
       ctx,
     });
@@ -238,9 +238,9 @@ const seedEnumVariantNamespace = ({
       return;
     }
 
-    const symbols = bucket.get(variantName) ?? new Set<SymbolId>();
+    const symbols = bucket.get(variant.name) ?? new Set<SymbolId>();
     symbols.add(variantSymbol);
-    bucket.set(variantName, symbols);
+    bucket.set(variant.name, symbols);
     seeded = true;
   });
 
@@ -251,15 +251,20 @@ const seedEnumVariantNamespace = ({
 };
 
 const resolveObjectTypeSymbol = ({
-  name,
+  target,
   scope,
   ctx,
 }: {
-  name: string;
+  target: ParsedTypeAliasDecl["target"];
   scope: number;
   ctx: BindingContext;
 }): SymbolId | undefined => {
-  const symbol = ctx.symbolTable.resolve(name, scope);
+  const symbol = resolveNominalTypeSymbol({
+    target,
+    scope,
+    symbolTable: ctx.symbolTable,
+    moduleMembers: ctx.moduleMembers,
+  });
   if (typeof symbol !== "number") {
     return undefined;
   }

--- a/packages/compiler/src/semantics/binding/name-collisions.ts
+++ b/packages/compiler/src/semantics/binding/name-collisions.ts
@@ -29,14 +29,11 @@ const symbolsNamedInScope = ({
   skipSymbol?: SymbolId;
 }): ScopeSymbol[] => {
   const symbols: ScopeSymbol[] = [];
-  for (const symbolId of ctx.symbolTable.symbolsInScope(scope)) {
+  for (const symbolId of ctx.symbolTable.symbolsNamedInScope(name, scope)) {
     if (symbolId === skipSymbol) {
       continue;
     }
     const record = ctx.symbolTable.getSymbol(symbolId);
-    if (record.name !== name) {
-      continue;
-    }
     symbols.push({
       symbolId,
       record,

--- a/packages/compiler/src/semantics/enum-namespace.ts
+++ b/packages/compiler/src/semantics/enum-namespace.ts
@@ -185,6 +185,16 @@ export const enumVariantTypeNamesFromAliasTarget = (
   return dedupeEnumNamespaceMembers(collected).map((entry) => entry.name);
 };
 
+export const enumVariantTypeTargetsFromAliasTarget = (
+  target: Expr | undefined,
+): readonly { name: string; target: Expr }[] | undefined => {
+  const collected = collectUnionNominalTargets(target);
+  if (!collected || collected.length === 0) {
+    return undefined;
+  }
+  return collected;
+};
+
 export const enumNamespaceMemberNamesFromMetadata = (
   source?: Record<string, unknown>,
 ): string[] | undefined => {
@@ -213,6 +223,26 @@ const collectUnionNominalMembers = (
   return nominal
     ? [{ name: nominal.name, typeArguments: nominal.typeArguments }]
     : undefined;
+};
+
+const collectUnionNominalTargets = (
+  expr: Expr | undefined,
+): { name: string; target: Expr }[] | undefined => {
+  if (!expr) {
+    return undefined;
+  }
+
+  if (isForm(expr) && expr.calls("|") && expr.length === 3) {
+    const left = collectUnionNominalTargets(expr.at(1));
+    const right = collectUnionNominalTargets(expr.at(2));
+    if (!left || !right) {
+      return undefined;
+    }
+    return [...left, ...right];
+  }
+
+  const nominal = extractNominalTypeTarget(expr);
+  return nominal ? [{ name: nominal.name, target: expr }] : undefined;
 };
 
 const dedupeEnumNamespaceMembers = (

--- a/packages/compiler/src/semantics/hir/nodes.ts
+++ b/packages/compiler/src/semantics/hir/nodes.ts
@@ -593,6 +593,7 @@ export interface HirEffectHandlerExpr extends HirExpressionBase {
 export interface HirObjectLiteralExpr extends HirExpressionBase {
   exprKind: "object-literal";
   literalKind: "structural" | "nominal";
+  nominalConstruction?: "fieldwise-call";
   target?: HirTypeExpr;
   targetSymbol?: SymbolId;
   entries: readonly HirObjectLiteralEntry[];

--- a/packages/compiler/src/semantics/lowering/expressions/call.ts
+++ b/packages/compiler/src/semantics/lowering/expressions/call.ts
@@ -13,21 +13,26 @@ import {
   parseValueBraceEntries,
 } from "../../../parser/surface/index.js";
 import { literalShouldLowerAsObjectLiteral } from "../../constructors.js";
-import type { HirExprId } from "../../ids.js";
+import type { HirExprId, SymbolId } from "../../ids.js";
 import type { HirTypeExpr } from "../../hir/index.js";
 import { lowerTypeExpr } from "../type-expressions.js";
 import { resolveNamedTypeTarget } from "../named-type-resolution.js";
 import { toSourceSpan } from "../../../parser/surface/utils.js";
 import {
   isObjectLiteralForm,
+  lowerNominalObjectLiteralCall,
   lowerObjectLiteralExpr,
 } from "./object-literal.js";
 import type { LoweringFormParams, LoweringParams } from "./types.js";
 import { lowerConstructorLiteralCall } from "./constructor-call.js";
 import { createBoolLiteralExpr } from "./literal-helpers.js";
 import { resolveTypeSymbol } from "../resolution.js";
-import { lowerNominalTargetTypeArgumentsFromMetadata } from "../../nominal-type-target.js";
+import {
+  lowerNominalTargetTypeArgumentsFromMetadata,
+  resolveNominalTypeSymbol,
+} from "../../nominal-type-target.js";
 import { substituteTypeParametersInTypeExpr } from "../../hir/type-expr-substitution.js";
+import { importedSymbolTargetFromMetadata } from "../../enum-namespace.js";
 
 type LowerCallFromElementsParams = LoweringParams & {
   calleeExpr: Expr;
@@ -36,6 +41,14 @@ type LowerCallFromElementsParams = LoweringParams & {
 };
 
 type LowerNominalObjectLiteralParams = LoweringParams & {
+  callee: Expr;
+  args: readonly Expr[];
+  ast: Expr;
+  fallbackTypeArguments?: HirTypeExpr[];
+  allowedTargetSymbols?: ReadonlySet<number>;
+};
+
+type LowerImplicitFieldwiseCallParams = LoweringParams & {
   callee: Expr;
   args: readonly Expr[];
   ast: Expr;
@@ -181,8 +194,9 @@ export const lowerNominalObjectLiteral = ({
 }: LowerNominalObjectLiteralParams): HirExprId | undefined => {
   if (args.length === 0) return undefined;
 
-  const calleeResolution = resolveNominalTarget({
+  const calleeResolution = resolveAllowedNominalTarget({
     callee,
+    allowedTargetSymbols,
     ctx,
     scope: scopes.current(),
   });
@@ -310,6 +324,167 @@ export const lowerNominalObjectLiteral = ({
       targetSymbol: calleeResolution.symbol,
     },
   });
+};
+
+export const lowerImplicitFieldwiseCall = ({
+  callee,
+  args,
+  ast,
+  fallbackTypeArguments,
+  allowedTargetSymbols,
+  ctx,
+  scopes,
+  lowerExpr,
+}: LowerImplicitFieldwiseCallParams): HirExprId | undefined => {
+  const genericsForm = args[0];
+  const hasGenerics =
+    isForm(genericsForm) && formCallsInternal(genericsForm, "generics");
+  const valueArgs = args.slice(hasGenerics ? 1 : 0);
+  const parsedTypeArguments = hasGenerics
+    ? ((genericsForm as Form).rest
+        .map((entry) => lowerTypeExpr(entry, ctx, scopes.current()))
+        .filter(Boolean) as HirTypeExpr[])
+    : undefined;
+  const calleeResolution = resolveAllowedNominalTarget({
+    callee,
+    allowedTargetSymbols,
+    ctx,
+    scope: scopes.current(),
+  });
+  if (!calleeResolution) {
+    return undefined;
+  }
+  if (
+    allowedTargetSymbols &&
+    !allowedTargetSymbols.has(calleeResolution.symbol)
+  ) {
+    return undefined;
+  }
+
+  const record = ctx.symbolTable.getSymbol(calleeResolution.symbol);
+  const metadata = record.metadata as { entity?: unknown } | undefined;
+  const isNominalOrAlias =
+    record.kind === "type" &&
+    (metadata?.entity === "object" || metadata?.entity === "type-alias");
+  if (!isNominalOrAlias) {
+    return undefined;
+  }
+
+  if (nominalTypeDeclaresInit(calleeResolution.symbol, ctx)) {
+    return undefined;
+  }
+
+  const typeArguments =
+    calleeResolution.typeArguments ??
+    (parsedTypeArguments && fallbackTypeArguments
+      ? [...parsedTypeArguments, ...fallbackTypeArguments]
+      : (parsedTypeArguments ?? fallbackTypeArguments));
+  const target: HirTypeExpr = {
+    typeKind: "named",
+    path: calleeResolution.path,
+    symbol: calleeResolution.symbol,
+    ast: ast.syntaxId,
+    span: toSourceSpan(ast),
+    typeArguments:
+      typeArguments && typeArguments.length > 0 ? typeArguments : undefined,
+  };
+
+  return lowerNominalObjectLiteralCall({
+    arguments: valueArgs,
+    target,
+    targetSymbol: calleeResolution.symbol,
+    ast,
+    ctx,
+    scopes,
+    lowerExpr,
+  });
+};
+
+const resolveAllowedNominalTarget = ({
+  callee,
+  allowedTargetSymbols,
+  ctx,
+  scope,
+}: {
+  callee: Expr;
+  allowedTargetSymbols?: ReadonlySet<number>;
+  ctx: LoweringParams["ctx"];
+  scope: number;
+}): NominalTargetResolution | undefined => {
+  const lexical = resolveNominalTarget({ callee, ctx, scope });
+  if (
+    !allowedTargetSymbols ||
+    (lexical && allowedTargetSymbols.has(lexical.symbol))
+  ) {
+    return lexical;
+  }
+  if (allowedTargetSymbols.size !== 1 || !isIdentifierAtom(callee)) {
+    return undefined;
+  }
+  return {
+    symbol: Array.from(allowedTargetSymbols)[0]!,
+    path: [callee.value],
+    calleeSyntax: callee,
+    typeArguments: undefined,
+  };
+};
+
+const nominalTypeDeclaresInit = (
+  symbol: SymbolId,
+  ctx: LoweringParams["ctx"],
+): boolean => {
+  let currentSymbol = symbol;
+  let current: Pick<
+    LoweringParams["ctx"],
+    | "symbolTable"
+    | "staticMethods"
+    | "dependencies"
+    | "decls"
+    | "scopeByNode"
+    | "moduleMembers"
+  > = ctx;
+  let currentModuleId = ctx.moduleId;
+  const visited = new Set<string>();
+
+  while (true) {
+    const key = `${currentModuleId}:${currentSymbol}`;
+    if (visited.has(key)) {
+      return false;
+    }
+    visited.add(key);
+    if (current.staticMethods.get(currentSymbol)?.get("init")?.size) {
+      return true;
+    }
+    const alias = current.decls.getTypeAlias(currentSymbol);
+    if (alias) {
+      const aliasScope = alias.form
+        ? current.scopeByNode.get(alias.form.syntaxId)
+        : undefined;
+      const targetSymbol = resolveNominalTypeSymbol({
+        target: alias.target,
+        scope: aliasScope ?? current.symbolTable.rootScope,
+        symbolTable: current.symbolTable,
+        moduleMembers: current.moduleMembers,
+      });
+      if (typeof targetSymbol === "number") {
+        currentSymbol = targetSymbol;
+        continue;
+      }
+    }
+    const imported = importedSymbolTargetFromMetadata(
+      current.symbolTable.getSymbol(currentSymbol).metadata,
+    );
+    if (!imported) {
+      return false;
+    }
+    const dependency = current.dependencies.get(imported.moduleId);
+    if (!dependency) {
+      return false;
+    }
+    current = dependency;
+    currentModuleId = imported.moduleId;
+    currentSymbol = imported.symbol;
+  }
 };
 
 const resolveEnclosingFunctionDecl = ({
@@ -605,6 +780,18 @@ export const lowerCall = ({
   });
   if (typeof nominalLiteral === "number") {
     return nominalLiteral;
+  }
+
+  const fieldwiseCall = lowerImplicitFieldwiseCall({
+    callee,
+    args: form.rest,
+    ast: form,
+    ctx,
+    scopes,
+    lowerExpr,
+  });
+  if (typeof fieldwiseCall === "number") {
+    return fieldwiseCall;
   }
 
   return lowerCallFromElements({

--- a/packages/compiler/src/semantics/lowering/expressions/object-literal.ts
+++ b/packages/compiler/src/semantics/lowering/expressions/object-literal.ts
@@ -60,6 +60,7 @@ export const lowerNominalObjectLiteralCall = ({
     ast: ast.syntaxId,
     span: toSourceSpan(ast),
     literalKind: "nominal",
+    nominalConstruction: "fieldwise-call",
     target,
     targetSymbol,
     entries: arguments_.map((argument) => ({

--- a/packages/compiler/src/semantics/lowering/expressions/object-literal.ts
+++ b/packages/compiler/src/semantics/lowering/expressions/object-literal.ts
@@ -1,10 +1,11 @@
-import type { Form } from "../../../parser/index.js";
+import type { Expr, Form } from "../../../parser/index.js";
 import { toSourceSpan } from "../../../parser/surface/utils.js";
-import type { HirExprId } from "../../ids.js";
-import type { HirObjectLiteralEntry } from "../../hir/index.js";
+import type { HirExprId, SymbolId } from "../../ids.js";
+import type { HirObjectLiteralEntry, HirTypeExpr } from "../../hir/index.js";
 import type { LowerObjectLiteralOptions } from "../types.js";
 import type { LoweringFormParams, LoweringParams } from "./types.js";
 import {
+  parseSurfaceCallArguments,
   parseValueBraceEntries,
   type SurfaceValueBraceEntry,
 } from "../../../parser/surface/index.js";
@@ -31,6 +32,42 @@ export const lowerObjectLiteralExpr = ({
     target: options.target,
     targetSymbol: options.targetSymbol,
     entries,
+  });
+};
+
+export const lowerNominalObjectLiteralCall = ({
+  arguments: argumentExprs,
+  target,
+  targetSymbol,
+  ast,
+  ctx,
+  scopes,
+  lowerExpr,
+}: LoweringParams & {
+  arguments: readonly Expr[];
+  target: HirTypeExpr;
+  targetSymbol: SymbolId;
+  ast: Expr;
+}): HirExprId | undefined => {
+  const arguments_ = parseSurfaceCallArguments(argumentExprs);
+  if (arguments_.some((argument) => !argument.label)) {
+    return undefined;
+  }
+
+  return ctx.builder.addExpression({
+    kind: "expr",
+    exprKind: "object-literal",
+    ast: ast.syntaxId,
+    span: toSourceSpan(ast),
+    literalKind: "nominal",
+    target,
+    targetSymbol,
+    entries: arguments_.map((argument) => ({
+      kind: "field" as const,
+      name: argument.label!.value,
+      value: lowerExpr(argument.value, ctx, scopes),
+      span: toSourceSpan(argument.syntax),
+    })),
   });
 };
 

--- a/packages/compiler/src/semantics/lowering/expressions/static-access.ts
+++ b/packages/compiler/src/semantics/lowering/expressions/static-access.ts
@@ -17,7 +17,10 @@ import {
   resolveModuleMemberResolution,
   resolveStaticMethodResolution,
 } from "./resolution-helpers.js";
-import { lowerNominalObjectLiteral } from "./call.js";
+import {
+  lowerImplicitFieldwiseCall,
+  lowerNominalObjectLiteral,
+} from "./call.js";
 import type { LoweringFormParams, LoweringParams } from "./types.js";
 import {
   resolveConstructorResolution,
@@ -295,12 +298,6 @@ const lowerStaticMethodCall = ({
     ...namespaceTypeArguments,
   ];
 
-  const args = parseSurfaceCallArguments(
-    elements.slice(hasTypeArguments ? 2 : 1),
-  ).map((argument) => ({
-    ...(argument.label ? { label: argument.label.value } : {}),
-    expr: lowerExpr(argument.value, ctx, scopes),
-  }));
   const namespaceMemberSymbols =
     methodTable.get(calleeExpr.value) ?? new Set<SymbolId>();
 
@@ -308,7 +305,7 @@ const lowerStaticMethodCall = ({
     callee: calleeExpr,
     args: memberForm.rest,
     ast: accessForm,
-    fallbackTypeArguments: combinedTypeArguments,
+    fallbackTypeArguments: namespaceTypeArguments,
     allowedTargetSymbols: namespaceMemberSymbols,
     ctx,
     scopes,
@@ -317,6 +314,27 @@ const lowerStaticMethodCall = ({
   if (typeof nominal === "number") {
     return nominal;
   }
+
+  const fieldwise = lowerImplicitFieldwiseCall({
+    callee: calleeExpr,
+    args: memberForm.rest,
+    ast: accessForm,
+    fallbackTypeArguments: namespaceTypeArguments,
+    allowedTargetSymbols: namespaceMemberSymbols,
+    ctx,
+    scopes,
+    lowerExpr,
+  });
+  if (typeof fieldwise === "number") {
+    return fieldwise;
+  }
+
+  const args = parseSurfaceCallArguments(
+    elements.slice(hasTypeArguments ? 2 : 1),
+  ).map((argument) => ({
+    ...(argument.label ? { label: argument.label.value } : {}),
+    expr: lowerExpr(argument.value, ctx, scopes),
+  }));
 
   const resolution = resolveStaticMethodResolution({
     name: calleeExpr.value,
@@ -509,25 +527,6 @@ const lowerModuleQualifiedCall = ({
       ? [...(typeArguments ?? []), ...targetCallTypeArguments]
       : typeArguments;
 
-  const args = parseSurfaceCallArguments(
-    elements.slice(hasTypeArguments ? 2 : 1),
-  ).map((argument) => ({
-    ...(argument.label ? { label: argument.label.value } : {}),
-    expr: lowerExpr(argument.value, ctx, scopes),
-  }));
-
-  const nominal = lowerNominalObjectLiteral({
-    callee: calleeExpr,
-    args: memberForm.rest,
-    ast: accessForm,
-    ctx,
-    scopes,
-    lowerExpr,
-  });
-  if (typeof nominal === "number") {
-    return nominal;
-  }
-
   const baseResolution = resolveModuleMemberResolution({
     name: calleeExpr.value,
     moduleSymbol,
@@ -538,6 +537,42 @@ const lowerModuleQualifiedCall = ({
     const moduleName = ctx.symbolTable.getSymbol(moduleSymbol).name;
     throw new Error(`module ${moduleName} does not export ${calleeExpr.value}`);
   }
+  const memberSymbols = memberTable.get(calleeExpr.value) ?? new Set<SymbolId>();
+
+  const nominal = lowerNominalObjectLiteral({
+    callee: calleeExpr,
+    args: memberForm.rest,
+    ast: accessForm,
+    fallbackTypeArguments: combinedTypeArguments,
+    allowedTargetSymbols: memberSymbols,
+    ctx,
+    scopes,
+    lowerExpr,
+  });
+  if (typeof nominal === "number") {
+    return nominal;
+  }
+
+  const fieldwise = lowerImplicitFieldwiseCall({
+    callee: calleeExpr,
+    args: memberForm.rest,
+    ast: accessForm,
+    fallbackTypeArguments: combinedTypeArguments,
+    allowedTargetSymbols: memberSymbols,
+    ctx,
+    scopes,
+    lowerExpr,
+  });
+  if (typeof fieldwise === "number") {
+    return fieldwise;
+  }
+
+  const args = parseSurfaceCallArguments(
+    elements.slice(hasTypeArguments ? 2 : 1),
+  ).map((argument) => ({
+    ...(argument.label ? { label: argument.label.value } : {}),
+    expr: lowerExpr(argument.value, ctx, scopes),
+  }));
   const aliasTargetTypeArguments =
     baseResolution.kind === "symbol" &&
     ctx.symbolTable.getSymbol(baseResolution.symbol).kind === "type"

--- a/packages/compiler/src/semantics/pipeline.ts
+++ b/packages/compiler/src/semantics/pipeline.ts
@@ -137,6 +137,9 @@ export const semanticsPipeline = (
       arena: typingState?.arena,
       effects: typingState?.effects,
       imports: binding.imports,
+      sourceImportLocals: binding.uses.flatMap((use) =>
+        use.entries.flatMap((entry) => entry.imports.map((entry) => entry.local)),
+      ),
       moduleId: module.id,
       packageId: binding.packageId,
       moduleExports: exports ?? new Map(),

--- a/packages/compiler/src/semantics/typing/__tests__/call-diagnostics.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/call-diagnostics.test.ts
@@ -246,6 +246,26 @@ pub fn main() -> i32
     ).toHaveLength(7);
   });
 
+  it("rejects conflicting inferred arguments for fieldwise aliases", () => {
+    const ast = parse(
+      `
+obj Pair<A, B> { first: A, second: B }
+type Same<T> = Pair<T, T>
+
+pub fn main() -> i32
+  let _pair = Same(first: 1, second: true)
+  0
+`,
+      "/proj/src/fieldwise-alias-conflicting-inference.voyd",
+    );
+
+    expect(() => semanticsPipeline(ast)).toThrow(
+      expect.objectContaining({
+        diagnostic: expect.objectContaining({ code: "TY0027" }),
+      }),
+    );
+  });
+
   it("reports missing fields for fieldwise calls", () => {
     const ast = parse(
       `

--- a/packages/compiler/src/semantics/typing/__tests__/call-diagnostics.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/call-diagnostics.test.ts
@@ -294,6 +294,24 @@ pub fn main() -> i32
     expect(() => semanticsPipeline(ast)).toThrow(/argument count mismatch/i);
   });
 
+  it("keeps brace construction compatible with union member type arguments", () => {
+    const ast = parse(
+      `
+obj Some<T> { value: T }
+obj None {}
+type Option<T> = Some<T> | None
+
+pub fn main() -> i32
+  let _value: Option<i32> = None<i32> {}
+  0
+`,
+      "/proj/src/brace-union-member-type-argument.voyd",
+    );
+
+    const result = semanticsPipeline(ast);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("rejects uninferable generic alias arguments in fieldwise calls", () => {
     const ast = parse(
       `

--- a/packages/compiler/src/semantics/typing/__tests__/call-diagnostics.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/call-diagnostics.test.ts
@@ -203,23 +203,129 @@ pub fn main() -> i32
     expect(caught.diagnostic.message).toMatch(/expected major, got no label/i);
   });
 
-  it("diagnoses constructor calls on types without value constructors", () => {
+  it("constructs nominal fields when a type has no explicit init", () => {
     const ast = loadAst("constructor_call_without_init.voyd");
+    const result = semanticsPipeline(ast);
+    expect(result.diagnostics).toHaveLength(0);
+  });
 
-    let caught: unknown;
-    try {
-      semanticsPipeline(ast);
-    } catch (error) {
-      caught = error;
-    }
+  it("supports fieldwise calls for empty, optional, value, generic, and alias targets", () => {
+    const ast = parse(
+      `
+obj Empty {}
+obj Some<T> { value: T }
+obj None {}
+type Optional<T> = Some<T> | None
+obj OptionalBox { value?: i32 }
+val Point { x: i32, y: i32 }
+obj Box<T> { value: T }
+type BoxAlias<T> = Box<T>
+obj Animal { id: i32 }
+obj Dog: Animal { id: i32 }
+obj AnimalBox<T: Animal> { value: T }
+type AnimalBoxAlias<T: Animal> = AnimalBox<T>
 
-    expect(caught instanceof DiagnosticError).toBe(true);
-    if (!(caught instanceof DiagnosticError)) {
-      return;
-    }
+pub fn main() -> i32
+  let _empty = Empty()
+  let _optional = OptionalBox()
+  let point = Point(y: 2, x: 1)
+  let box = Box(value: 3)
+  let alias = BoxAlias(value: 4)
+  let constrained = AnimalBoxAlias(value: Dog(id: 5))
+  point.x + point.y + box.value + alias.value + constrained.value.id
+`,
+      "/proj/src/fieldwise-calls.voyd",
+    );
 
-    expect(caught.diagnostic.code).toBe("TY0041");
-    expect(caught.diagnostic.message).toMatch(/is a type, not a value/i);
+    const result = semanticsPipeline(ast);
+    expect(result.diagnostics).toHaveLength(0);
+    expect(
+      Array.from(result.hir.expressions.values()).filter(
+        (expr) => expr.exprKind === "object-literal" && expr.literalKind === "nominal",
+      ),
+    ).toHaveLength(7);
+  });
+
+  it("reports missing fields for fieldwise calls", () => {
+    const ast = parse(
+      `
+obj Person { age: i32 }
+
+pub fn main() -> i32
+  let _person = Person()
+  0
+`,
+      "/proj/src/fieldwise-call-missing-field.voyd",
+    );
+
+    expect(() => semanticsPipeline(ast)).toThrow(
+      expect.objectContaining({ diagnostic: expect.objectContaining({ code: "TY0037" }) }),
+    );
+  });
+
+  it("rejects excess explicit type arguments on fieldwise aliases", () => {
+    const ast = parse(
+      `
+obj Box<T> { value: T }
+type BoxAlias<T> = Box<T>
+
+pub fn main() -> i32
+  let _box = BoxAlias<i32, bool>(value: 1)
+  0
+`,
+      "/proj/src/fieldwise-alias-extra-type-argument.voyd",
+    );
+
+    expect(() => semanticsPipeline(ast)).toThrow(/argument count mismatch/i);
+  });
+
+  it("rejects excess explicit type arguments on direct fieldwise calls", () => {
+    const ast = parse(
+      `
+obj Box<T> { value: T }
+
+pub fn main() -> i32
+  let _box = Box<i32, bool>(value: 1)
+  0
+`,
+      "/proj/src/fieldwise-extra-type-argument.voyd",
+    );
+
+    expect(() => semanticsPipeline(ast)).toThrow(/argument count mismatch/i);
+  });
+
+  it("rejects uninferable generic alias arguments in fieldwise calls", () => {
+    const ast = parse(
+      `
+obj Box<T> { value: T }
+type Alias<T, U> = Box<T>
+
+pub fn main() -> i32
+  let box = Alias(value: 1)
+  box.value
+`,
+      "/proj/src/fieldwise-alias-unresolved-type-argument.voyd",
+    );
+
+    expect(() => semanticsPipeline(ast)).toThrow(/missing 1 type argument/i);
+  });
+
+  it("infers zero-field generic construction from the expected union type", () => {
+    const ast = parse(
+      `
+obj Ready<T> {}
+obj Other {}
+type Signal<T> = Ready<T> | Other
+
+pub fn main() -> i32
+  let _signal: Signal<i32> = Ready()
+  0
+`,
+      "/proj/src/fieldwise-call-expected-type.voyd",
+    );
+
+    const result = semanticsPipeline(ast);
+    expect(result.diagnostics).toHaveLength(0);
   });
 
   it("infers generic constructor type arguments for zero-arg calls from expected types", () => {

--- a/packages/compiler/src/semantics/typing/__tests__/value-position-diagnostics.test.ts
+++ b/packages/compiler/src/semantics/typing/__tests__/value-position-diagnostics.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { semanticsPipeline } from "../../pipeline.js";
 import { loadAst } from "../../__tests__/load-ast.js";
 import { DiagnosticError } from "../../../diagnostics/index.js";
+import { parse } from "../../../parser/index.js";
 
 describe("value position diagnostics", () => {
   it("reports type aliases used as values with a direct typing diagnostic", () => {
@@ -68,5 +69,35 @@ describe("value position diagnostics", () => {
     const source = readFileSync(fixturePath, "utf8");
     const { start, end } = caught.diagnostic.span;
     expect(source.slice(start, end)).toContain("scalar.x");
+  });
+
+  it("rejects a qualified union member type used as a value", () => {
+    const ast = parse(
+      `
+obj Apple {}
+obj Banana {}
+type Fruit = Apple | Banana
+
+pub fn main() -> i32
+  let _fruit: Fruit = Fruit::Apple
+  0
+`,
+      "/proj/src/qualified-type-as-value.voyd",
+    );
+
+    let caught: unknown;
+    try {
+      semanticsPipeline(ast);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught instanceof DiagnosticError).toBe(true);
+    if (!(caught instanceof DiagnosticError)) {
+      return;
+    }
+
+    expect(caught.diagnostic.code).toBe("TY0041");
+    expect(caught.diagnostic.message).toMatch(/Apple.*type.*not a value/i);
   });
 });

--- a/packages/compiler/src/semantics/typing/context-from-typing-result.ts
+++ b/packages/compiler/src/semantics/typing/context-from-typing-result.ts
@@ -50,6 +50,7 @@ export const createTypingContextFromTypingResult = ({
   dependencies,
   importsByLocal,
   importAliasesByModule,
+  sourceImportLocals: typing.sourceImportLocals,
   arena: typing.arena,
   table: typing.table,
   effects: typing.effects,

--- a/packages/compiler/src/semantics/typing/context.ts
+++ b/packages/compiler/src/semantics/typing/context.ts
@@ -92,6 +92,7 @@ export const createTypingContext = (inputs: TypingInputs): TypingContext => {
     dependencies,
     importsByLocal,
     importAliasesByModule,
+    sourceImportLocals: new Set(inputs.sourceImportLocals ?? []),
     arena,
     table,
     effects,

--- a/packages/compiler/src/semantics/typing/expressions/identifier.ts
+++ b/packages/compiler/src/semantics/typing/expressions/identifier.ts
@@ -47,6 +47,23 @@ export const getValueType = (
 ): TypeId => {
   const hasExplicitAliasConstructorTypeArguments =
     (options.aliasConstructorTypeArguments?.length ?? 0) > 0;
+  const record = ctx.symbolTable.getSymbol(symbol);
+  if (
+    record.kind !== "value" &&
+    record.kind !== "parameter" &&
+    record.kind !== "effect-op"
+  ) {
+    return emitDiagnostic({
+      ctx,
+      code: "TY0041",
+      params: {
+        kind: "symbol-not-a-value",
+        name: record.name,
+        symbolKind: record.kind,
+      },
+      span: normalizeSpan(options.span),
+    });
+  }
   if (!hasExplicitAliasConstructorTypeArguments) {
     const cached = ctx.valueTypes.get(symbol);
     if (typeof cached === "number") {
@@ -54,7 +71,6 @@ export const getValueType = (
     }
   }
 
-  const record = ctx.symbolTable.getSymbol(symbol);
   const metadata = (record.metadata ?? {}) as {
     intrinsic?: boolean;
     intrinsicName?: string;

--- a/packages/compiler/src/semantics/typing/expressions/match.ts
+++ b/packages/compiler/src/semantics/typing/expressions/match.ts
@@ -25,9 +25,12 @@ import type { TypingContext, TypingState } from "../types.js";
 import {
   canonicalSymbolRefInTypingContext,
   canonicalSymbolRefForTypingContext,
+  localSymbolForSymbolRef,
   symbolRefKey as symbolRefKeyForTyping,
 } from "../symbol-ref-utils.js";
 import { bindPatternFromType, recordPatternType } from "./patterns.js";
+import { isPackageVisible, isPublicVisibility } from "../../hir/index.js";
+import { importedSymbolTargetFromMetadata } from "../../enum-namespace.js";
 
 export const typeMatchExpr = (
   expr: HirMatchExpr,
@@ -149,7 +152,7 @@ const createMatchCoverageTracker = ({
   const discriminantDesc = ctx.arena.get(discriminantType);
   if (discriminantDesc.kind !== "union") {
     return {
-      patternNominalHints: undefined,
+      patternNominalHints: collectNominalPatternHints(discriminantType, ctx),
       trackArm: () => undefined,
       ensureExhaustive: () => undefined,
     };
@@ -477,6 +480,7 @@ const collectTupleCandidates = (
 type NominalPatternHint = {
   nominal: TypeId;
   memberType: TypeId;
+  name: string;
 };
 
 type NominalPatternOwnerKey = string;
@@ -484,6 +488,7 @@ type NominalPatternOwnerKey = string;
 type NominalPatternHints = {
   unique: Map<NominalPatternOwnerKey, NominalPatternHint>;
   ambiguous: Set<NominalPatternOwnerKey>;
+  byName: Map<string, readonly NominalPatternHint[]>;
 };
 
 const collectNominalPatternHints = (
@@ -491,15 +496,14 @@ const collectNominalPatternHints = (
   ctx: TypingContext
 ): NominalPatternHints | undefined => {
   const desc = ctx.arena.get(discriminantType);
-  if (desc.kind !== "union") {
-    return undefined;
-  }
+  const members = desc.kind === "union" ? desc.members : [discriminantType];
 
   const counts = new Map<NominalPatternOwnerKey, number>();
   const unique = new Map<NominalPatternOwnerKey, NominalPatternHint>();
   const ambiguous = new Set<NominalPatternOwnerKey>();
+  const byName = new Map<string, NominalPatternHint[]>();
 
-  desc.members.forEach((member) => {
+  members.forEach((member) => {
     const nominal = getNominalComponent(member, ctx);
     if (typeof nominal !== "number") {
       return;
@@ -511,20 +515,67 @@ const collectNominalPatternHints = (
     ) {
       return;
     }
+    const localOwner = localSymbolForSymbolRef(nominalDesc.owner, ctx);
+    const isContextuallyReachable = !(
+      nominalDesc.owner.moduleId !== ctx.moduleId &&
+      (typeof localOwner !== "number" ||
+        !isReachableNominalPatternOwner(nominalDesc.owner, ctx))
+    );
     const ownerKey = symbolRefKeyForTyping(
       canonicalSymbolRefInTypingContext(nominalDesc.owner, ctx),
     );
+    const name = nominalDesc.name;
+    if (!name) {
+      return;
+    }
+    const hint = { nominal, memberType: member, name };
+    if (isContextuallyReachable) {
+      const named = byName.get(name) ?? [];
+      named.push(hint);
+      byName.set(name, named);
+    }
     const count = (counts.get(ownerKey) ?? 0) + 1;
     counts.set(ownerKey, count);
     if (count === 1) {
-      unique.set(ownerKey, { nominal, memberType: member });
+      unique.set(ownerKey, hint);
     } else {
       unique.delete(ownerKey);
       ambiguous.add(ownerKey);
     }
   });
 
-  return unique.size > 0 || ambiguous.size > 0 ? { unique, ambiguous } : undefined;
+  return unique.size > 0 || ambiguous.size > 0
+    ? { unique, ambiguous, byName }
+    : undefined;
+};
+
+const isReachableNominalPatternOwner = (
+  owner: { moduleId: string; symbol: number },
+  ctx: TypingContext,
+): boolean => {
+  const canonicalOwner = canonicalSymbolRefInTypingContext(owner, ctx);
+  for (const dependency of ctx.dependencies.values()) {
+    for (const exported of dependency.exports.values()) {
+      const accessible =
+        dependency.packageId === ctx.packageId
+          ? isPackageVisible(exported.visibility)
+          : isPublicVisibility(exported.visibility);
+      if (!accessible) {
+        continue;
+      }
+      const candidate = canonicalSymbolRefInTypingContext(
+        { moduleId: dependency.moduleId, symbol: exported.symbol },
+        ctx,
+      );
+      const reachesOwner =
+        candidate.moduleId === canonicalOwner.moduleId &&
+        candidate.symbol === canonicalOwner.symbol;
+      if (reachesOwner) {
+        return true;
+      }
+    }
+  }
+  return false;
 };
 
 const reportRedundantMatchArm = ({
@@ -576,7 +627,10 @@ const resolveNominalPatternSymbol = (
 
   if (typeof typeExpr.symbol === "number") {
     const symbol = typeExpr.symbol;
-    if (ctx.objects.getTemplate(symbol)) {
+    if (
+      isSourceLexicalTypeSymbol({ typeExpr, symbol, ctx }) &&
+      ctx.objects.getTemplate(symbol)
+    ) {
       return symbol;
     }
   }
@@ -585,7 +639,16 @@ const resolveNominalPatternSymbol = (
   if (!name) {
     return undefined;
   }
-  return ctx.objects.resolveName(name);
+  const candidates = new Set([
+    ctx.symbolTable.resolve(name, ctx.symbolTable.rootScope),
+    ctx.objects.resolveName(name),
+  ]);
+  return Array.from(candidates).find(
+    (candidate): candidate is SymbolId =>
+      typeof candidate === "number" &&
+      isSourceLexicalTypeSymbol({ typeExpr, symbol: candidate, ctx }) &&
+      Boolean(ctx.objects.getTemplate(candidate)),
+  );
 };
 
 const resolveMatchPatternType = ({
@@ -617,6 +680,74 @@ const resolveMatchPatternType = ({
       : undefined;
   const isGenericAlias = (aliasTemplate?.params.length ?? 0) > 0;
   const hasTypeArguments = (namedType?.typeArguments?.length ?? 0) > 0;
+  const unresolvedContextualName =
+    namedType &&
+    typeof nominalSymbol !== "number" &&
+    typeof aliasSymbol !== "number" &&
+    !hasSourceLexicalTypeBinding(namedType, ctx) &&
+    namedType.path.length === 1
+      ? namedType.path[0]
+      : undefined;
+
+  if (unresolvedContextualName && hints) {
+    const candidates = hints.byName.get(unresolvedContextualName) ?? [];
+    if (hasTypeArguments && candidates.length > 0 && namedType) {
+      const ownerSymbols = new Set(
+        candidates.flatMap((candidate) => {
+          const candidateDesc = ctx.arena.get(candidate.nominal);
+          if (
+            candidateDesc.kind !== "nominal-object" &&
+            candidateDesc.kind !== "value-object"
+          ) {
+            return [];
+          }
+          const owner = localSymbolForSymbolRef(candidateDesc.owner, ctx);
+          return typeof owner === "number" ? [owner] : [];
+        }),
+      );
+      if (ownerSymbols.size === 1) {
+        return resolveTypeExpr(
+          { ...namedType, symbol: Array.from(ownerSymbols)[0] },
+          ctx,
+          state,
+          ctx.primitives.unknown,
+        );
+      }
+    }
+    if (candidates.length === 1) {
+      return candidates[0]!.memberType;
+    }
+    if (candidates.length > 1) {
+      const related = discriminantSpan
+        ? [
+            diagnosticFromCode({
+              code: "TY0002",
+              params: { kind: "discriminant-note" },
+              severity: "note",
+              span: discriminantSpan,
+            }),
+          ]
+        : undefined;
+      emitDiagnostic({
+        ctx,
+        code: "TY0020",
+        params: {
+          kind: "ambiguous-nominal-match-pattern",
+          typeName: unresolvedContextualName,
+        },
+        span: patternSpan,
+        related,
+      });
+      return ctx.primitives.unknown;
+    }
+    emitDiagnostic({
+      ctx,
+      code: "TY0026",
+      params: { kind: "undefined-type", name: unresolvedContextualName },
+      span: patternSpan,
+    });
+    return ctx.primitives.unknown;
+  }
 
   if (aliasSymbol && isGenericAlias && !hasTypeArguments) {
     const inferred = inferAliasPatternType({
@@ -706,7 +837,10 @@ const resolveAliasPatternSymbol = (
 
   if (typeof typeExpr.symbol === "number") {
     const symbol = typeExpr.symbol;
-    if (ctx.typeAliases.hasTemplate(symbol)) {
+    if (
+      isSourceLexicalTypeSymbol({ typeExpr, symbol, ctx }) &&
+      isTypeAliasSymbol(symbol, ctx)
+    ) {
       return symbol;
     }
   }
@@ -715,7 +849,74 @@ const resolveAliasPatternSymbol = (
   if (!name) {
     return undefined;
   }
-  return ctx.typeAliases.resolveName(name);
+  const candidates = new Set([
+    ctx.symbolTable.resolve(name, ctx.symbolTable.rootScope),
+    ctx.typeAliases.resolveName(name),
+  ]);
+  return Array.from(candidates).find(
+    (candidate): candidate is SymbolId =>
+      typeof candidate === "number" &&
+      isSourceLexicalTypeSymbol({ typeExpr, symbol: candidate, ctx }) &&
+      isTypeAliasSymbol(candidate, ctx),
+  );
+};
+
+const isTypeAliasSymbol = (symbol: SymbolId, ctx: TypingContext): boolean => {
+  if (ctx.typeAliases.hasTemplate(symbol)) {
+    return true;
+  }
+  const record = ctx.symbolTable.getSymbol(symbol);
+  return (
+    record.kind === "type" &&
+    (record.metadata as { entity?: unknown } | undefined)?.entity ===
+      "type-alias"
+  );
+};
+
+const isSourceLexicalTypeSymbol = ({
+  typeExpr,
+  symbol,
+  ctx,
+}: {
+  typeExpr: HirTypeExpr & { typeKind: "named" };
+  symbol: SymbolId;
+  ctx: TypingContext;
+}): boolean => {
+  if (typeExpr.path.length > 1) {
+    return true;
+  }
+  const record = ctx.symbolTable.getSymbol(symbol);
+  return (
+    !importedSymbolTargetFromMetadata(record.metadata) ||
+    ctx.sourceImportLocals.has(symbol)
+  );
+};
+
+const hasSourceLexicalTypeBinding = (
+  typeExpr: HirTypeExpr & { typeKind: "named" },
+  ctx: TypingContext,
+): boolean => {
+  const name = typeExpr.path.at(-1);
+  const candidates = new Set([
+    typeExpr.symbol,
+    name
+      ? ctx.symbolTable.resolve(name, ctx.symbolTable.rootScope)
+      : undefined,
+  ]);
+  return Array.from(candidates).some((candidate) => {
+    if (typeof candidate !== "number") {
+      return false;
+    }
+    const record = ctx.symbolTable.getSymbol(candidate);
+    const isTypeLike =
+      record.kind === "type" ||
+      record.kind === "trait" ||
+      record.kind === "type-parameter";
+    return (
+      isTypeLike &&
+      isSourceLexicalTypeSymbol({ typeExpr, symbol: candidate, ctx })
+    );
+  });
 };
 
 type AliasPatternInference =

--- a/packages/compiler/src/semantics/typing/expressions/object-literal.ts
+++ b/packages/compiler/src/semantics/typing/expressions/object-literal.ts
@@ -1,19 +1,33 @@
 import type {
+  HirNamedTypeExpr,
   HirObjectLiteralEntry,
   HirObjectLiteralExpr,
 } from "../../hir/index.js";
-import type { SourceSpan, TypeId, TypeParamId } from "../../ids.js";
+import type {
+  SourceSpan,
+  SymbolId,
+  TypeId,
+  TypeParamId,
+} from "../../ids.js";
 import { typeExpression, withSpeculativeExprTyping } from "../expressions.js";
 import { composeEffectRows, getExprEffectRow } from "../effects.js";
 import {
   ensureObjectType,
   ensureTypeMatches,
+  getNominalComponent,
   getObjectTemplate,
   getStructuralFields,
   getSymbolName,
+  resolveTypeAlias,
   resolveTypeExpr,
   typeSatisfies,
+  unifyWithBudget,
 } from "../type-system.js";
+import { localSymbolForSymbolRef } from "../symbol-ref-utils.js";
+import {
+  resolveImportedAliasInferenceTarget,
+  resolveImportedTypeExpr,
+} from "../imports.js";
 import { bindTypeParams as bindTypeParamsFromType } from "../type-relations.js";
 import { typeDescriptorToUserString } from "../type-arena.js";
 import type { ObjectField, TypingContext, TypingState } from "../types.js";
@@ -24,8 +38,18 @@ import {
   reportInaccessibleFieldRequirement,
 } from "../visibility.js";
 import { emitDiagnostic, normalizeSpan } from "../../../diagnostics/index.js";
+import { nominalTypeTargetTypeArgumentsFromMetadata } from "../../nominal-type-target.js";
 
 type StructuralLiteralField = Pick<ObjectField, "name" | "type" | "optional">;
+
+type FieldwiseAliasResolution = {
+  aliasSymbol: SymbolId;
+  namedTarget: HirNamedTypeExpr;
+  target: TypeId;
+  appliedArgs: readonly TypeId[];
+  inferenceParams: readonly TypeParamId[];
+  unresolvedSubstitution: ReadonlyMap<TypeParamId, TypeId>;
+};
 
 export const typeObjectLiteralExpr = (
   expr: HirObjectLiteralExpr,
@@ -34,7 +58,7 @@ export const typeObjectLiteralExpr = (
   expectedType?: TypeId,
 ): TypeId => {
   if (expr.literalKind === "nominal") {
-    return typeNominalObjectLiteral(expr, ctx, state);
+    return typeNominalObjectLiteral(expr, ctx, state, expectedType);
   }
 
   const expectedFields =
@@ -153,19 +177,190 @@ const structuralLiteralFieldForValue = ({
   };
 };
 
+const resolveFieldwiseAliasTarget = ({
+  namedTarget,
+  aliasSymbol,
+  ctx,
+  state,
+}: {
+  namedTarget: HirNamedTypeExpr;
+  aliasSymbol: SymbolId;
+  ctx: TypingContext;
+  state: TypingState;
+}): FieldwiseAliasResolution => {
+  const explicitArgs =
+    namedTarget.typeArguments?.map((arg) =>
+      resolveTypeExpr(arg, ctx, state, ctx.primitives.unknown),
+    ) ?? [];
+  const localTemplate = ctx.typeAliases.getTemplate(aliasSymbol);
+  const metadata = nominalTypeTargetTypeArgumentsFromMetadata({
+    source: ctx.symbolTable.getSymbol(aliasSymbol).metadata,
+  });
+  const knownParamCount = localTemplate
+    ? localTemplate.params.length
+    : metadata?.typeParameterNames.length;
+  const paramCount = knownParamCount ?? explicitArgs.length;
+  const inferenceParams = Array.from(
+    { length: Math.max(0, paramCount - explicitArgs.length) },
+    () => ctx.arena.freshTypeParam(),
+  );
+  const appliedArgs = Array.from(
+    { length: Math.max(paramCount, explicitArgs.length) },
+    (_, index) => {
+      const explicit = explicitArgs[index];
+      if (typeof explicit === "number") {
+        return explicit;
+      }
+      const inference = inferenceParams[index - explicitArgs.length]!;
+      return ctx.arena.internTypeParamRef(inference);
+    },
+  );
+  if (localTemplate && inferenceParams.length > 0) {
+    const typeParamMap = new Map(
+      localTemplate.params.map((param, index) => [
+        param.symbol,
+        appliedArgs[index]!,
+      ]),
+    );
+    localTemplate.params.forEach((param, index) => {
+      const inference = inferenceParams[index - explicitArgs.length];
+      if (!param.constraint || typeof inference !== "number") {
+        return;
+      }
+      const constraint = resolveTypeExpr(
+        param.constraint,
+        ctx,
+        state,
+        ctx.primitives.unknown,
+        typeParamMap,
+      );
+      ctx.typeParameterConstraints.set(inference, constraint);
+    });
+  }
+  const target =
+    !localTemplate && inferenceParams.length > 0
+      ? resolveImportedAliasInferenceTarget({
+          expr: namedTarget,
+          typeArgs: appliedArgs,
+          ctx,
+          state,
+        })
+      : resolveFieldwiseAliasWithArguments({
+          namedTarget,
+          aliasSymbol,
+          typeArgs: appliedArgs,
+          ctx,
+          state,
+        });
+  if (typeof target !== "number") {
+    throw new Error("missing type alias inference target");
+  }
+  return {
+    aliasSymbol,
+    namedTarget,
+    target,
+    appliedArgs,
+    inferenceParams,
+    unresolvedSubstitution: new Map(
+      inferenceParams.map((param) => [param, ctx.primitives.unknown]),
+    ),
+  };
+};
+
+const resolveFieldwiseAliasWithArguments = ({
+  namedTarget,
+  aliasSymbol,
+  typeArgs,
+  ctx,
+  state,
+}: {
+  namedTarget: HirNamedTypeExpr;
+  aliasSymbol: SymbolId;
+  typeArgs: readonly TypeId[];
+  ctx: TypingContext;
+  state: TypingState;
+}): TypeId => {
+  const relaxedState =
+    state.mode === "relaxed" ? state : { ...state, mode: "relaxed" as const };
+  if (ctx.typeAliases.hasTemplate(aliasSymbol)) {
+    return resolveTypeAlias(aliasSymbol, ctx, relaxedState, typeArgs);
+  }
+  const imported = resolveImportedTypeExpr({
+    expr: namedTarget,
+    typeArgs,
+    ctx,
+    state: relaxedState,
+  });
+  if (typeof imported !== "number") {
+    throw new Error("missing imported type alias target");
+  }
+  return imported;
+};
+
 const typeNominalObjectLiteral = (
   expr: HirObjectLiteralExpr,
   ctx: TypingContext,
   state: TypingState,
+  expectedType?: TypeId,
 ): TypeId => {
   const namedTarget =
     expr.target?.typeKind === "named" ? expr.target : undefined;
-  const targetSymbol =
+  const declaredTargetSymbol =
     expr.targetSymbol ??
     namedTarget?.symbol ??
     (namedTarget ? ctx.objects.resolveName(namedTarget.path[0]!) : undefined);
+  const declaredTargetRecord =
+    typeof declaredTargetSymbol === "number"
+      ? ctx.symbolTable.getSymbol(declaredTargetSymbol)
+      : undefined;
+  const isAliasTarget =
+    (declaredTargetRecord?.metadata as { entity?: unknown } | undefined)
+      ?.entity === "type-alias";
+  const aliasResolution =
+    namedTarget && isAliasTarget && typeof declaredTargetSymbol === "number"
+      ? resolveFieldwiseAliasTarget({
+          namedTarget,
+          aliasSymbol: declaredTargetSymbol,
+          ctx,
+          state,
+        })
+      : undefined;
+  const resolvedTarget = aliasResolution?.target;
+  const nominalTarget =
+    typeof resolvedTarget === "number"
+      ? getNominalComponent(resolvedTarget, ctx)
+      : undefined;
+  const nominalTargetDesc =
+    typeof nominalTarget === "number" ? ctx.arena.get(nominalTarget) : undefined;
+  const resolvedTargetSymbol =
+    nominalTargetDesc?.kind === "nominal-object" ||
+    nominalTargetDesc?.kind === "value-object"
+      ? localSymbolForSymbolRef(nominalTargetDesc.owner, ctx)
+      : undefined;
+  const targetSymbol =
+    resolvedTargetSymbol ??
+    declaredTargetSymbol;
   if (typeof targetSymbol !== "number") {
     throw new Error("nominal object literal missing target type");
+  }
+
+  if (
+    isAliasTarget &&
+    typeof resolvedTarget === "number" &&
+    resolvedTarget !== ctx.primitives.unknown &&
+    typeof nominalTarget !== "number"
+  ) {
+    const targetName = namedTarget?.path.at(-1) ?? getSymbolName(targetSymbol, ctx);
+    return emitDiagnostic({
+      ctx,
+      code: "TY0041",
+      params: {
+        kind: "symbol-not-a-value",
+        name: targetName,
+        symbolKind: "type",
+      },
+      span: normalizeSpan(expr.span),
+    });
   }
 
   const template = getObjectTemplate(targetSymbol, ctx, state);
@@ -178,17 +373,27 @@ const typeNominalObjectLiteral = (
     template.fields.map((field) => [field.name, field]),
   );
   const explicitTypeArgs =
-    namedTarget?.typeArguments?.map((arg) =>
-      resolveTypeExpr(arg, ctx, state, ctx.primitives.unknown),
-    ) ?? [];
+    isAliasTarget &&
+    (nominalTargetDesc?.kind === "nominal-object" ||
+      nominalTargetDesc?.kind === "value-object")
+      ? nominalTargetDesc.typeArgs
+      : (namedTarget?.typeArguments?.map((arg) =>
+          resolveTypeExpr(arg, ctx, state, ctx.primitives.unknown),
+        ) ?? []);
+  const typeParamBindings = new Map<TypeParamId, TypeId>();
+  const expectedTypeArgs = expectedNominalTypeArgsForTarget({
+    expectedType,
+    targetSymbol,
+    ctx,
+  });
   const hasExplicitTypeArgsForAllParams =
+    (aliasResolution?.inferenceParams.length ?? 0) === 0 &&
     template.params.length > 0 &&
     template.params.every(
       (_, index) =>
         typeof explicitTypeArgs[index] === "number" &&
         explicitTypeArgs[index] !== ctx.primitives.unknown,
     );
-  const typeParamBindings = new Map<TypeParamId, TypeId>();
 
   if (!hasExplicitTypeArgsForAllParams) {
     withSpeculativeExprTyping(ctx, () => {
@@ -205,14 +410,27 @@ const typeNominalObjectLiteral = (
     });
   }
 
-  const typeArgs = template.params.map((param, index) => {
-    const explicit = explicitTypeArgs[index];
-    if (typeof explicit === "number") {
-      return explicit;
-    }
-    const inferred = typeParamBindings.get(param.typeParam);
-    return inferred ?? ctx.primitives.unknown;
-  });
+  const typeArgs = Array.from(
+    { length: Math.max(template.params.length, explicitTypeArgs.length) },
+    (_, index) => {
+      const param = template.params[index];
+      const explicit = explicitTypeArgs[index];
+      const needsAliasInference =
+        typeof explicit === "number" &&
+        aliasResolution?.unresolvedSubstitution &&
+        ctx.arena.substitute(
+          explicit,
+          aliasResolution.unresolvedSubstitution,
+        ) !== explicit;
+      if (typeof explicit === "number" && !needsAliasInference) {
+        return explicit;
+      }
+      const inferred = param
+        ? typeParamBindings.get(param.typeParam)
+        : undefined;
+      return inferred ?? expectedTypeArgs?.[index] ?? ctx.primitives.unknown;
+    },
+  );
 
   const objectInfo = ensureObjectType(targetSymbol, ctx, state, typeArgs);
   if (!objectInfo) {
@@ -267,7 +485,84 @@ const typeNominalObjectLiteral = (
     expr.entries.map((entry) => getExprEffectRow(entry.value, ctx)),
   );
   ctx.effects.setExprEffect(expr.id, effectRow);
+  if (!aliasResolution || aliasResolution.inferenceParams.length === 0) {
+    return objectInfo.type;
+  }
+
+  const unified = unifyWithBudget({
+    actual: objectInfo.type,
+    expected: resolvedTarget!,
+    options: {
+      location: expr.ast,
+      reason: "fieldwise alias construction",
+      allowUnknown: true,
+    },
+    ctx,
+    span: normalizeSpan(expr.span),
+  });
+  if (!unified.ok) {
+    return objectInfo.type;
+  }
+
+  const inferredAliasArgs = aliasResolution.appliedArgs.map((arg) =>
+    ctx.arena.substitute(arg, unified.substitution),
+  );
+  const hasUnresolvedAliasArg = inferredAliasArgs.some(
+    (arg) =>
+      ctx.arena.substitute(arg, aliasResolution.unresolvedSubstitution) !== arg,
+  );
+  if (hasUnresolvedAliasArg) {
+    const unresolvedCount = inferredAliasArgs.filter(
+      (arg) =>
+        ctx.arena.substitute(arg, aliasResolution.unresolvedSubstitution) !==
+        arg,
+    ).length;
+    throw new Error(
+      `type alias ${ctx.symbolTable.getSymbol(aliasResolution.aliasSymbol).name} is missing ${unresolvedCount} type argument(s)`,
+    );
+  }
+
+  resolveFieldwiseAliasWithArguments({
+    namedTarget: aliasResolution.namedTarget,
+    aliasSymbol: aliasResolution.aliasSymbol,
+    typeArgs: inferredAliasArgs,
+    ctx,
+    state,
+  });
   return objectInfo.type;
+};
+
+const expectedNominalTypeArgsForTarget = ({
+  expectedType,
+  targetSymbol,
+  ctx,
+}: {
+  expectedType?: TypeId;
+  targetSymbol: SymbolId;
+  ctx: TypingContext;
+}): readonly TypeId[] | undefined => {
+  if (
+    typeof expectedType !== "number" ||
+    expectedType === ctx.primitives.unknown
+  ) {
+    return undefined;
+  }
+  const expectedDesc = ctx.arena.get(expectedType);
+  const members = expectedDesc.kind === "union" ? expectedDesc.members : [expectedType];
+  const candidates = members.flatMap((member) => {
+    const nominal = getNominalComponent(member, ctx);
+    if (typeof nominal !== "number") {
+      return [];
+    }
+    const desc = ctx.arena.get(nominal);
+    if (desc.kind !== "nominal-object" && desc.kind !== "value-object") {
+      return [];
+    }
+    return localSymbolForSymbolRef(desc.owner, ctx) === targetSymbol
+      ? [desc.typeArgs]
+      : [];
+  });
+  return candidates.length === 1 ? candidates[0] : undefined;
 };
 
 const bindNominalObjectEntry = ({

--- a/packages/compiler/src/semantics/typing/expressions/object-literal.ts
+++ b/packages/compiler/src/semantics/typing/expressions/object-literal.ts
@@ -505,7 +505,22 @@ const typeNominalObjectLiteral = (
     span: normalizeSpan(expr.span),
   });
   if (!unified.ok) {
-    return objectInfo.type;
+    return emitDiagnostic({
+      ctx,
+      code: "TY0027",
+      params: {
+        kind: "type-mismatch",
+        actual: typeDescriptorToUserString(
+          ctx.arena.get(objectInfo.type),
+          ctx.arena,
+        ),
+        expected: typeDescriptorToUserString(
+          ctx.arena.get(resolvedTarget!),
+          ctx.arena,
+        ),
+      },
+      span: normalizeSpan(expr.span),
+    });
   }
 
   const inferredAliasArgs = aliasResolution.appliedArgs.map((arg) =>

--- a/packages/compiler/src/semantics/typing/expressions/object-literal.ts
+++ b/packages/compiler/src/semantics/typing/expressions/object-literal.ts
@@ -410,8 +410,12 @@ const typeNominalObjectLiteral = (
     });
   }
 
+  const typeArgumentCount =
+    expr.nominalConstruction === "fieldwise-call"
+      ? Math.max(template.params.length, explicitTypeArgs.length)
+      : template.params.length;
   const typeArgs = Array.from(
-    { length: Math.max(template.params.length, explicitTypeArgs.length) },
+    { length: typeArgumentCount },
     (_, index) => {
       const param = template.params[index];
       const explicit = explicitTypeArgs[index];

--- a/packages/compiler/src/semantics/typing/imports.ts
+++ b/packages/compiler/src/semantics/typing/imports.ts
@@ -425,6 +425,110 @@ export const resolveImportedTypeExpr = ({
   return localType;
 };
 
+export const resolveImportedAliasInferenceTarget = ({
+  expr,
+  typeArgs,
+  ctx,
+  state,
+}: {
+  expr: HirNamedTypeExpr;
+  typeArgs: readonly TypeId[];
+  ctx: TypingContext;
+  state: { mode: TypeCheckMode };
+}): TypeId | undefined => {
+  const symbol = expr.symbol;
+  if (typeof symbol !== "number") {
+    return undefined;
+  }
+  const target = importTargetFor(symbol, ctx);
+  const dependency = target ? ctx.dependencies.get(target.moduleId) : undefined;
+  if (!target || !dependency) {
+    return undefined;
+  }
+
+  const depCtx = makeDependencyContext(dependency, ctx);
+  const template = depCtx.typeAliases.getTemplate(target.symbol);
+  if (!template || template.params.length !== typeArgs.length) {
+    return undefined;
+  }
+  const depState = createTypingState(state.mode);
+  const resolveInferenceTarget = (args: readonly TypeId[]): TypeId => {
+    const typeParamMap = new Map(
+      template.params.map((param, index) => [param.symbol, args[index]!]),
+    );
+    template.params.forEach((param, index) => {
+      if (!param.constraint) {
+        return;
+      }
+      const argument = args[index];
+      if (typeof argument !== "number") {
+        return;
+      }
+      const argumentDesc = depCtx.arena.get(argument);
+      if (argumentDesc.kind !== "type-param-ref") {
+        return;
+      }
+      const constraint = resolveTypeExpr(
+        param.constraint,
+        depCtx,
+        depState,
+        depCtx.primitives.unknown,
+        typeParamMap,
+      );
+      depCtx.typeParameterConstraints.set(argumentDesc.param, constraint);
+    });
+    return resolveTypeExpr(
+      template.target,
+      depCtx,
+      depState,
+      depCtx.primitives.unknown,
+      typeParamMap,
+    );
+  };
+
+  if (
+    typingContextsShareInterners({
+      sourceArena: depCtx.arena,
+      targetArena: ctx.arena,
+      sourceEffects: depCtx.effects,
+      targetEffects: ctx.effects,
+    })
+  ) {
+    return resolveInferenceTarget(typeArgs);
+  }
+
+  const forwardParamMap = new Map<TypeParamId, TypeParamId>();
+  const forward = createTranslation({
+    sourceArena: ctx.arena,
+    targetArena: depCtx.arena,
+    sourceEffects: ctx.effects,
+    targetEffects: depCtx.effects,
+    paramMap: forwardParamMap,
+    cache: new Map(),
+    mapSymbol: (owner) =>
+      mapLocalSymbolToDependency({ owner, dependency, ctx }),
+  });
+  const reverseParamMap = new Map<TypeParamId, TypeParamId>();
+  const back = createTranslation({
+    sourceArena: depCtx.arena,
+    targetArena: ctx.arena,
+    sourceEffects: depCtx.effects,
+    targetEffects: ctx.effects,
+    paramMap: reverseParamMap,
+    cache: new Map(),
+    mapSymbol: (owner) =>
+      mapDependencySymbolToLocal({ owner, dependency, ctx }),
+  });
+  const dependencyArgs = typeArgs.map((arg) => forward(arg));
+  forwardParamMap.forEach((targetParam, sourceParam) => {
+    reverseParamMap.set(targetParam, sourceParam);
+  });
+  const dependencyTarget = resolveInferenceTarget(dependencyArgs);
+  const localTarget = back(dependencyTarget);
+  ensureImportedOwnerTemplatesAvailable({ types: [localTarget], ctx });
+  return localTarget;
+};
+
 const resolveImportedAlias = (
   symbol: SymbolId,
   args: readonly TypeId[],

--- a/packages/compiler/src/semantics/typing/types.ts
+++ b/packages/compiler/src/semantics/typing/types.ts
@@ -55,6 +55,7 @@ export interface TypingInputs {
     local: SymbolId;
     target?: { moduleId: string; symbol: SymbolId };
   }[];
+  sourceImportLocals?: readonly SymbolId[];
   moduleId?: string;
   packageId?: string;
   moduleExports?: Map<string, ModuleExportTable>;
@@ -87,6 +88,7 @@ export interface TypingResult {
   callTypeArguments: ReadonlyMap<HirExprId, ReadonlyMap<string, readonly TypeId[]>>;
   callInstanceKeys: ReadonlyMap<HirExprId, ReadonlyMap<string, string>>;
   callTraitDispatches: ReadonlySet<HirExprId>;
+  sourceImportLocals: ReadonlySet<SymbolId>;
   functionInstantiationInfo: ReadonlyMap<
     SymbolRefKey,
     ReadonlyMap<string, readonly TypeId[]>
@@ -711,6 +713,7 @@ export interface TypingContext {
   dependencies: Map<string, DependencySemantics>;
   importsByLocal: Map<SymbolId, { moduleId: string; symbol: SymbolId }>;
   importAliasesByModule: Map<string, Map<SymbolId, SymbolId>>;
+  sourceImportLocals: ReadonlySet<SymbolId>;
   arena: TypeArena;
   table: TypeTable;
   effects: EffectTable;

--- a/packages/compiler/src/semantics/typing/typing.ts
+++ b/packages/compiler/src/semantics/typing/typing.ts
@@ -107,6 +107,7 @@ const snapshotTypingResult = ({
     callTypeArguments: cloneNestedMap(ctx.callResolution.typeArguments),
     callInstanceKeys: cloneNestedMap(ctx.callResolution.instanceKeys),
     callTraitDispatches: new Set(ctx.callResolution.traitDispatches),
+    sourceImportLocals: new Set(ctx.sourceImportLocals),
     functionInstantiationInfo: ctx.functions.snapshotInstantiationInfo(),
     functionInstanceExprTypes: ctx.functions.snapshotInstanceExprTypes(),
     functionInstanceValueTypes: ctx.functions.snapshotInstanceValueTypes(),

--- a/packages/reference/docs/modules.md
+++ b/packages/reference/docs/modules.md
@@ -49,6 +49,19 @@ use src::math::all
 
 Bare paths are not valid in `use` declarations.
 
+The exception is a nominal union or enum alias already in scope. Its member
+namespace can be imported directly, whether the alias is local or imported.
+
+```voyd
+use src::drinks::{ Drink }
+use Drink::{ Coffee, Tea }
+use Drink::all
+```
+
+For a locally declared enum, its variant names are already in the declaring
+module's scope; importing them again is accepted as an idempotent namespace
+selection and is mainly useful for consistency or re-export declarations.
+
 ## Re-exports
 
 Use `pub use` to re-export names.

--- a/packages/reference/docs/types/enums.md
+++ b/packages/reference/docs/types/enums.md
@@ -12,10 +12,12 @@ pub enum MaybeDrink
   Some<T> { value: T }
 ```
 
-Construct variants through the enum namespace.
+Construct variants through the enum namespace. Parentheses provide fieldwise
+construction when the variant does not declare an `init` constructor.
 
 ```voyd
-let drink: MaybeDrink<i32> = MaybeDrink::Some<i32> { value: 10 }
+let first: MaybeDrink<i32> = MaybeDrink::Some<i32>(value: 10)
+let second: MaybeDrink<i32> = MaybeDrink::Some<i32> { value: 10 }
 ```
 
 Unit variants are also valid, including generic unit variants.
@@ -25,7 +27,7 @@ pub enum Signal
   Idle
   Ready<T>
 
-let signal: Signal<i32> = Signal::Ready<i32> {}
+let signal: Signal<i32> = Signal::Ready<i32>()
 ```
 
 Match on enum variants with normal `match` syntax.
@@ -37,6 +39,22 @@ match(drink)
   MaybeDrink::Some { value }:
     value
 ```
+
+When a variant name is not otherwise in scope, a match pattern can infer it
+from the discriminant's enum members.
+
+```voyd
+use src::drinks::{ MaybeDrink }
+
+match(drink)
+  None:
+    0
+  Some { value }:
+    value
+```
+
+Qualify the pattern when another visible type has the same name or when the
+discriminant contains ambiguous instances of the same generic variant.
 
 `enum` is implemented as macro-backed sugar over nominal unions, but the surface
 syntax above is the stable language feature most users should care about.

--- a/packages/reference/docs/types/objects.md
+++ b/packages/reference/docs/types/objects.md
@@ -75,15 +75,32 @@ load_id(user)
 
 ## Constructors
 
-Nominal objects support constructor-literal syntax and `init` overloads.
+Nominal objects support fieldwise construction with braces or labeled call
+arguments.
 
 ```voyd
+obj Empty {}
+
 obj Color {
   x: i32,
   y: i32,
   z: i32
 }
 
+Empty()
+Color(x: 1, y: 2, z: 3)
+Color { x: 1, y: 2, z: 3 }
+```
+
+Fieldwise calls require labels and follow the same field completeness,
+visibility, and type rules as nominal object literals. Optional fields may be
+omitted.
+
+Declaring an `init` opts the type out of implicit fieldwise calls. Parenthesized
+construction then resolves exclusively through the declared `init` overloads,
+while braces remain direct field construction where field visibility permits.
+
+```voyd
 impl Color
   fn init(x: i32, y: i32, z: i32) -> Color
     Color { x, y, z }
@@ -92,7 +109,8 @@ Color { x: 1, y: 2, z: 3 }
 Color(1, 2, 3)
 ```
 
-Constructors also resolve through aliases that target nominal objects.
+Both fieldwise calls and declared constructors resolve through aliases that
+target nominal objects.
 
 ```voyd
 pub type Vec3Alias = Color

--- a/packages/reference/docs/types/unions.md
+++ b/packages/reference/docs/types/unions.md
@@ -58,6 +58,23 @@ match(value)
     0
 ```
 
+An imported union alias also supplies contextual member lookup inside a match,
+so its nominal members do not need separate imports when their names are
+unambiguous and visible.
+
+```voyd
+use src::optional::{ Optional }
+
+match(value)
+  Some { value }:
+    value
+  None:
+    0
+```
+
+Outside a match, import the member or continue to qualify it through the union
+namespace.
+
 ## Same-head variants
 
 Voyd also supports unions whose members share the same nominal head, as long as

--- a/tests/conformance/cases/modules/enum-ergonomics/fruit.voyd
+++ b/tests/conformance/cases/modules/enum-ergonomics/fruit.voyd
@@ -1,0 +1,8 @@
+pub enum Fruit
+  Apple
+  Banana { age: i32 }
+  Orange { age: i32 }
+
+impl Banana
+  pub fn init({ age: i32 }) -> Banana
+    Banana { age: age + 1 }

--- a/tests/conformance/cases/modules/enum-ergonomics/main.voyd
+++ b/tests/conformance/cases/modules/enum-ergonomics/main.voyd
@@ -1,0 +1,51 @@
+use src::fruit::{ Fruit }
+
+obj Empty {}
+obj Person { age: i32 }
+val Count { value: i32 }
+obj Box<T> { value: T }
+type BoxAlias<T> = Box<T>
+
+obj Guarded { value: i32 }
+
+impl Guarded
+  fn init({ value: i32 }) -> Guarded
+    Guarded { value: value + 1 }
+
+type GuardedAlias = Guarded
+
+enum Signal
+  Idle
+  Ready
+
+use Signal::{ Idle, Ready }
+
+fn fruit_age(fruit: Fruit) -> i32
+  match(fruit)
+    Apple:
+      0
+    Banana { age }:
+      age
+    Orange { age }:
+      age
+
+pub fn fieldwise_construction() -> i32
+  let _empty = Empty()
+  let person = Person(age: 5)
+  let count = Count(value: 7)
+  let box = BoxAlias<i32>(value: 9)
+  let guarded = Guarded(value: 1)
+  let guarded_alias = GuardedAlias(value: 1)
+  let orange = Fruit::Orange(age: 2)
+  person.age + count.value + box.value + guarded.value + guarded_alias.value + fruit_age(orange)
+
+pub fn contextual_enum_match() -> i32
+  fruit_age(Fruit::Banana(age: 5))
+
+pub fn local_namespace_use() -> i32
+  let signal: Signal = Ready()
+  match(signal)
+    Idle:
+      0
+    Ready:
+      1

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -959,6 +959,32 @@
       ]
     },
     {
+      "id": "modules.enum-ergonomics",
+      "title": "Enum construction and matching ergonomics",
+      "entry": "cases/modules/enum-ergonomics/main.voyd",
+      "tags": ["modules", "enums", "unions", "runtime"],
+      "cases": [
+        {
+          "id": "modules.enum-ergonomics.fieldwise-construction",
+          "title": "constructs nominal values from labeled fields",
+          "entryName": "fieldwise_construction",
+          "expect": { "kind": "equals", "value": 27 }
+        },
+        {
+          "id": "modules.enum-ergonomics.contextual-match",
+          "title": "resolves imported variants from the match discriminant",
+          "entryName": "contextual_enum_match",
+          "expect": { "kind": "equals", "value": 6 }
+        },
+        {
+          "id": "modules.enum-ergonomics.local-namespace-use",
+          "title": "accepts local enum namespace imports",
+          "entryName": "local_namespace_use",
+          "expect": { "kind": "equals", "value": 1 }
+        }
+      ]
+    },
+    {
       "id": "modules.source-pkg.inline",
       "title": "Inline modules named pkg",
       "entry": "cases/modules/source-level-pkg/src/inline_pkg_module.voyd",


### PR DESCRIPTION
## Summary

- add implicit fieldwise parenthesized construction for nominal objects, values, enum/union members, aliases, and type/module-qualified namespaces while preserving declared init dispatch
- add contextual unqualified match-pattern lookup with visibility, lexical-precedence, generic, and ambiguity handling
- make local and imported union namespaces work through alias, qualified-member, and re-export chains with canonical deduplication
- report bare type symbols in value position as TY0041 during typing
- document the syntax and add compiler plus conformance coverage

## Root cause

Parenthesized syntax previously entered ordinary call lowering only, so a nominal type without init had no callable value even though brace syntax had a separate nominal-literal path. Enum members are emitted as nominal object types and aliases, which exposed that inconsistency. The type-as-value issue was separate: cached value typing was consulted before validating the symbol kind, allowing a cached type symbol to reach codegen.

## Validation

- npm test
- npm run typecheck
- npm run test:codegen
- npm run test:audit
- npm run lint
- full conformance suite
- repeated implementation-gap, architecture, and correctness review stages until clean

## Follow-up

- V-425 tracks contextual effect-operation lookup parity for handler clauses.