### PR TITLE
Fix local bootstrap dependency resolution

### DIFF
--- a/apps/cli/src/__tests__/arg-parser.test.ts
+++ b/apps/cli/src/__tests__/arg-parser.test.ts
@@ -118,18 +118,20 @@ describe("getConfigFromCli", () => {
     expect(config.bootstrapTemplate).toBe("web-ssr");
   });
 
-  it("supports bootstrap dry-run and force flags", () => {
+  it("supports bootstrap dry-run, force, and published-package flags", () => {
     const config = runWithArgv([
       "node",
       "voyd",
       "bootstrap",
       "--dry-run",
       "--force",
+      "--published",
     ]);
     expect(config.bootstrap).toBe(true);
     expect(config.bootstrapDir).toBe(".");
     expect(config.bootstrapDryRun).toBe(true);
     expect(config.bootstrapForce).toBe(true);
+    expect(config.bootstrapUsePublished).toBe(true);
   });
 
   it("parses package adapter and application registry generation", () => {

--- a/apps/cli/src/__tests__/bootstrap.test.ts
+++ b/apps/cli/src/__tests__/bootstrap.test.ts
@@ -1,14 +1,20 @@
 // @vitest-environment happy-dom
 
+import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { createSdk, type CompileResult } from "@voyd-lang/sdk";
 import { createVoydHost } from "@voyd-lang/sdk/js-host";
 import { createVxDomRenderer } from "@voyd-lang/vx-dom";
-import { printBootstrapResult, runBootstrap } from "../bootstrap/index.js";
+import {
+  detectLocalVoydRoot,
+  printBootstrapResult,
+  runBootstrap,
+} from "../bootstrap/index.js";
 
 const createTempDir = () => mkdtemp(resolve(tmpdir(), "voyd-bootstrap-"));
 const repoRoot = resolve(import.meta.dirname, "../../../..");
@@ -25,6 +31,29 @@ const expectCompileSuccess = (
 };
 
 describe("runBootstrap", () => {
+  it("detects a local checkout by root package name and otherwise falls back", async () => {
+    const root = await createTempDir();
+    const moduleUrl = pathToFileURL(
+      resolve(root, "apps/cli/dist/bootstrap/index.js"),
+    ).href;
+    const packagePath = resolve(root, "package.json");
+    try {
+      await writeFile(packagePath, JSON.stringify({ name: "voyd-monorepo" }));
+      expect(detectLocalVoydRoot(moduleUrl)).toBe(root);
+
+      await writeFile(packagePath, JSON.stringify({ name: "some-other-project" }));
+      expect(detectLocalVoydRoot(moduleUrl)).toBeUndefined();
+
+      await writeFile(packagePath, "not json");
+      expect(detectLocalVoydRoot(moduleUrl)).toBeUndefined();
+
+      await rm(packagePath);
+      expect(detectLocalVoydRoot(moduleUrl)).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("scaffolds the vx-spa starter", async () => {
     const root = await createTempDir();
     const target = resolve(root, "my app");
@@ -35,6 +64,7 @@ describe("runBootstrap", () => {
       });
 
       expect(result.targetDir).toBe(target);
+      expect(result.localVoydRoot).toBe(repoRoot);
       expect(result.files).toContain("index.html");
       expect(result.files).toContain("src/main.voyd");
       expect(result.files).toContain("src/app/model.voyd");
@@ -54,7 +84,11 @@ describe("runBootstrap", () => {
       expect(packageJson.scripts.dev).toBe("vite");
       expect(packageJson.scripts.build).toBe("npm run typecheck && vite build");
       expect(packageJson.scripts.typecheck).toBe("npm run voyd:build && tsc --noEmit");
-      expect(packageJson.dependencies["@voyd-lang/vx-dom"]).toMatch(/^\^/);
+      expect(packageJson.dependencies["@voyd-lang/sdk"]).toContain("packages/sdk");
+      expect(packageJson.dependencies["@voyd-lang/vx-dom"]).toContain("packages/vx-dom");
+      expect(packageJson.dependencies["@voyd-lang/compiler"]).toContain("packages/compiler");
+      expect(packageJson.devDependencies["@voyd-lang/cli"]).toContain("apps/cli");
+      expect(packageJson.devDependencies.tsx).toBe("^4.20.4");
       expect(packageJson.devDependencies.tailwindcss).toBe("^4.3.0");
       expect(packageJson.devDependencies["@tailwindcss/vite"]).toBe("^4.3.0");
 
@@ -67,10 +101,15 @@ describe("runBootstrap", () => {
       expect(viteConfig).toContain("while (completedCompilation < requestedCompilation)");
       expect(viteConfig).toContain("if (await compileLatest())");
       expect(viteConfig).toContain('includes("/src/generated/")');
+      expect(viteConfig).toContain('resolve: { conditions: ["development"] }');
 
       const compileScript = await readFile(resolve(target, "scripts/compile-voyd.mjs"), "utf8");
       expect(compileScript).toContain('resolve(rootDir, "src/generated/.staging")');
       expect(compileScript).toContain("promoteGeneratedFiles");
+
+      const runVoyd = await readFile(resolve(target, "scripts/run-voyd.mjs"), "utf8");
+      expect(runVoyd).toContain("const useVoydSources = true");
+      expect(runVoyd).toContain('VOYD_DEV: "1"');
 
       const css = await readFile(resolve(target, "src/style.css"), "utf8");
       expect(css).toContain('@import "tailwindcss";');
@@ -102,10 +141,12 @@ describe("runBootstrap", () => {
       });
 
       expect(result.targetDir).toBe(target);
+      expect(result.localVoydRoot).toBe(repoRoot);
       expect(result.files).toContain("src/main.voyd");
       expect(result.files).toContain("src/client.ts");
       expect(result.files).toContain("src/app/ui.voyd");
       expect(result.files).toContain("src/server/page.voyd");
+      expect(result.files).toContain("scripts/diagnostics.mjs");
       expect(result.files).toContain("data/articles/home.md");
       expect(result.nextSteps).toEqual(["npm install", "npm run dev"]);
 
@@ -118,13 +159,18 @@ describe("runBootstrap", () => {
         devDependencies: Record<string, string>;
       };
       expect(packageJson.name).toBe("mini-wiki");
-      expect(packageJson.scripts.dev).toBe("node scripts/dev.mjs");
-      expect(packageJson.scripts.build).toBe(
-        "npm run typecheck && vite build && node scripts/check-voyd.mjs",
+      expect(packageJson.scripts.dev).toBe(
+        "node --conditions=development --import tsx scripts/dev.mjs",
       );
-      expect(packageJson.dependencies["@voyd-lang/web"]).toMatch(/^\^/);
-      expect(packageJson.dependencies["@voyd-lang/vx-dom"]).toMatch(/^\^/);
-      expect(packageJson.devDependencies["@voyd-lang/cli"]).toMatch(/^\^/);
+      expect(packageJson.scripts.build).toBe(
+        "npm run typecheck && vite build && node --conditions=development --import tsx scripts/check-voyd.mjs",
+      );
+      expect(packageJson.dependencies["@voyd-lang/web"]).toContain("packages/web");
+      expect(packageJson.dependencies["@voyd-lang/vx-dom"]).toContain("packages/vx-dom");
+      expect(packageJson.dependencies["@voyd-lang/compiler"]).toContain("packages/compiler");
+      expect(packageJson.dependencies["@voyd-lang/std"]).toContain("packages/std");
+      expect(packageJson.devDependencies["@voyd-lang/cli"]).toContain("apps/cli");
+      expect(packageJson.devDependencies.tsx).toBe("^4.20.4");
       expect(packageJson.devDependencies.tailwindcss).toBe("^4.3.0");
       expect(packageJson.devDependencies["@tailwindcss/vite"]).toBe("^4.3.0");
 
@@ -135,11 +181,54 @@ describe("runBootstrap", () => {
       expect(serverScript).toContain('process.once("SIGINT"');
       expect(serverScript).toContain("app.closed.then");
       expect(serverScript).toContain("Voyd server stopped unexpectedly");
+      expect(serverScript).toContain("throw compilationError(result.diagnostics)");
+      expect(serverScript).toContain("console.error(errorMessage(error))");
+
+      const diagnosticsPath = resolve(target, "scripts/diagnostics.mjs");
+      const pagePath = resolve(target, "src/server/page.voyd");
+      const pageSource = await readFile(pagePath, "utf8");
+      const diagnosticStart = pageSource.indexOf("Response::ok()");
+      const diagnostic = {
+        code: "TY0006",
+        message: "function 'missing' is not defined",
+        severity: "error",
+        phase: "typing",
+        span: {
+          file: pagePath,
+          start: diagnosticStart,
+          end: diagnosticStart + "Response::ok".length,
+        },
+      };
+      const diagnosticLine = pageSource.slice(0, diagnosticStart).split("\n").length;
+      const diagnosticColumn = diagnosticStart -
+        pageSource.lastIndexOf("\n", diagnosticStart - 1);
+      const diagnosticsProbe = [
+        `const diagnostics = await import(${JSON.stringify(pathToFileURL(diagnosticsPath).href)});`,
+        `const diagnostic = ${JSON.stringify(diagnostic)};`,
+        "const error = diagnostics.compilationError([diagnostic]);",
+        "console.log(JSON.stringify({",
+        "  formatted: diagnostics.formatDiagnostic(diagnostic),",
+        "  message: diagnostics.errorMessage(error),",
+        "}));",
+      ].join("\n");
+      const diagnosticsResult = JSON.parse(execFileSync(
+        process.execPath,
+        ["--input-type=module", "--eval", diagnosticsProbe],
+        { encoding: "utf8" },
+      )) as { formatted: string; message: string };
+      const formattedDiagnostic = diagnosticsResult.formatted;
+      expect(formattedDiagnostic).toContain(
+        `${pagePath}:${diagnosticLine}:${diagnosticColumn}`,
+      );
+      expect(formattedDiagnostic).toContain("TY0006: function 'missing' is not defined");
+      expect(diagnosticsResult.message).toBe(formattedDiagnostic);
 
       const readme = await readFile(resolve(target, "README.md"), "utf8");
       expect(readme).toContain("npm run dev");
       expect(readme).toContain("src/app");
       expect(readme).toContain("render identically");
+      expect(readme).toContain(repoRoot);
+      expect(readme).toContain("links the complete local Voyd dependency set");
 
       const gitignore = await readFile(resolve(target, ".gitignore"), "utf8");
       expect(gitignore).toContain("data/articles/*.md");
@@ -155,6 +244,7 @@ describe("runBootstrap", () => {
       expect(devScript).toContain("/\\.(voyd|ts|css)$/");
       expect(devScript).toContain("void queueRebuild()");
       expect(devScript).toContain("while (rebuildRequested)");
+      expect(devScript).toContain("console.error(errorMessage(error))");
       expect(devScript).toContain("await checkServer({ optimize: false })");
       expect(devScript.indexOf("await checkServer")).toBeLessThan(
         devScript.indexOf('await run("vite"'),
@@ -179,11 +269,13 @@ describe("runBootstrap", () => {
       const checkScript = await readFile(resolve(target, "scripts/check-voyd.mjs"), "utf8");
       expect(checkScript).toContain("optimize: true");
       expect(checkScript).toContain("compileClient");
+      expect(checkScript).toContain('from "./diagnostics.mjs"');
 
       const viteConfig = await readFile(resolve(target, "vite.config.mjs"), "utf8");
       expect(viteConfig).toContain("compileClient");
       expect(viteConfig).toContain('entryFileNames: "assets/client.js"');
       expect(viteConfig).toContain('assetFileNames: "assets/[name][extname]"');
+      expect(viteConfig).toContain('resolve: { conditions: ["development"] }');
 
       const clientTs = await readFile(resolve(target, "src/client.ts"), "utf8");
       expect(clientTs).toContain("createVoydHost");
@@ -211,6 +303,8 @@ describe("runBootstrap", () => {
       expect(pageVoyd).toContain("src::app::ui::view");
       expect(pageVoyd).toContain('<div id="article-editor">{view(model)}</div>');
       expect(pageVoyd).not.toContain("static_view");
+      expect(pageVoyd).toContain("document(");
+      expect(pageVoyd).toContain("hydrate_named<Model>(");
       expect(pageVoyd).toContain('id: "article-editor"');
 
       const css = await readFile(resolve(target, "src/style.css"), "utf8");
@@ -296,6 +390,40 @@ pub fn client_tree() -> Html<Msg>
     }
   }, 300_000);
 
+  it("can scaffold against published Voyd packages from a local checkout", async () => {
+    const root = await createTempDir();
+    const target = resolve(root, "published-app");
+    try {
+      const result = await runBootstrap({
+        dir: target,
+        template: "web-ssr",
+        usePublished: true,
+      });
+      expect(result.localVoydRoot).toBeUndefined();
+
+      const packageJson = JSON.parse(
+        await readFile(resolve(target, "package.json"), "utf8"),
+      ) as {
+        scripts: Record<string, string>;
+        dependencies: Record<string, string>;
+        devDependencies: Record<string, string>;
+      };
+      expect(packageJson.scripts.dev).toBe("node scripts/dev.mjs");
+      expect(packageJson.dependencies["@voyd-lang/sdk"]).toMatch(/^\^/);
+      expect(packageJson.dependencies["@voyd-lang/web"]).toMatch(/^\^/);
+      expect(packageJson.dependencies["@voyd-lang/compiler"]).toBeUndefined();
+      expect(packageJson.devDependencies["@voyd-lang/cli"]).toMatch(/^\^/);
+      expect(packageJson.devDependencies.tsx).toBeUndefined();
+
+      const runVoyd = await readFile(resolve(target, "scripts/run-voyd.mjs"), "utf8");
+      expect(runVoyd).toContain("const useVoydSources = false");
+      const viteConfig = await readFile(resolve(target, "vite.config.mjs"), "utf8");
+      expect(viteConfig).not.toContain('conditions: ["development"]');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("prints a dry run without writing files", async () => {
     const root = await createTempDir();
     const target = resolve(root, "dry-run-app");
@@ -359,6 +487,7 @@ pub fn client_tree() -> Html<Msg>
         targetDir: "/tmp/my app",
         template: "vx-spa",
         dryRun: false,
+        localVoydRoot: undefined,
         files: ["package.json"],
         nextSteps: ["npm install"],
       });

--- a/apps/cli/src/__tests__/bootstrap.test.ts
+++ b/apps/cli/src/__tests__/bootstrap.test.ts
@@ -87,6 +87,10 @@ describe("runBootstrap", () => {
       expect(packageJson.dependencies["@voyd-lang/sdk"]).toContain("packages/sdk");
       expect(packageJson.dependencies["@voyd-lang/vx-dom"]).toContain("packages/vx-dom");
       expect(packageJson.dependencies["@voyd-lang/compiler"]).toContain("packages/compiler");
+      expect(packageJson.dependencies["@msgpack/msgpack"]).toBe("^3.1.2");
+      expect(packageJson.dependencies.binaryen).toBe("^125.0.0");
+      expect(packageJson.dependencies.commander).toBe("^14.0.0");
+      expect(packageJson.dependencies["import-meta-resolve"]).toBe("^4.2.0");
       expect(packageJson.devDependencies["@voyd-lang/cli"]).toContain("apps/cli");
       expect(packageJson.devDependencies.tsx).toBe("^4.20.4");
       expect(packageJson.devDependencies.tailwindcss).toBe("^4.3.0");
@@ -94,6 +98,7 @@ describe("runBootstrap", () => {
 
       const tsConfig = await readFile(resolve(target, "tsconfig.json"), "utf8");
       expect(tsConfig).not.toContain('"node"');
+      expect(tsConfig).toContain('"preserveSymlinks": true');
 
       const viteConfig = await readFile(resolve(target, "vite.config.mjs"), "utf8");
       expect(viteConfig).toContain("compileVoyd");
@@ -101,7 +106,9 @@ describe("runBootstrap", () => {
       expect(viteConfig).toContain("while (completedCompilation < requestedCompilation)");
       expect(viteConfig).toContain("if (await compileLatest())");
       expect(viteConfig).toContain('includes("/src/generated/")');
-      expect(viteConfig).toContain('resolve: { conditions: ["development"] }');
+      expect(viteConfig).toContain(
+        'resolve: { conditions: ["development"], preserveSymlinks: true }',
+      );
 
       const compileScript = await readFile(resolve(target, "scripts/compile-voyd.mjs"), "utf8");
       expect(compileScript).toContain('resolve(rootDir, "src/generated/.staging")');
@@ -110,6 +117,13 @@ describe("runBootstrap", () => {
       const runVoyd = await readFile(resolve(target, "scripts/run-voyd.mjs"), "utf8");
       expect(runVoyd).toContain("const useVoydSources = true");
       expect(runVoyd).toContain('VOYD_DEV: "1"');
+      expect(runVoyd).toContain(
+        '"--preserve-symlinks --preserve-symlinks-main"',
+      );
+      expect(runVoyd).toContain("NODE_OPTIONS: nodeOptions");
+      expect(runVoyd).toContain(
+        'resolve(cwd, "node_modules/@voyd-lang/cli/bin/voyd.js")',
+      );
 
       const css = await readFile(resolve(target, "src/style.css"), "utf8");
       expect(css).toContain('@import "tailwindcss";');
@@ -160,15 +174,19 @@ describe("runBootstrap", () => {
       };
       expect(packageJson.name).toBe("mini-wiki");
       expect(packageJson.scripts.dev).toBe(
-        "node --conditions=development --import tsx scripts/dev.mjs",
+        "node --preserve-symlinks --preserve-symlinks-main --conditions=development --import tsx scripts/dev.mjs",
       );
       expect(packageJson.scripts.build).toBe(
-        "npm run typecheck && vite build && node --conditions=development --import tsx scripts/check-voyd.mjs",
+        "npm run typecheck && vite build && node --preserve-symlinks --preserve-symlinks-main --conditions=development --import tsx scripts/check-voyd.mjs",
       );
       expect(packageJson.dependencies["@voyd-lang/web"]).toContain("packages/web");
       expect(packageJson.dependencies["@voyd-lang/vx-dom"]).toContain("packages/vx-dom");
       expect(packageJson.dependencies["@voyd-lang/compiler"]).toContain("packages/compiler");
       expect(packageJson.dependencies["@voyd-lang/std"]).toContain("packages/std");
+      expect(packageJson.dependencies["@msgpack/msgpack"]).toBe("^3.1.2");
+      expect(packageJson.dependencies.binaryen).toBe("^125.0.0");
+      expect(packageJson.dependencies.commander).toBe("^14.0.0");
+      expect(packageJson.dependencies["import-meta-resolve"]).toBe("^4.2.0");
       expect(packageJson.devDependencies["@voyd-lang/cli"]).toContain("apps/cli");
       expect(packageJson.devDependencies.tsx).toBe("^4.20.4");
       expect(packageJson.devDependencies.tailwindcss).toBe("^4.3.0");
@@ -275,7 +293,21 @@ describe("runBootstrap", () => {
       expect(viteConfig).toContain("compileClient");
       expect(viteConfig).toContain('entryFileNames: "assets/client.js"');
       expect(viteConfig).toContain('assetFileNames: "assets/[name][extname]"');
-      expect(viteConfig).toContain('resolve: { conditions: ["development"] }');
+      expect(viteConfig).toContain(
+        'resolve: { conditions: ["development"], preserveSymlinks: true }',
+      );
+
+      const tsConfig = await readFile(resolve(target, "tsconfig.json"), "utf8");
+      expect(tsConfig).toContain('"preserveSymlinks": true');
+
+      const runVoyd = await readFile(resolve(target, "scripts/run-voyd.mjs"), "utf8");
+      expect(runVoyd).toContain(
+        '"--preserve-symlinks --preserve-symlinks-main"',
+      );
+      expect(runVoyd).toContain("NODE_OPTIONS: nodeOptions");
+      expect(runVoyd).toContain(
+        'resolve(cwd, "node_modules/@voyd-lang/cli/bin/voyd.js")',
+      );
 
       const clientTs = await readFile(resolve(target, "src/client.ts"), "utf8");
       expect(clientTs).toContain("createVoydHost");
@@ -412,13 +444,19 @@ pub fn client_tree() -> Html<Msg>
       expect(packageJson.dependencies["@voyd-lang/sdk"]).toMatch(/^\^/);
       expect(packageJson.dependencies["@voyd-lang/web"]).toMatch(/^\^/);
       expect(packageJson.dependencies["@voyd-lang/compiler"]).toBeUndefined();
+      expect(packageJson.dependencies["@msgpack/msgpack"]).toBeUndefined();
+      expect(packageJson.dependencies.binaryen).toBeUndefined();
       expect(packageJson.devDependencies["@voyd-lang/cli"]).toMatch(/^\^/);
       expect(packageJson.devDependencies.tsx).toBeUndefined();
 
       const runVoyd = await readFile(resolve(target, "scripts/run-voyd.mjs"), "utf8");
       expect(runVoyd).toContain("const useVoydSources = false");
+      expect(runVoyd).toContain("if (!useVoydSources) return process.env");
       const viteConfig = await readFile(resolve(target, "vite.config.mjs"), "utf8");
       expect(viteConfig).not.toContain('conditions: ["development"]');
+      expect(viteConfig).not.toContain("preserveSymlinks");
+      const tsConfig = await readFile(resolve(target, "tsconfig.json"), "utf8");
+      expect(tsConfig).not.toContain("preserveSymlinks");
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/apps/cli/src/bootstrap/index.ts
+++ b/apps/cli/src/bootstrap/index.ts
@@ -1,6 +1,8 @@
 import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
 import { mkdir, readdir, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import type { BootstrapTemplate } from "../config/types.js";
 import { webSsrLoader } from "./loaders/web-ssr.js";
 import { vxSpaLoader } from "./loaders/vx-spa.js";
@@ -10,15 +12,29 @@ import type {
   BootstrapLoader,
   BootstrapPlan,
   BootstrapResult,
+  BootstrapVoydPackage,
 } from "./types.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../../package.json") as { version: string };
+const VOYD_MONOREPO_PACKAGE_NAME = "voyd-monorepo";
 
 const loaders = new Map<BootstrapTemplate, BootstrapLoader>([
   [vxSpaLoader.id, vxSpaLoader],
   [webSsrLoader.id, webSsrLoader],
 ]);
+
+const voydWorkspacePaths: Record<BootstrapVoydPackage, string> = {
+  "@voyd-lang/cli": "apps/cli",
+  "@voyd-lang/compiler": "packages/compiler",
+  "@voyd-lang/js-host": "packages/js-host",
+  "@voyd-lang/lib": "packages/lib",
+  "@voyd-lang/package-adapter": "packages/package-adapter",
+  "@voyd-lang/sdk": "packages/sdk",
+  "@voyd-lang/std": "packages/std",
+  "@voyd-lang/vx-dom": "packages/vx-dom",
+  "@voyd-lang/web": "packages/web",
+};
 
 export async function runBootstrap(
   config: BootstrapConfig,
@@ -29,7 +45,11 @@ export async function runBootstrap(
     throw new Error(`Unknown bootstrap template: ${config.template}`);
   }
 
-  const plan = loader.plan(createContext(targetDir));
+  const context = createContext({
+    targetDir,
+    usePublished: config.usePublished ?? false,
+  });
+  const plan = loader.plan(context);
   if (!config.force && !config.dryRun) {
     await assertTargetWritable(targetDir);
   }
@@ -42,6 +62,7 @@ export async function runBootstrap(
     targetDir,
     template: plan.template,
     dryRun: config.dryRun ?? false,
+    localVoydRoot: context.localVoydRoot,
     files: plan.files.map((file) => file.path),
     nextSteps: plan.nextSteps,
   };
@@ -50,6 +71,9 @@ export async function runBootstrap(
 export function printBootstrapResult(result: BootstrapResult): void {
   const verb = result.dryRun ? "Would create" : "Created";
   console.log(`${verb} ${result.template} project in ${result.targetDir}`);
+  if (result.localVoydRoot) {
+    console.log(`Using local Voyd packages from ${result.localVoydRoot}`);
+  }
   console.log("");
   result.files.forEach((file) => console.log(`  ${file}`));
 
@@ -63,11 +87,41 @@ export function printBootstrapResult(result: BootstrapResult): void {
   result.nextSteps.forEach((step) => console.log(`  ${step}`));
 }
 
-const createContext = (targetDir: string): BootstrapContext => ({
+const createContext = ({
   targetDir,
-  packageName: toPackageName(basename(targetDir)),
-  voydVersion: version,
-});
+  usePublished,
+}: {
+  targetDir: string;
+  usePublished: boolean;
+}): BootstrapContext => {
+  const localVoydRoot = usePublished ? undefined : detectLocalVoydRoot();
+  return {
+    targetDir,
+    packageName: toPackageName(basename(targetDir)),
+    voydVersion: version,
+    localVoydRoot,
+    voydPackageSpec: (name) => localVoydRoot
+      ? pathToFileURL(resolve(localVoydRoot, voydWorkspacePaths[name])).href
+      : `^${version}`,
+  };
+};
+
+export const detectLocalVoydRoot = (
+  moduleUrl: string = import.meta.url,
+): string | undefined => {
+  const moduleDir = dirname(fileURLToPath(moduleUrl));
+  const candidate = resolve(moduleDir, "../../../..");
+  try {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(candidate, "package.json"), "utf8"),
+    ) as { name?: unknown };
+    return packageJson.name === VOYD_MONOREPO_PACKAGE_NAME
+      ? candidate
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 const toPackageName = (value: string): string => {
   const normalized = value

--- a/apps/cli/src/bootstrap/index.ts
+++ b/apps/cli/src/bootstrap/index.ts
@@ -94,16 +94,57 @@ const createContext = ({
   targetDir: string;
   usePublished: boolean;
 }): BootstrapContext => {
-  const localVoydRoot = usePublished ? undefined : detectLocalVoydRoot();
+  const detectedLocalVoydRoot = usePublished ? undefined : detectLocalVoydRoot();
+  const localVoydExternalDependencies = detectedLocalVoydRoot
+    ? tryReadLocalVoydExternalDependencies(detectedLocalVoydRoot)
+    : undefined;
+  const localVoydRoot = localVoydExternalDependencies
+    ? detectedLocalVoydRoot
+    : undefined;
   return {
     targetDir,
     packageName: toPackageName(basename(targetDir)),
     voydVersion: version,
     localVoydRoot,
+    localVoydExternalDependencies: localVoydExternalDependencies ?? {},
     voydPackageSpec: (name) => localVoydRoot
       ? pathToFileURL(resolve(localVoydRoot, voydWorkspacePaths[name])).href
       : `^${version}`,
   };
+};
+
+const tryReadLocalVoydExternalDependencies = (
+  localVoydRoot: string,
+): Record<string, string> | undefined => {
+  try {
+    return readLocalVoydExternalDependencies(localVoydRoot);
+  } catch {
+    return undefined;
+  }
+};
+
+const readLocalVoydExternalDependencies = (
+  localVoydRoot: string,
+): Record<string, string> => {
+  const voydPackageNames = new Set(Object.keys(voydWorkspacePaths));
+  return Object.values(voydWorkspacePaths)
+    .flatMap((workspacePath) => {
+      const packageJson = JSON.parse(
+        readFileSync(resolve(localVoydRoot, workspacePath, "package.json"), "utf8"),
+      ) as { dependencies?: Record<string, string> };
+      return Object.entries(packageJson.dependencies ?? {})
+        .filter(([name]) => !voydPackageNames.has(name));
+    })
+    .reduce<Record<string, string>>((dependencies, [name, spec]) => {
+      const previousSpec = dependencies[name];
+      if (previousSpec && previousSpec !== spec) {
+        throw new Error(
+          `Local Voyd packages require conflicting versions of ${name}: ${previousSpec} and ${spec}`,
+        );
+      }
+      dependencies[name] = spec;
+      return dependencies;
+    }, {});
 };
 
 export const detectLocalVoydRoot = (

--- a/apps/cli/src/bootstrap/loaders/vx-spa.ts
+++ b/apps/cli/src/bootstrap/loaders/vx-spa.ts
@@ -1,18 +1,22 @@
-import type { BootstrapLoader, BootstrapPlan } from "../types.js";
+import type {
+  BootstrapContext,
+  BootstrapLoader,
+  BootstrapPlan,
+} from "../types.js";
 
 export const vxSpaLoader: BootstrapLoader = {
   id: "vx-spa",
   description: "Vite + VX single-page app",
-  plan: ({ packageName, voydVersion }): BootstrapPlan => ({
+  plan: (context): BootstrapPlan => ({
     template: "vx-spa",
     files: [
       { path: "index.html", content: indexHtml },
-      { path: "package.json", content: packageJson(packageName, voydVersion) },
-      { path: "vite.config.mjs", content: viteConfig },
+      { path: "package.json", content: packageJson(context) },
+      { path: "vite.config.mjs", content: viteConfig(!!context.localVoydRoot) },
       { path: "tsconfig.json", content: tsConfig },
       { path: ".gitignore", content: gitIgnore },
       { path: "scripts/compile-voyd.mjs", content: compileVoydScript },
-      { path: "scripts/run-voyd.mjs", content: runVoydScript },
+      { path: "scripts/run-voyd.mjs", content: runVoydScript(!!context.localVoydRoot) },
       { path: "src/main.ts", content: mainTs },
       { path: "src/main.voyd", content: mainVoyd },
       { path: "src/app.voyd", content: appModuleVoyd },
@@ -25,9 +29,17 @@ export const vxSpaLoader: BootstrapLoader = {
   }),
 };
 
-const packageJson = (packageName: string, voydVersion: string): string =>
-  `${JSON.stringify({
-    name: packageName,
+const packageJson = (context: BootstrapContext): string => {
+  const localDependencies = context.localVoydRoot ? {
+    "@voyd-lang/compiler": context.voydPackageSpec("@voyd-lang/compiler"),
+    "@voyd-lang/js-host": context.voydPackageSpec("@voyd-lang/js-host"),
+    "@voyd-lang/lib": context.voydPackageSpec("@voyd-lang/lib"),
+    "@voyd-lang/package-adapter": context.voydPackageSpec("@voyd-lang/package-adapter"),
+    "@voyd-lang/std": context.voydPackageSpec("@voyd-lang/std"),
+  } : {};
+  const localDevDependencies = context.localVoydRoot ? { tsx: "^4.20.4" } : {};
+  return `${JSON.stringify({
+    name: context.packageName,
     private: true,
     type: "module",
     scripts: {
@@ -38,17 +50,20 @@ const packageJson = (packageName: string, voydVersion: string): string =>
       typecheck: "npm run voyd:build && tsc --noEmit",
     },
     dependencies: {
-      "@voyd-lang/sdk": `^${voydVersion}`,
-      "@voyd-lang/vx-dom": `^${voydVersion}`,
+      "@voyd-lang/sdk": context.voydPackageSpec("@voyd-lang/sdk"),
+      "@voyd-lang/vx-dom": context.voydPackageSpec("@voyd-lang/vx-dom"),
+      ...localDependencies,
     },
     devDependencies: {
       "@tailwindcss/vite": "^4.3.0",
-      "@voyd-lang/cli": `^${voydVersion}`,
+      "@voyd-lang/cli": context.voydPackageSpec("@voyd-lang/cli"),
       tailwindcss: "^4.3.0",
+      ...localDevDependencies,
       typescript: "^5.8.3",
       vite: "^8.0.0",
     },
   }, null, 2)}\n`;
+};
 
 const tsConfig = `${JSON.stringify({
   compilerOptions: {
@@ -84,7 +99,8 @@ const indexHtml = `<!doctype html>
 </html>
 `;
 
-const viteConfig = `import tailwindcss from "@tailwindcss/vite";
+const viteConfig = (useVoydSources: boolean): string =>
+  `import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 import { compileVoyd } from "./scripts/compile-voyd.mjs";
 
@@ -123,16 +139,20 @@ const voyd = () => ({
 
 export default defineConfig({
   plugins: [voyd(), tailwindcss()],
-});
+${useVoydSources ? '  resolve: { conditions: ["development"] },\n' : ""}});
 `;
 
-const runVoydScript = `import { spawn } from "node:child_process";
+const runVoydScript = (useVoydSources: boolean): string =>
+  `import { spawn } from "node:child_process";
+
+const useVoydSources = ${useVoydSources};
 
 export function runVoyd(args, { cwd }) {
   const command = process.platform === "win32" ? "voyd.cmd" : "voyd";
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd,
+      env: useVoydSources ? { ...process.env, VOYD_DEV: "1" } : process.env,
       stdio: ["ignore", "pipe", "pipe"],
     });
     const stdout = [];

--- a/apps/cli/src/bootstrap/loaders/vx-spa.ts
+++ b/apps/cli/src/bootstrap/loaders/vx-spa.ts
@@ -13,7 +13,7 @@ export const vxSpaLoader: BootstrapLoader = {
       { path: "index.html", content: indexHtml },
       { path: "package.json", content: packageJson(context) },
       { path: "vite.config.mjs", content: viteConfig(!!context.localVoydRoot) },
-      { path: "tsconfig.json", content: tsConfig },
+      { path: "tsconfig.json", content: tsConfig(!!context.localVoydRoot) },
       { path: ".gitignore", content: gitIgnore },
       { path: "scripts/compile-voyd.mjs", content: compileVoydScript },
       { path: "scripts/run-voyd.mjs", content: runVoydScript(!!context.localVoydRoot) },
@@ -50,6 +50,7 @@ const packageJson = (context: BootstrapContext): string => {
       typecheck: "npm run voyd:build && tsc --noEmit",
     },
     dependencies: {
+      ...context.localVoydExternalDependencies,
       "@voyd-lang/sdk": context.voydPackageSpec("@voyd-lang/sdk"),
       "@voyd-lang/vx-dom": context.voydPackageSpec("@voyd-lang/vx-dom"),
       ...localDependencies,
@@ -65,24 +66,26 @@ const packageJson = (context: BootstrapContext): string => {
   }, null, 2)}\n`;
 };
 
-const tsConfig = `${JSON.stringify({
-  compilerOptions: {
-    target: "ES2022",
-    useDefineForClassFields: true,
-    module: "ESNext",
-    lib: ["ES2022", "DOM", "DOM.Iterable"],
-    types: ["vite/client"],
-    skipLibCheck: true,
-    moduleResolution: "bundler",
-    customConditions: ["development"],
-    allowImportingTsExtensions: true,
-    isolatedModules: true,
-    moduleDetection: "force",
-    noEmit: true,
-    strict: true,
-  },
-  include: ["src"],
-}, null, 2)}\n`;
+const tsConfig = (useVoydSources: boolean): string =>
+  `${JSON.stringify({
+    compilerOptions: {
+      target: "ES2022",
+      useDefineForClassFields: true,
+      module: "ESNext",
+      lib: ["ES2022", "DOM", "DOM.Iterable"],
+      types: ["vite/client"],
+      skipLibCheck: true,
+      moduleResolution: "bundler",
+      customConditions: ["development"],
+      allowImportingTsExtensions: true,
+      isolatedModules: true,
+      moduleDetection: "force",
+      noEmit: true,
+      strict: true,
+      ...(useVoydSources ? { preserveSymlinks: true } : {}),
+    },
+    include: ["src"],
+  }, null, 2)}\n`;
 
 const indexHtml = `<!doctype html>
 <html lang="en">
@@ -139,20 +142,27 @@ const voyd = () => ({
 
 export default defineConfig({
   plugins: [voyd(), tailwindcss()],
-${useVoydSources ? '  resolve: { conditions: ["development"] },\n' : ""}});
+${useVoydSources ? '  resolve: { conditions: ["development"], preserveSymlinks: true },\n' : ""}});
 `;
 
 const runVoydScript = (useVoydSources: boolean): string =>
   `import { spawn } from "node:child_process";
+import { resolve } from "node:path";
 
 const useVoydSources = ${useVoydSources};
+const voydSourceNodeOptions = "--preserve-symlinks --preserve-symlinks-main";
 
 export function runVoyd(args, { cwd }) {
-  const command = process.platform === "win32" ? "voyd.cmd" : "voyd";
+  const command = useVoydSources
+    ? process.execPath
+    : process.platform === "win32" ? "voyd.cmd" : "voyd";
+  const commandArgs = useVoydSources
+    ? [resolve(cwd, "node_modules/@voyd-lang/cli/bin/voyd.js"), ...args]
+    : args;
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
+    const child = spawn(command, commandArgs, {
       cwd,
-      env: useVoydSources ? { ...process.env, VOYD_DEV: "1" } : process.env,
+      env: voydEnvironment(),
       stdio: ["ignore", "pipe", "pipe"],
     });
     const stdout = [];
@@ -170,6 +180,14 @@ export function runVoyd(args, { cwd }) {
         "voyd exited with status " + code));
     });
   });
+}
+
+function voydEnvironment() {
+  if (!useVoydSources) return process.env;
+  const nodeOptions = [process.env.NODE_OPTIONS, voydSourceNodeOptions]
+    .filter(Boolean)
+    .join(" ");
+  return { ...process.env, NODE_OPTIONS: nodeOptions, VOYD_DEV: "1" };
 }
 
 function missingCliError(error) {

--- a/apps/cli/src/bootstrap/loaders/web-ssr.ts
+++ b/apps/cli/src/bootstrap/loaders/web-ssr.ts
@@ -12,7 +12,7 @@ export const webSsrLoader: BootstrapLoader = {
     files: [
       { path: "package.json", content: packageJson(context) },
       { path: "vite.config.mjs", content: viteConfig(!!context.localVoydRoot) },
-      { path: "tsconfig.json", content: tsConfig },
+      { path: "tsconfig.json", content: tsConfig(!!context.localVoydRoot) },
       { path: ".gitignore", content: gitIgnore },
       { path: "README.md", content: readme(context) },
       { path: "scripts/run-voyd.mjs", content: runVoydScript(!!context.localVoydRoot) },
@@ -44,7 +44,7 @@ export const webSsrLoader: BootstrapLoader = {
 
 const packageJson = (context: BootstrapContext): string => {
   const node = context.localVoydRoot
-    ? "node --conditions=development --import tsx"
+    ? "node --preserve-symlinks --preserve-symlinks-main --conditions=development --import tsx"
     : "node";
   const localDependencies = context.localVoydRoot ? {
     "@voyd-lang/compiler": context.voydPackageSpec("@voyd-lang/compiler"),
@@ -66,6 +66,7 @@ const packageJson = (context: BootstrapContext): string => {
       typecheck: "tsc --noEmit",
     },
     dependencies: {
+      ...context.localVoydExternalDependencies,
       "@voyd-lang/sdk": context.voydPackageSpec("@voyd-lang/sdk"),
       "@voyd-lang/vx-dom": context.voydPackageSpec("@voyd-lang/vx-dom"),
       "@voyd-lang/web": context.voydPackageSpec("@voyd-lang/web"),
@@ -83,23 +84,25 @@ const packageJson = (context: BootstrapContext): string => {
   }, null, 2)}\n`;
 };
 
-const tsConfig = `${JSON.stringify({
-  compilerOptions: {
-    target: "ES2022",
-    module: "ESNext",
-    lib: ["ES2022", "DOM", "DOM.Iterable"],
-    types: ["node", "vite/client"],
-    skipLibCheck: true,
-    moduleResolution: "bundler",
-    customConditions: ["development"],
-    allowImportingTsExtensions: true,
-    isolatedModules: true,
-    moduleDetection: "force",
-    noEmit: true,
-    strict: true,
-  },
-  include: ["src"],
-}, null, 2)}\n`;
+const tsConfig = (useVoydSources: boolean): string =>
+  `${JSON.stringify({
+    compilerOptions: {
+      target: "ES2022",
+      module: "ESNext",
+      lib: ["ES2022", "DOM", "DOM.Iterable"],
+      types: ["node", "vite/client"],
+      skipLibCheck: true,
+      moduleResolution: "bundler",
+      customConditions: ["development"],
+      allowImportingTsExtensions: true,
+      isolatedModules: true,
+      moduleDetection: "force",
+      noEmit: true,
+      strict: true,
+      ...(useVoydSources ? { preserveSymlinks: true } : {}),
+    },
+    include: ["src"],
+  }, null, 2)}\n`;
 
 const viteConfig = (useVoydSources: boolean): string =>
   `import tailwindcss from "@tailwindcss/vite";
@@ -124,7 +127,7 @@ const voydClient = () => ({
 
 export default defineConfig({
   plugins: [voydClient(), tailwindcss()],
-${useVoydSources ? '  resolve: { conditions: ["development"] },\n' : ""}  publicDir: false,
+${useVoydSources ? '  resolve: { conditions: ["development"], preserveSymlinks: true },\n' : ""}  publicDir: false,
   build: {
     outDir: "public",
     emptyOutDir: false,
@@ -141,15 +144,22 @@ ${useVoydSources ? '  resolve: { conditions: ["development"] },\n' : ""}  public
 
 const runVoydScript = (useVoydSources: boolean): string =>
   `import { spawn } from "node:child_process";
+import { resolve } from "node:path";
 
 const useVoydSources = ${useVoydSources};
+const voydSourceNodeOptions = "--preserve-symlinks --preserve-symlinks-main";
 
 export function runVoyd(args, { cwd }) {
-  const command = process.platform === "win32" ? "voyd.cmd" : "voyd";
+  const command = useVoydSources
+    ? process.execPath
+    : process.platform === "win32" ? "voyd.cmd" : "voyd";
+  const commandArgs = useVoydSources
+    ? [resolve(cwd, "node_modules/@voyd-lang/cli/bin/voyd.js"), ...args]
+    : args;
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
+    const child = spawn(command, commandArgs, {
       cwd,
-      env: useVoydSources ? { ...process.env, VOYD_DEV: "1" } : process.env,
+      env: voydEnvironment(),
       stdio: ["ignore", "pipe", "pipe"],
     });
     const stdout = [];
@@ -167,6 +177,14 @@ export function runVoyd(args, { cwd }) {
         "voyd exited with status " + code));
     });
   });
+}
+
+function voydEnvironment() {
+  if (!useVoydSources) return process.env;
+  const nodeOptions = [process.env.NODE_OPTIONS, voydSourceNodeOptions]
+    .filter(Boolean)
+    .join(" ");
+  return { ...process.env, NODE_OPTIONS: nodeOptions, VOYD_DEV: "1" };
 }
 
 function missingCliError(error) {

--- a/apps/cli/src/bootstrap/loaders/web-ssr.ts
+++ b/apps/cli/src/bootstrap/loaders/web-ssr.ts
@@ -1,17 +1,22 @@
-import type { BootstrapLoader, BootstrapPlan } from "../types.js";
+import type {
+  BootstrapContext,
+  BootstrapLoader,
+  BootstrapPlan,
+} from "../types.js";
 
 export const webSsrLoader: BootstrapLoader = {
   id: "web-ssr",
   description: "SSR web app with Tailwind",
-  plan: ({ packageName, voydVersion }): BootstrapPlan => ({
+  plan: (context): BootstrapPlan => ({
     template: "web-ssr",
     files: [
-      { path: "package.json", content: packageJson(packageName, voydVersion) },
-      { path: "vite.config.mjs", content: viteConfig },
+      { path: "package.json", content: packageJson(context) },
+      { path: "vite.config.mjs", content: viteConfig(!!context.localVoydRoot) },
       { path: "tsconfig.json", content: tsConfig },
       { path: ".gitignore", content: gitIgnore },
-      { path: "README.md", content: readme(packageName) },
-      { path: "scripts/run-voyd.mjs", content: runVoydScript },
+      { path: "README.md", content: readme(context) },
+      { path: "scripts/run-voyd.mjs", content: runVoydScript(!!context.localVoydRoot) },
+      { path: "scripts/diagnostics.mjs", content: diagnosticsScript },
       { path: "scripts/compile-client.mjs", content: compileClientScript },
       { path: "scripts/check-voyd.mjs", content: checkVoydScript },
       { path: "scripts/serve.mjs", content: serveScript },
@@ -37,32 +42,46 @@ export const webSsrLoader: BootstrapLoader = {
   }),
 };
 
-const packageJson = (packageName: string, voydVersion: string): string =>
-  `${JSON.stringify({
-    name: packageName,
+const packageJson = (context: BootstrapContext): string => {
+  const node = context.localVoydRoot
+    ? "node --conditions=development --import tsx"
+    : "node";
+  const localDependencies = context.localVoydRoot ? {
+    "@voyd-lang/compiler": context.voydPackageSpec("@voyd-lang/compiler"),
+    "@voyd-lang/js-host": context.voydPackageSpec("@voyd-lang/js-host"),
+    "@voyd-lang/lib": context.voydPackageSpec("@voyd-lang/lib"),
+    "@voyd-lang/package-adapter": context.voydPackageSpec("@voyd-lang/package-adapter"),
+    "@voyd-lang/std": context.voydPackageSpec("@voyd-lang/std"),
+  } : {};
+  const localDevDependencies = context.localVoydRoot ? { tsx: "^4.20.4" } : {};
+  return `${JSON.stringify({
+    name: context.packageName,
     private: true,
     type: "module",
     scripts: {
-      dev: "node scripts/dev.mjs",
-      build: "npm run typecheck && vite build && node scripts/check-voyd.mjs",
-      start: "node scripts/serve.mjs",
-      "voyd:check": "node scripts/check-voyd.mjs",
+      dev: `${node} scripts/dev.mjs`,
+      build: `npm run typecheck && vite build && ${node} scripts/check-voyd.mjs`,
+      start: `${node} scripts/serve.mjs`,
+      "voyd:check": `${node} scripts/check-voyd.mjs`,
       typecheck: "tsc --noEmit",
     },
     dependencies: {
-      "@voyd-lang/sdk": `^${voydVersion}`,
-      "@voyd-lang/vx-dom": `^${voydVersion}`,
-      "@voyd-lang/web": `^${voydVersion}`,
+      "@voyd-lang/sdk": context.voydPackageSpec("@voyd-lang/sdk"),
+      "@voyd-lang/vx-dom": context.voydPackageSpec("@voyd-lang/vx-dom"),
+      "@voyd-lang/web": context.voydPackageSpec("@voyd-lang/web"),
+      ...localDependencies,
     },
     devDependencies: {
       "@tailwindcss/vite": "^4.3.0",
       "@types/node": "^22.5.1",
-      "@voyd-lang/cli": `^${voydVersion}`,
+      "@voyd-lang/cli": context.voydPackageSpec("@voyd-lang/cli"),
       tailwindcss: "^4.3.0",
+      ...localDevDependencies,
       typescript: "^5.8.3",
       vite: "^8.0.0",
     },
   }, null, 2)}\n`;
+};
 
 const tsConfig = `${JSON.stringify({
   compilerOptions: {
@@ -82,7 +101,8 @@ const tsConfig = `${JSON.stringify({
   include: ["src"],
 }, null, 2)}\n`;
 
-const viteConfig = `import tailwindcss from "@tailwindcss/vite";
+const viteConfig = (useVoydSources: boolean): string =>
+  `import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 import { compileClient } from "./scripts/compile-client.mjs";
 
@@ -104,7 +124,7 @@ const voydClient = () => ({
 
 export default defineConfig({
   plugins: [voydClient(), tailwindcss()],
-  publicDir: false,
+${useVoydSources ? '  resolve: { conditions: ["development"] },\n' : ""}  publicDir: false,
   build: {
     outDir: "public",
     emptyOutDir: false,
@@ -119,13 +139,17 @@ export default defineConfig({
 });
 `;
 
-const runVoydScript = `import { spawn } from "node:child_process";
+const runVoydScript = (useVoydSources: boolean): string =>
+  `import { spawn } from "node:child_process";
+
+const useVoydSources = ${useVoydSources};
 
 export function runVoyd(args, { cwd }) {
   const command = process.platform === "win32" ? "voyd.cmd" : "voyd";
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd,
+      env: useVoydSources ? { ...process.env, VOYD_DEV: "1" } : process.env,
       stdio: ["ignore", "pipe", "pipe"],
     });
     const stdout = [];
@@ -172,10 +196,81 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 }
 `;
 
+const diagnosticsScript = `import { readFileSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+
+class VoydCompilationError extends Error {}
+
+export function compilationError(diagnostics) {
+  return new VoydCompilationError(diagnostics.map(formatDiagnostic).join("\\n"));
+}
+
+export function errorMessage(error) {
+  if (error instanceof VoydCompilationError) return error.message;
+  return error instanceof Error ? error.stack ?? error.message : String(error);
+}
+
+export function formatDiagnostic(diagnostic) {
+  const context = sourceContext(diagnostic.span);
+  const location = context
+    ? context.path + ":" + context.line + ":" + context.column
+    : fallbackLocation(diagnostic.span);
+  const phase = diagnostic.phase ? " [" + diagnostic.phase + "]" : "";
+  const header = location + " " + diagnostic.severity.toUpperCase() + phase +
+    " " + diagnostic.code + ": " + diagnostic.message;
+  if (!context) return header;
+
+  const gutter = String(context.line);
+  const padding = " ".repeat(gutter.length);
+  const marker = " ".repeat(context.column - 1) + "^".repeat(context.length);
+  return [
+    header,
+    padding + " |",
+    gutter + " | " + context.text,
+    padding + " | " + marker,
+  ].join("\\n");
+}
+
+function sourceContext(span) {
+  if (!span) return;
+  const path = isAbsolute(span.file) ? span.file : resolve(span.file);
+  let source;
+  try {
+    source = readFileSync(path, "utf8");
+  } catch {
+    return;
+  }
+
+  const start = clamp(span.start, source.length);
+  const end = clamp(Math.max(span.end, start + 1), source.length);
+  const lineStart = source.lastIndexOf("\\n", Math.max(0, start - 1)) + 1;
+  const nextLine = source.indexOf("\\n", start);
+  const lineEnd = nextLine < 0 ? source.length : nextLine;
+  return {
+    path,
+    line: source.slice(0, lineStart).split("\\n").length,
+    column: start - lineStart + 1,
+    length: Math.max(1, Math.min(end, lineEnd) - start),
+    text: source.slice(lineStart, lineEnd),
+  };
+}
+
+function fallbackLocation(span) {
+  if (!span) return "voyd";
+  const path = isAbsolute(span.file) ? span.file : resolve(span.file);
+  return path + ":" + span.start + "-" + span.end;
+}
+
+function clamp(value, max) {
+  return Math.max(0, Math.min(value, max));
+}
+`;
+
 const checkVoydScript = `import { createSdk } from "@voyd-lang/sdk";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { compileClient } from "./compile-client.mjs";
+import { formatDiagnostic } from "./diagnostics.mjs";
 
 const rootDir = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const result = await createSdk().compile({
@@ -191,18 +286,12 @@ if (!result.success) {
 
 await compileClient();
 console.log("Voyd server and client compiled successfully.");
-
-function formatDiagnostic(diagnostic) {
-  const location = diagnostic.location
-    ? diagnostic.location.filePath + ":" + diagnostic.location.start.line + ":" + diagnostic.location.start.column
-    : diagnostic.file ?? "voyd";
-  return location + " " + diagnostic.severity + ": " + diagnostic.message;
-}
 `;
 
 const serveScript = `import { createSdk } from "@voyd-lang/sdk";
 import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { compilationError, errorMessage } from "./diagnostics.mjs";
 
 const rootDir = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const entryPath = resolve(rootDir, "src/main.voyd");
@@ -225,7 +314,7 @@ export async function serve({
     },
   });
   if (!result.success) {
-    throw new Error(result.diagnostics.map((diagnostic) => diagnostic.message).join("\\n"));
+    throw compilationError(result.diagnostics);
   }
   return result;
 }
@@ -237,7 +326,7 @@ export async function checkServer({ optimize = false } = {}) {
     runtimeDiagnostics: true,
   });
   if (!result.success) {
-    throw new Error(result.diagnostics.map((diagnostic) => diagnostic.message).join("\\n"));
+    throw compilationError(result.diagnostics);
   }
 }
 
@@ -247,6 +336,13 @@ function readPort() {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await runServer().catch((error) => {
+    console.error(errorMessage(error));
+    process.exitCode = 1;
+  });
+}
+
+async function runServer() {
   const app = await serve();
   console.log("Voyd app ready at " + app.url);
   let closing = false;
@@ -378,6 +474,7 @@ const devScript = `import { rename, rm } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { errorMessage } from "./diagnostics.mjs";
 import { checkServer, serve } from "./serve.mjs";
 import { watchSource } from "./watch-source.mjs";
 
@@ -394,7 +491,13 @@ const stopWatching = watchSource(sourceDir, (file) => {
   if (file && !/\\.(voyd|ts|css)$/.test(file)) return;
   void queueRebuild();
 });
-await queueRebuild({ failFast: true });
+try {
+  await queueRebuild({ failFast: true });
+} catch (error) {
+  stopWatching();
+  console.error(errorMessage(error));
+  process.exitCode = 1;
+}
 
 async function queueRebuild({ failFast = false } = {}) {
   rebuildRequested = true;
@@ -407,7 +510,7 @@ async function queueRebuild({ failFast = false } = {}) {
         await rebuild();
       } catch (error) {
         if (failFast) throw error;
-        console.error(error);
+        console.error(errorMessage(error));
       }
     }
   } finally {
@@ -1078,20 +1181,28 @@ data/articles/*.md
 !data/articles/webassembly.md
 `;
 
-const readme = (packageName: string) => `# ${packageName}
+const readme = (context: BootstrapContext) => `# ${context.packageName}
 
 This is a server-rendered Voyd application with a hydrated VX editor.
+${context.localVoydRoot ? `
+This project uses Voyd source packages from \`${context.localVoydRoot}\`. Running
+\`npm install\` links the complete local Voyd dependency set automatically.
+` : ""}
 
 ## Architecture
 
 - \`src/main.voyd\` owns HTTP routes and server startup.
-- \`src/server\` owns persistence and the server-rendered document shell.
-- \`src/app\` owns the shared model, update logic, and exact markup. The server
-  and browser both call the same \`view\`.
+- \`src/server\` owns persistence, HTTP responses, and the server-only document
+  shell (including the page chrome outside the hydrated editor).
+- \`src/app\` owns the shared model, update logic, and hydrated markup. The
+  server and browser both call the same \`view\` for that interactive region.
 - \`src/client.voyd\` is the browser Program entrypoint.
 - \`src/client.ts\` is the generic Wasm hydration bridge.
 
 Code inside \`#article-editor\` must render identically on the server and client.
+The outer document, metadata, navigation, and hydration bootstrap are only
+rendered by the server because the browser does not update them. Move markup
+into \`src/app/ui.voyd\` and inside the hydration root if it must be interactive.
 Server rendering automatically releases closure-backed event handlers after it
 builds the HTML. The development bridge reports hydration differences without
 preventing recovery.

--- a/apps/cli/src/bootstrap/types.ts
+++ b/apps/cli/src/bootstrap/types.ts
@@ -5,12 +5,26 @@ export type BootstrapConfig = {
   template: BootstrapTemplate;
   dryRun?: boolean;
   force?: boolean;
+  usePublished?: boolean;
 };
+
+export type BootstrapVoydPackage =
+  | "@voyd-lang/cli"
+  | "@voyd-lang/compiler"
+  | "@voyd-lang/js-host"
+  | "@voyd-lang/lib"
+  | "@voyd-lang/package-adapter"
+  | "@voyd-lang/sdk"
+  | "@voyd-lang/std"
+  | "@voyd-lang/vx-dom"
+  | "@voyd-lang/web";
 
 export type BootstrapContext = {
   targetDir: string;
   packageName: string;
   voydVersion: string;
+  localVoydRoot?: string;
+  voydPackageSpec(name: BootstrapVoydPackage): string;
 };
 
 export type BootstrapFile = {
@@ -34,6 +48,7 @@ export type BootstrapResult = {
   targetDir: string;
   template: BootstrapTemplate;
   dryRun: boolean;
+  localVoydRoot?: string;
   files: string[];
   nextSteps: string[];
 };

--- a/apps/cli/src/bootstrap/types.ts
+++ b/apps/cli/src/bootstrap/types.ts
@@ -24,6 +24,7 @@ export type BootstrapContext = {
   packageName: string;
   voydVersion: string;
   localVoydRoot?: string;
+  localVoydExternalDependencies: Record<string, string>;
   voydPackageSpec(name: BootstrapVoydPackage): string;
 };
 

--- a/apps/cli/src/config/arg-parser.ts
+++ b/apps/cli/src/config/arg-parser.ts
@@ -196,6 +196,10 @@ const parseBootstrapConfig = (argv: readonly string[]): VoydConfig => {
       "vx-spa",
     )
     .option("--dry-run", "print files that would be created without writing")
+    .option(
+      "--published",
+      "use published Voyd packages instead of a detected local checkout",
+    )
     .option("-f, --force", "allow writing into a non-empty directory");
 
   program.parse(["node", "voyd bootstrap", ...argv]);
@@ -209,6 +213,7 @@ const parseBootstrapConfig = (argv: readonly string[]): VoydConfig => {
     bootstrapTemplate: opts.template,
     bootstrapDryRun: opts.dryRun,
     bootstrapForce: opts.force,
+    bootstrapUsePublished: opts.published,
     doc: false,
     docFormat: "html",
   };

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -48,6 +48,8 @@ export type VoydConfig = {
   bootstrapDryRun?: boolean;
   /** Allow bootstrap to write into a non-empty directory */
   bootstrapForce?: boolean;
+  /** Use published Voyd dependencies instead of a detected local checkout */
+  bootstrapUsePublished?: boolean;
   /** Generate package-adapter bindings. */
   generateAdapter?: boolean;
   /** Generate an application adapter registry. */

--- a/apps/cli/src/exec.ts
+++ b/apps/cli/src/exec.ts
@@ -51,6 +51,7 @@ async function main() {
       template: config.bootstrapTemplate ?? "vx-spa",
       dryRun: config.bootstrapDryRun,
       force: config.bootstrapForce,
+      usePublished: config.bootstrapUsePublished,
     });
     return printBootstrapResult(result);
   }


### PR DESCRIPTION
## Summary

- detect a local Voyd monorepo by checking the root package name
- generate a complete `file:`-linked Voyd dependency graph with development export conditions
- preserve registry-based behavior as the fallback and add `--published` as an explicit opt-out
- restore the latest SSR hydration APIs, improve compiler diagnostic locations, and clarify the server/shared UI boundary

## Root cause

A linked local CLI was generating templates from the current checkout while still installing published runtime packages. That mixed the latest template code with older package APIs, which caused errors such as `hydrate_named is not defined`. The generated diagnostic formatter also read the compiler diagnostic in the wrong shape, so compiler failures fell through to a JavaScript call stack instead of showing a Voyd source location.

## Impact

Local contributors can now run the linked CLI and then `npm install` without manually linking every workspace package. If the CLI is not running from a checkout whose root package is named `voyd-monorepo`—including shallow paths, missing package files, malformed JSON, or unrelated parent directories—it safely falls back to normal published-package behavior.

The SSR template keeps the interactive UI in the shared app module. The server page owns only the server-rendered document shell and static chrome around the hydration root.

## Validation

- `npm run typecheck`
- `npm run test:audit`
- `npm test`
- generated a fresh local-source SSR project
- verified clean `npm install`, `npm run build`, and `npm run dev`
- verified SSR output and file/line/column compiler diagnostics