### PR TITLE
Resolve hoisted CLI in bootstrapped workspaces

### DIFF
--- a/apps/cli/src/__tests__/bootstrap.test.ts
+++ b/apps/cli/src/__tests__/bootstrap.test.ts
@@ -2,7 +2,7 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -121,9 +121,7 @@ describe("runBootstrap", () => {
         '"--preserve-symlinks --preserve-symlinks-main"',
       );
       expect(runVoyd).toContain("NODE_OPTIONS: nodeOptions");
-      expect(runVoyd).toContain(
-        'resolve(cwd, "node_modules/@voyd-lang/cli/bin/voyd.js")',
-      );
+      expect(runVoyd).toContain("resolveVoydCliEntry(cwd)");
 
       const css = await readFile(resolve(target, "src/style.css"), "utf8");
       expect(css).toContain('@import "tailwindcss";');
@@ -305,9 +303,29 @@ describe("runBootstrap", () => {
         '"--preserve-symlinks --preserve-symlinks-main"',
       );
       expect(runVoyd).toContain("NODE_OPTIONS: nodeOptions");
-      expect(runVoyd).toContain(
-        'resolve(cwd, "node_modules/@voyd-lang/cli/bin/voyd.js")',
+      expect(runVoyd).toContain("resolveVoydCliEntry(cwd)");
+
+      const hoistedCliEntry = resolve(
+        root,
+        "node_modules/@voyd-lang/cli/bin/voyd.js",
       );
+      await mkdir(resolve(root, "node_modules/@voyd-lang/cli/bin"), {
+        recursive: true,
+      });
+      await writeFile(hoistedCliEntry, "");
+      const resolverProbe = [
+        `const { resolveVoydCliEntry } = await import(${JSON.stringify(
+          pathToFileURL(resolve(target, "scripts/run-voyd.mjs")).href,
+        )});`,
+        `console.log(resolveVoydCliEntry(${JSON.stringify(
+          resolve(target, "apps/web"),
+        )}));`,
+      ].join("\n");
+      expect(execFileSync(
+        process.execPath,
+        ["--input-type=module", "--eval", resolverProbe],
+        { encoding: "utf8" },
+      ).trim()).toBe(hoistedCliEntry);
 
       const clientTs = await readFile(resolve(target, "src/client.ts"), "utf8");
       expect(clientTs).toContain("createVoydHost");

--- a/apps/cli/src/bootstrap/loaders/vx-spa.ts
+++ b/apps/cli/src/bootstrap/loaders/vx-spa.ts
@@ -147,7 +147,8 @@ ${useVoydSources ? '  resolve: { conditions: ["development"], preserveSymlinks: 
 
 const runVoydScript = (useVoydSources: boolean): string =>
   `import { spawn } from "node:child_process";
-import { resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 
 const useVoydSources = ${useVoydSources};
 const voydSourceNodeOptions = "--preserve-symlinks --preserve-symlinks-main";
@@ -157,7 +158,7 @@ export function runVoyd(args, { cwd }) {
     ? process.execPath
     : process.platform === "win32" ? "voyd.cmd" : "voyd";
   const commandArgs = useVoydSources
-    ? [resolve(cwd, "node_modules/@voyd-lang/cli/bin/voyd.js"), ...args]
+    ? [resolveVoydCliEntry(cwd), ...args]
     : args;
   return new Promise((resolve, reject) => {
     const child = spawn(command, commandArgs, {
@@ -180,6 +181,20 @@ export function runVoyd(args, { cwd }) {
         "voyd exited with status " + code));
     });
   });
+}
+
+export function resolveVoydCliEntry(cwd) {
+  let directory = resolve(cwd);
+  while (true) {
+    const candidate = resolve(
+      directory,
+      "node_modules/@voyd-lang/cli/bin/voyd.js",
+    );
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(directory);
+    if (parent === directory) throw missingCliError({ code: "ENOENT" });
+    directory = parent;
+  }
 }
 
 function voydEnvironment() {

--- a/apps/cli/src/bootstrap/loaders/web-ssr.ts
+++ b/apps/cli/src/bootstrap/loaders/web-ssr.ts
@@ -144,7 +144,8 @@ ${useVoydSources ? '  resolve: { conditions: ["development"], preserveSymlinks: 
 
 const runVoydScript = (useVoydSources: boolean): string =>
   `import { spawn } from "node:child_process";
-import { resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 
 const useVoydSources = ${useVoydSources};
 const voydSourceNodeOptions = "--preserve-symlinks --preserve-symlinks-main";
@@ -154,7 +155,7 @@ export function runVoyd(args, { cwd }) {
     ? process.execPath
     : process.platform === "win32" ? "voyd.cmd" : "voyd";
   const commandArgs = useVoydSources
-    ? [resolve(cwd, "node_modules/@voyd-lang/cli/bin/voyd.js"), ...args]
+    ? [resolveVoydCliEntry(cwd), ...args]
     : args;
   return new Promise((resolve, reject) => {
     const child = spawn(command, commandArgs, {
@@ -177,6 +178,20 @@ export function runVoyd(args, { cwd }) {
         "voyd exited with status " + code));
     });
   });
+}
+
+export function resolveVoydCliEntry(cwd) {
+  let directory = resolve(cwd);
+  while (true) {
+    const candidate = resolve(
+      directory,
+      "node_modules/@voyd-lang/cli/bin/voyd.js",
+    );
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(directory);
+    if (parent === directory) throw missingCliError({ code: "ENOENT" });
+    directory = parent;
+  }
 }
 
 function voydEnvironment() {


### PR DESCRIPTION
## Summary

- resolve the local Voyd CLI by walking ancestor `node_modules` directories
- preserve the discovered symlink path so local package imports still resolve through the generated workspace
- cover nested workspace apps with a generated-launcher regression test

## Root cause

The local-source bootstrap launcher assumed the CLI always lived at `<app>/node_modules/@voyd-lang/cli/bin/voyd.js`. npm workspaces commonly hoist that dependency to the workspace root, leaving the generated app without its own `node_modules` directory and causing `MODULE_NOT_FOUND`.

## Impact

Both `vx-spa` and `web-ssr` starters now support standalone installs and nested npm workspace installs while retaining symlink-preserving local-source behavior.

## Validation

- `npm run typecheck`
- `npm run test:audit`
- `npm test`
- focused bootstrap regression suite
- bootstrapped a fresh `web-ssr` app at `apps/web` inside an isolated temporary npm workspace
- installed dependencies only from the workspace root and verified `apps/web/node_modules` did not exist
- verified `npm run build`
- verified `npm run dev` reached ready state
- fetched the SSR root successfully and confirmed the hydration payload