### PR TITLE
[V-428] Fix stale language server module resolution

### DIFF
--- a/packages/compiler/src/modules/fs-host.ts
+++ b/packages/compiler/src/modules/fs-host.ts
@@ -2,28 +2,42 @@ import { readFile, readdir, stat } from "node:fs/promises";
 import type { ModuleHost } from "./types.js";
 import { createNodePathAdapter } from "./node-path-adapter.js";
 
-export const createFsModuleHost = (): ModuleHost => {
+export type FsModuleHostOptions = {
+  cacheFileSystemQueries?: boolean;
+};
+
+export const createFsModuleHost = ({
+  cacheFileSystemQueries = true,
+}: FsModuleHostOptions = {}): ModuleHost => {
   const fileCache = new Map<string, boolean>();
   const dirCache = new Map<string, boolean>();
   const pathAdapter = createNodePathAdapter();
 
   const isDirectory = async (path: string): Promise<boolean> => {
-    const cached = dirCache.get(path);
-    if (typeof cached === "boolean") {
-      return cached;
+    if (cacheFileSystemQueries) {
+      const cached = dirCache.get(path);
+      if (typeof cached === "boolean") {
+        return cached;
+      }
     }
     const result = await stat(path).then((info) => info.isDirectory()).catch(() => false);
-    dirCache.set(path, result);
+    if (cacheFileSystemQueries) {
+      dirCache.set(path, result);
+    }
     return result;
   };
 
   const fileExists = async (path: string): Promise<boolean> => {
-    const cached = fileCache.get(path);
-    if (typeof cached === "boolean") {
-      return cached;
+    if (cacheFileSystemQueries) {
+      const cached = fileCache.get(path);
+      if (typeof cached === "boolean") {
+        return cached;
+      }
     }
     const result = await stat(path).then((info) => info.isFile()).catch(() => false);
-    fileCache.set(path, result);
+    if (cacheFileSystemQueries) {
+      fileCache.set(path, result);
+    }
     return result;
   };
 

--- a/packages/language-server/src/__tests__/analysis-coordinator.test.ts
+++ b/packages/language-server/src/__tests__/analysis-coordinator.test.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
+import { FileChangeType } from "vscode-languageserver/lib/node/main.js";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { toFileUri } from "../project/files.js";
 import { AnalysisCoordinator } from "../server/analysis-coordinator.js";
@@ -116,6 +117,41 @@ describe("analysis coordinator", () => {
       await rm(project.rootDir, { recursive: true, force: true });
       await rm(missingStd.rootDir, { recursive: true, force: true });
       await rm(completeStd.rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("discovers imported modules created after the initial analysis", async () => {
+    const project = await createProject({
+      "src/main.voyd":
+        `use src::generated::value\n\nfn main() -> i32\n  value()\n`,
+    });
+    const std = await createProject({
+      "pkg.voyd": "",
+    });
+
+    try {
+      await withStdRoot(std.rootDir, async () => {
+        const mainPath = project.filePathFor("src/main.voyd");
+        const mainUri = toFileUri(mainPath);
+        const generatedPath = project.filePathFor("src/generated.voyd");
+        const generatedUri = toFileUri(generatedPath);
+        const coordinator = new AnalysisCoordinator();
+
+        const initial = await coordinator.getCoreForUri(mainUri);
+        const initialDiagnostics = initial.analysis.diagnosticsByUri.get(mainUri) ?? [];
+        expect(initialDiagnostics.some(({ code }) => code === "BD0001")).toBe(true);
+
+        await writeFile(generatedPath, `pub fn value() -> i32\n  42\n`, "utf8");
+        await coordinator.handleWatchedFileChanges([
+          { uri: generatedUri, type: FileChangeType.Created },
+        ]);
+
+        const updated = await coordinator.getCoreForUri(mainUri);
+        expect(updated.analysis.diagnosticsByUri.get(mainUri) ?? []).toHaveLength(0);
+      });
+    } finally {
+      await rm(project.rootDir, { recursive: true, force: true });
+      await rm(std.rootDir, { recursive: true, force: true });
     }
   });
 

--- a/packages/language-server/src/server/analysis-coordinator.ts
+++ b/packages/language-server/src/server/analysis-coordinator.ts
@@ -238,7 +238,9 @@ const mergeSymbolLookupByUri = ({
 
 export class AnalysisCoordinator {
   readonly openDocuments = new Map<string, string>();
-  readonly #fileSystemHost = createFsModuleHost();
+  readonly #fileSystemHost = createFsModuleHost({
+    cacheFileSystemQueries: false,
+  });
   readonly #moduleHost = createOverlayModuleHost({
     openDocuments: this.openDocuments,
     fallbackHost: this.#fileSystemHost,


### PR DESCRIPTION
## Summary

- make filesystem-query caching an explicit compiler filesystem-host option
- disable filesystem-query caching for the long-running language server
- add regression coverage for imports whose modules are created after initial analysis

## Root cause

The language server reused one filesystem host for its entire lifetime. That host permanently cached negative `fileExists` and `isDirectory` results, so newly created source files and package directories remained unavailable to module resolution after watcher invalidation.

Full compiler builds did not reproduce the problem because each build creates a fresh filesystem host.

## Impact

VSCode now discovers newly created modules and package directories without requiring a language-server restart, eliminating stale `BD0001` diagnostics such as those observed in Tessyl.

## Validation

- `npm run --workspace @voyd-lang/language-server test` — 51 passed, 1 skipped
- `npm test` — 18/18 tasks passed
- `npm run typecheck` — 17/17 tasks passed
- `npm run test:audit`
- Tessyl `npm run voyd:check` — server and client compiled successfully

Linear: [V-428](https://linear.app/voyd-lang/issue/V-428/fix-language-server-diagnostics-that-disagree-with-full-compiler)