### PR TITLE
[V-429] Support explicit VX runtime hosts without browser defaults

### DIFF
--- a/packages/reference/docs/vx.md
+++ b/packages/reference/docs/vx.md
@@ -747,6 +747,31 @@ const mounted = await mountVxApp({
 });
 ```
 
+By default, `mountVxApp` installs the standard browser commands and
+subscriptions, then applies `runtimeHost` as overrides. Set
+`runtimeHostMode: "explicit"` when an embedder needs an exact capability set:
+
+```ts
+const mounted = await mountVxApp({
+  container,
+  app,
+  runtimeHostMode: "explicit",
+  runtimeHost: {
+    commands: {
+      analytics_track: async (command) => {
+        await analytics.track(command.value);
+      },
+    },
+  },
+});
+```
+
+Explicit mode installs only the supplied commands, subscriptions, and error
+handler. Omitting `runtimeHost` in explicit mode provides no external
+capabilities. Structural VX commands such as `none`, `message`, `batch`, and
+`map` remain available, while any unknown external capability fails with the
+normal missing-handler error.
+
 For an ongoing host listener, use a configured runtime subscription:
 
 ```voyd

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -903,6 +903,145 @@ describe("vx-dom browser renderer", () => {
     expect(container.textContent).toBe("Count: 1");
   });
 
+  it("uses only supplied runtime host capabilities in explicit mode", async () => {
+    const runCommand = vi.fn();
+    const runSubscription = vi.fn(() => undefined);
+    const syncSubscriptions = vi.fn();
+    const app: VxAppRuntime = {
+      init: () => ({
+        frame: counterNode(0),
+        subscriptions: { type: "sub", kind: "custom_sub", key: "main" },
+        commands: { type: "cmd", kind: "custom_command" },
+      }),
+      render: () => counterNode(0),
+      dispatch: () => counterNode(0),
+      syncSubscriptions,
+    };
+
+    await mountVxApp({
+      container,
+      app,
+      runtimeHostMode: "explicit",
+      runtimeHost: {
+        commands: { custom_command: runCommand },
+        subscriptions: { custom_sub: runSubscription },
+      },
+    });
+
+    expect(runCommand).toHaveBeenCalledOnce();
+    expect(runSubscription).toHaveBeenCalledOnce();
+    expect(syncSubscriptions).not.toHaveBeenCalled();
+  });
+
+  it("does not install browser defaults in explicit runtime host mode", async () => {
+    const onError = vi.fn();
+    const commandApp: VxAppRuntime = {
+      init: () => ({
+        frame: counterNode(0),
+        commands: { type: "cmd", kind: "delay", value: 0 },
+      }),
+      render: () => counterNode(0),
+      dispatch: () => counterNode(0),
+    };
+
+    await expect(mountVxApp({
+      container,
+      app: commandApp,
+      runtimeHostMode: "explicit",
+      runtimeHost: { onError },
+    })).rejects.toThrow('no runtime command handler registered for "delay"');
+    expect(onError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ phase: "commands" }),
+    );
+
+    const subscriptionApp: VxAppRuntime = {
+      init: () => ({
+        frame: counterNode(0),
+        subscriptions: { type: "sub", kind: "location_change", key: "main" },
+      }),
+      render: () => counterNode(0),
+      dispatch: () => counterNode(0),
+      syncSubscriptions: vi.fn(),
+    };
+
+    await expect(mountVxApp({
+      container,
+      app: subscriptionApp,
+      runtimeHostMode: "explicit",
+    })).rejects.toThrow(
+      'no runtime subscription handler registered for "location_change"',
+    );
+    expect(subscriptionApp.syncSubscriptions).not.toHaveBeenCalled();
+  });
+
+  it("treats inherited runtime host properties as missing handlers", async () => {
+    const app: VxAppRuntime = {
+      init: () => ({
+        frame: counterNode(0),
+        commands: { type: "cmd", kind: "constructor" },
+      }),
+      render: () => counterNode(0),
+      dispatch: () => counterNode(0),
+    };
+
+    await expect(mountVxApp({
+      container,
+      app,
+      runtimeHostMode: "explicit",
+      runtimeHost: { commands: {} },
+    })).rejects.toThrow('no runtime command handler registered for "constructor"');
+
+    app.init = () => ({
+      frame: counterNode(0),
+      subscriptions: { type: "sub", kind: "toString", key: "main" },
+    });
+
+    await expect(mountVxApp({
+      container,
+      app,
+      runtimeHostMode: "explicit",
+      runtimeHost: { subscriptions: {} },
+    })).rejects.toThrow(
+      'no runtime subscription handler registered for "toString"',
+    );
+  });
+
+  it("keeps structural commands available in explicit runtime host mode", async () => {
+    const seenMessages: VxRuntimeMessage[] = [];
+    const app: VxAppRuntime = {
+      init: () => ({
+        frame: counterNode(0),
+        commands: {
+          type: "cmd",
+          kind: "batch",
+          children: [
+            { type: "cmd", kind: "none" },
+            {
+              type: "cmd",
+              kind: "map",
+              handlerId: 12,
+              child: { type: "cmd", kind: "message", value: "ready" },
+            },
+          ],
+        },
+      }),
+      render: () => counterNode(seenMessages.length),
+      dispatch: (message) => {
+        seenMessages.push(message);
+        return counterNode(seenMessages.length);
+      },
+    };
+
+    await mountVxApp({ container, app, runtimeHostMode: "explicit" });
+
+    expect(seenMessages).toEqual([{
+      kind: "map",
+      handlerId: 12,
+      message: { kind: "msgpack", value: "ready" },
+    }]);
+  });
+
   it("reports command diagnostics for unknown runtime command kinds", async () => {
     const onError = vi.fn();
     const app: VxAppRuntime = {

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -975,7 +975,7 @@ describe("vx-dom browser renderer", () => {
     expect(subscriptionApp.syncSubscriptions).not.toHaveBeenCalled();
   });
 
-  it("treats inherited runtime host maps and handlers as missing", async () => {
+  it("ignores inherited runtime host capabilities", async () => {
     const app: VxAppRuntime = {
       init: () => ({
         frame: counterNode(0),
@@ -1041,6 +1041,22 @@ describe("vx-dom browser renderer", () => {
       'no runtime subscription handler registered for "inherited_sub"',
     );
     expect(runSubscription).not.toHaveBeenCalled();
+
+    const onError = vi.fn();
+    app.init = () => ({
+      frame: counterNode(0),
+      commands: { type: "cmd", kind: "missing_handler" },
+    });
+
+    await expect(mountVxApp({
+      container,
+      app,
+      runtimeHostMode: "explicit",
+      runtimeHost: Object.create({ onError }),
+    })).rejects.toThrow(
+      'no runtime command handler registered for "missing_handler"',
+    );
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it("keeps structural commands available in explicit runtime host mode", async () => {

--- a/packages/vx-dom/src/__tests__/browser.test.ts
+++ b/packages/vx-dom/src/__tests__/browser.test.ts
@@ -975,7 +975,7 @@ describe("vx-dom browser renderer", () => {
     expect(subscriptionApp.syncSubscriptions).not.toHaveBeenCalled();
   });
 
-  it("treats inherited runtime host properties as missing handlers", async () => {
+  it("treats inherited runtime host maps and handlers as missing", async () => {
     const app: VxAppRuntime = {
       init: () => ({
         frame: counterNode(0),
@@ -1005,6 +1005,42 @@ describe("vx-dom browser renderer", () => {
     })).rejects.toThrow(
       'no runtime subscription handler registered for "toString"',
     );
+
+    const runCommand = vi.fn();
+    app.init = () => ({
+      frame: counterNode(0),
+      commands: { type: "cmd", kind: "inherited_command" },
+    });
+
+    await expect(mountVxApp({
+      container,
+      app,
+      runtimeHostMode: "explicit",
+      runtimeHost: Object.create({
+        commands: { inherited_command: runCommand },
+      }),
+    })).rejects.toThrow(
+      'no runtime command handler registered for "inherited_command"',
+    );
+    expect(runCommand).not.toHaveBeenCalled();
+
+    const runSubscription = vi.fn();
+    app.init = () => ({
+      frame: counterNode(0),
+      subscriptions: { type: "sub", kind: "inherited_sub", key: "main" },
+    });
+
+    await expect(mountVxApp({
+      container,
+      app,
+      runtimeHostMode: "explicit",
+      runtimeHost: Object.create({
+        subscriptions: { inherited_sub: runSubscription },
+      }),
+    })).rejects.toThrow(
+      'no runtime subscription handler registered for "inherited_sub"',
+    );
+    expect(runSubscription).not.toHaveBeenCalled();
   });
 
   it("keeps structural commands available in explicit runtime host mode", async () => {

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -452,7 +452,10 @@ async function mountRuntimeApp(
   const runtimeHost = options.runtimeHostMode === "explicit"
     ? options.runtimeHost ?? {}
     : createBrowserVxRuntimeHost(options.runtimeHost);
-  const reportError = createRuntimeErrorReporter(options.onError ?? runtimeHost.onError);
+  const runtimeHostOnError = Object.hasOwn(runtimeHost, "onError")
+    ? runtimeHost.onError
+    : undefined;
+  const reportError = createRuntimeErrorReporter(options.onError ?? runtimeHostOnError);
   const retainedHandlerReleaser = retainedHandlerReleaserFor(app, options.handlers);
   const afterCommandCallbacks: Array<Array<() => void>> = [];
   let queue = Promise.resolve();

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -1515,8 +1515,11 @@ async function runCommands(
   const command = nextTaskObserver
     ? attachTaskObserver(commandEnvelope, nextTaskObserver)
     : commandEnvelope;
-  const executor = host?.commands && Object.hasOwn(host.commands, commandEnvelope.kind)
-    ? host.commands[commandEnvelope.kind]
+  const commands = host && Object.hasOwn(host, "commands")
+    ? host.commands
+    : undefined;
+  const executor = commands && Object.hasOwn(commands, commandEnvelope.kind)
+    ? commands[commandEnvelope.kind]
     : undefined;
   if (!executor) throw new Error(`vx-dom: no runtime command handler registered for "${commandEnvelope.kind}"`);
   await executor(command, context);
@@ -1992,8 +1995,11 @@ async function syncRuntimeSubscriptions(
       active.delete(key);
       await disposeActiveSubscription(previous, releaser, active);
     }
-    const runner = host?.subscriptions && Object.hasOwn(host.subscriptions, subscription.kind)
-      ? host.subscriptions[subscription.kind]
+    const subscriptions = host && Object.hasOwn(host, "subscriptions")
+      ? host.subscriptions
+      : undefined;
+    const runner = subscriptions && Object.hasOwn(subscriptions, subscription.kind)
+      ? subscriptions[subscription.kind]
       : undefined;
     if (!runner) throw new Error(`vx-dom: no runtime subscription handler registered for "${subscription.kind}"`);
     const mappedContext = mutableMappedSubscriptionContext(subscription, context);

--- a/packages/vx-dom/src/browser.ts
+++ b/packages/vx-dom/src/browser.ts
@@ -94,6 +94,8 @@ export type MountedVxApp = {
   getSnapshot(): unknown;
 };
 
+export type VxRuntimeHostMode = "browser" | "explicit";
+
 export type MountVxAppOptions = {
   container: Element;
   componentFn?: VoydComponentFn;
@@ -106,6 +108,7 @@ export type MountVxAppOptions = {
   handlers?: RetainedEventHandlerRegistry;
   app?: VxAppRuntime;
   runtimeHost?: VxRuntimeHostOptions;
+  runtimeHostMode?: VxRuntimeHostMode;
   onError?: VxRuntimeErrorHandler;
   onHydrationMismatch?: HydrationMismatchHandler;
   dispatch?: (message: VxMessage) => Promise<void> | void;
@@ -446,7 +449,9 @@ async function mountRuntimeApp(
   let previousSubscriptions: unknown;
   const abortController = new AbortController();
   const activeSubscriptions = new Map<string, ActiveSubscription>();
-  const runtimeHost = createBrowserVxRuntimeHost(options.runtimeHost);
+  const runtimeHost = options.runtimeHostMode === "explicit"
+    ? options.runtimeHost ?? {}
+    : createBrowserVxRuntimeHost(options.runtimeHost);
   const reportError = createRuntimeErrorReporter(options.onError ?? runtimeHost.onError);
   const retainedHandlerReleaser = retainedHandlerReleaserFor(app, options.handlers);
   const afterCommandCallbacks: Array<Array<() => void>> = [];
@@ -540,7 +545,11 @@ async function mountRuntimeApp(
 
     let commandPhaseStarted = false;
     try {
-      if (step.subscriptions !== undefined && app.syncSubscriptions) {
+      if (
+        step.subscriptions !== undefined &&
+        options.runtimeHostMode !== "explicit" &&
+        app.syncSubscriptions
+      ) {
         const previous = previousSubscriptions;
         previousSubscriptions = step.subscriptions;
         try {
@@ -1506,7 +1515,9 @@ async function runCommands(
   const command = nextTaskObserver
     ? attachTaskObserver(commandEnvelope, nextTaskObserver)
     : commandEnvelope;
-  const executor = host?.commands?.[commandEnvelope.kind];
+  const executor = host?.commands && Object.hasOwn(host.commands, commandEnvelope.kind)
+    ? host.commands[commandEnvelope.kind]
+    : undefined;
   if (!executor) throw new Error(`vx-dom: no runtime command handler registered for "${commandEnvelope.kind}"`);
   await executor(command, context);
 }
@@ -1981,7 +1992,9 @@ async function syncRuntimeSubscriptions(
       active.delete(key);
       await disposeActiveSubscription(previous, releaser, active);
     }
-    const runner = host?.subscriptions?.[subscription.kind];
+    const runner = host?.subscriptions && Object.hasOwn(host.subscriptions, subscription.kind)
+      ? host.subscriptions[subscription.kind]
+      : undefined;
     if (!runner) throw new Error(`vx-dom: no runtime subscription handler registered for "${subscription.kind}"`);
     const mappedContext = mutableMappedSubscriptionContext(subscription, context);
     const dispose = await runner(subscription, mappedContext.context);

--- a/packages/vx-dom/src/index.ts
+++ b/packages/vx-dom/src/index.ts
@@ -28,6 +28,7 @@ export type {
   RenderOptions,
   VoydHydrationRoot,
   VxDomRenderer,
+  VxRuntimeHostMode,
 } from "./browser.js";
 export {
   renderNodeToString,


### PR DESCRIPTION
## Summary

- add `runtimeHostMode: "browser" | "explicit"` to VX mount options
- preserve browser defaults and runtime-host overrides in the default browser mode
- make explicit mode use only supplied command, subscription, and error handlers
- keep structural VX commands available and preserve missing-handler diagnostics
- document the exact-capability mode in the VX reference

## Root cause

`mountRuntimeApp` always composed the supplied runtime host with browser defaults, so embedders could not define an exact capability boundary. App-owned subscription syncing and prototype-inherited handler names could also bypass an explicit allowlist.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run test:audit`
- `npm run --workspace @voyd-lang/vx-dom test` (119 tests)

## Review

Completed the requested agentic review loop: implementation-gap and architecture reviews passed; correctness review findings were fixed; a fresh correctness review passed with no findings.