### PR TITLE
Configure Voyd package directories through package.json

### DIFF
--- a/apps/cli/src/__tests__/cli-e2e.test.ts
+++ b/apps/cli/src/__tests__/cli-e2e.test.ts
@@ -104,6 +104,41 @@ const createPkgDirRelativeFixture = async (): Promise<{
   return { cwd: root, entryPath };
 };
 
+const createConfiguredPkgDirFixture = async (): Promise<{
+  cwd: string;
+  entryPath: string;
+}> => {
+  const root = await mkdtemp(resolve(tmpdir(), "voyd-cli-pkg-dir-config-"));
+  const packageRoot = resolve(root, "workspace", "apps", "consumer");
+  const srcRoot = resolve(packageRoot, "src");
+  const packageSrcRoot = resolve(
+    packageRoot,
+    "voyd-packages",
+    "my_pkg",
+    "src",
+  );
+  const entryPath = resolve(srcRoot, "main.voyd");
+  await mkdir(srcRoot, { recursive: true });
+  await writePackageFixture(packageSrcRoot);
+  await writeFile(
+    resolve(packageRoot, "package.json"),
+    JSON.stringify({
+      voyd: { packageDirectories: ["./voyd-packages"] },
+    }),
+  );
+  await writeFile(
+    entryPath,
+    [
+      "use pkg::my_pkg::all",
+      "",
+      "pub fn main() -> i32",
+      "  plus_one(41)",
+      "",
+    ].join("\n"),
+  );
+  return { cwd: root, entryPath };
+};
+
 const createPkgDirRelativeTestFixture = async (): Promise<{
   cwd: string;
   testRoot: string;
@@ -535,6 +570,27 @@ describe("voyd cli package resolution", { timeout: CLI_E2E_TIMEOUT_MS }, () => {
         fixture.entryPath,
         "--pkg-dir",
         "../pkgs",
+      ]);
+      const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+
+      if (result.status !== 0) {
+        throw new Error(`voyd compile failed: ${output}`);
+      }
+
+      expect(output).not.toContain("Unable to resolve module");
+    } finally {
+      await rm(fixture.cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("loads package directories from package.json", async () => {
+    assertCliRunnerAvailable();
+
+    const fixture = await createConfiguredPkgDirFixture();
+    try {
+      const result = runCli(fixture.cwd, [
+        "--emit-ir-ast",
+        fixture.entryPath,
       ]);
       const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
 

--- a/apps/cli/src/package-dirs.ts
+++ b/apps/cli/src/package-dirs.ts
@@ -1,5 +1,4 @@
-import { resolve } from "node:path";
-import { collectNodeModulesDirs } from "@voyd-lang/sdk";
+import { resolveVoydPackageDirectories } from "@voyd-lang/lib/package-directories.js";
 
 export const resolvePackageDirs = ({
   srcRoot,
@@ -8,7 +7,8 @@ export const resolvePackageDirs = ({
   srcRoot: string;
   additionalPkgDirs: readonly string[];
 }): string[] => {
-  const configured = additionalPkgDirs.map((dir) => resolve(srcRoot, dir));
-  const nodeModules = collectNodeModulesDirs(srcRoot);
-  return Array.from(new Set([...configured, ...nodeModules]));
+  return resolveVoydPackageDirectories({
+    sourceRoot: srcRoot,
+    additionalPackageDirectories: additionalPkgDirs,
+  });
 };

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -38,7 +38,10 @@ export const activate = (context: vscode.ExtensionContext): void => {
   const clientOptions: LanguageClientOptions = {
     documentSelector: [{ scheme: "file", language: "voyd" }],
     synchronize: {
-      fileEvents: vscode.workspace.createFileSystemWatcher("**/*.{voyd,vd}"),
+      fileEvents: [
+        vscode.workspace.createFileSystemWatcher("**/*.{voyd,vd}"),
+        vscode.workspace.createFileSystemWatcher("**/package.json"),
+      ],
     },
   };
 

--- a/docs/testing/test-inventory.json
+++ b/docs/testing/test-inventory.json
@@ -2006,6 +2006,12 @@
     "rationale": "Keep co-located: protects one package or app implementation contract at the cheapest precise boundary."
   },
   {
+    "file": "packages/lib/src/lib/__tests__/package-directories.test.ts",
+    "owner": "package-unit",
+    "disposition": "package-local",
+    "rationale": "Keep co-located: protects shared Node tooling semantics for package.json directory inheritance, path precedence, defaults, and validation."
+  },
+  {
     "file": "packages/lib/src/lib/__tests__/resolve-src.test.ts",
     "owner": "package-unit",
     "disposition": "package-local",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12565,6 +12565,7 @@
       "version": "0.3.1",
       "dependencies": {
         "@voyd-lang/compiler": "^0.3.1",
+        "@voyd-lang/lib": "^0.3.1",
         "@voyd-lang/std": "^0.3.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.12",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@voyd-lang/compiler": "^0.3.1",
+    "@voyd-lang/lib": "^0.3.1",
     "@voyd-lang/std": "^0.3.1",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12",

--- a/packages/language-server/src/__tests__/analysis-coordinator.test.ts
+++ b/packages/language-server/src/__tests__/analysis-coordinator.test.ts
@@ -155,6 +155,92 @@ describe("analysis coordinator", () => {
     }
   });
 
+  it("reloads package directory configuration when package.json changes", async () => {
+    const project = await createProject({
+      "src/main.voyd":
+        `use pkg::my_pkg::all\n\nfn main() -> i32\n  value()\n`,
+      "voyd-packages/my_pkg/src/pkg.voyd":
+        `pub fn value() -> i32\n  42\n`,
+    });
+    const std = await createProject({
+      "pkg.voyd": "",
+    });
+
+    try {
+      await withStdRoot(std.rootDir, async () => {
+        const mainPath = project.filePathFor("src/main.voyd");
+        const mainUri = toFileUri(mainPath);
+        const manifestPath = project.filePathFor("package.json");
+        const coordinator = new AnalysisCoordinator();
+
+        const initial = await coordinator.getCoreForUri(mainUri);
+        expect(initial.analysis.graph.modules.has("pkg:my_pkg::pkg")).toBe(false);
+
+        const unrelatedManifestPath = project.filePathFor(
+          "unrelated/package.json",
+        );
+        await mkdir(path.dirname(unrelatedManifestPath), { recursive: true });
+        await writeFile(unrelatedManifestPath, "{}", "utf8");
+        const unrelatedChanged = await coordinator.handleWatchedFileChanges([
+          {
+            uri: toFileUri(unrelatedManifestPath),
+            type: FileChangeType.Created,
+          },
+        ]);
+        expect(unrelatedChanged).toBe(false);
+
+        await writeFile(
+          manifestPath,
+          JSON.stringify({
+            voyd: { packageDirectories: ["./voyd-packages"] },
+          }),
+          "utf8",
+        );
+        const changed = await coordinator.handleWatchedFileChanges([
+          { uri: toFileUri(manifestPath), type: FileChangeType.Created },
+        ]);
+
+        expect(changed).toBe(true);
+        const updated = await coordinator.getCoreForUri(mainUri);
+        expect(updated.analysis.graph.modules.has("pkg:my_pkg::pkg")).toBe(true);
+        expect(updated.analysis.diagnosticsByUri.get(mainUri) ?? []).toHaveLength(0);
+      });
+    } finally {
+      await rm(project.rootDir, { recursive: true, force: true });
+      await rm(std.rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports invalid package configuration without rejecting analysis", async () => {
+    const project = await createProject({
+      "package.json": JSON.stringify({
+        voyd: { packageDirectories: "./voyd-packages" },
+      }),
+      "src/main.voyd": `fn main() -> i32\n  42\n`,
+    });
+    const std = await createProject({
+      "pkg.voyd": "",
+    });
+
+    try {
+      await withStdRoot(std.rootDir, async () => {
+        const mainUri = toFileUri(project.filePathFor("src/main.voyd"));
+        const coordinator = new AnalysisCoordinator();
+
+        const { analysis } = await coordinator.getCoreForUri(mainUri);
+        expect(analysis.diagnosticsByUri.get(mainUri)).toEqual([
+          expect.objectContaining({
+            code: "VOYD_CONFIG",
+            message: expect.stringMatching(/voyd\.packageDirectories/),
+          }),
+        ]);
+      });
+    } finally {
+      await rm(project.rootDir, { recursive: true, force: true });
+      await rm(std.rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("reuses unaffected module semantics after an edit", async () => {
     const project = await createProject({
       "src/main.voyd":

--- a/packages/language-server/src/__tests__/project.test.ts
+++ b/packages/language-server/src/__tests__/project.test.ts
@@ -86,11 +86,14 @@ describe("language server project analysis", () => {
     }
   });
 
-  it("resolves local packages from an ancestor voyd directory", async () => {
+  it("resolves package directories configured in package.json", async () => {
     const project = await createProject({
+      "packages/native/package.json": JSON.stringify({
+        voyd: { packageDirectories: ["./local-packages"] },
+      }),
       "packages/native/examples/chart/main.voyd":
         `use pkg::native_sdk::all\n\nfn main() -> i32\n  answer()\n`,
-      "packages/native/voyd/native_sdk/src/pkg.voyd":
+      "packages/native/local-packages/native_sdk/src/pkg.voyd":
         `pub fn answer() -> i32\n  42\n`,
     });
 
@@ -100,7 +103,7 @@ describe("language server project analysis", () => {
       );
       const roots = resolveModuleRoots(entryPath);
       expect(roots.pkgDirs).toContain(
-        project.filePathFor("packages/native/voyd"),
+        project.filePathFor("packages/native/local-packages"),
       );
 
       const analysis = await analyzeProject({

--- a/packages/language-server/src/__tests__/project.test.ts
+++ b/packages/language-server/src/__tests__/project.test.ts
@@ -86,6 +86,41 @@ describe("language server project analysis", () => {
     }
   });
 
+  it("resolves local packages from an ancestor voyd directory", async () => {
+    const project = await createProject({
+      "packages/native/examples/chart/main.voyd":
+        `use pkg::native_sdk::all\n\nfn main() -> i32\n  answer()\n`,
+      "packages/native/voyd/native_sdk/src/pkg.voyd":
+        `pub fn answer() -> i32\n  42\n`,
+    });
+
+    try {
+      const entryPath = project.filePathFor(
+        "packages/native/examples/chart/main.voyd",
+      );
+      const roots = resolveModuleRoots(entryPath);
+      expect(roots.pkgDirs).toContain(
+        project.filePathFor("packages/native/voyd"),
+      );
+
+      const analysis = await analyzeProject({
+        entryPath,
+        roots,
+        openDocuments: new Map(),
+      });
+      const diagnostics = analysis.diagnosticsByUri.get(toFileUri(entryPath)) ?? [];
+
+      expect(
+        diagnostics.some((diagnostic) =>
+          diagnostic.message.includes("pkg:native_sdk::pkg"),
+        ),
+      ).toBe(false);
+      expect(analysis.graph.modules.has("pkg:native_sdk::pkg")).toBe(true);
+    } finally {
+      await rm(project.rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("resolves go-to-definition for imported functions", async () => {
     const project = await createProject({
       "src/main.voyd": `use src::util::helper\n\nfn main() -> i32\n  helper(1)\n`,

--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -8,6 +8,7 @@ export {
   prepareRenameAtPosition,
   renameAtPosition,
   resolveEntryPath,
+  resolveModuleRootContext,
   resolveModuleRoots,
   toFileUri,
   type ProjectAnalysis,

--- a/packages/language-server/src/project.ts
+++ b/packages/language-server/src/project.ts
@@ -9,6 +9,7 @@ import {
   createOverlayModuleHost,
   normalizeFilePath,
   resolveEntryPath,
+  resolveModuleRootContext,
   resolveModuleRoots,
   toFileUri,
 } from "./project/files.js";
@@ -40,6 +41,7 @@ export {
   prepareRenameAtPosition,
   renameAtPosition,
   resolveEntryPath,
+  resolveModuleRootContext,
   resolveModuleRoots,
   toFileUri,
 };

--- a/packages/language-server/src/project/files.ts
+++ b/packages/language-server/src/project/files.ts
@@ -30,6 +30,20 @@ const collectNodeModulesDirs = (startDir: string): string[] => {
   }
 };
 
+const collectLocalVoydPackageDirs = (startDir: string): string[] => {
+  const dirs: string[] = [];
+  let current = path.resolve(startDir);
+
+  while (true) {
+    dirs.push(path.join(current, "voyd"));
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return dirs;
+    }
+    current = parent;
+  }
+};
+
 const hasStdSourceLayout = (rootPath: string): boolean =>
   existsSync(path.join(rootPath, "pkg.voyd"));
 
@@ -189,7 +203,10 @@ export const resolveModuleRoots = (entryPath: string): ModuleRoots => {
   return {
     src,
     std: resolveStdRoot(),
-    pkgDirs: dedupe(collectNodeModulesDirs(src)),
+    pkgDirs: dedupe([
+      ...collectLocalVoydPackageDirs(src),
+      ...collectNodeModulesDirs(src),
+    ]),
   };
 };
 

--- a/packages/language-server/src/project/files.ts
+++ b/packages/language-server/src/project/files.ts
@@ -3,6 +3,10 @@ import { createRequire } from "node:module";
 import { access, readdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { URI } from "vscode-uri";
+import {
+  inspectVoydPackageDirectories,
+  type VoydPackageDirectoryIssue,
+} from "@voyd-lang/lib/package-directories.js";
 import { createFsModuleHost } from "@voyd-lang/compiler/modules/fs-host.js";
 import { createNodePathAdapter } from "@voyd-lang/compiler/modules/node-path-adapter.js";
 import type { ModuleHost, ModuleRoots } from "@voyd-lang/compiler/modules/types.js";
@@ -15,34 +19,6 @@ const fsExists = async (targetPath: string): Promise<boolean> =>
   access(targetPath)
     .then(() => true)
     .catch(() => false);
-
-const collectNodeModulesDirs = (startDir: string): string[] => {
-  const dirs: string[] = [];
-  let current = path.resolve(startDir);
-
-  while (true) {
-    dirs.push(path.join(current, "node_modules"));
-    const parent = path.dirname(current);
-    if (parent === current) {
-      return dirs;
-    }
-    current = parent;
-  }
-};
-
-const collectLocalVoydPackageDirs = (startDir: string): string[] => {
-  const dirs: string[] = [];
-  let current = path.resolve(startDir);
-
-  while (true) {
-    dirs.push(path.join(current, "voyd"));
-    const parent = path.dirname(current);
-    if (parent === current) {
-      return dirs;
-    }
-    current = parent;
-  }
-};
 
 const hasStdSourceLayout = (rootPath: string): boolean =>
   existsSync(path.join(rootPath, "pkg.voyd"));
@@ -198,17 +174,54 @@ const resolveSrcRootFromEntry = (entryPath: string): string => {
   }
 };
 
-export const resolveModuleRoots = (entryPath: string): ModuleRoots => {
+export type ModuleRootContext = {
+  roots: ModuleRoots;
+  manifestPaths: readonly string[];
+  issues: readonly VoydPackageDirectoryIssue[];
+};
+
+export type ModulePackageContext = {
+  src: string;
+  pkgDirs: readonly string[];
+  manifestPaths: readonly string[];
+  issues: readonly VoydPackageDirectoryIssue[];
+};
+
+export const resolveModulePackageContext = (
+  entryPath: string,
+): ModulePackageContext => {
   const src = resolveSrcRootFromEntry(entryPath);
+  const inspection = inspectVoydPackageDirectories({ sourceRoot: src });
   return {
     src,
-    std: resolveStdRoot(),
-    pkgDirs: dedupe([
-      ...collectLocalVoydPackageDirs(src),
-      ...collectNodeModulesDirs(src),
-    ]),
+    pkgDirs: inspection.packageDirectories,
+    manifestPaths: inspection.manifestPaths,
+    issues: inspection.issues,
   };
 };
+
+export const moduleRootContextFromPackageContext = ({
+  src,
+  pkgDirs,
+  manifestPaths,
+  issues,
+}: ModulePackageContext): ModuleRootContext => ({
+  roots: {
+    src,
+    std: resolveStdRoot(),
+    pkgDirs,
+  },
+  manifestPaths,
+  issues,
+});
+
+export const resolveModuleRootContext = (
+  entryPath: string,
+): ModuleRootContext =>
+  moduleRootContextFromPackageContext(resolveModulePackageContext(entryPath));
+
+export const resolveModuleRoots = (entryPath: string): ModuleRoots =>
+  resolveModuleRootContext(entryPath).roots;
 
 export const createOverlayModuleHost = ({
   openDocuments,

--- a/packages/language-server/src/server/analysis-coordinator.ts
+++ b/packages/language-server/src/server/analysis-coordinator.ts
@@ -1,8 +1,12 @@
 import path from "node:path";
+import type { VoydPackageDirectoryIssue } from "@voyd-lang/lib/package-directories.js";
 import { createFsModuleHost } from "@voyd-lang/compiler/modules/fs-host.js";
 import type { ModuleHost, ModuleRoots } from "@voyd-lang/compiler/modules/types.js";
 import { isSemanticsAnalysisCancelledError } from "@voyd-lang/compiler/modules/semantic-analysis.js";
-import { type DidChangeWatchedFilesParams } from "vscode-languageserver/lib/node/main.js";
+import {
+  DiagnosticSeverity,
+  type DidChangeWatchedFilesParams,
+} from "vscode-languageserver/lib/node/main.js";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { URI } from "vscode-uri";
 import {
@@ -11,8 +15,11 @@ import {
   buildProjectNavigationIndexForModules,
   isProjectAnalysisCancelledError,
   resolveEntryPath,
-  resolveModuleRoots,
 } from "../project.js";
+import {
+  moduleRootContextFromPackageContext,
+  resolveModulePackageContext,
+} from "../project/files.js";
 import {
   buildCompletionExportEntriesByFirstCharacter,
   buildCompletionIndex,
@@ -35,6 +42,8 @@ type UriContext = {
   filePath: string;
   entryPath: string;
   roots: ModuleRoots;
+  manifestPaths: readonly string[];
+  packageConfigIssues: readonly VoydPackageDirectoryIssue[];
   cacheKey: string;
 };
 
@@ -82,6 +91,38 @@ const isCancelledError = (error: unknown): boolean =>
 const toImpactedModuleSet = (
   moduleIds: readonly string[],
 ): Set<string> => new Set(moduleIds);
+
+const withPackageConfigDiagnostics = ({
+  analysis,
+  uri,
+  issues,
+}: {
+  analysis: ProjectCoreAnalysis;
+  uri: string;
+  issues: readonly VoydPackageDirectoryIssue[];
+}): ProjectCoreAnalysis => {
+  if (issues.length === 0) {
+    return analysis;
+  }
+
+  const diagnosticsByUri = new Map(analysis.diagnosticsByUri);
+  const existing = diagnosticsByUri.get(uri) ?? [];
+  diagnosticsByUri.set(uri, [
+    ...issues.map(({ message }) => ({
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 0 },
+      },
+      severity: DiagnosticSeverity.Error,
+      code: "VOYD_CONFIG",
+      source: "voyd",
+      message,
+    })),
+    ...existing,
+  ]);
+
+  return { ...analysis, diagnosticsByUri };
+};
 
 const mergeOccurrencesByUri = ({
   base,
@@ -254,6 +295,10 @@ export class AnalysisCoordinator {
   readonly #navigationInFlight = new Map<string, Promise<ProjectNavigationIndex>>();
   readonly #completionCache = new Map<string, CompletionCacheEntry>();
   readonly #completionInFlight = new Map<string, Promise<CompletionAnalysis>>();
+  readonly #modulePackageContextsByEntryPath = new Map<
+    string,
+    ReturnType<typeof resolveModulePackageContext>
+  >();
 
   constructor({
     exportIndex = new ExportIndexService(),
@@ -284,11 +329,22 @@ export class AnalysisCoordinator {
   async handleWatchedFileChanges(
     changes: DidChangeWatchedFilesParams["changes"],
   ): Promise<boolean> {
-    const voydFilePaths = changes
-      .map((change) => normalizeFilePathFromUri(change.uri))
+    const changedFilePaths = changes.map((change) =>
+      normalizeFilePathFromUri(change.uri),
+    );
+    const packageConfigPaths = changedFilePaths.filter(
+      (filePath) => path.basename(filePath) === "package.json",
+    );
+    const packageConfigChanged = this.#invalidateModuleRootContexts(
+      packageConfigPaths,
+    );
+    const voydFilePaths = changedFilePaths
       .filter((filePath) => filePath.endsWith(".voyd"));
     if (voydFilePaths.length === 0) {
-      return false;
+      if (packageConfigChanged) {
+        this.#revision += 1;
+      }
+      return packageConfigChanged;
     }
 
     const updated = await this.#exportIndex.applyWatchedFileChanges({
@@ -300,7 +356,7 @@ export class AnalysisCoordinator {
     }
 
     this.#registerFileChanges(voydFilePaths);
-    return true;
+    return updated || packageConfigChanged;
   }
 
   async getCoreForUri(
@@ -309,7 +365,11 @@ export class AnalysisCoordinator {
     const { context, entry } = await this.#getCoreEntryForUri(uri);
     return {
       context,
-      analysis: entry.analysis,
+      analysis: withPackageConfigDiagnostics({
+        analysis: entry.analysis,
+        uri,
+        issues: context.packageConfigIssues,
+      }),
     };
   }
 
@@ -501,8 +561,7 @@ export class AnalysisCoordinator {
     const std = roots.std ? path.resolve(roots.std) : "";
     const pkg = roots.pkg ? path.resolve(roots.pkg) : "";
     const pkgDirs = [...(roots.pkgDirs ?? [])]
-      .map((pkgDir) => path.resolve(pkgDir))
-      .sort();
+      .map((pkgDir) => path.resolve(pkgDir));
     const hasResolvePackageRoot = roots.resolvePackageRoot ? "custom-pkg-resolver" : "";
     return [
       path.resolve(entryPath),
@@ -527,9 +586,8 @@ export class AnalysisCoordinator {
     }
 
     const fallbackContext: UriContext = {
-      filePath: context.filePath,
+      ...context,
       entryPath: context.filePath,
-      roots: context.roots,
       cacheKey: AnalysisCoordinator.#contextCacheKey({
         entryPath: context.filePath,
         roots: context.roots,
@@ -545,17 +603,50 @@ export class AnalysisCoordinator {
   async #resolveUriContext(uri: string): Promise<UriContext> {
     const filePath = normalizeFilePathFromUri(uri);
     const projectEntryPath = await resolveEntryPath(filePath);
-    const roots = resolveModuleRoots(projectEntryPath);
+    const normalizedEntryPath = path.resolve(projectEntryPath);
+    let modulePackageContext = this.#modulePackageContextsByEntryPath.get(
+      normalizedEntryPath,
+    );
+    if (!modulePackageContext) {
+      modulePackageContext = resolveModulePackageContext(normalizedEntryPath);
+      this.#modulePackageContextsByEntryPath.set(
+        normalizedEntryPath,
+        modulePackageContext,
+      );
+    }
+    const moduleRootContext = moduleRootContextFromPackageContext(
+      modulePackageContext,
+    );
+    const { roots, manifestPaths, issues } = moduleRootContext;
     const cacheKey = AnalysisCoordinator.#contextCacheKey({
-      entryPath: projectEntryPath,
+      entryPath: normalizedEntryPath,
       roots,
     });
     return {
       filePath,
-      entryPath: projectEntryPath,
+      entryPath: normalizedEntryPath,
       roots,
+      manifestPaths,
+      packageConfigIssues: issues,
       cacheKey,
     };
+  }
+
+  #invalidateModuleRootContexts(manifestPaths: readonly string[]): boolean {
+    if (manifestPaths.length === 0) {
+      return false;
+    }
+
+    const changed = new Set(manifestPaths.map((manifestPath) => path.resolve(manifestPath)));
+    let invalidated = false;
+    this.#modulePackageContextsByEntryPath.forEach((context, entryPath) => {
+      if (!context.manifestPaths.some((manifestPath) => changed.has(manifestPath))) {
+        return;
+      }
+      this.#modulePackageContextsByEntryPath.delete(entryPath);
+      invalidated = true;
+    });
+    return invalidated;
   }
 
   #isRunStale(revision: number): boolean {

--- a/packages/lib/src/lib/__tests__/package-directories.test.ts
+++ b/packages/lib/src/lib/__tests__/package-directories.test.ts
@@ -1,0 +1,76 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import {
+  inspectVoydPackageDirectories,
+  resolveVoydPackageDirectories,
+} from "../package-directories.js";
+
+describe("resolveVoydPackageDirectories", () => {
+  it("combines explicit, inherited package.json, and node_modules directories", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "voyd-package-config-"));
+    const projectRoot = path.join(root, "workspace");
+    const packageRoot = path.join(projectRoot, "apps", "consumer");
+    const sourceRoot = path.join(packageRoot, "src");
+
+    try {
+      await mkdir(sourceRoot, { recursive: true });
+      await writeFile(
+        path.join(projectRoot, "package.json"),
+        JSON.stringify({
+          voyd: { packageDirectories: ["./shared-packages"] },
+        }),
+      );
+      await writeFile(
+        path.join(packageRoot, "package.json"),
+        JSON.stringify({
+          voyd: { packageDirectories: ["./local-packages"] },
+        }),
+      );
+
+      const directories = resolveVoydPackageDirectories({
+        sourceRoot,
+        additionalPackageDirectories: ["../override-packages"],
+      });
+
+      expect(directories.slice(0, 3)).toEqual([
+        path.join(packageRoot, "override-packages"),
+        path.join(packageRoot, "local-packages"),
+        path.join(projectRoot, "shared-packages"),
+      ]);
+      expect(directories).toContain(path.join(sourceRoot, "node_modules"));
+      expect(directories).toContain(path.join(projectRoot, "node_modules"));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects malformed package directory configuration", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "voyd-package-config-"));
+
+    try {
+      await writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ voyd: { packageDirectories: "./packages" } }),
+      );
+
+      expect(() =>
+        resolveVoydPackageDirectories({ sourceRoot: root }),
+      ).toThrow(/voyd\.packageDirectories.*array of non-empty strings/);
+
+      const inspection = inspectVoydPackageDirectories({ sourceRoot: root });
+      expect(inspection.packageDirectories).toContain(
+        path.join(root, "node_modules"),
+      );
+      expect(inspection.issues).toEqual([
+        expect.objectContaining({
+          manifestPath: path.join(root, "package.json"),
+          message: expect.stringMatching(/voyd\.packageDirectories/),
+        }),
+      ]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/lib/src/lib/index.ts
+++ b/packages/lib/src/lib/index.ts
@@ -1,6 +1,7 @@
 export * from "./fast-shift-array.js";
 export * from "./helpers.js";
 export * from "./murmur-hash.js";
+export * from "./package-directories.js";
 export * from "./read-string.js";
 export * from "./resolve-src.js";
 export * from "./resolve-std.js";

--- a/packages/lib/src/lib/package-directories.ts
+++ b/packages/lib/src/lib/package-directories.ts
@@ -1,0 +1,152 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+export type VoydPackageDirectoryIssue = {
+  manifestPath: string;
+  message: string;
+};
+
+export type VoydPackageDirectoryInspection = {
+  packageDirectories: string[];
+  manifestPaths: string[];
+  issues: VoydPackageDirectoryIssue[];
+};
+
+export const resolveVoydPackageDirectories = ({
+  sourceRoot,
+  additionalPackageDirectories = [],
+}: {
+  sourceRoot: string;
+  additionalPackageDirectories?: readonly string[];
+}): string[] => {
+  const inspection = inspectVoydPackageDirectories({
+    sourceRoot,
+    additionalPackageDirectories,
+  });
+  if (inspection.issues.length > 0) {
+    throw new Error(inspection.issues.map(({ message }) => message).join("\n"));
+  }
+  return inspection.packageDirectories;
+};
+
+export const inspectVoydPackageDirectories = ({
+  sourceRoot,
+  additionalPackageDirectories = [],
+}: {
+  sourceRoot: string;
+  additionalPackageDirectories?: readonly string[];
+}): VoydPackageDirectoryInspection => {
+  const resolvedSourceRoot = path.resolve(sourceRoot);
+  const explicitDirectories = additionalPackageDirectories.map((directory) =>
+    path.resolve(resolvedSourceRoot, directory),
+  );
+  const ancestorDirectories = collectAncestorDirectories(resolvedSourceRoot);
+  const manifestPaths = ancestorDirectories.map((directory) =>
+    path.join(directory, "package.json"),
+  );
+  const inspectedManifests = manifestPaths.map(inspectPackageManifest);
+  const configuredDirectories = inspectedManifests.flatMap(
+    ({ packageDirectories }) => packageDirectories,
+  );
+  const nodeModulesDirectories = ancestorDirectories.map((directory) =>
+    path.join(directory, "node_modules"),
+  );
+
+  return {
+    packageDirectories: dedupePaths([
+      ...explicitDirectories,
+      ...configuredDirectories,
+      ...nodeModulesDirectories,
+    ]),
+    manifestPaths,
+    issues: inspectedManifests.flatMap(({ issues }) => issues),
+  };
+};
+
+const collectAncestorDirectories = (startDirectory: string): string[] => {
+  const directories: string[] = [];
+  let current = path.resolve(startDirectory);
+
+  while (true) {
+    directories.push(current);
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return directories;
+    }
+    current = parent;
+  }
+};
+
+const inspectPackageManifest = (
+  manifestPath: string,
+): Pick<VoydPackageDirectoryInspection, "packageDirectories" | "issues"> => {
+  if (!existsSync(manifestPath)) {
+    return { packageDirectories: [], issues: [] };
+  }
+
+  const manifestResult = readPackageJson(manifestPath);
+  if (!manifestResult.success) {
+    return {
+      packageDirectories: [],
+      issues: [{ manifestPath, message: manifestResult.message }],
+    };
+  }
+
+  const manifest = manifestResult.value;
+  if (!isRecord(manifest) || !isRecord(manifest.voyd)) {
+    return { packageDirectories: [], issues: [] };
+  }
+
+  const configured = manifest.voyd.packageDirectories;
+  if (configured === undefined) {
+    return { packageDirectories: [], issues: [] };
+  }
+  if (
+    !Array.isArray(configured) ||
+    configured.some((entry) => !isNonEmptyString(entry))
+  ) {
+    return {
+      packageDirectories: [],
+      issues: [
+        {
+          manifestPath,
+          message: `Invalid voyd.packageDirectories in ${manifestPath}: expected an array of non-empty strings`,
+        },
+      ],
+    };
+  }
+
+  const manifestDirectory = path.dirname(manifestPath);
+  return {
+    packageDirectories: configured.map((entry) =>
+      path.resolve(manifestDirectory, entry),
+    ),
+    issues: [],
+  };
+};
+
+const readPackageJson = (
+  manifestPath: string,
+): { success: true; value: unknown } | { success: false; message: string } => {
+  try {
+    return {
+      success: true,
+      value: JSON.parse(readFileSync(manifestPath, "utf8")) as unknown,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      message: `Unable to read ${manifestPath}: ${message}`,
+    };
+  }
+};
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const dedupePaths = (paths: readonly string[]): string[] =>
+  Array.from(new Set(paths));

--- a/packages/reference/docs/cli.md
+++ b/packages/reference/docs/cli.md
@@ -82,6 +82,22 @@ voyd test ./workspace/apps/consumer/test --pkg-dir ../pkgs
 to the target source root. For `voyd test`, it is resolved relative to the test
 root.
 
+Package directories shared by the CLI and editor can be declared in
+`package.json`:
+
+```json
+{
+  "voyd": {
+    "packageDirectories": ["./voyd-packages"]
+  }
+}
+```
+
+Configured paths are resolved relative to the `package.json` that declares
+them. Configuration is inherited from ancestor manifests, with nearer
+manifests searched first. Explicit `--pkg-dir` values are searched before
+configured directories, followed by ancestor `node_modules` directories.
+
 ## Generate API documentation
 
 ```bash


### PR DESCRIPTION
## Summary

- add a general `voyd.packageDirectories` configuration field to ancestor `package.json` manifests
- share one package-directory resolver between the CLI and language server
- watch relevant manifests in VS Code and refresh only affected language-server project contexts
- report invalid package-directory configuration as `VOYD_CONFIG` diagnostics without preventing editor analysis

## Configuration

```json
{
  "voyd": {
    "packageDirectories": ["./voyd-packages"]
  }
}
```

Paths are resolved relative to the manifest that declares them. The search order is explicit CLI `--pkg-dir` values, configured directories from nearest ancestor manifests outward, then ancestor `node_modules` directories.

## Root cause

Compilation clients could supply package roots programmatically, but the CLI and editor had no shared declarative project configuration for non-`node_modules` package directories. Tessyl therefore compiled with its custom package root while the language server analyzed the same source without it. This PR fixes that configuration boundary rather than recognizing Tessyl or a directory named `voyd` specially.

Tessyl can opt in with:

```json
{
  "voyd": {
    "packageDirectories": ["./voyd"]
  }
}
```

## Validation

- exact Tessyl chart analysis loads `pkg:tessyl_native::pkg` with no relevant diagnostics
- `npm test` — 18/18 tasks
- `npm run typecheck` — 17/17 affected tasks
- `npm run test:audit`
- full CLI end-to-end suite — 16 tests
- focused resolver, language-server project, and coordinator suites
- VS Code production bundle build
- clean agentic review loop: implementation gap, architecture, and correctness

The added CLI end-to-end case protects default manifest-to-compiler wiring; deeper precedence, validation, and reload behavior remains in the faster shared-resolver and language-server suites.