### PR TITLE
Fix VS Code local-install source resolution

### DIFF
--- a/apps/vscode/vite.server.config.ts
+++ b/apps/vscode/vite.server.config.ts
@@ -2,11 +2,11 @@ import path from "node:path";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  resolve: {
-    conditions: ["development"],
-  },
   ssr: {
     noExternal: true,
+    resolve: {
+      conditions: ["development"],
+    },
   },
   build: {
     ssr: path.resolve(__dirname, "../../packages/language-server/src/server.ts"),


### PR DESCRIPTION
## Summary

- apply the `development` package export condition to Vite's SSR resolver
- let the bundled language server resolve workspace package source when generated `dist` output is absent

## Root cause

The VS Code server bundle is an SSR build. Its config set `resolve.conditions` at the root, but Vite used the SSR environment's separate default conditions for that build. As a result, `@voyd-lang/lib/package-directories.js` selected the package's `dist` export instead of its `development` source export. A checkout with stale lib output had the older generated files but not the newly added module, causing `npm run install:local --workspace=voyd-vscode` to fail.

## Validation

- reproduced the failure with `packages/lib/dist` removed
- `npm run package --workspace=voyd-vscode` succeeds with the entire lib `dist` directory absent
- `npm test` — 18/18 tasks
- `npm run typecheck` — 6/6 affected dependency tasks
- `npm run test:audit`

The full packaging command covers everything in `install:local` except invoking VS Code to install the generated VSIX.