### PR TITLE
Preserve compiler typing state across language-server updates

### DIFF
--- a/packages/compiler/src/modules/__tests__/semantic-analysis.test.ts
+++ b/packages/compiler/src/modules/__tests__/semantic-analysis.test.ts
@@ -60,6 +60,7 @@ describe("analyzeModuleSemantics", () => {
       graph: updatedGraph,
       previousSemantics: initial.semantics,
       changedModuleIds: new Set(["src::util"]),
+      typingState: initial.typingState,
       recoverFromTypingErrors: true,
     });
 
@@ -70,6 +71,7 @@ describe("analyzeModuleSemantics", () => {
     expect(updated.semantics.get("src::helper")).toBe(initial.semantics.get("src::helper"));
     expect(updated.semantics.get("src::main")).not.toBe(initial.semantics.get("src::main"));
     expect(updated.semantics.get("src::util")).not.toBe(initial.semantics.get("src::util"));
+    expect(updated.typingState).toBe(initial.typingState);
   });
 
   it("falls back to full recompute for unknown changed module ids", async () => {
@@ -90,10 +92,46 @@ describe("analyzeModuleSemantics", () => {
       graph,
       previousSemantics: initial.semantics,
       changedModuleIds: new Set(["src::does_not_exist"]),
+      typingState: initial.typingState,
       recoverFromTypingErrors: true,
     });
 
     expect(updated.recomputedModuleIds.length).toBe(graph.modules.size);
+    expect(updated.typingState).not.toBe(initial.typingState);
+  });
+
+  it("rejects semantics paired with a different typing state", async () => {
+    const root = resolve("/proj/src");
+    const entryPath = `${root}${sep}main.voyd`;
+    const graph = await createGraph({
+      entryPath,
+      files: {
+        [entryPath]: `fn main() -> i32\n  1\n`,
+      },
+    });
+    const initial = analyzeModuleSemantics({ graph });
+    const unrelated = analyzeModuleSemantics({ graph });
+
+    expect(() =>
+      analyzeModuleSemantics({
+        graph,
+        previousSemantics: initial.semantics,
+        changedModuleIds: new Set(["src::main"]),
+        typingState: unrelated.typingState,
+      }),
+    ).toThrow(/does not match typingState/);
+
+    expect(() =>
+      analyzeModuleSemantics({
+        graph,
+        previousSemantics: initial.semantics,
+        changedModuleIds: new Set(["src::main"]),
+        typingState: {
+          arena: initial.typingState.arena,
+          effectInterner: unrelated.typingState.effectInterner,
+        },
+      }),
+    ).toThrow(/does not match typingState/);
   });
 
   it("supports cancellation before semantics work begins", async () => {

--- a/packages/compiler/src/modules/semantic-analysis.ts
+++ b/packages/compiler/src/modules/semantic-analysis.ts
@@ -25,6 +25,11 @@ import { getModuleSccGroups } from "./scc.js";
 import { collectCyclicModuleExportSurfaces } from "./cyclic-export-surfaces.js";
 import { cloneSemanticsMapForTypingState } from "./semantic-snapshot.js";
 
+export type SemanticsTypingState = {
+  arena: TypeArena;
+  effectInterner: EffectInterner;
+};
+
 export type AnalyzeModuleSemanticsOptions = {
   graph: ModuleGraph;
   includeTests?: boolean;
@@ -32,10 +37,7 @@ export type AnalyzeModuleSemanticsOptions = {
   captureDependencySnapshot?: boolean;
   previousSemantics?: ReadonlyMap<string, SemanticsPipelineResult>;
   changedModuleIds?: ReadonlySet<string>;
-  typingState?: {
-    arena: TypeArena;
-    effectInterner: EffectInterner;
-  };
+  typingState?: SemanticsTypingState;
   isCancelled?: () => boolean;
 };
 
@@ -50,6 +52,7 @@ export type AnalyzeModuleSemanticsResult = {
   semantics: Map<string, SemanticsPipelineResult>;
   diagnostics: Diagnostic[];
   recomputedModuleIds: readonly string[];
+  typingState: SemanticsTypingState;
   dependencySnapshot?: ReusableDependencySemanticsSnapshot;
 };
 
@@ -90,25 +93,28 @@ export const analyzeModuleSemantics = ({
   typingState,
   isCancelled,
 }: AnalyzeModuleSemanticsOptions): AnalyzeModuleSemanticsResult => {
+  if (previousSemantics && !typingState) {
+    throw new Error("previousSemantics requires its matching typingState");
+  }
+
+  const mismatchedTypingStateModuleId = typingState
+    ? Array.from(previousSemantics?.entries() ?? []).find(
+        ([, entry]) =>
+          entry.typing.arena !== typingState.arena ||
+          entry.typing.effects.internRow !== typingState.effectInterner.internRow,
+      )?.[0]
+    : undefined;
+  if (mismatchedTypingStateModuleId) {
+    throw new Error(
+      `previousSemantics for ${mismatchedTypingStateModuleId} does not match typingState`,
+    );
+  }
+
   const sccGroups = getModuleSccGroups({ graph });
   const semantics = new Map<string, SemanticsPipelineResult>();
   const exports = new Map<string, ModuleExportTable>();
   const diagnostics: Diagnostic[] = [];
   const recomputedModuleIds: string[] = [];
-  const arena = typingState?.arena ?? createTypeArena();
-  const effectInterner = typingState?.effectInterner ?? createEffectInterner();
-  let dependencySnapshot: ReusableDependencySemanticsSnapshot | undefined;
-  const shouldCaptureDependencySnapshot = captureDependencySnapshot === true;
-  const isReusableDependencyScc = createReusableDependencySccPredicate({
-    graph,
-    groups: sccGroups,
-  });
-  const reusableDependencyModuleIds = new Set(
-    sccGroups
-      .filter(isReusableDependencyScc)
-      .flatMap((group) => group.moduleIds),
-  );
-
   const cycleModuleIdsByModuleId = new Map<string, readonly string[]>();
   sccGroups.forEach((group) => {
     if (!group.cyclic) return;
@@ -123,6 +129,24 @@ export const analyzeModuleSemantics = ({
     changedModuleIds,
   });
   const isIncremental = incrementalModuleIds !== undefined;
+  const activeTypingState = isIncremental
+    ? typingState!
+    : {
+        arena: createTypeArena(),
+        effectInterner: createEffectInterner(),
+      };
+  const { arena, effectInterner } = activeTypingState;
+  let dependencySnapshot: ReusableDependencySemanticsSnapshot | undefined;
+  const shouldCaptureDependencySnapshot = captureDependencySnapshot === true;
+  const isReusableDependencyScc = createReusableDependencySccPredicate({
+    graph,
+    groups: sccGroups,
+  });
+  const reusableDependencyModuleIds = new Set(
+    sccGroups
+      .filter(isReusableDependencyScc)
+      .flatMap((group) => group.moduleIds),
+  );
   const recomputeSet = new Set(incrementalModuleIds ?? graph.modules.keys());
 
   if (isIncremental && previousSemantics) {
@@ -233,6 +257,7 @@ export const analyzeModuleSemantics = ({
     semantics,
     diagnostics,
     recomputedModuleIds,
+    typingState: activeTypingState,
     dependencySnapshot,
   };
 };

--- a/packages/compiler/src/pipeline-shared.ts
+++ b/packages/compiler/src/pipeline-shared.ts
@@ -16,7 +16,10 @@ import type { CodegenOptions } from "./codegen/context.js";
 import type { ContinuationBackendKind } from "./codegen/codegen.js";
 import { buildProgramCodegenView } from "./semantics/codegen-view/index.js";
 import { optimizeProgram } from "./optimize/pipeline.js";
-import { analyzeModuleSemantics } from "./modules/semantic-analysis.js";
+import {
+  analyzeModuleSemantics,
+  type SemanticsTypingState,
+} from "./modules/semantic-analysis.js";
 import type { ReusableDependencySemanticsSnapshot } from "./modules/semantic-analysis.js";
 import {
   commitDependencySnapshot,
@@ -24,8 +27,6 @@ import {
   prepareDependencySnapshotReuse,
   type CompilerDependencySnapshotCache,
 } from "./modules/dependency-snapshot-cache.js";
-import type { EffectInterner } from "./semantics/effects/effect-table.js";
-import type { TypeArena } from "./semantics/typing/type-arena.js";
 import { formatTestExportName } from "./tests/exports.js";
 import type { SourceSpan, SymbolId } from "./semantics/ids.js";
 import { getSymbolTable } from "./semantics/_internal/symbol-table.js";
@@ -61,10 +62,7 @@ export type AnalyzeModulesOptions = {
   captureDependencySnapshot?: boolean;
   previousSemantics?: ReadonlyMap<string, SemanticsPipelineResult>;
   changedModuleIds?: ReadonlySet<string>;
-  typingState?: {
-    arena: TypeArena;
-    effectInterner: EffectInterner;
-  };
+  typingState?: SemanticsTypingState;
   isCancelled?: () => boolean;
 };
 
@@ -73,6 +71,7 @@ export type AnalyzeModulesResult = {
   diagnostics: Diagnostic[];
   tests: readonly TestCase[];
   recomputedModuleIds: readonly string[];
+  typingState: SemanticsTypingState;
   dependencySnapshot?: ReusableDependencySemanticsSnapshot;
 };
 
@@ -143,8 +142,13 @@ export const analyzeModules = ({
   typingState,
   isCancelled,
 }: AnalyzeModulesOptions): AnalyzeModulesResult => {
-  const { semantics, diagnostics, recomputedModuleIds, dependencySnapshot } =
-    analyzeModuleSemantics({
+  const {
+    semantics,
+    diagnostics,
+    recomputedModuleIds,
+    typingState: nextTypingState,
+    dependencySnapshot,
+  } = analyzeModuleSemantics({
       graph,
       includeTests,
       recoverFromTypingErrors,
@@ -165,6 +169,7 @@ export const analyzeModules = ({
     diagnostics,
     tests,
     recomputedModuleIds,
+    typingState: nextTypingState,
     dependencySnapshot,
   };
 };

--- a/packages/language-server/src/__tests__/analysis-coordinator.test.ts
+++ b/packages/language-server/src/__tests__/analysis-coordinator.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { FileChangeType } from "vscode-languageserver/lib/node/main.js";
 import { TextDocument } from "vscode-languageserver-textdocument";
+import { definitionsAtPosition } from "../project.js";
 import { toFileUri } from "../project/files.js";
 import { AnalysisCoordinator } from "../server/analysis-coordinator.js";
 
@@ -241,6 +242,73 @@ describe("analysis coordinator", () => {
     }
   });
 
+  it("keeps package semantics valid after opening an imported definition", async () => {
+    const mainSource =
+      `use pkg::demo::all\n\nfn passthrough<Model, Msg>(value: Tessera<Model, Msg>) -> Tessera<Model, Msg>\n  value\n`;
+    const apiSource =
+      `use std::vx::Program\n\npub type Tessera<Model, Msg> = Program<Model, Msg>\n`;
+    const project = await createProject({
+      "package.json": JSON.stringify({
+        voyd: { packageDirectories: ["./voyd-packages"] },
+      }),
+      "examples/main.voyd": mainSource,
+      "voyd-packages/demo/package.json": JSON.stringify({
+        name: "demo",
+        version: "0.0.0",
+      }),
+      "voyd-packages/demo/src/pkg.voyd":
+        `pub src::api\npub use src::api::{ Tessera }\n`,
+      "voyd-packages/demo/src/api.voyd": apiSource,
+    });
+
+    try {
+      const mainPath = project.filePathFor("examples/main.voyd");
+      const mainUri = toFileUri(mainPath);
+      const apiPath = project.filePathFor("voyd-packages/demo/src/api.voyd");
+      const apiUri = toFileUri(apiPath);
+      const coordinator = new AnalysisCoordinator();
+      coordinator.updateDocument(
+        TextDocument.create(mainUri, "voyd", 1, mainSource),
+      );
+
+      const initial = await coordinator.getCoreForUri(mainUri);
+      expect(initial.analysis.diagnosticsByUri.get(mainUri) ?? []).toHaveLength(0);
+
+      const initialNavigation = await coordinator.getNavigationForUri(mainUri);
+      expect(
+        definitionsAtPosition({
+          analysis: initialNavigation,
+          uri: mainUri,
+          position: { line: 2, character: 36 },
+        }),
+      ).toEqual([
+        expect.objectContaining({ uri: apiUri }),
+      ]);
+
+      coordinator.updateDocument(
+        TextDocument.create(apiUri, "voyd", 1, apiSource),
+      );
+
+      const updated = await coordinator.getCoreForUri(mainUri);
+      expect(updated.analysis.diagnosticsByUri.get(mainUri) ?? []).toHaveLength(0);
+      expect(updated.analysis.diagnosticsByUri.get(apiUri) ?? []).toHaveLength(0);
+      expect(updated.analysis.graph.modules.has("pkg:demo::pkg")).toBe(true);
+
+      const updatedNavigation = await coordinator.getNavigationForUri(mainUri);
+      expect(
+        definitionsAtPosition({
+          analysis: updatedNavigation,
+          uri: mainUri,
+          position: { line: 2, character: 36 },
+        }),
+      ).toEqual([
+        expect.objectContaining({ uri: apiUri }),
+      ]);
+    } finally {
+      await rm(project.rootDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
   it("reuses unaffected module semantics after an edit", async () => {
     const project = await createProject({
       "src/main.voyd":
@@ -288,6 +356,61 @@ describe("analysis coordinator", () => {
       expect(updated.analysis.semantics.get("src::main")).not.toBe(initialMainSemantics);
       expect(updated.analysis.semantics.get("src::util")).not.toBe(initialUtilSemantics);
       expect(updated.analysis.semantics.get("src::helper")).toBe(initialHelperSemantics);
+    } finally {
+      await rm(project.rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("refreshes incremental typing state after a bounded number of edits", async () => {
+    const project = await createProject({
+      "src/main.voyd": `use src::helper::helper\n\nfn main() -> i32\n  helper()\n`,
+      "src/helper.voyd": `pub fn helper() -> i32\n  1\n`,
+    });
+
+    try {
+      const mainUri = toFileUri(project.filePathFor("src/main.voyd"));
+      const coordinator = new AnalysisCoordinator({
+        maxIncrementalAnalysisRuns: 1,
+      });
+      coordinator.updateDocument(
+        TextDocument.create(
+          mainUri,
+          "voyd",
+          1,
+          `use src::helper::helper\n\nfn main() -> i32\n  helper()\n`,
+        ),
+      );
+
+      const initial = await coordinator.getCoreForUri(mainUri);
+      const initialHelper = initial.analysis.semantics.get("src::helper");
+      expect(initialHelper).toBeDefined();
+
+      coordinator.updateDocument(
+        TextDocument.create(
+          mainUri,
+          "voyd",
+          2,
+          `use src::helper::helper\n\nfn main() -> i32\n  helper() + 1\n`,
+        ),
+      );
+      const incremental = await coordinator.getCoreForUri(mainUri);
+      expect(incremental.analysis.semantics.get("src::helper")).toBe(
+        initialHelper,
+      );
+
+      coordinator.updateDocument(
+        TextDocument.create(
+          mainUri,
+          "voyd",
+          3,
+          `use src::helper::helper\n\nfn main() -> i32\n  helper() + 2\n`,
+        ),
+      );
+      const refreshed = await coordinator.getCoreForUri(mainUri);
+      expect(refreshed.analysis.semantics.get("src::helper")).not.toBe(
+        initialHelper,
+      );
+      expect(refreshed.analysis.diagnosticsByUri.get(mainUri) ?? []).toHaveLength(0);
     } finally {
       await rm(project.rootDir, { recursive: true, force: true });
     }

--- a/packages/language-server/src/project.ts
+++ b/packages/language-server/src/project.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import type { Diagnostic as CompilerDiagnostic } from "@voyd-lang/compiler/diagnostics/index.js";
 import { modulePathToString } from "@voyd-lang/compiler/modules/path.js";
 import type { ModuleGraph, ModuleNode } from "@voyd-lang/compiler/modules/types.js";
+import type { SemanticsTypingState } from "@voyd-lang/compiler/modules/semantic-analysis.js";
 import { loadModuleGraph } from "@voyd-lang/compiler/pipeline.js";
 import { analyzeModules } from "@voyd-lang/compiler/pipeline-shared.js";
 import { buildDiagnosticsByUri } from "./project/diagnostics.js";
@@ -58,6 +59,7 @@ export type IncrementalProjectCoreResult = {
   analysis: ProjectCoreAnalysis;
   recomputedModuleIds: readonly string[];
   changedModuleIds: readonly string[];
+  typingState: SemanticsTypingState;
   incremental: boolean;
 };
 
@@ -355,10 +357,12 @@ export const analyzeProjectCoreIncremental = async ({
   openDocuments,
   host,
   previousAnalysis,
+  previousTypingState,
   changedFilePaths,
   isCancelled,
 }: AnalysisInputs & {
   previousAnalysis?: ProjectCoreAnalysis;
+  previousTypingState?: SemanticsTypingState;
   changedFilePaths?: ReadonlySet<string>;
   isCancelled?: () => boolean;
 }): Promise<IncrementalProjectCoreResult> => {
@@ -390,16 +394,22 @@ export const analyzeProjectCoreIncremental = async ({
     previousAnalysis,
     nextModuleIdByFilePath,
   });
+  const canReuseSemantics =
+    previousAnalysis !== undefined && previousTypingState !== undefined;
 
   const {
     semantics,
     diagnostics: semanticDiagnostics,
     recomputedModuleIds,
+    typingState,
   } = analyzeModules({
     graph,
     recoverFromTypingErrors: true,
-    previousSemantics: previousAnalysis?.semantics,
-    changedModuleIds,
+    previousSemantics: canReuseSemantics
+      ? previousAnalysis.semantics
+      : undefined,
+    changedModuleIds: canReuseSemantics ? changedModuleIds : undefined,
+    typingState: canReuseSemantics ? previousTypingState : undefined,
     isCancelled,
   });
   throwIfProjectAnalysisCancelled(isCancelled);
@@ -413,7 +423,8 @@ export const analyzeProjectCoreIncremental = async ({
     }),
     recomputedModuleIds,
     changedModuleIds: Array.from(changedModuleIds ?? []),
-    incremental: changedModuleIds !== undefined,
+    typingState,
+    incremental: canReuseSemantics && typingState === previousTypingState,
   };
 };
 

--- a/packages/language-server/src/server/analysis-coordinator.ts
+++ b/packages/language-server/src/server/analysis-coordinator.ts
@@ -2,7 +2,10 @@ import path from "node:path";
 import type { VoydPackageDirectoryIssue } from "@voyd-lang/lib/package-directories.js";
 import { createFsModuleHost } from "@voyd-lang/compiler/modules/fs-host.js";
 import type { ModuleHost, ModuleRoots } from "@voyd-lang/compiler/modules/types.js";
-import { isSemanticsAnalysisCancelledError } from "@voyd-lang/compiler/modules/semantic-analysis.js";
+import {
+  isSemanticsAnalysisCancelledError,
+  type SemanticsTypingState,
+} from "@voyd-lang/compiler/modules/semantic-analysis.js";
 import {
   DiagnosticSeverity,
   type DidChangeWatchedFilesParams,
@@ -51,6 +54,8 @@ type CoreCacheEntry = {
   revision: number;
   analysis: ProjectCoreAnalysis;
   recomputedModuleIds: readonly string[];
+  typingState: SemanticsTypingState;
+  incrementalRuns: number;
 };
 
 type NavigationCacheEntry = {
@@ -287,6 +292,7 @@ export class AnalysisCoordinator {
     fallbackHost: this.#fileSystemHost,
   });
   readonly #exportIndex: ExportIndexService;
+  readonly #maxIncrementalAnalysisRuns: number;
   #revision = 0;
   readonly #changedFilesByRevision = new Map<number, ReadonlySet<string>>();
   readonly #coreCache = new Map<string, CoreCacheEntry>();
@@ -302,10 +308,13 @@ export class AnalysisCoordinator {
 
   constructor({
     exportIndex = new ExportIndexService(),
+    maxIncrementalAnalysisRuns = 100,
   }: {
     exportIndex?: ExportIndexService;
+    maxIncrementalAnalysisRuns?: number;
   } = {}) {
     this.#exportIndex = exportIndex;
+    this.#maxIncrementalAnalysisRuns = maxIncrementalAnalysisRuns;
   }
 
   updateDocument(document: TextDocument): void {
@@ -768,12 +777,18 @@ export class AnalysisCoordinator {
         openDocuments: this.openDocuments,
       });
 
+      const refreshTypingState =
+        cached !== undefined &&
+        cached.incrementalRuns >= this.#maxIncrementalAnalysisRuns;
       const incremental = await analyzeProjectCoreIncremental({
         entryPath: context.entryPath,
         roots: context.roots,
         openDocuments: this.openDocuments,
         host: this.#createCancellableModuleHost(runRevision),
         previousAnalysis: cached?.analysis,
+        previousTypingState: refreshTypingState
+          ? undefined
+          : cached?.typingState,
         changedFilePaths: this.#changedFilesSince(cached?.revision ?? -1),
         isCancelled: () => this.#isRunStale(runRevision),
       });
@@ -781,6 +796,10 @@ export class AnalysisCoordinator {
         revision: runRevision,
         analysis: incremental.analysis,
         recomputedModuleIds: incremental.recomputedModuleIds,
+        typingState: incremental.typingState,
+        incrementalRuns: incremental.incremental
+          ? (cached?.incrementalRuns ?? 0) + 1
+          : 0,
       };
 
       if (this.#revision === runRevision) {


### PR DESCRIPTION
## Summary

- carry the compiler type arena and effect interner alongside cached language-server semantics
- reject missing or mismatched incremental typing state and start a fresh generation whenever incremental reuse falls back
- rotate the language-server typing generation after 100 incremental analyses so append-only compiler state stays bounded
- add regressions for opening an imported generic package definition, mismatched arena/interner pairs, clean fallback, and bounded state refresh

## Root cause

The language server reused `previousSemantics` after editor updates but created a fresh type arena and effect interner. The cached semantics' TypeIds were then interpreted through unrelated compiler state. In Tessyl, opening the definition of `Tessera<Model, Msg> = Program<Model, Msg>` caused a hidden `TY9999` typing failure, which cascaded into the false `BD0001` “module is not available for import” diagnostics. Reloading the window worked temporarily because it forced a coherent full analysis.

This is a general incremental-analysis fix. Tessyl's configured `voyd.packageDirectories: ["./voyd"]` layout, including `voyd/tessyl_native/package.json` and `src/pkg.voyd`, is valid and does not need to be reorganized for module resolution.

## Validation

- exact Tessyl go-to-definition/open-document replay: clean diagnostics throughout
- `npm test`
- `npm run typecheck`
- `npm run test:audit`
- `npm run package --workspace=voyd-vscode`
- 100k language-server incremental performance gate
- focused compiler/language-server regressions (13 tests)
- agentic implementation-gap, architecture, and correctness reviews; all clean after addressing bounded state lifetime and arena/interner pairing
