### PR TITLE
[V-432] Add user-defined declaration attribute macros

### DIFF
--- a/apps/cli/src/__tests__/cli-e2e.test.ts
+++ b/apps/cli/src/__tests__/cli-e2e.test.ts
@@ -560,6 +560,58 @@ describe("voyd cli package resolution", { timeout: CLI_E2E_TIMEOUT_MS }, () => {
     }
   });
 
+  it("shows imported attribute macro expansion in the parser AST", async () => {
+    assertCliRunnerAvailable();
+
+    const root = await mkdtemp(resolve(tmpdir(), "voyd-cli-attribute-ast-"));
+    const srcRoot = resolve(root, "src");
+    const entryPath = resolve(srcRoot, "main.voyd");
+    await mkdir(srcRoot, { recursive: true });
+    await writeFile(
+      resolve(srcRoot, "macros.voyd"),
+      [
+        "pub attribute macro replace(args, declaration)",
+        "  `(fn expanded() -> i32",
+        "    42)",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(
+      entryPath,
+      [
+        "use src::macros::all",
+        "",
+        "@replace",
+        "fn original() -> i32",
+        "  1",
+        "",
+      ].join("\n"),
+    );
+
+    try {
+      const result = runCli(root, ["--emit-parser-ast", entryPath]);
+      const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+      if (result.status !== 0) {
+        throw new Error(`voyd parser AST failed: ${output}`);
+      }
+
+      expect(JSON.parse(result.stdout)).toEqual(
+        expect.arrayContaining([
+          expect.arrayContaining([
+            "fn",
+            expect.arrayContaining([
+              "->",
+              expect.arrayContaining(["expanded"]),
+            ]),
+          ]),
+        ]),
+      );
+      expect(output).not.toContain("original");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("resolves --pkg-dir relative to the target source root", async () => {
     assertCliRunnerAvailable();
 

--- a/apps/cli/src/exec.ts
+++ b/apps/cli/src/exec.ts
@@ -74,10 +74,6 @@ async function main() {
     return runWasm(entryPath, config.entry);
   }
 
-  if (config.emitParserAst) {
-    return printJson(await getParserAst(entryPath));
-  }
-
   let rootsPromise: Promise<ModuleRoots> | undefined;
   const getRoots = () => {
     rootsPromise ??= getModuleRoots({
@@ -86,6 +82,10 @@ async function main() {
     });
     return rootsPromise;
   };
+
+  if (config.emitParserAst) {
+    return printJson(await getParserAst(entryPath, await getRoots()));
+  }
 
   if (config.doc) {
     return emitDocumentation({
@@ -221,14 +221,21 @@ const serializeHir = (hir: HirGraph) => ({
   expressions: Array.from(hir.expressions.entries()),
 });
 
-async function getParserAst(entryPath: string) {
-  const { parse } = await import("@voyd-lang/sdk/compiler");
-  const file = readFileSync(entryPath, { encoding: "utf8" });
-  return parse(file, entryPath).toJSON();
+async function getParserAst(entryPath: string, roots: ModuleRoots) {
+  const { loadModuleGraph } = await import("@voyd-lang/sdk/compiler");
+  const graph = await loadModuleGraph({ entryPath, roots });
+  assertNoDiagnostics(graph.diagnostics);
+  const entryModule = graph.modules.get(graph.entry);
+  if (!entryModule) {
+    throw new Error("No expanded parser AST available for entry module");
+  }
+  return entryModule.ast.toJSON();
 }
 
 async function getCoreAst(entryPath: string) {
-  return await getParserAst(entryPath);
+  const { parse } = await import("@voyd-lang/sdk/compiler");
+  const file = readFileSync(entryPath, { encoding: "utf8" });
+  return parse(file, entryPath).toJSON();
 }
 
 async function getIrAST(entryPath: string, roots: ModuleRoots) {

--- a/apps/vscode/scripts/test-grammar.mjs
+++ b/apps/vscode/scripts/test-grammar.mjs
@@ -174,6 +174,7 @@ assertMatchesAny(
     "trait",
     "let",
     "var",
+    "attribute",
     "macro",
     "macro_let",
     "eff",
@@ -264,13 +265,17 @@ assertMatchesAny(
   ),
 );
 
-assert(attributePattern, "Expected compiler attribute grammar pattern to exist");
-["boundary", "compiler_contract", "effect", "external", "intrinsic", "intrinsic_type", "serializer"].forEach(
+assert(attributePattern, "Expected attribute grammar pattern to exist");
+["boundary", "compiler_contract", "effect", "external", "instrument", "intrinsic", "intrinsic_type", "serializer"].forEach(
   (attribute) =>
     assert(
       matchesEntirePattern(attributePattern, `@${attribute}`),
       `Expected @${attribute} to be highlighted as an attribute`,
     ),
+);
+assert(
+  !matchesEntirePattern(attributePattern, "@"),
+  "Expected an attribute to require an identifier name",
 );
 
 assert(namespacePattern, "Expected module namespace grammar pattern to exist");

--- a/docs/architecture/compiler-surface-syntax.md
+++ b/docs/architecture/compiler-surface-syntax.md
@@ -10,8 +10,9 @@ between those layers.
 
 `ModuleHeaderView` is built from base-expanded syntax. It contains only the
 module items needed before functional macro expansion: uses and exports, inline
-modules, external module declarations, and macro declarations. Module discovery
-and macro import ordering consume this view.
+modules, external module declarations, functional macro declarations, and
+declaration attribute macro declarations. Module discovery and macro import
+ordering consume this view.
 
 `SurfaceModuleView` is built after functional and post-syntax macro expansion.
 It contains normalized declarations and their signatures, parameters, fields,
@@ -26,6 +27,14 @@ view from mutable `module.ast`. A missing header after graph construction or a
 missing surface after expansion is an invariant failure. The standalone
 semantics entry point is the sole initializer allowed to materialize and attach
 an expanded surface for a caller-supplied module.
+
+Declaration attribute macros share the functional macro namespace, evaluator,
+import graph, hygiene model, and invalidation path. Expansion associates a run
+of generic `@name(...)` forms with the following declaration before surface
+normalization. Reserved compiler attributes are retained for specialized
+post-syntax handlers; imported user attributes expand first and may emit a
+declaration sequence. The expanded `module.ast` remains the compiler's macro
+inspection surface.
 
 Expression-level normalizers are parser-owned, syntax-identity-cached accessors.
 Binding and lowering may request the same normalized lambda, binding, match,

--- a/packages/compiler/src/modules/__tests__/doc-comments.test.ts
+++ b/packages/compiler/src/modules/__tests__/doc-comments.test.ts
@@ -218,4 +218,26 @@ pub eff Time
     const sleepOp = effectDecl?.operations.find((op) => op.name === "sleep");
     expect(sleepOp?.documentation).toBe(" Sleep docs.");
   });
+
+  it("preserves declaration and parameter docs through attribute expansion", async () => {
+    const { diagnostics, semantics } = await compileSingleModule(`
+attribute macro preserve(args, declaration)
+  declaration
+
+/// Documented function.
+@preserve
+pub fn documented(
+  /// Documented parameter.
+  value: i32
+) -> i32
+  value
+`);
+
+    expect(diagnostics.filter((entry) => entry.code === "MD0004")).toHaveLength(0);
+    const documented = semantics
+      .get("src::main")
+      ?.binding.functions.find((fn) => fn.name === "documented");
+    expect(documented?.documentation).toBe(" Documented function.");
+    expect(documented?.params[0]?.documentation).toBe(" Documented parameter.");
+  });
 });

--- a/packages/compiler/src/modules/__tests__/graph.test.ts
+++ b/packages/compiler/src/modules/__tests__/graph.test.ts
@@ -91,6 +91,46 @@ declare_reserved_module()
     );
   });
 
+  it("stabilizes imports needed by declaration attribute expansion", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `
+macro import_attributes()
+  syntax_template (use src::attributes::decorate)
+
+import_attributes()
+
+@decorate
+fn original() -> i32
+  1
+`,
+      [`${root}${sep}attributes.voyd`]: `
+pub attribute macro decorate(args, declaration)
+  emit_many(
+    declaration,
+    \`(fn generated() -> i32
+      42)
+  )
+`,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    expect(graph.diagnostics).toHaveLength(0);
+    const functionNames = graph.modules
+      .get("src::main")
+      ?.surface?.items.flatMap((item) =>
+        item.kind === "function"
+          ? [item.declaration.signature.name.value]
+          : [],
+      );
+    expect(functionNames).toEqual(["original", "generated"]);
+  });
+
   it("drops generated inline modules that disappear after re-expansion", async () => {
     const root = resolve("/proj/src");
     const host = createMemoryHost({
@@ -1088,6 +1128,49 @@ pub use self::outer::all
           },
         }),
       ]),
+    );
+  });
+
+  it("imports attribute macros with aliases and emits companion declarations", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `
+use src::macros::companion as generate_companion
+
+@generate_companion(description: "generated")
+fn original() -> i32
+  1
+`,
+      [`${root}${sep}macros.voyd`]: `
+pub attribute macro companion(args, declaration)
+  if args.length() == 1 then:
+    emit_many(
+      declaration,
+      \`(fn generated() -> i32
+        42)
+    )
+  else:
+    panic("expected one argument")
+`,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    expect(graph.diagnostics).toHaveLength(0);
+    const functionNames = graph.modules
+      .get("src::main")
+      ?.surface?.items.flatMap((item) =>
+        item.kind === "function"
+          ? [item.declaration.signature.name.value]
+          : [],
+      );
+    expect(functionNames).toEqual(["original", "generated"]);
+    expect(graph.modules.get("src::macros")?.macroExports).toContain(
+      "companion",
     );
   });
 });

--- a/packages/compiler/src/modules/__tests__/macro-expansion-errors.test.ts
+++ b/packages/compiler/src/modules/__tests__/macro-expansion-errors.test.ts
@@ -5,6 +5,7 @@ import { createNodePathAdapter } from "../node-path-adapter.js";
 import type { ModuleHost } from "../types.js";
 import { buildModuleGraph } from "../graph.js";
 import { isIntAtom } from "../../parser/index.js";
+import { analyzeModules } from "../../pipeline-shared.js";
 
 const createMemoryHost = (files: Record<string, string>): ModuleHost =>
   createMemoryModuleHost({ files, pathAdapter: createNodePathAdapter() });
@@ -103,5 +104,331 @@ describe("expandModuleMacros diagnostics", () => {
     expect(diagnostic?.message).toMatch(/serializer/i);
     expect(diagnostic?.message).toMatch(/duplicate/i);
     expect(diagnostic?.span.file).toContain("main.voyd");
+  });
+
+  it("reports unknown declaration attributes at the invocation", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `
+@missing
+fn value() -> i32
+  1
+`,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    const diagnostic = graph.diagnostics.find((entry) => entry.code === "MD0003");
+    expect(diagnostic?.message).toMatch(/unknown attribute '@missing'/i);
+    expect(diagnostic?.span.start).toBe(2);
+  });
+
+  it("does not cascade surface errors for unknown method attributes", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `
+obj Box {}
+
+impl Box
+  @missing
+  fn value(self) -> i32
+    1
+`,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    expect(graph.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "MD0003",
+        message: expect.stringMatching(/unknown attribute '@missing'/i),
+      }),
+    ]);
+  });
+
+  it("reports ambiguous imported attribute macros and recommends aliases", async () => {
+    const root = resolve("/proj/src");
+    const attributeMacro = `
+pub attribute macro decorate(args, declaration)
+  declaration
+`;
+    const source = `
+use src::first::all
+use src::second::all
+
+@decorate
+fn value() -> i32
+  1
+`;
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: source,
+      [`${root}${sep}first.voyd`]: attributeMacro,
+      [`${root}${sep}second.voyd`]: attributeMacro,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    const diagnostic = graph.diagnostics.find((entry) => entry.code === "MD0003");
+    expect(diagnostic?.message).toMatch(/macro 'decorate' is ambiguous/i);
+    expect(diagnostic?.message).toMatch(/explicit alias/i);
+    expect(diagnostic?.span.start).toBe(source.indexOf("@decorate"));
+    expect(graph.diagnostics.some((entry) => entry.code === "MD0002")).toBe(false);
+  });
+
+  it("preserves attribute macro ambiguity through public re-exports", async () => {
+    const root = resolve("/proj/src");
+    const attributeMacro = `
+pub attribute macro decorate(args, declaration)
+  declaration
+`;
+    const source = `
+use src::barrel::all
+
+@decorate
+fn value() -> i32
+  1
+`;
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: source,
+      [`${root}${sep}barrel.voyd`]: `
+pub use src::first::all
+pub use src::second::all
+`,
+      [`${root}${sep}first.voyd`]: attributeMacro,
+      [`${root}${sep}second.voyd`]: attributeMacro,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    const diagnostic = graph.diagnostics.find((entry) => entry.code === "MD0003");
+    expect(diagnostic?.message).toMatch(/macro 'decorate' is ambiguous/i);
+    expect(diagnostic?.span.start).toBe(source.indexOf("@decorate"));
+  });
+
+  it("reports attribute macro ambiguity introduced by generated imports", async () => {
+    const root = resolve("/proj/src");
+    const attributeMacro = `
+pub attribute macro decorate(args, declaration)
+  declaration
+`;
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `
+use src::first::all
+
+macro import_second()
+  syntax_template (use src::second::all)
+
+import_second()
+
+@decorate
+fn value() -> i32
+  1
+`,
+      [`${root}${sep}first.voyd`]: attributeMacro,
+      [`${root}${sep}second.voyd`]: attributeMacro,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    const diagnostic = graph.diagnostics.find((entry) => entry.code === "MD0003");
+    expect(diagnostic?.message).toMatch(/macro 'decorate' is ambiguous/i);
+    expect(diagnostic?.message).toMatch(/explicit alias/i);
+  });
+
+  it.each([
+    {
+      name: "duplicate attribute",
+      declarations: `
+attribute macro preserve(args, declaration)
+  declaration
+`,
+      attributes: "@preserve\n@preserve",
+      expectedMessage: /duplicate user-defined attribute/i,
+    },
+    {
+      name: "functional macro used as an attribute",
+      declarations: `
+macro preserve(value)
+  value
+`,
+      attributes: "@preserve",
+      expectedMessage: /functional macro, not an attribute macro/i,
+    },
+  ])(
+    "recovers from $name without cascading or blocking later expansion",
+    async ({ declarations, attributes, expectedMessage }) => {
+      const root = resolve("/proj/src");
+      const host = createMemoryHost({
+        [`${root}${sep}main.voyd`]: `
+${declarations}
+macro declare_helper()
+  \`(fn helper() -> i32
+    2)
+
+${attributes}
+fn value() -> i32
+  1
+
+declare_helper()
+`,
+      });
+
+      const graph = await buildModuleGraph({
+        entryPath: `${root}${sep}main.voyd`,
+        host,
+        roots: { src: root },
+      });
+
+      expect(graph.diagnostics).toEqual([
+        expect.objectContaining({
+          code: "MD0003",
+          message: expect.stringMatching(expectedMessage),
+        }),
+      ]);
+      const functionNames = graph.modules
+        .get("src::main")
+        ?.surface?.items.flatMap((item) =>
+          item.kind === "function"
+            ? [item.declaration.signature.name.value]
+            : [],
+        );
+      expect(functionNames).toEqual(["value", "helper"]);
+    },
+  );
+
+  it("rolls back generated macro exports when an attribute expansion fails", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `
+macro requires_value(value)
+  value
+
+attribute macro broken(args, declaration)
+  emit_many(
+    \`(pub macro ghost(value)
+      value),
+    \`(requires_value())
+  )
+
+@broken
+fn value() -> i32
+  1
+`,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    expect(graph.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "MD0003",
+        message: expect.stringMatching(/expected 1 arguments, received 0/i),
+      }),
+    ]);
+    const module = graph.modules.get("src::main");
+    expect(module?.macroExports).not.toContain("ghost");
+    expect(
+      module?.surface?.items.some((item) => item.kind === "function"),
+    ).toBe(true);
+  });
+
+  it("rejects compiler-reserved attribute macro names", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `
+attribute macro external(args, declaration)
+  declaration
+`,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    const diagnostic = graph.diagnostics.find((entry) => entry.code === "MD0003");
+    expect(diagnostic?.message).toMatch(
+      /attribute macro name 'external' is reserved/i,
+    );
+  });
+
+  it("maps diagnostics from generated declarations to the attribute invocation", async () => {
+    const root = resolve("/proj/src");
+    const source = `
+attribute macro invalid(args, declaration)
+  \`(not_a_declaration generated)
+
+@invalid
+fn value() -> i32
+  1
+`;
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: source,
+    });
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    const diagnostic = graph.diagnostics.find((entry) => entry.code === "MD0002");
+    expect(diagnostic?.message).toMatch(/unsupported top-level form/i);
+    expect(diagnostic?.span.start).toBe(source.indexOf("@invalid"));
+  });
+
+  it("maps nested generated binding diagnostics to the attribute invocation", async () => {
+    const root = resolve("/proj/src");
+    const source = `
+attribute macro invalid(args, declaration)
+  \`(fn generated() -> i32
+    missing_value)
+
+@invalid
+fn value() -> i32
+  1
+`;
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: source,
+    });
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+    const analyzed = analyzeModules({
+      graph,
+      recoverFromTypingErrors: true,
+    });
+
+    const diagnostic = analyzed.diagnostics.find((entry) =>
+      entry.message.includes("missing_value"),
+    );
+    expect(diagnostic).toBeDefined();
+    expect(diagnostic?.span.start).toBe(source.indexOf("@invalid"));
   });
 });

--- a/packages/compiler/src/modules/__tests__/use-decl.test.ts
+++ b/packages/compiler/src/modules/__tests__/use-decl.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { isForm, parse } from "../../parser/index.js";
+import { isForm, parse, parseBase } from "../../parser/index.js";
 import { classifyTopLevelDecl } from "../use-decl.js";
 
 const classifyFirst = (source: string) => {
   const ast = parse(source, "use-decl-test.voyd");
+  const first = ast.rest[0];
+  if (!isForm(first)) {
+    throw new Error("expected first top-level entry to be a form");
+  }
+  return classifyTopLevelDecl(first);
+};
+
+const classifyFirstBase = (source: string) => {
+  const ast = parseBase(source, "use-decl-test.voyd");
   const first = ast.rest[0];
   if (!isForm(first)) {
     throw new Error("expected first top-level entry to be a form");
@@ -53,6 +62,19 @@ describe("classifyTopLevelDecl", () => {
       classifyFirst("pub macro inc(value)\n  syntax_template (+ $value 1.0)"),
     ).toMatchObject({
       kind: "macro-decl",
+    });
+  });
+
+  it("classifies attribute macro declarations", () => {
+    expect(
+      classifyFirstBase(
+        "pub attribute macro preserve(args, declaration)\n  declaration",
+      ),
+    ).toMatchObject({
+      kind: "macro-decl",
+      macroKind: "attribute",
+      name: "preserve",
+      visibility: "pub",
     });
   });
 

--- a/packages/compiler/src/modules/macro-expansion.ts
+++ b/packages/compiler/src/modules/macro-expansion.ts
@@ -1,4 +1,4 @@
-import { Form, IdentifierAtom } from "../parser/index.js";
+import { Form, IdentifierAtom, isForm, type Syntax } from "../parser/index.js";
 import { toSourceSpan } from "../parser/surface/utils.js";
 import type { NormalizedUseEntry } from "../parser/surface/use-path.js";
 import { resolveModuleRequest } from "./resolve.js";
@@ -42,6 +42,10 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
     string,
     Map<string, MacroScopeUseEntry>
   >();
+  const documentationByLocationByModule = new Map<
+    string,
+    DocumentationByLocation
+  >();
   const invalidatedModules = new Map<string, number>();
   const processedInvalidationByModule = new Map<string, number>();
   let nextInvalidationGeneration = 0;
@@ -57,6 +61,7 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
       exportsByModule.delete(moduleId);
       sourceAstByModule.delete(moduleId);
       scopeUseEntriesByModule.delete(moduleId);
+      documentationByLocationByModule.delete(moduleId);
     },
     expand: (graph) => {
       const diagnostics: Diagnostic[] = [];
@@ -76,6 +81,10 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
         }
         const moduleDiagnostics: Diagnostic[] = [];
         const sourceAst = sourceAstByModule.get(id);
+        const documentationByLocation =
+          documentationByLocationByModule.get(id) ??
+          indexDocumentationByLocation(module);
+        documentationByLocationByModule.set(id, documentationByLocation);
         if (sourceAst && isInvalidated) {
           module.ast = sourceAst.clone();
         } else if (!sourceAst) {
@@ -99,13 +108,61 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
           module,
           entries: scopeUseEntries,
           exportsByModule,
+          sourceEntryKeys: new Set(
+            collectUseEntries(headerItems).map(useEntryKey),
+          ),
         });
         const scope = new MacroScope();
-        importedMacros.forEach((macro) => scope.defineMacro(macro));
+        importedMacros.macros.forEach((macro) => scope.defineMacro(macro));
+        importedMacros.ambiguousNames.forEach((name) =>
+          scope.defineAmbiguousMacro(name),
+        );
+        module.macroImports = Array.from(importedMacros.macros.entries()).map(
+          ([name, macro]) => ({ name, kind: macro.kind }),
+        );
+        const attributeMacroReferences: NonNullable<
+          ModuleNode["attributeMacroReferences"]
+        >[number][] = [];
+        const unknownAttributeSpans: ReturnType<typeof toSourceSpan>[] = [];
+        const unknownAttributeKeys = new Set<string>();
 
         const functionalResult = expandFunctionalMacros(module.ast, {
           scope,
+          moduleId: id,
           strictMacroSignatures: true,
+          onAttributeExpansion: ({ invocationName, macro }) => {
+            if (!macro.moduleId || !macro.declarationName.location) {
+              return;
+            }
+            attributeMacroReferences.push({
+              name: invocationName.value,
+              macroId: macro.id.value,
+              definitionName: macro.declarationName.value,
+              definitionModuleId: macro.moduleId,
+              invocationSpan: toSourceSpan(invocationName),
+              definitionSpan: toSourceSpan(macro.declarationName),
+            });
+          },
+          onUnknownAttribute: (invocationName) => {
+            const span = toSourceSpan(invocationName);
+            const key = `${invocationName.value}:${span.file}:${span.start}:${span.end}`;
+            if (unknownAttributeKeys.has(key)) {
+              return;
+            }
+            unknownAttributeKeys.add(key);
+            unknownAttributeSpans.push(span);
+            moduleDiagnostics.push(
+              diagnosticFromCode({
+                code: "MD0003",
+                params: {
+                  kind: "macro-expansion-failed",
+                  macro: "attributeDispatcher",
+                  errorMessage: `unknown attribute '@${invocationName.value}'`,
+                },
+                span,
+              }),
+            );
+          },
           onError: (error) =>
             reportMacroExpansionError({
               diagnostics: moduleDiagnostics,
@@ -114,12 +171,26 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
               fallbackSyntax: module.ast,
             }),
         });
+        module.attributeMacroReferences = attributeMacroReferences;
         module.ast = applyPostSyntaxMacros(
           functionalResult.form,
           moduleDiagnostics,
         );
         module.surface = createSurfaceModuleView(module.ast);
+        remapExpandedDocumentation({ module, documentationByLocation });
         module.surface.issues.forEach((issue) => {
+          const isUnknownAttributeIssue =
+            issue.message ===
+              "unsupported top-level form; expected a declaration" &&
+            unknownAttributeSpans.some(
+              (span) =>
+                span.file === issue.span.file &&
+                span.start >= issue.span.start &&
+                span.start <= issue.span.end,
+            );
+          if (isUnknownAttributeIssue) {
+            return;
+          }
           moduleDiagnostics.push(
             diagnosticFromCode({
               code: "MD0002",
@@ -151,7 +222,7 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
           localExports,
         });
         const previousExports = exportsByModule.get(id);
-        module.macroExports = Array.from(exportedMacros.keys());
+        module.macroExports = Array.from(exportedMacros.macros.keys());
         exportsByModule.set(id, exportedMacros);
         const exportNamesChanged = !haveSameMacroExportNames(
           previousExports,
@@ -159,7 +230,8 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
         );
         const rebuiltExportDefinitions =
           isInvalidated &&
-          ((previousExports?.size ?? 0) > 0 || exportedMacros.size > 0);
+          (macroExportNameCount(previousExports) > 0 ||
+            macroExportNameCount(exportedMacros) > 0);
         const propagationGeneration = rebuiltExportDefinitions
           ? invalidationGeneration
           : exportNamesChanged
@@ -185,7 +257,10 @@ export const createModuleMacroExpander = (): ModuleMacroExpander => {
   };
 };
 
-type MacroExportTable = Map<string, MacroDefinition>;
+type MacroExportTable = {
+  macros: Map<string, MacroDefinition>;
+  ambiguousNames: Set<string>;
+};
 type UseEntryWithVisibility = NormalizedUseEntry & {
   visibility: "module" | "pub";
 };
@@ -193,13 +268,108 @@ type MacroScopeUseEntry = {
   entry: UseEntryWithVisibility;
   inlineModuleNames: ReadonlySet<string>;
 };
+type DocumentationByLocation = {
+  declarations: ReadonlyMap<string, string>;
+  parameters: ReadonlyMap<string, string>;
+};
+
+const indexDocumentationByLocation = (
+  module: ModuleNode,
+): DocumentationByLocation => {
+  const declarations = new Map<string, string>();
+  const parameters = new Map<string, string>();
+  const docs = module.docs;
+  if (!docs) {
+    return { declarations, parameters };
+  }
+
+  visitSyntax(module.ast, (syntax) => {
+    const key = documentationLocationKey(syntax);
+    if (!key) {
+      return;
+    }
+    const declaration = docs.declarationsBySyntaxId.get(syntax.syntaxId);
+    if (declaration !== undefined) {
+      declarations.set(key, declaration);
+    }
+    const parameter = docs.parametersBySyntaxId.get(syntax.syntaxId);
+    if (parameter !== undefined) {
+      parameters.set(key, parameter);
+    }
+  });
+  return { declarations, parameters };
+};
+
+const remapExpandedDocumentation = ({
+  module,
+  documentationByLocation,
+}: {
+  module: ModuleNode;
+  documentationByLocation: DocumentationByLocation;
+}): void => {
+  const docs = module.docs;
+  if (!docs) {
+    return;
+  }
+  const declarations = new Map(docs.declarationsBySyntaxId);
+  const parameters = new Map(docs.parametersBySyntaxId);
+  visitSyntax(module.ast, (syntax) => {
+    const key = documentationLocationKey(syntax);
+    if (!key) {
+      return;
+    }
+    const declaration = documentationByLocation.declarations.get(key);
+    if (declaration !== undefined) {
+      declarations.set(syntax.syntaxId, declaration);
+    }
+    const parameter = documentationByLocation.parameters.get(key);
+    if (parameter !== undefined) {
+      parameters.set(syntax.syntaxId, parameter);
+    }
+  });
+  module.docs = {
+    ...docs,
+    declarationsBySyntaxId: declarations,
+    parametersBySyntaxId: parameters,
+  };
+};
+
+const visitSyntax = (
+  syntax: Syntax,
+  visit: (entry: Syntax) => void,
+): void => {
+  visit(syntax);
+  if (isForm(syntax)) {
+    syntax.toArray().forEach((entry) => visitSyntax(entry, visit));
+  }
+};
+
+const documentationLocationKey = (syntax: Syntax): string | undefined => {
+  const location = syntax.location;
+  return location
+    ? [
+        syntax.syntaxType,
+        location.filePath,
+        location.startIndex,
+        location.endIndex,
+      ].join(":")
+    : undefined;
+};
 
 const haveSameMacroExportNames = (
   previous: MacroExportTable | undefined,
   current: MacroExportTable,
 ): boolean =>
-  (previous?.size ?? 0) === current.size &&
-  Array.from(current.keys()).every((name) => previous?.has(name));
+  macroExportNameCount(previous) === macroExportNameCount(current) &&
+  Array.from(current.macros.keys()).every((name) =>
+    previous?.macros.has(name),
+  ) &&
+  Array.from(current.ambiguousNames).every((name) =>
+    previous?.ambiguousNames.has(name),
+  );
+
+const macroExportNameCount = (table: MacroExportTable | undefined): number =>
+  (table?.macros.size ?? 0) + (table?.ambiguousNames.size ?? 0);
 
 const invalidateMacroImporters = ({
   graph,
@@ -296,7 +466,7 @@ const indexExports = (exports: MacroDefinition[]): MacroExportTable => {
   exports.forEach((macro) => {
     table.set(macro.name.value, macro);
   });
-  return table;
+  return { macros: table, ambiguousNames: new Set() };
 };
 
 const collectInlineModuleNames = (
@@ -313,15 +483,52 @@ const collectMacroImports = ({
   module,
   entries,
   exportsByModule,
+  sourceEntryKeys,
 }: {
   module: ModuleNode;
   entries: MacroScopeUseEntry[];
   exportsByModule: Map<string, MacroExportTable>;
-}): Map<string, MacroDefinition> => {
+  sourceEntryKeys: ReadonlySet<string>;
+}): {
+  macros: Map<string, MacroDefinition>;
+  ambiguousNames: Set<string>;
+} => {
   const imports = new Map<string, MacroDefinition>();
+  const importedFromSource = new Map<string, boolean>();
+  const ambiguousNames = new Set<string>();
+  const addImport = ({
+    name,
+    macro,
+    fromSource,
+  }: {
+    name: string;
+    macro: MacroDefinition;
+    fromSource: boolean;
+  }): void => {
+    if (ambiguousNames.has(name)) {
+      return;
+    }
+    const existing = imports.get(name);
+    const hasAttributeMacro =
+      existing?.kind === "attribute" || macro.kind === "attribute";
+    if (
+      existing &&
+      existing.id.value !== macro.id.value &&
+      (hasAttributeMacro ||
+        (importedFromSource.get(name) === true && fromSource))
+    ) {
+      imports.delete(name);
+      ambiguousNames.add(name);
+      return;
+    }
+    ambiguousNames.delete(name);
+    imports.set(name, macro);
+    importedFromSource.set(name, fromSource);
+  };
   const moduleIsPackageRoot =
     module.origin.kind === "file" && module.path.segments.at(-1) === "pkg";
   entries.forEach(({ entry, inlineModuleNames }) => {
+    const fromSource = sourceEntryKeys.has(useEntryKey(entry));
     if (!entry.hasExplicitPrefix) {
       return;
     }
@@ -352,8 +559,12 @@ const collectMacroImports = ({
     }
 
     if (entry.selectionKind === "all") {
-      exportedMacros.forEach((macro, name) => {
-        imports.set(name, macro);
+      exportedMacros.macros.forEach((macro, name) => {
+        addImport({ name, macro, fromSource });
+      });
+      exportedMacros.ambiguousNames.forEach((name) => {
+        imports.delete(name);
+        ambiguousNames.add(name);
       });
       return;
     }
@@ -363,18 +574,24 @@ const collectMacroImports = ({
       return;
     }
 
-    const macro = exportedMacros.get(targetName);
+    const alias = entry.alias ?? targetName;
+    if (exportedMacros.ambiguousNames.has(targetName)) {
+      imports.delete(alias);
+      ambiguousNames.add(alias);
+      return;
+    }
+
+    const macro = exportedMacros.macros.get(targetName);
     if (!macro) {
       return;
     }
 
-    const alias = entry.alias ?? targetName;
     const definition =
       alias === macro.name.value ? macro : cloneMacroWithAlias(macro, alias);
-    imports.set(alias, definition);
+    addImport({ name: alias, macro: definition, fromSource });
   });
 
-  return imports;
+  return { macros: imports, ambiguousNames };
 };
 
 const collectMacroReexports = ({
@@ -390,7 +607,33 @@ const collectMacroReexports = ({
   exportsByModule: Map<string, MacroExportTable>;
   localExports: MacroExportTable;
 }): MacroExportTable => {
-  const exports = new Map(localExports);
+  const exports = new Map(localExports.macros);
+  const ambiguousNames = new Set(localExports.ambiguousNames);
+  const addReexport = (name: string, macro: MacroDefinition): void => {
+    if (localExports.macros.has(name) || ambiguousNames.has(name)) {
+      return;
+    }
+    const existing = exports.get(name);
+    if (
+      existing &&
+      existing.id.value !== macro.id.value &&
+      (existing.kind === "attribute" || macro.kind === "attribute")
+    ) {
+      exports.delete(name);
+      ambiguousNames.add(name);
+      return;
+    }
+    if (!existing) {
+      exports.set(name, macro);
+    }
+  };
+  const addAmbiguousReexport = (name: string): void => {
+    if (localExports.macros.has(name)) {
+      return;
+    }
+    exports.delete(name);
+    ambiguousNames.add(name);
+  };
   const moduleIsPackageRoot =
     module.origin.kind === "file" && module.path.segments.at(-1) === "pkg";
   entries
@@ -427,11 +670,10 @@ const collectMacroReexports = ({
       }
 
       if (entry.selectionKind === "all") {
-        exportedMacros.forEach((macro, name) => {
-          if (!exports.has(name)) {
-            exports.set(name, macro);
-          }
-        });
+        exportedMacros.macros.forEach((macro, name) =>
+          addReexport(name, macro),
+        );
+        exportedMacros.ambiguousNames.forEach(addAmbiguousReexport);
         return;
       }
 
@@ -440,23 +682,26 @@ const collectMacroReexports = ({
         return;
       }
 
-      const macro = exportedMacros.get(targetName);
+      const alias = entry.alias ?? targetName;
+      if (exportedMacros.ambiguousNames.has(targetName)) {
+        addAmbiguousReexport(alias);
+        return;
+      }
+
+      const macro = exportedMacros.macros.get(targetName);
       if (!macro) {
         return;
       }
 
-      const alias = entry.alias ?? targetName;
-      if (!exports.has(alias)) {
-        exports.set(
-          alias,
-          alias === macro.name.value
-            ? macro
-            : cloneMacroWithAlias(macro, alias),
-        );
-      }
+      addReexport(
+        alias,
+        alias === macro.name.value
+          ? macro
+          : cloneMacroWithAlias(macro, alias),
+      );
     });
 
-  return exports;
+  return { macros: exports, ambiguousNames };
 };
 
 const collectUseEntries = (
@@ -510,11 +755,14 @@ const cloneMacroWithAlias = (
   macro: MacroDefinition,
   alias: string,
 ): MacroDefinition => ({
+  kind: macro.kind,
   name: new IdentifierAtom(alias),
+  declarationName: macro.declarationName.clone(),
   parameters: macro.parameters.map((param) => param.clone()),
   body: macro.body.map((expr) => cloneExpr(expr)),
   scope: macro.scope,
   id: macro.id.clone(),
+  moduleId: macro.moduleId,
 });
 
 const sortModules = (graph: ModuleGraph): string[] => {

--- a/packages/compiler/src/modules/types.ts
+++ b/packages/compiler/src/modules/types.ts
@@ -92,6 +92,20 @@ export interface ModuleNode {
    * Includes local `pub macro` exports and `pub use` re-exports.
    */
   macroExports?: readonly string[];
+  /** Macro names imported into this module after alias resolution. */
+  macroImports?: readonly {
+    name: string;
+    kind: "function" | "attribute";
+  }[];
+  /** Source links retained for language tooling after attribute expansion. */
+  attributeMacroReferences?: readonly {
+    name: string;
+    macroId: string;
+    definitionName: string;
+    definitionModuleId: string;
+    invocationSpan: SourceSpan;
+    definitionSpan: SourceSpan;
+  }[];
 }
 
 type ModuleDiagnosticContext = {

--- a/packages/compiler/src/parser/surface/use-decl.ts
+++ b/packages/compiler/src/parser/surface/use-decl.ts
@@ -37,6 +37,7 @@ export type TopLevelDeclClassification =
       name?: string;
       nameSyntax?: IdentifierAtom;
       visibility: TopLevelUseDeclVisibility;
+      macroKind: "function" | "attribute";
     }
   | { kind: "other" };
 
@@ -54,11 +55,13 @@ const PUB_DECL_KEYWORDS = new Set([
   "macro",
   "macro_let",
   "functional-macro",
+  "attribute-macro",
   "define-macro-variable",
 ]);
 
 const MACRO_DECL_KEYWORDS = new Set([
   "functional-macro",
+  "attribute-macro",
   "define-macro-variable",
   "macro",
   "macro_let",
@@ -141,6 +144,27 @@ export const classifyTopLevelDecl = (
   const { visibility, keywordExpr, offset } = visibilityAndKeywordFor(form);
   const keyword = isIdentifierAtom(keywordExpr) ? keywordExpr.value : undefined;
 
+  if (keyword === "attribute") {
+    const macroKeyword = form.at(offset + 1);
+    const signature = form.at(offset + 2);
+    if (
+      isIdentifierAtom(macroKeyword) &&
+      macroKeyword.value === "macro" &&
+      isForm(signature)
+    ) {
+      const potentialName = signature.at(0);
+      const nameSyntax = isIdentifierAtom(potentialName)
+        ? potentialName
+        : undefined;
+      return {
+        kind: "macro-decl",
+        visibility,
+        macroKind: "attribute",
+        ...(nameSyntax ? { name: nameSyntax.value, nameSyntax } : {}),
+      };
+    }
+  }
+
   if (keyword === "use") {
     const pathExpr = form.at(offset + 1);
     if (!pathExpr) {
@@ -162,6 +186,7 @@ export const classifyTopLevelDecl = (
     return {
       kind: "macro-decl",
       visibility,
+      macroKind: keyword === "attribute-macro" ? "attribute" : "function",
       ...(nameSyntax ? { name: nameSyntax.value, nameSyntax } : {}),
     };
   }

--- a/packages/compiler/src/parser/syntax-macros/__tests__/functional-macros.test.ts
+++ b/packages/compiler/src/parser/syntax-macros/__tests__/functional-macros.test.ts
@@ -271,4 +271,205 @@ pub declare_value NumberLike
       ["object_literal", [":", "answer", "i32"]],
     ]);
   });
+
+  test("expands declaration attribute macros with structured arguments", () => {
+    const code = `\
+attribute macro companion(args, declaration)
+  if args.length() == 1 then:
+    emit_many(
+      declaration,
+      \`(fn generated() -> i32
+        42)
+    )
+  else:
+    panic("expected one attribute argument")
+
+@companion(description: "generated helper")
+fn original() -> i32
+  1
+`;
+
+    const plain = toPlain(parse(code));
+    expect(plain).toContainEqual([
+      "fn",
+      ["->", ["original"], "i32"],
+      ["block", "1"],
+    ]);
+    expect(plain).toContainEqual([
+      "fn",
+      ["->", ["generated"], "i32"],
+      ["block", "42"],
+    ]);
+  });
+
+  test("applies stacked attribute macros from top to bottom", () => {
+    const code = `\
+attribute macro add_first(args, declaration)
+  emit_many(
+    declaration,
+    \`(fn first_companion() -> i32
+      1)
+  )
+
+attribute macro add_second(args, declaration)
+  emit_many(
+    declaration,
+    \`(fn second_companion() -> i32
+      2)
+  )
+
+@add_first
+@add_second
+fn original() -> i32
+  0
+`;
+
+    const declarationNames = toPlain(parse(code)).flatMap((entry) =>
+      Array.isArray(entry) && entry[0] === "fn"
+        ? [((entry[1] as Plain)[1] as Plain)[0]]
+        : [],
+    );
+    expect(declarationNames).toEqual([
+      "original",
+      "first_companion",
+      "second_companion",
+    ]);
+  });
+
+  test("bounds recursive attribute expansion", () => {
+    const ast = parseBase(`\
+attribute macro recurse(args, declaration)
+  emit_many(\`(@ recurse), declaration)
+
+@recurse
+fn original() -> i32
+  0
+`);
+
+    expect(() =>
+      expandFunctionalMacros(ast, {
+        strictMacroSignatures: true,
+        maxAttributeExpansionDepth: 3,
+      }),
+    ).toThrow(/attribute macro expansion exceeded the depth limit of 3/i);
+  });
+
+  test("dispatches reserved compiler attributes after user expansion", () => {
+    const ast = parse(`\
+attribute macro preserve(args, declaration)
+  declaration
+
+@preserve
+@effect(id: "voyd.example.time")
+eff Time
+  now
+`);
+    const effect = ast.rest.find(
+      (entry) => entry instanceof Form && entry.calls("eff"),
+    );
+
+    expect(effect?.attributes?.effect).toEqual({ id: "voyd.example.time" });
+  });
+
+  test("rejects duplicate user-defined attributes", () => {
+    expect(() =>
+      parse(`\
+attribute macro preserve(args, declaration)
+  declaration
+
+@preserve
+@preserve
+fn value() -> i32
+  1
+`),
+    ).toThrow(/duplicate user-defined attribute '@preserve'/i);
+  });
+
+  test("rejects functional macros used as attributes", () => {
+    expect(() =>
+      parse(`\
+macro ordinary(value)
+  value
+
+@ordinary
+fn value() -> i32
+  1
+`),
+    ).toThrow(/functional macro, not an attribute macro/i);
+  });
+
+  test("preserves unresolved attributes in context-free parser output", () => {
+    const plain = toPlain(parse(`\
+@imported_attribute
+fn value() -> i32
+  1
+`));
+
+    expect(plain).toContainEqual(["@", "imported_attribute"]);
+  });
+
+  test("applies attribute macros to visibility-modified methods", () => {
+    const plain = toPlain(
+      parse(`\
+attribute macro preserve(args, declaration)
+  declaration
+
+obj Box {}
+
+impl Box
+  @preserve
+  api fn answer(self) -> i32
+    42
+`),
+    );
+
+    expect(
+      containsDeep(plain, [
+        "api",
+        "fn",
+        ["->", ["answer", "self"], "i32"],
+        ["block", "42"],
+      ]),
+    ).toBe(true);
+  });
+
+  test("applies attribute macros to enum declarations", () => {
+    const plain = toPlain(
+      parse(`\
+attribute macro preserve(args, declaration)
+  declaration
+
+@preserve
+enum Status
+  Ready
+`),
+    );
+
+    expect(plain).toContainEqual(["enum", "Status", ["block", "Ready"]]);
+  });
+
+  test("expands attributes emitted by ordinary functional macros", () => {
+    const plain = toPlain(
+      parse(`\
+attribute macro preserve(args, declaration)
+  declaration
+
+macro declare_attributed()
+  emit_many(
+    \`(@ preserve),
+    \`(fn generated() -> i32
+      42)
+  )
+
+declare_attributed()
+`),
+    );
+
+    expect(plain).toContainEqual([
+      "fn",
+      ["->", ["generated"], "i32"],
+      ["block", "42"],
+    ]);
+    expect(plain).not.toContainEqual(["@", "preserve"]);
+  });
 });

--- a/packages/compiler/src/parser/syntax-macros/functional-macro-expander/evaluator.ts
+++ b/packages/compiler/src/parser/syntax-macros/functional-macro-expander/evaluator.ts
@@ -114,6 +114,7 @@ export function expandMacroCall(
 ): Expr {
   const invocationScope = new MacroScope(macro.scope);
   const args = call.toArray().slice(1).map(cloneExpr);
+  const preservedLocations = collectSyntaxLocationKeys(args);
   const bodyArguments = new Form({
     location: call.location?.clone(),
     elements: args.map(cloneExpr),
@@ -145,9 +146,68 @@ export function expandMacroCall(
   });
 
   const normalized = expectExpr(result, "macro expansion result");
-  if (call.location) normalized.setLocation(call.location.clone());
+  if (call.location) {
+    rebaseGeneratedSyntax({
+      syntax: normalized,
+      invocationLocation: call.location,
+      preservedLocations,
+    });
+  }
   return normalized;
 }
+
+const rebaseGeneratedSyntax = ({
+  syntax,
+  invocationLocation,
+  preservedLocations,
+}: {
+  syntax: Syntax;
+  invocationLocation: NonNullable<Syntax["location"]>;
+  preservedLocations: ReadonlySet<string>;
+}): void => {
+  const key = syntaxLocationKey(syntax);
+  if (!key || !preservedLocations.has(key)) {
+    syntax.setLocation(invocationLocation.clone());
+  }
+  if (isForm(syntax)) {
+    syntax.toArray().forEach((entry) =>
+      rebaseGeneratedSyntax({
+        syntax: entry,
+        invocationLocation,
+        preservedLocations,
+      }),
+    );
+  }
+};
+
+const collectSyntaxLocationKeys = (
+  roots: readonly Syntax[],
+): Set<string> => {
+  const keys = new Set<string>();
+  const visit = (syntax: Syntax): void => {
+    const key = syntaxLocationKey(syntax);
+    if (key) {
+      keys.add(key);
+    }
+    if (isForm(syntax)) {
+      syntax.toArray().forEach(visit);
+    }
+  };
+  roots.forEach(visit);
+  return keys;
+};
+
+const syntaxLocationKey = (syntax: Syntax): string | undefined => {
+  const location = syntax.location;
+  return location
+    ? [
+        syntax.syntaxType,
+        location.filePath,
+        location.startIndex,
+        location.endIndex,
+      ].join(":")
+    : undefined;
+};
 
 function callLambda(lambda: MacroLambdaValue, args: Expr[]): MacroEvalResult {
   const lambdaScope = new MacroScope(lambda.scope);

--- a/packages/compiler/src/parser/syntax-macros/functional-macro-expander/renderers.ts
+++ b/packages/compiler/src/parser/syntax-macros/functional-macro-expander/renderers.ts
@@ -5,7 +5,9 @@ import { cloneExpr } from "./helpers.js";
 
 export const renderFunctionalMacro = (macro: MacroDefinition): Form =>
   new Form([
-    new IdentifierAtom("functional-macro"),
+    new IdentifierAtom(
+      macro.kind === "attribute" ? "attribute-macro" : "functional-macro",
+    ),
     macro.id.clone(),
     new Form([
       new IdentifierAtom("parameters"),

--- a/packages/compiler/src/parser/syntax-macros/functional-macro-expander/scope.ts
+++ b/packages/compiler/src/parser/syntax-macros/functional-macro-expander/scope.ts
@@ -7,6 +7,7 @@ import type {
 export class MacroScope {
   #parent?: MacroScope;
   #macros = new Map<string, MacroDefinition>();
+  #ambiguousMacros = new Set<string>();
   #variables = new Map<string, MacroVariableBinding>();
 
   constructor(parent?: MacroScope) {
@@ -17,11 +18,38 @@ export class MacroScope {
     return new MacroScope(this);
   }
 
+  checkpoint(): () => void {
+    const macros = new Map(this.#macros);
+    const ambiguousMacros = new Set(this.#ambiguousMacros);
+    const variables = new Map(
+      Array.from(this.#variables, ([name, binding]) => [
+        name,
+        { ...binding },
+      ]),
+    );
+    return () => {
+      this.#macros = macros;
+      this.#ambiguousMacros = ambiguousMacros;
+      this.#variables = variables;
+    };
+  }
+
   defineMacro(definition: MacroDefinition) {
+    this.#ambiguousMacros.delete(definition.name.value);
     this.#macros.set(definition.name.value, definition);
   }
 
+  defineAmbiguousMacro(name: string) {
+    this.#macros.delete(name);
+    this.#ambiguousMacros.add(name);
+  }
+
   getMacro(name: string): MacroDefinition | undefined {
+    if (this.#ambiguousMacros.has(name)) {
+      throw new Error(
+        `Macro '${name}' is ambiguous; import it with an explicit alias`,
+      );
+    }
     return this.#macros.get(name) ?? this.#parent?.getMacro(name);
   }
 

--- a/packages/compiler/src/parser/syntax-macros/functional-macro-expander/syntax-macro.ts
+++ b/packages/compiler/src/parser/syntax-macros/functional-macro-expander/syntax-macro.ts
@@ -2,6 +2,7 @@ import { Form } from "../../ast/form.js";
 import {
   Expr,
   IdentifierAtom,
+  InternalIdentifierAtom,
   isForm,
   isIdentifierAtom,
   isInternalIdentifierAtom,
@@ -23,6 +24,7 @@ import type { MacroDefinition, MacroVariableBinding } from "./types.js";
 import { nextMacroId } from "./macro-id.js";
 
 type MacroDefinitionInput = {
+  kind: MacroDefinition["kind"];
   signature: Form;
   bodyExpressions: Expr[];
   visibility: "pub" | "module";
@@ -32,7 +34,26 @@ type ExpandFunctionalMacroOptions = {
   scope?: MacroScope;
   strictMacroSignatures?: boolean;
   onError?: (error: SyntaxMacroError) => void;
+  maxAttributeExpansionDepth?: number;
+  attributeExpansionDepth?: number;
+  moduleId?: string;
+  onAttributeExpansion?: (event: {
+    invocationName: IdentifierAtom;
+    macro: MacroDefinition;
+  }) => void;
+  onUnknownAttribute?: (invocationName: IdentifierAtom) => void;
 };
+
+const DEFAULT_MAX_ATTRIBUTE_EXPANSION_DEPTH = 64;
+const RESERVED_ATTRIBUTE_NAMES = new Set([
+  "boundary",
+  "compiler_contract",
+  "effect",
+  "external",
+  "intrinsic",
+  "intrinsic_type",
+  "serializer",
+]);
 
 export const functionalMacroExpander: SyntaxMacro = (form: Form): Form =>
   expandFunctionalMacros(form).form;
@@ -71,16 +92,31 @@ const expandExpr = (
       strictMacroSignatures: options.strictMacroSignatures === true,
     });
     if (macroDefinition) {
-      return expandMacroDefinition(macroDefinition, scope, exports);
+      return expandMacroDefinition(
+        macroDefinition,
+        scope,
+        exports,
+        options.moduleId,
+      );
     }
 
     if (expr.calls("macro_let")) {
       return expandMacroLet(expr, scope);
     }
 
+    if (isAttributeForm(expr)) {
+      return expr;
+    }
+
     const head = expr.at(0);
     const macro = isIdentifierAtom(head) ? scope.getMacro(head.value) : undefined;
     if (macro) {
+      if (macro.kind === "attribute") {
+        throw new SyntaxMacroError(
+          `Attribute macro '${macro.name.value}' must be invoked with '@' before a declaration`,
+          expr,
+        );
+      }
       const expanded = expandMacroCall(expr, macro, scope);
       return expandExpr(expanded, scope, exports, options);
     }
@@ -111,23 +147,319 @@ const expandForm = (
   const bodyScope = createsScopeFor(head) ? scope.child() : scope;
   const elements = form.toArray();
   const result: Expr[] = [];
+  const allowsAttributes = isTopLevelAst(form) || form.calls("block");
 
-  elements.forEach((child, index) => {
+  for (let index = 0; index < elements.length; index += 1) {
+    const child = elements[index]!;
     if (isModuleName(head, index)) {
       result.push(child);
-      return;
+      continue;
+    }
+
+    if (allowsAttributes && isForm(child) && isAttributeForm(child)) {
+      const { attributes, targetIndex } = collectConsecutiveAttributes({
+        elements,
+        startIndex: index,
+      });
+      const target = elements[targetIndex];
+      if (!target) {
+        throw new SyntaxMacroError(
+          "attribute is missing a following declaration",
+          child,
+        );
+      }
+      const exportedMacroCount = exports.length;
+      const rollbackScope = bodyScope.checkpoint();
+      const pendingErrors: SyntaxMacroError[] = [];
+      const pendingUnknownAttributes: IdentifierAtom[] = [];
+      const pendingAttributeExpansions: Array<{
+        invocationName: IdentifierAtom;
+        macro: MacroDefinition;
+      }> = [];
+      const transactionOptions: ExpandFunctionalMacroOptions = {
+        ...options,
+        onError: options.onError
+          ? (error) => pendingErrors.push(error)
+          : undefined,
+        onUnknownAttribute: options.onUnknownAttribute
+          ? (name) => pendingUnknownAttributes.push(name)
+          : undefined,
+        onAttributeExpansion: options.onAttributeExpansion
+          ? (event) => pendingAttributeExpansions.push(event)
+          : undefined,
+      };
+      try {
+        result.push(
+          ...expandAttributedDeclaration({
+            attributes,
+            target,
+            scope: bodyScope,
+            exports,
+            options: transactionOptions,
+          }),
+        );
+        pendingErrors.forEach((error) => options.onError?.(error));
+        pendingUnknownAttributes.forEach((name) =>
+          options.onUnknownAttribute?.(name),
+        );
+        pendingAttributeExpansions.forEach((event) =>
+          options.onAttributeExpansion?.(event),
+        );
+      } catch (error) {
+        exports.length = exportedMacroCount;
+        rollbackScope();
+        const macroError = toSyntaxMacroError(error, child);
+        if (!options.onError) {
+          throw macroError;
+        }
+        options.onError(macroError);
+        result.push(
+          ...expandTargetWithoutUserAttributes({
+            attributes,
+            target,
+            scope: bodyScope,
+            exports,
+            options,
+          }),
+        );
+      }
+      index = targetIndex;
+      continue;
     }
 
     const expanded = expandExpr(child, bodyScope, exports, options);
-    if (isTopLevelAst(form) && isForm(expanded) && isEmitManyForm(expanded)) {
-      result.push(...expanded.rest);
-      return;
+    if (allowsAttributes && isForm(expanded) && isEmitManyForm(expanded)) {
+      const emittedSequence = new Form({
+        location: expanded.location?.clone(),
+        elements: [
+          new InternalIdentifierAtom("ast"),
+          ...expanded.rest.map(cloneExpr),
+        ],
+      });
+      result.push(
+        ...expandForm(emittedSequence, bodyScope, exports, options).rest,
+      );
+      continue;
     }
     result.push(expanded);
-  });
+  }
 
   return recreateForm(form, result);
 };
+
+type ParsedAttribute = {
+  form: Form;
+  name: IdentifierAtom;
+  args: readonly Expr[];
+};
+
+const isAttributeForm = (expr: Expr): boolean =>
+  isForm(expr) && expr.calls("@");
+
+const parseAttribute = (form: Form): ParsedAttribute => {
+  const target = form.at(1);
+  if (isIdentifierAtom(target)) {
+    return { form, name: target, args: [] };
+  }
+  if (isForm(target)) {
+    const name = target.at(0);
+    if (isIdentifierAtom(name)) {
+      return { form, name, args: target.rest };
+    }
+  }
+  throw new SyntaxMacroError("attribute name must be an identifier", form);
+};
+
+const collectConsecutiveAttributes = ({
+  elements,
+  startIndex,
+}: {
+  elements: readonly Expr[];
+  startIndex: number;
+}): { attributes: ParsedAttribute[]; targetIndex: number } => {
+  const attributes: ParsedAttribute[] = [];
+  let targetIndex = startIndex;
+  while (targetIndex < elements.length) {
+    const candidate = elements[targetIndex];
+    if (!candidate || !isForm(candidate) || !isAttributeForm(candidate)) {
+      break;
+    }
+    attributes.push(parseAttribute(candidate));
+    targetIndex += 1;
+  }
+  return { attributes, targetIndex };
+};
+
+const expandAttributedDeclaration = ({
+  attributes,
+  target,
+  scope,
+  exports,
+  options,
+}: {
+  attributes: readonly ParsedAttribute[];
+  target: Expr;
+  scope: MacroScope;
+  exports: MacroDefinition[];
+  options: ExpandFunctionalMacroOptions;
+}): Expr[] => {
+  if (!isSupportedAttributeTarget(target)) {
+    throw new SyntaxMacroError(
+      "attributes must precede a supported declaration",
+      target,
+    );
+  }
+
+  const reserved: Form[] = [];
+  const userAttributes: Array<ParsedAttribute & { macro: MacroDefinition }> = [];
+  const seenUserAttributes = new Set<string>();
+
+  for (const attribute of attributes) {
+    const name = attribute.name.value;
+    if (RESERVED_ATTRIBUTE_NAMES.has(name)) {
+      reserved.push(attribute.form.clone());
+      continue;
+    }
+
+    let macro: MacroDefinition | undefined;
+    try {
+      macro = scope.getMacro(name);
+    } catch (error) {
+      throw new SyntaxMacroError(
+        error instanceof Error ? error.message : String(error),
+        attribute.form,
+      );
+    }
+    if (!macro) {
+      if (!options.onUnknownAttribute) {
+        return [
+          ...attributes.map((entry) => entry.form.clone()),
+          expandExpr(target, scope, exports, options),
+        ];
+      }
+      options.onUnknownAttribute(attribute.name);
+      return expandTargetWithoutUserAttributes({
+        attributes,
+        target,
+        scope,
+        exports,
+        options,
+      });
+    }
+    if (macro.kind !== "attribute") {
+      throw new SyntaxMacroError(
+        `'@${name}' resolves to a functional macro, not an attribute macro`,
+        attribute.form,
+      );
+    }
+    if (seenUserAttributes.has(name)) {
+      throw new SyntaxMacroError(
+        `duplicate user-defined attribute '@${name}'`,
+        attribute.form,
+      );
+    }
+    seenUserAttributes.add(name);
+    userAttributes.push({ ...attribute, macro });
+  }
+
+  if (userAttributes.length === 0) {
+    return [...reserved, expandExpr(target, scope, exports, options)];
+  }
+
+  const depth = options.attributeExpansionDepth ?? 0;
+  const maxDepth =
+    options.maxAttributeExpansionDepth ?? DEFAULT_MAX_ATTRIBUTE_EXPANSION_DEPTH;
+  if (depth >= maxDepth) {
+    throw new SyntaxMacroError(
+      `attribute macro expansion exceeded the depth limit of ${maxDepth}`,
+      userAttributes[0]!.form,
+    );
+  }
+
+  let expanded = cloneExpr(target);
+  userAttributes.forEach(({ form, macro, args }) => {
+    options.onAttributeExpansion?.({
+      invocationName: parseAttribute(form).name,
+      macro,
+    });
+    const argumentList = new Form({
+      location: form.location?.clone(),
+      elements: args.map(cloneExpr),
+    });
+    const invocation = new Form({
+      location: form.location?.clone(),
+      elements: [macro.name.clone(), argumentList, expanded],
+    });
+    expanded = expandMacroCall(invocation, macro, scope);
+  });
+
+  const emitted =
+    isForm(expanded) && isEmitManyForm(expanded) ? expanded.rest : [expanded];
+  const expansionAst = new Form({
+    location: expanded.location?.clone(),
+    elements: [
+      new InternalIdentifierAtom("ast"),
+      ...emitted.map(cloneExpr),
+    ],
+  });
+  const recursivelyExpanded = expandExpr(expansionAst, scope, exports, {
+    ...options,
+    attributeExpansionDepth: depth + 1,
+  });
+  return [
+    ...reserved,
+    ...(isForm(recursivelyExpanded) && isTopLevelAst(recursivelyExpanded)
+      ? recursivelyExpanded.rest
+      : [recursivelyExpanded]),
+  ];
+};
+
+const expandTargetWithoutUserAttributes = ({
+  attributes,
+  target,
+  scope,
+  exports,
+  options,
+}: {
+  attributes: readonly ParsedAttribute[];
+  target: Expr;
+  scope: MacroScope;
+  exports: MacroDefinition[];
+  options: ExpandFunctionalMacroOptions;
+}): Expr[] => [
+  ...attributes
+    .filter((entry) => RESERVED_ATTRIBUTE_NAMES.has(entry.name.value))
+    .map((entry) => entry.form.clone()),
+  expandExpr(target, scope, exports, options),
+];
+
+const isSupportedAttributeTarget = (expr: Expr): expr is Form => {
+  if (!isForm(expr)) {
+    return false;
+  }
+  const first = expr.at(0);
+  const keyword =
+    isIdentifierAtom(first) && DECLARATION_MODIFIERS.has(first.value)
+      ? expr.at(1)
+      : first;
+  return isIdentifierAtom(keyword) && ATTRIBUTE_TARGET_HEADS.has(keyword.value);
+};
+
+const DECLARATION_MODIFIERS = new Set(["pub", "api", "pri", "#"]);
+
+const ATTRIBUTE_TARGET_HEADS = new Set([
+  "fn",
+  "let",
+  "type",
+  "obj",
+  "val",
+  "trait",
+  "impl",
+  "eff",
+  "mod",
+  "test",
+  "enum",
+]);
 
 const expandVisibilityWrappedMacroCall = ({
   expr,
@@ -152,6 +484,12 @@ const expandVisibilityWrappedMacroCall = ({
   const macro = scope.getMacro(macroName.value);
   if (!macro) {
     return undefined;
+  }
+  if (macro.kind === "attribute") {
+    throw new SyntaxMacroError(
+      `Attribute macro '${macro.name.value}' must be invoked with '@' before a declaration`,
+      expr,
+    );
   }
 
   const invocation = recreateForm(expr, [macroName, ...expr.toArray().slice(2)]);
@@ -221,7 +559,8 @@ const PUB_ELIGIBLE_TOP_LEVEL_HEADS = new Set([
 const expandMacroDefinition = (
   definition: MacroDefinitionInput,
   scope: MacroScope,
-  exports: MacroDefinition[]
+  exports: MacroDefinition[],
+  moduleId: string | undefined,
 ): Expr => {
   const signature = definition.signature;
   const name = expectIdentifier(signature.at(0), "macro name");
@@ -236,11 +575,14 @@ const expandMacroDefinition = (
     );
 
   const macro: MacroDefinition = {
+    kind: definition.kind,
     name: name.clone(),
+    declarationName: name.clone(),
     parameters,
     body: definition.bodyExpressions,
     scope,
     id: new IdentifierAtom(`${name.value}#${nextMacroId()}`),
+    moduleId,
   };
 
   scope.defineMacro(macro);
@@ -292,6 +634,7 @@ const parseMacroDefinition = ({
 }): MacroDefinitionInput | null => {
   let index = 0;
   let visibility: MacroDefinitionInput["visibility"] = "module";
+  let kind: MacroDefinitionInput["kind"] = "function";
   const first = form.at(0);
 
   if (isIdentifierAtom(first) && first.value === "pub") {
@@ -299,7 +642,12 @@ const parseMacroDefinition = ({
     index = 1;
   }
 
-  const keyword = form.at(index);
+  let keyword = form.at(index);
+  if (isIdentifierAtom(keyword) && keyword.value === "attribute") {
+    kind = "attribute";
+    index += 1;
+    keyword = form.at(index);
+  }
   if (!isIdentifierAtom(keyword) || keyword.value !== "macro") {
     return null;
   }
@@ -324,7 +672,19 @@ const parseMacroDefinition = ({
     .slice(index + 2)
     .map(cloneExpr);
 
-  return { signature, bodyExpressions, visibility };
+  if (kind === "attribute") {
+    const name = signature.at(0);
+    if (isIdentifierAtom(name) && RESERVED_ATTRIBUTE_NAMES.has(name.value)) {
+      throw new Error(`attribute macro name '${name.value}' is reserved`);
+    }
+    if (signature.length !== 3) {
+      throw new Error(
+        "attribute macro signature must accept (arguments, declaration)",
+      );
+    }
+  }
+
+  return { kind, signature, bodyExpressions, visibility };
 };
 
 const toSyntaxMacroError = (error: unknown, syntax: Expr): SyntaxMacroError => {

--- a/packages/compiler/src/parser/syntax-macros/functional-macro-expander/types.ts
+++ b/packages/compiler/src/parser/syntax-macros/functional-macro-expander/types.ts
@@ -19,11 +19,14 @@ export type MacroVariableBinding = {
 };
 
 export type MacroDefinition = {
+  kind: "function" | "attribute";
   name: IdentifierAtom;
+  declarationName: IdentifierAtom;
   parameters: IdentifierAtom[];
   body: Expr[];
   scope: MacroScope;
   id: IdentifierAtom;
+  moduleId?: string;
 };
 
 export type EvalOpts = {

--- a/packages/language-server/src/__tests__/project.test.ts
+++ b/packages/language-server/src/__tests__/project.test.ts
@@ -151,6 +151,91 @@ describe("language server project analysis", () => {
     }
   }, 15_000);
 
+  it("supports navigation and hover for imported attribute macros", async () => {
+    const project = await createProject({
+      "src/main.voyd": `use src::macros::decorate as tagged
+
+@tagged
+fn value() -> i32
+  1
+`,
+      "src/macros.voyd": `/// Adds generated declarations.
+pub attribute macro decorate(args, declaration)
+  declaration
+`,
+    });
+
+    try {
+      const entryPath = project.filePathFor("src/main.voyd");
+      const analysis = await analyzeProject({
+        entryPath,
+        roots: resolveModuleRoots(entryPath),
+        openDocuments: new Map(),
+      });
+      const uri = toFileUri(entryPath);
+
+      const definitions = definitionsAtPosition({
+        analysis,
+        uri,
+        position: { line: 2, character: 3 },
+      });
+      expect(definitions).toHaveLength(1);
+      expect(definitions[0]?.uri).toBe(
+        toFileUri(project.filePathFor("src/macros.voyd")),
+      );
+      expect(definitions[0]?.range.start.line).toBe(1);
+
+      const hover = hoverAtPosition({
+        analysis,
+        uri,
+        position: { line: 2, character: 3 },
+      });
+      expect(hover?.contents).toMatchObject({
+        kind: "markdown",
+      });
+      expect(JSON.stringify(hover?.contents)).toContain(
+        "attribute macro decorate(arguments, declaration)",
+      );
+      expect(JSON.stringify(hover?.contents)).toContain(
+        "Adds generated declarations.",
+      );
+    } finally {
+      await rm(project.rootDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it("completes imported attribute macro aliases after '@'", async () => {
+    const project = await createProject({
+      "src/main.voyd": `use src::macros::decorate as tagged
+
+@ta
+fn value() -> i32
+  1
+`,
+      "src/macros.voyd": `pub attribute macro decorate(args, declaration)
+  declaration
+`,
+    });
+
+    try {
+      const entryPath = project.filePathFor("src/main.voyd");
+      const analysis = await analyzeProject({
+        entryPath,
+        roots: resolveModuleRoots(entryPath),
+        openDocuments: new Map(),
+      });
+      const completions = completionsAtPosition({
+        analysis,
+        uri: toFileUri(entryPath),
+        position: { line: 2, character: 3 },
+      });
+
+      expect(completions.items.map((item) => item.label)).toContain("tagged");
+    } finally {
+      await rm(project.rootDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
   it("resolves go-to-definition for imported module-level lets", async () => {
     const project = await createProject({
       "src/main.voyd": `use src::constants::answer\n\nfn main() -> i32\n  answer\n`,

--- a/packages/language-server/src/project/completion.ts
+++ b/packages/language-server/src/project/completion.ts
@@ -20,6 +20,15 @@ import type { CompletionAnalysis } from "./types.js";
 const MAX_COMPLETION_ITEMS = 200;
 const MAX_AUTO_IMPORT_ITEMS = 40;
 const AUTO_IMPORT_MIN_PREFIX_LENGTH = 2;
+const COMPILER_ATTRIBUTE_NAMES = [
+  "boundary",
+  "compiler_contract",
+  "effect",
+  "external",
+  "intrinsic",
+  "intrinsic_type",
+  "serializer",
+] as const;
 
 const isIdentifierCharacter = (value: string | undefined): boolean =>
   Boolean(value && /[A-Za-z0-9_]/.test(value));
@@ -436,6 +445,52 @@ export const completionsAtPosition = ({
     source,
     cursorOffset,
   });
+  const lineStart = source.lastIndexOf("\n", replacement.start - 1) + 1;
+  const beforeAttributeName = source
+    .slice(lineStart, replacement.start)
+    .trim();
+  if (beforeAttributeName === "@") {
+    const module = analysis.graph.modules.get(moduleId);
+    const localAttributeNames =
+      module?.header?.items.flatMap((item) =>
+        item.kind === "macro" &&
+        item.declaration.macroKind === "attribute" &&
+        item.declaration.name
+          ? [item.declaration.name]
+          : [],
+      ) ?? [];
+    const importedAttributeNames =
+      module?.macroImports?.flatMap((macro) =>
+        macro.kind === "attribute" ? [macro.name] : [],
+      ) ?? [];
+    const names = Array.from(
+      new Set([
+        ...COMPILER_ATTRIBUTE_NAMES,
+        ...localAttributeNames,
+        ...importedAttributeNames,
+      ]),
+    )
+      .filter((name) =>
+        startsWithPrefix({ name, prefix: replacement.prefix }),
+      )
+      .sort();
+    return {
+      isIncomplete: false,
+      items: names.map((name) => ({
+        label: name,
+        kind: CompletionItemKind.Function,
+        detail: COMPILER_ATTRIBUTE_NAMES.includes(
+          name as (typeof COMPILER_ATTRIBUTE_NAMES)[number],
+        )
+          ? "compiler attribute"
+          : "attribute macro",
+        textEdit: {
+          range: lineIndex.range(replacement.start, replacement.end),
+          newText: name,
+        },
+      })),
+    };
+  }
   const activeScope = findActiveScope({
     analysis,
     moduleId,

--- a/packages/language-server/src/project/symbol-index.ts
+++ b/packages/language-server/src/project/symbol-index.ts
@@ -79,6 +79,13 @@ const throwIfCancelled = (isCancelled: (() => boolean) | undefined): void => {
 };
 
 const keyForSymbol = ({ moduleId, symbol }: SymbolRef): string => `${moduleId}::${symbol}`;
+const keyForMacro = ({
+  moduleId,
+  macroId,
+}: {
+  moduleId: string;
+  macroId: string;
+}): string => `macro::${moduleId}::${macroId}`;
 const keyForExternalParameterLabel = ({
   moduleId,
   symbol,
@@ -425,6 +432,8 @@ export const buildSymbolIndex = async ({
   const occurrencesByUri = new Map<string, SymbolOccurrence[]>();
   const occurrencesByKey = new Map<string, SymbolOccurrence[]>();
   const dedupeKeys = new Set<string>();
+  const macroDocumentationByCanonicalKey = new Map<string, string>();
+  const macroTypeInfoByCanonicalKey = new Map<string, string>();
 
   const addOccurrenceFromLocation = ({
     symbolRef,
@@ -745,6 +754,64 @@ export const buildSymbolIndex = async ({
         (moduleNode.origin.kind === "file" ? moduleNode.origin.filePath : moduleId),
     );
     moduleIdByFilePath.set(filePath, moduleId);
+
+    moduleNode.attributeMacroReferences?.forEach((reference) => {
+      const canonicalKey = keyForMacro({
+        moduleId: reference.definitionModuleId,
+        macroId: reference.macroId,
+      });
+      const addMacroOccurrence = ({
+        span,
+        occurrenceModuleId,
+        name,
+        kind,
+      }: {
+        span: SourceSpan;
+        occurrenceModuleId: string;
+        name: string;
+        kind: SymbolOccurrence["kind"];
+      }): void => {
+        const occurrenceFile = path.resolve(span.file);
+        const lineIndex = lineIndexByFile.get(occurrenceFile);
+        const range = spanRange({ span, lineIndex });
+        if (!range) {
+          return;
+        }
+        addCustomOccurrenceFromRange({
+          canonicalKey,
+          moduleId: occurrenceModuleId,
+          symbol: MODULE_SYMBOL_SENTINEL,
+          uri: toFileUri(occurrenceFile),
+          range,
+          kind,
+          name,
+        });
+      };
+
+      addMacroOccurrence({
+        span: reference.definitionSpan,
+        occurrenceModuleId: reference.definitionModuleId,
+        name: reference.definitionName,
+        kind: "declaration",
+      });
+      addMacroOccurrence({
+        span: reference.invocationSpan,
+        occurrenceModuleId: moduleId,
+        name: reference.name,
+        kind: "reference",
+      });
+
+      const documentation = graph.modules
+        .get(reference.definitionModuleId)
+        ?.docs?.macroDeclarationsByName.get(reference.definitionName);
+      if (documentation !== undefined) {
+        macroDocumentationByCanonicalKey.set(canonicalKey, documentation);
+      }
+      macroTypeInfoByCanonicalKey.set(
+        canonicalKey,
+        `attribute macro ${reference.definitionName}(arguments, declaration)`,
+      );
+    });
   });
 
   semantics.forEach((entry, moduleId) => {
@@ -1200,12 +1267,20 @@ export const buildSymbolIndex = async ({
   const documentationByCanonicalKey = new Map<string, string>();
   const typeInfoByCanonicalKey = new Map<string, string>();
   sortedDeclarations.forEach((entries, canonicalKey) => {
-    const documentation = entries
-      .map((entry) => symbolDocumentationByModule.get(entry.moduleId)?.get(entry.symbol))
-      .find((doc): doc is string => doc !== undefined);
+    const documentation =
+      macroDocumentationByCanonicalKey.get(canonicalKey) ??
+      entries
+        .map((entry) => symbolDocumentationByModule.get(entry.moduleId)?.get(entry.symbol))
+        .find((doc): doc is string => doc !== undefined);
 
     if (documentation !== undefined) {
       documentationByCanonicalKey.set(canonicalKey, documentation);
+    }
+
+    const macroTypeInfo = macroTypeInfoByCanonicalKey.get(canonicalKey);
+    if (macroTypeInfo !== undefined) {
+      typeInfoByCanonicalKey.set(canonicalKey, macroTypeInfo);
+      return;
     }
 
     const typeInfo = entries

--- a/packages/lib/assets/voyd.tmLanguage.json
+++ b/packages/lib/assets/voyd.tmLanguage.json
@@ -44,7 +44,7 @@
     },
     "attributes": {
       "name": "meta.annotation.voyd",
-      "match": "(@)\\s*(boundary|compiler_contract|effect|external|intrinsic|intrinsic_type|serializer)\\b",
+      "match": "(@)\\s*([A-Za-z_][\\w]*)\\b",
       "captures": {
         "1": { "name": "punctuation.definition.annotation.voyd" },
         "2": { "name": "entity.name.function.attribute.voyd" }
@@ -198,7 +198,7 @@
         },
         {
           "name": "storage.type.voyd",
-          "match": "\\b(fn|type|obj|val|trait|let|var|macro|macro_let|eff|test|enum)\\b"
+          "match": "\\b(fn|type|obj|val|trait|let|var|attribute|macro|macro_let|eff|test|enum)\\b"
         },
         {
           "name": "entity.name.type.voyd",

--- a/packages/reference/docs/macros.md
+++ b/packages/reference/docs/macros.md
@@ -44,8 +44,68 @@ The standard library uses this model to implement surface features such as
 pub use src::base_macros::all
 ```
 
+## Declaration attribute macros
+
+An attribute macro is a functional macro that receives a structured list of
+attribute arguments and the syntax for the declaration immediately following
+the attribute. It runs before binding and type checking.
+
+```voyd
+pub attribute macro companion(arguments, declaration)
+  emit_many(
+    declaration,
+    \`(fn generated_companion() -> i32
+      42)
+  )
+```
+
+Import and apply an exported attribute macro with the ordinary macro import
+rules. Import aliases also rename the attribute:
+
+```voyd
+use pkg::tools::companion as generate_companion
+
+@generate_companion(description: "Generated helper")
+fn original() -> i32
+  1
+```
+
+The first macro parameter is a syntax list containing the arguments exactly as
+written. Labeled arguments are `:` forms, so macros can inspect them with the
+existing syntax helpers such as `length`, `get`, and `calls`. The second
+parameter is declaration syntax. Returning that syntax preserves the
+declaration; returning replacement syntax removes it; `emit_many` preserves or
+replaces it with any number of declarations.
+
+Attribute macros are supported on functions, module lets, type aliases,
+objects, values, enums, traits, impls, effects, modules, and tests. Generated
+declarations are expanded normally and may contain ordinary macro calls or more
+attributes.
+
+Consecutive user attributes run from top to bottom. Each macro receives the
+syntax emitted by the previous macro, so a macro in a stack may receive an
+`emit_many` declaration sequence. Expansion is limited to 64 nested attribute
+expansions; exceeding the limit is a compile-time diagnostic at the attribute
+invocation.
+
+Compiler attributes (`@boundary`, `@compiler_contract`, `@effect`,
+`@external`, `@intrinsic`, `@intrinsic_type`, and `@serializer`) are reserved.
+They cannot be declared as user attribute macros. When compiler and user
+attributes are stacked, all user expansion runs first and compiler attributes
+are then attached to the first emitted declaration. Put the preserved target
+first when an attribute macro also emits companions.
+
+Two imported macros with the same unaliased name are ambiguous. Use normal
+import aliases to select explicit attribute names. Unknown attributes and using
+a functional macro with `@` are compile-time errors rather than inert metadata.
+
+Preserved syntax retains its source locations, including member and parameter
+locations. This keeps documentation and diagnostics attached to the preserved
+declaration. Generated syntax is attributed to the attribute invocation while
+syntax spliced from the input retains its original provenance.
+
 ## What this page does not cover
 
-Voyd has internal parser and syntax-macro machinery, but that is not currently
-documented as stable user-facing API. This reference only covers functional
-macros that user code can define today.
+Voyd has internal parser and syntax-macro machinery that is not a stable
+user-facing API. Functional macros and declaration attribute macros are the
+supported compile-time transformation surface.

--- a/tests/conformance/cases/modules/macro/macros.voyd
+++ b/tests/conformance/cases/modules/macro/macros.voyd
@@ -1,2 +1,12 @@
 pub macro inc(value)
   syntax_template (+ $value 1.0)
+
+pub attribute macro with_companion(args, declaration)
+  if args.length() == 1 then:
+    emit_many(
+      declaration,
+      `(fn attribute_bonus() -> i32
+        39)
+    )
+  else:
+    panic("with_companion expects one argument")

--- a/tests/conformance/cases/modules/macro/main.voyd
+++ b/tests/conformance/cases/modules/macro/main.voyd
@@ -2,3 +2,10 @@ use src::macros::all
 
 pub fn main() -> f64
   inc(2.0)
+
+@with_companion(description: "portable attribute macro")
+pub fn attribute_original() -> i32
+  3
+
+pub fn attribute_main() -> i32
+  attribute_original() + attribute_bonus()

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -1009,6 +1009,12 @@
           "title": "expands public macros imported from sibling modules",
           "entryName": "main",
           "expect": { "kind": "equals", "value": 3 }
+        },
+        {
+          "id": "modules.macros.declaration-attribute",
+          "title": "expands imported declaration attribute macros with companions",
+          "entryName": "attribute_main",
+          "expect": { "kind": "equals", "value": 42 }
         }
       ]
     },


### PR DESCRIPTION
## Summary

- add first-class declaration attribute macros with structured arguments, deterministic stacking, emit-many expansion, bounded recursion, and compiler-attribute reservation
- integrate macro imports, aliases, ambiguity/re-export handling, provenance, documentation, invalidation, and transactional error recovery across the module graph
- add LSP navigation/hover/completion, grammar and reference updates, conformance coverage, and graph-aware parser AST inspection

## Validation

- npm test
- npm run typecheck
- npm run test:audit
- focused CLI parser-AST end-to-end test
- agentic implementation-gap, architecture, and correctness review loop completed cleanly