### PR TITLE
[V-431] Expose provider-neutral Shape reification and fallible codecs

### DIFF
--- a/docs/testing/test-inventory.json
+++ b/docs/testing/test-inventory.json
@@ -672,6 +672,13 @@
     "portableGap": "Keep escape facts, specialization names, and struct.new absence locally; extract representative optimized parity cases missing from conformance, especially heap alias mutation (2/77), nested mutation (15/11), branch aliasing (1/9), side-effect argument order (20/40), and block/reassignment statements (8/12)."
   },
   {
+    "file": "packages/compiler/src/codegen/__tests__/shape-reification.test.ts",
+    "owner": "compiler-implementation",
+    "reviewed": "2026-07-18",
+    "disposition": "compiler-local",
+    "rationale": "Keeps the intrinsic's unsupported-type failure in compiler codegen, where the compile-time diagnostic and boundary-schema integration are owned."
+  },
+  {
     "file": "packages/compiler/src/codegen/__tests__/specialization-policy.test.ts",
     "owner": "compiler-implementation",
     "reviewed": "2026-07-10",
@@ -2108,6 +2115,27 @@
     "rationale": "Keep co-located: protects a Voyd source package or library contract through the native test runner."
   },
   {
+    "file": "packages/std/src/data_decode_errors.test.voyd",
+    "owner": "voyd-library",
+    "reviewed": "2026-07-18",
+    "disposition": "library-local",
+    "rationale": "Keeps path-aware structural decoding failures and unknown-field policy with the std::data API that defines them."
+  },
+  {
+    "file": "packages/std/src/data_decode_success.test.voyd",
+    "owner": "voyd-library",
+    "reviewed": "2026-07-18",
+    "disposition": "library-local",
+    "rationale": "Keeps successful provider-neutral decoding behavior with the std::data API and its generated boundary-codec adapter."
+  },
+  {
+    "file": "packages/std/src/data_decode_variants.test.voyd",
+    "owner": "voyd-library",
+    "reviewed": "2026-07-18",
+    "disposition": "library-local",
+    "rationale": "Keeps array-path and named-variant decode failures with the std::data API that defines those errors."
+  },
+  {
     "file": "packages/std/src/deque.test.voyd",
     "owner": "voyd-library",
     "disposition": "library-local",
@@ -2196,6 +2224,13 @@
     "owner": "voyd-library",
     "disposition": "library-local",
     "rationale": "Keep co-located: protects a Voyd source package or library contract through the native test runner."
+  },
+  {
+    "file": "packages/std/src/meta_shape.test.voyd",
+    "owner": "voyd-library",
+    "reviewed": "2026-07-18",
+    "disposition": "library-local",
+    "rationale": "Keeps the public std::meta Shape graph, source documentation, and supported type coverage with the library API that exposes it."
   },
   {
     "file": "packages/std/src/msgpack.test.voyd",

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/shape-reification-module-let.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/shape-reification-module-let.voyd
@@ -1,0 +1,8 @@
+use std::meta::{ Shape, shape_of }
+
+obj ModuleLetProfile { age: i32 }
+
+let profile_shape: Shape = shape_of<ModuleLetProfile>()
+
+pub fn main() -> i32
+  1

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/shape-reification-unsupported.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/shape-reification-unsupported.voyd
@@ -1,0 +1,7 @@
+use std::dict::Dict
+use std::meta::shape_of
+use std::string::type::String
+
+pub fn main() -> i32
+  shape_of<Dict<String, i32>>()
+  0

--- a/packages/compiler/src/codegen/__tests__/shape-reification.test.ts
+++ b/packages/compiler/src/codegen/__tests__/shape-reification.test.ts
@@ -1,0 +1,47 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compileProgram } from "../../pipeline.js";
+import { createFsModuleHost } from "../../modules/fs-host.js";
+
+const fixtureRoot = resolve(import.meta.dirname, "__fixtures__");
+const stdRoot = resolve(import.meta.dirname, "../../../../std/src");
+
+describe("shape reification", () => {
+  it("compiles string metadata used by module-level shapes", async () => {
+    const result = await compileProgram({
+      entryPath: resolve(fixtureRoot, "shape-reification-module-let.voyd"),
+      roots: { src: fixtureRoot, std: stdRoot },
+      host: createFsModuleHost(),
+      codegenOptions: { validate: true },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error(JSON.stringify(result.diagnostics, null, 2));
+    }
+    expect(result.wasm).toBeDefined();
+  });
+
+  it("reports unsupported types at compile time", async () => {
+    const result = await compileProgram({
+      entryPath: resolve(fixtureRoot, "shape-reification-unsupported.voyd"),
+      roots: { src: fixtureRoot, std: stdRoot },
+      host: createFsModuleHost(),
+      codegenOptions: { validate: true },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected unsupported shape reification to fail");
+    }
+    expect(result.diagnostics[0]?.span.start).toBeGreaterThan(0);
+    expect(
+      result.diagnostics.find(
+        (diagnostic) =>
+          diagnostic.code === "CG0001" &&
+          diagnostic.message.includes("shape_of<Dict") &&
+          diagnostic.message.includes("boundary-compatible DTO"),
+      ),
+    ).toBeDefined();
+  });
+});

--- a/packages/compiler/src/codegen/boundary/schema.ts
+++ b/packages/compiler/src/codegen/boundary/schema.ts
@@ -31,6 +31,7 @@ export type BoundaryFieldSchema = {
   typeId: TypeId;
   schema: BoundarySchema;
   optional?: boolean;
+  documentation?: string;
 };
 
 export type BoundaryRecordSchema = {
@@ -39,12 +40,14 @@ export type BoundaryRecordSchema = {
   aliases?: readonly TypeId[];
   name: string;
   tag?: string;
+  documentation?: string;
   fields: readonly BoundaryFieldSchema[];
 };
 
 export type BoundaryVariantSchema = {
   name: string;
   typeId: TypeId;
+  documentation?: string;
   fields: readonly BoundaryFieldSchema[];
 };
 
@@ -53,12 +56,14 @@ export type BoundaryUnionSchema = {
   typeId: TypeId;
   aliases?: readonly TypeId[];
   name: string;
+  documentation?: string;
   variants: readonly BoundaryVariantSchema[];
 };
 
 export type BoundaryRefSchema = {
   kind: "ref";
   typeId: TypeId;
+  name?: string;
 };
 
 export type BoundarySchema =
@@ -77,6 +82,8 @@ export class BoundarySchemaError extends Error {
 
 export type BoundarySchemaOptions = {
   tagStandaloneVariants?: boolean;
+  includeDocumentation?: boolean;
+  portableNames?: boolean;
 };
 
 export const deriveBoundarySchema = ({
@@ -213,7 +220,13 @@ const deriveBoundarySchemaInternal = ({
   options: BoundarySchemaOptions;
 }): BoundarySchema => {
   if (active.has(typeId)) {
-    return { kind: "ref", typeId };
+    return {
+      kind: "ref",
+      typeId,
+      ...(options.portableNames
+        ? { name: portableBoundaryName({ typeId, ctx }) }
+        : {}),
+    };
   }
 
   const primitive = primitiveSchema({ typeId, ctx });
@@ -376,8 +389,13 @@ const deriveRecordSchema = ({
   return {
     kind: "record",
     typeId,
-    name: formatBoundaryType({ typeId, ctx }),
+    name: options.portableNames
+      ? portableBoundaryName({ typeId, ctx })
+      : formatBoundaryType({ typeId, ctx }),
     tag: standaloneTag,
+    ...(options.includeDocumentation
+      ? { documentation: documentationForType({ typeId, ctx }) }
+      : {}),
     fields,
   };
 };
@@ -419,6 +437,9 @@ const deriveBoundaryFields = ({
       name: field.name,
       typeId: fieldTypeId,
       optional: field.optional ? true : undefined,
+      ...(options.includeDocumentation && sourceField?.documentation
+        ? { documentation: sourceField.documentation }
+        : {}),
       schema: deriveBoundarySchemaInternal({
         typeId: fieldTypeId,
         ctx,
@@ -482,6 +503,9 @@ const deriveUnionSchema = ({
     return {
       name,
       typeId: member,
+      ...(options.includeDocumentation
+        ? { documentation: documentationForType({ typeId: member, ctx }) }
+        : {}),
       fields: deriveBoundaryFields({
         ownerTypeId: member,
         fields: info.fields,
@@ -495,10 +519,81 @@ const deriveUnionSchema = ({
   return {
     kind: "union",
     typeId,
-    name: formatBoundaryType({ typeId, ctx }),
+    name: options.portableNames
+      ? portableBoundaryName({ typeId, ctx })
+      : formatBoundaryType({ typeId, ctx }),
+    ...(options.includeDocumentation
+      ? { documentation: documentationForType({ typeId, ctx }) }
+      : {}),
     variants,
   };
 };
+
+const portableBoundaryName = ({
+  typeId,
+  ctx,
+}: {
+  typeId: TypeId;
+  ctx: CodegenContext;
+}): string => portableBoundaryIdentity({ typeId, ctx }).name;
+
+const documentationForType = ({
+  typeId,
+  ctx,
+}: {
+  typeId: TypeId;
+  ctx: CodegenContext;
+}): string | undefined =>
+  portableBoundaryIdentity({ typeId, ctx }).documentation;
+
+const portableBoundaryIdentity = ({
+  typeId,
+  ctx,
+}: {
+  typeId: TypeId;
+  ctx: CodegenContext;
+}): { name: string; documentation?: string } => {
+  const desc = ctx.program.types.getTypeDesc(typeId);
+  const nominal =
+    desc.kind === "nominal-object" || desc.kind === "value-object"
+      ? typeId
+      : desc.kind === "intersection"
+        ? desc.nominal
+        : undefined;
+  const owner =
+    typeof nominal === "number"
+      ? ctx.program.objects.getNominalOwnerRef(nominal)
+      : undefined;
+  if (typeof owner === "number") {
+    return {
+      name:
+        ctx.program.symbols.getName(owner) ??
+        formatBoundaryType({ typeId, ctx }),
+      documentation: ctx.program.symbols.getDocumentation(owner),
+    };
+  }
+  const aliases = ctx.program.types
+    .getAliasSymbols(typeId)
+    .map((symbol) => ({
+      name: ctx.program.symbols.getName(symbol),
+      documentation: ctx.program.symbols.getDocumentation(symbol),
+    }))
+    .filter(
+      (identity): identity is { name: string; documentation: string | undefined } =>
+        typeof identity.name === "string",
+    )
+    .sort((left, right) => {
+      const byName = comparePortableText(left.name, right.name);
+      if (byName !== 0) return byName;
+      if (left.documentation === undefined) return 1;
+      if (right.documentation === undefined) return -1;
+      return comparePortableText(left.documentation, right.documentation);
+    });
+  return aliases[0] ?? { name: formatBoundaryType({ typeId, ctx }) };
+};
+
+const comparePortableText = (left: string, right: string): number =>
+  left === right ? 0 : left < right ? -1 : 1;
 
 const withSchemaAlias = ({
   schema,

--- a/packages/compiler/src/codegen/boundary/shape.ts
+++ b/packages/compiler/src/codegen/boundary/shape.ts
@@ -1,0 +1,762 @@
+import binaryen from "binaryen";
+import { arrayNewFixed } from "@voyd-lang/lib/binaryen-gc/index.js";
+import type {
+  CodegenContext,
+  FunctionContext,
+  StructuralFieldInfo,
+  StructuralTypeInfo,
+  TypeId,
+} from "../context.js";
+import {
+  coerceValueToType,
+  initStructuralValue,
+  lowerFixedArrayElementValue,
+  lowerValueForHeapField,
+} from "../structural.js";
+import { getFixedArrayWasmTypes, getStructuralTypeInfo } from "../types.js";
+import { coerceExprToWasmType } from "../wasm-type-coercions.js";
+import { emitStringLiteral } from "../expressions/primitives.js";
+import {
+  compileOptionalNoneValue,
+  compileOptionalSomeValue,
+} from "../optionals.js";
+import {
+  deriveBoundarySchema,
+  formatBoundaryType,
+  type BoundaryFieldSchema,
+  type BoundarySchema,
+  type BoundaryVariantSchema,
+} from "./schema.js";
+
+type RuntimeShapeModel = {
+  shapeTypeId: TypeId;
+  nodeTypeId: TypeId;
+  definitionTypeId: TypeId;
+  definitionArrayTypeId: TypeId;
+};
+
+type ShapeBuildState = {
+  model: RuntimeShapeModel;
+  referenced: Map<TypeId, ShapeReference>;
+  usedReferenceKeys: Set<string>;
+};
+
+type ShapeReference = {
+  key: string;
+  name: string;
+};
+
+export const emitBoundaryShape = ({
+  typeId,
+  resultTypeId,
+  ctx,
+  fnCtx,
+}: {
+  typeId: TypeId;
+  resultTypeId: TypeId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  const schema = deriveBoundarySchema({
+    typeId,
+    ctx,
+    label: `shape_of<${formatBoundaryType({ typeId, ctx })}>`,
+    options: {
+      includeDocumentation: true,
+      portableNames: true,
+      tagStandaloneVariants: true,
+    },
+  });
+  const model = runtimeShapeModel(resultTypeId, ctx);
+  const state: ShapeBuildState = {
+    model,
+    referenced: new Map(),
+    usedReferenceKeys: new Set(),
+  };
+  const root = emitShapeNode({ schema, state, ctx, fnCtx });
+
+  const emittedDefinitions = new Set<TypeId>();
+  const definitions: {
+    reference: ShapeReference;
+    typeId: TypeId;
+    value: binaryen.ExpressionRef;
+  }[] = [];
+  while (emittedDefinitions.size < state.referenced.size) {
+    const pendingDefinitions = [...state.referenced.entries()]
+      .filter(([referencedTypeId]) => !emittedDefinitions.has(referencedTypeId))
+      .sort((left, right) => comparePortableText(left[1].key, right[1].key));
+
+    pendingDefinitions.forEach(([referencedTypeId, reference]) => {
+      emittedDefinitions.add(referencedTypeId);
+      const definitionSchema = deriveBoundarySchema({
+        typeId: referencedTypeId,
+        ctx,
+        label: `shape definition ${reference.name}`,
+        options: {
+          includeDocumentation: true,
+          portableNames: true,
+          tagStandaloneVariants: true,
+        },
+      });
+      definitions.push({
+        reference,
+        typeId: referencedTypeId,
+        value: emitObject({
+          typeId: model.definitionTypeId,
+          fields: new Map([
+            ["key", emitStringLiteral(reference.key, ctx)],
+            ["name", emitStringLiteral(reference.name, ctx)],
+            [
+              "shape",
+              emitShapeNode({ schema: definitionSchema, state, ctx, fnCtx }),
+            ],
+            [
+              "documentation",
+              emitOptionalString({
+                value: schemaDocumentation(definitionSchema),
+                optionalTypeId: requiredStructuralField(
+                  model.definitionTypeId,
+                  "documentation",
+                  ctx,
+                ).typeId,
+                ctx,
+                fnCtx,
+              }),
+            ],
+          ]),
+          ctx,
+          fnCtx,
+        }),
+      });
+    });
+  }
+
+  definitions.sort((left, right) => {
+    const byKey = comparePortableText(
+      left.reference.key,
+      right.reference.key,
+    );
+    return byKey === 0 ? left.typeId - right.typeId : byKey;
+  });
+
+  const definitionArray = emitArray({
+    arrayTypeId: model.definitionArrayTypeId,
+    elements: definitions.map(({ value }) => value),
+    ctx,
+    fnCtx,
+  });
+  return emitObject({
+    typeId: model.shapeTypeId,
+    fields: new Map([
+      ["root", root],
+      ["definitions", definitionArray],
+    ]),
+    ctx,
+    fnCtx,
+  });
+};
+
+const comparePortableText = (left: string, right: string): number =>
+  left === right ? 0 : left < right ? -1 : 1;
+
+const emitShapeNode = ({
+  schema,
+  state,
+  ctx,
+  fnCtx,
+}: {
+  schema: BoundarySchema;
+  state: ShapeBuildState;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  switch (schema.kind) {
+    case "bool":
+      return emitShapeVariant({ name: "BoolShape", state, ctx, fnCtx });
+    case "i32":
+      return emitShapeVariant({ name: "I32Shape", state, ctx, fnCtx });
+    case "i64":
+      return emitShapeVariant({ name: "I64Shape", state, ctx, fnCtx });
+    case "f32":
+      return emitShapeVariant({ name: "F32Shape", state, ctx, fnCtx });
+    case "f64":
+      return emitShapeVariant({ name: "F64Shape", state, ctx, fnCtx });
+    case "string":
+      return emitShapeVariant({ name: "StringShape", state, ctx, fnCtx });
+    case "void":
+      return emitShapeVariant({ name: "UnitShape", state, ctx, fnCtx });
+    case "ref": {
+      const name = schema.name ?? formatTypeName(schema.typeId, ctx);
+      const reference = shapeReferenceFor({
+        typeId: schema.typeId,
+        name,
+        state,
+      });
+      return emitShapeVariant({
+        name: "RefShape",
+        fields: new Map([["key", emitStringLiteral(reference.key, ctx)]]),
+        state,
+        ctx,
+        fnCtx,
+      });
+    }
+    case "array":
+      return emitShapeVariant({
+        name: "ArrayShape",
+        fields: new Map([
+          [
+            "element",
+            emitShapeNode({ schema: schema.element, state, ctx, fnCtx }),
+          ],
+        ]),
+        state,
+        ctx,
+        fnCtx,
+      });
+    case "record": {
+      const memberTypeId = shapeVariantTypeId(
+        state.model.nodeTypeId,
+        "RecordShape",
+        ctx,
+      );
+      const fieldsTypeId = requiredStructuralField(
+        memberTypeId,
+        "fields",
+        ctx,
+      ).typeId;
+      return emitShapeVariant({
+        name: "RecordShape",
+        fields: new Map([
+          ["name", emitStringLiteral(schema.name, ctx)],
+          [
+            "documentation",
+            emitOptionalString({
+              value: schema.documentation,
+              optionalTypeId: requiredStructuralField(
+                memberTypeId,
+                "documentation",
+                ctx,
+              ).typeId,
+              ctx,
+              fnCtx,
+            }),
+          ],
+          [
+            "fields",
+            emitShapeFields({
+              fields: schema.fields,
+              arrayTypeId: fieldsTypeId,
+              state,
+              ctx,
+              fnCtx,
+            }),
+          ],
+        ]),
+        state,
+        ctx,
+        fnCtx,
+      });
+    }
+    case "union": {
+      const memberTypeId = shapeVariantTypeId(
+        state.model.nodeTypeId,
+        "UnionShape",
+        ctx,
+      );
+      const variantsArrayTypeId = requiredStructuralField(
+        memberTypeId,
+        "variants",
+        ctx,
+      ).typeId;
+      return emitShapeVariant({
+        name: "UnionShape",
+        fields: new Map([
+          ["name", emitStringLiteral(schema.name, ctx)],
+          [
+            "documentation",
+            emitOptionalString({
+              value: schema.documentation,
+              optionalTypeId: requiredStructuralField(
+                memberTypeId,
+                "documentation",
+                ctx,
+              ).typeId,
+              ctx,
+              fnCtx,
+            }),
+          ],
+          [
+            "variants",
+            emitShapeVariants({
+              variants: schema.variants,
+              arrayTypeId: variantsArrayTypeId,
+              state,
+              ctx,
+              fnCtx,
+            }),
+          ],
+        ]),
+        state,
+        ctx,
+        fnCtx,
+      });
+    }
+  }
+};
+
+const shapeReferenceFor = ({
+  typeId,
+  name,
+  state,
+}: {
+  typeId: TypeId;
+  name: string;
+  state: ShapeBuildState;
+}): ShapeReference => {
+  const existing = state.referenced.get(typeId);
+  if (existing) {
+    return existing;
+  }
+
+  let key = name;
+  let suffix = 2;
+  while (state.usedReferenceKeys.has(key)) {
+    key = `${name}#${suffix}`;
+    suffix += 1;
+  }
+  const reference = { key, name };
+  state.referenced.set(typeId, reference);
+  state.usedReferenceKeys.add(key);
+  return reference;
+};
+
+const emitShapeFields = ({
+  fields,
+  arrayTypeId,
+  state,
+  ctx,
+  fnCtx,
+}: {
+  fields: readonly BoundaryFieldSchema[];
+  arrayTypeId: TypeId;
+  state: ShapeBuildState;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  const fieldTypeId = arrayElementType(arrayTypeId, ctx);
+  const values = fields.map((field) =>
+    emitObject({
+      typeId: fieldTypeId,
+      fields: new Map([
+        ["name", emitStringLiteral(field.name, ctx)],
+        [
+          "shape",
+          emitShapeNode({ schema: field.schema, state, ctx, fnCtx }),
+        ],
+        ["optional", ctx.mod.i32.const(field.optional === true ? 1 : 0)],
+        [
+          "documentation",
+          emitOptionalString({
+            value: field.documentation,
+            optionalTypeId: requiredStructuralField(
+              fieldTypeId,
+              "documentation",
+              ctx,
+            ).typeId,
+            ctx,
+            fnCtx,
+          }),
+        ],
+      ]),
+      ctx,
+      fnCtx,
+    }),
+  );
+  return emitArray({ arrayTypeId, elements: values, ctx, fnCtx });
+};
+
+const emitShapeVariants = ({
+  variants,
+  arrayTypeId,
+  state,
+  ctx,
+  fnCtx,
+}: {
+  variants: readonly BoundaryVariantSchema[];
+  arrayTypeId: TypeId;
+  state: ShapeBuildState;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  const variantTypeId = arrayElementType(arrayTypeId, ctx);
+  const fieldsArrayTypeId = requiredStructuralField(
+    variantTypeId,
+    "fields",
+    ctx,
+  ).typeId;
+  const values = variants.map((variant) =>
+    emitObject({
+      typeId: variantTypeId,
+      fields: new Map([
+        ["name", emitStringLiteral(variant.name, ctx)],
+        [
+          "documentation",
+          emitOptionalString({
+            value: variant.documentation,
+            optionalTypeId: requiredStructuralField(
+              variantTypeId,
+              "documentation",
+              ctx,
+            ).typeId,
+            ctx,
+            fnCtx,
+          }),
+        ],
+        [
+          "fields",
+          emitShapeFields({
+            fields: variant.fields,
+            arrayTypeId: fieldsArrayTypeId,
+            state,
+            ctx,
+            fnCtx,
+          }),
+        ],
+      ]),
+      ctx,
+      fnCtx,
+    }),
+  );
+  return emitArray({ arrayTypeId, elements: values, ctx, fnCtx });
+};
+
+const emitShapeVariant = ({
+  name,
+  fields = new Map(),
+  state,
+  ctx,
+  fnCtx,
+}: {
+  name: string;
+  fields?: ReadonlyMap<string, binaryen.ExpressionRef>;
+  state: ShapeBuildState;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  const memberTypeId = shapeVariantTypeId(
+    state.model.nodeTypeId,
+    name,
+    ctx,
+  );
+  try {
+    return coerceValueToType({
+      value: emitObject({ typeId: memberTypeId, fields, ctx, fnCtx }),
+      actualType: memberTypeId,
+      targetType: state.model.nodeTypeId,
+      ctx,
+      fnCtx,
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `failed to construct ${name} (${memberTypeId}) as ShapeNode (${state.model.nodeTypeId}): ${detail}`,
+      { cause: error },
+    );
+  }
+};
+
+const emitObject = ({
+  typeId,
+  fields,
+  ctx,
+  fnCtx,
+}: {
+  typeId: TypeId;
+  fields: ReadonlyMap<string, binaryen.ExpressionRef>;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  const info = requiredStructuralInfo(typeId, ctx);
+  const fieldValues = info.fields.map((field) => {
+    const value = fields.get(field.name);
+    if (value === undefined) {
+      throw new Error(`shape runtime value is missing field ${field.name}`);
+    }
+    try {
+      return lowerFieldValue({ info, field, value, ctx, fnCtx });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `failed to initialize shape runtime field ${field.name} on type ${typeId}: ${detail}`,
+        { cause: error },
+      );
+    }
+  });
+  return initStructuralValue({ structInfo: info, fieldValues, ctx });
+};
+
+const emitOptionalString = ({
+  value,
+  optionalTypeId,
+  ctx,
+  fnCtx,
+}: {
+  value: string | undefined;
+  optionalTypeId: TypeId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  const optional = ctx.program.optionals.getOptionalInfo(
+    ctx.moduleId,
+    optionalTypeId,
+  );
+  if (!optional) {
+    throw new Error("shape documentation field must be Optional<String>");
+  }
+  return value
+    ? compileOptionalSomeValue({
+        targetTypeId: optionalTypeId,
+        value: emitStringLiteral(value, ctx),
+        valueTypeId: optional.innerType,
+        ctx,
+        fnCtx,
+      })
+    : compileOptionalNoneValue({ targetTypeId: optionalTypeId, ctx, fnCtx });
+};
+
+const emitArray = ({
+  arrayTypeId,
+  elements,
+  ctx,
+  fnCtx,
+}: {
+  arrayTypeId: TypeId;
+  elements: readonly binaryen.ExpressionRef[];
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  const info = requiredStructuralInfo(arrayTypeId, ctx);
+  const storage = requiredField(info, "storage", arrayTypeId);
+  requiredField(info, "count", arrayTypeId);
+  const owners = requiredField(info, "owners", arrayTypeId);
+  const elementTypeId = arrayElementType(arrayTypeId, ctx);
+  const storageTypes = getFixedArrayWasmTypes(storage.typeId, ctx);
+  const storageValue = arrayNewFixed(
+    ctx.mod,
+    storageTypes.heapType,
+    elements.map((element) =>
+      lowerFixedArrayElementValue({
+        value: element,
+        typeId: elementTypeId,
+        ctx,
+        fnCtx,
+      }),
+    ) as number[],
+  );
+  const fieldValues = info.fields.map((field) => {
+    const value =
+      field.name === "storage"
+        ? storageValue
+        : field.name === "count"
+          ? ctx.mod.i32.const(elements.length)
+          : field.name === "owners"
+            ? freshArrayOwners(owners.typeId, ctx, fnCtx)
+            : undefined;
+    if (value === undefined) {
+      throw new Error(`unexpected Array shape runtime field ${field.name}`);
+    }
+    try {
+      return lowerFieldValue({ info, field, value, ctx, fnCtx });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `failed to initialize shape array field ${field.name} on type ${arrayTypeId}: ${detail}`,
+        { cause: error },
+      );
+    }
+  });
+  return initStructuralValue({ structInfo: info, fieldValues, ctx });
+};
+
+const freshArrayOwners = (
+  typeId: TypeId,
+  ctx: CodegenContext,
+  fnCtx: FunctionContext,
+): binaryen.ExpressionRef => {
+  const info = requiredStructuralInfo(typeId, ctx);
+  const refs = requiredField(info, "refs", typeId);
+  return initStructuralValue({
+    structInfo: info,
+    fieldValues: [
+      lowerFieldValue({
+        info,
+        field: refs,
+        value: ctx.mod.i32.const(1),
+        ctx,
+        fnCtx,
+      }),
+    ],
+    ctx,
+  });
+};
+
+const lowerFieldValue = ({
+  info,
+  field,
+  value,
+  ctx,
+  fnCtx,
+}: {
+  info: StructuralTypeInfo;
+  field: StructuralFieldInfo;
+  value: binaryen.ExpressionRef;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef =>
+  info.layoutKind === "value-object"
+    ? coerceExprToWasmType({ expr: value, targetType: field.wasmType, ctx })
+    : lowerValueForHeapField({
+        value,
+        typeId: field.typeId,
+        targetType: field.heapWasmType,
+        ctx,
+        fnCtx,
+      });
+
+const runtimeShapeModel = (
+  shapeTypeId: TypeId,
+  ctx: CodegenContext,
+): RuntimeShapeModel => {
+  const shape = requiredStructuralInfo(shapeTypeId, ctx);
+  const nodeTypeId = requiredField(shape, "root", shapeTypeId).typeId;
+  const definitionArrayTypeId = requiredField(
+    shape,
+    "definitions",
+    shapeTypeId,
+  ).typeId;
+  return {
+    shapeTypeId,
+    nodeTypeId,
+    definitionArrayTypeId,
+    definitionTypeId: arrayElementType(definitionArrayTypeId, ctx),
+  };
+};
+
+const shapeVariantTypeId = (
+  nodeTypeId: TypeId,
+  name: string,
+  ctx: CodegenContext,
+): TypeId => {
+  const initial = ctx.program.types.getTypeDesc(nodeTypeId);
+  const desc =
+    initial.kind === "recursive"
+      ? ctx.program.types.getTypeDesc(
+          ctx.program.types.substitute(
+            initial.body,
+            new Map([[initial.binder, nodeTypeId]]),
+          ),
+        )
+      : initial;
+  if (desc.kind !== "union") {
+    throw new Error("std::meta::ShapeNode must be a union");
+  }
+  const match = desc.members.find(
+    (member) => nominalTypeName(member, ctx) === name,
+  );
+  if (match === undefined) {
+    throw new Error(`std::meta::ShapeNode is missing ${name}`);
+  }
+  return match;
+};
+
+const nominalTypeName = (typeId: TypeId, ctx: CodegenContext): string => {
+  const desc = ctx.program.types.getTypeDesc(typeId);
+  if (
+    (desc.kind === "nominal-object" || desc.kind === "value-object") &&
+    desc.name
+  ) {
+    return desc.name;
+  }
+  if (desc.kind === "intersection" && typeof desc.nominal === "number") {
+    return nominalTypeName(desc.nominal, ctx);
+  }
+  return "";
+};
+
+const arrayElementType = (
+  arrayTypeId: TypeId,
+  ctx: CodegenContext,
+): TypeId => {
+  const storage = getStructuralTypeInfo(arrayTypeId, ctx)?.fieldMap.get(
+    "storage",
+  );
+  if (storage) {
+    const storageDesc = ctx.program.types.getTypeDesc(storage.typeId);
+    if (
+      storageDesc.kind === "fixed-array" &&
+      ctx.program.types.getTypeDesc(storageDesc.element).kind !==
+        "type-param-ref"
+    ) {
+      return storageDesc.element;
+    }
+  }
+  const desc = ctx.program.types.getTypeDesc(arrayTypeId);
+  const nominal =
+    desc.kind === "intersection" && typeof desc.nominal === "number"
+      ? ctx.program.types.getTypeDesc(desc.nominal)
+      : desc;
+  if (
+    (nominal.kind !== "nominal-object" && nominal.kind !== "value-object") ||
+    nominal.typeArgs.length !== 1
+  ) {
+    throw new Error("shape runtime field must use Array<T>");
+  }
+  return nominal.typeArgs[0]!;
+};
+
+const requiredStructuralInfo = (
+  typeId: TypeId,
+  ctx: CodegenContext,
+): StructuralTypeInfo => {
+  const info = getStructuralTypeInfo(typeId, ctx);
+  if (!info) {
+    throw new Error(`shape runtime type ${typeId} has no structural layout`);
+  }
+  return info;
+};
+
+const requiredStructuralField = (
+  typeId: TypeId,
+  name: string,
+  ctx: CodegenContext,
+): StructuralFieldInfo =>
+  requiredField(requiredStructuralInfo(typeId, ctx), name, typeId);
+
+const requiredField = (
+  info: StructuralTypeInfo,
+  name: string,
+  typeId: TypeId,
+): StructuralFieldInfo => {
+  const field = info.fieldMap.get(name);
+  if (!field) {
+    throw new Error(`shape runtime type ${typeId} is missing field ${name}`);
+  }
+  return field;
+};
+
+const schemaDocumentation = (schema: BoundarySchema): string | undefined =>
+  schema.kind === "record" || schema.kind === "union"
+    ? schema.documentation
+    : undefined;
+
+const formatTypeName = (typeId: TypeId, ctx: CodegenContext): string => {
+  const desc = ctx.program.types.getTypeDesc(typeId);
+  if (desc.kind === "primitive") return desc.name;
+  if (
+    (desc.kind === "nominal-object" || desc.kind === "value-object") &&
+    desc.name
+  ) {
+    return desc.name;
+  }
+  return `type#${typeId}`;
+};

--- a/packages/compiler/src/codegen/expressions/objects.ts
+++ b/packages/compiler/src/codegen/expressions/objects.ts
@@ -689,6 +689,22 @@ export const compileFieldAccessExpr = (
   if (!actualField) {
     throw new Error(`object does not contain field ${expr.field}`);
   }
+  const actualFieldDesc = ctx.program.types.getTypeDesc(actualField.typeId);
+  const semanticFieldTypeId = getUnresolvedExprType(
+    expr.id,
+    ctx,
+    typeInstanceId,
+  );
+  const semanticFieldDesc = ctx.program.types.getTypeDesc(semanticFieldTypeId);
+  // Recursive object templates retain their binder placeholder in the stored
+  // layout. The expression's unresolved semantic type is the declared field
+  // type; unlike expectedFieldTypeId, it is not narrowed by the consumer.
+  const actualFieldTypeId =
+    actualFieldDesc.kind === "type-param-ref"
+      ? semanticFieldDesc.kind === "type-param-ref"
+        ? actualField.typeId
+        : semanticFieldTypeId
+      : actualField.typeId;
   const targetBinding =
     targetExpr?.exprKind === "identifier"
       ? getRequiredBinding(targetExpr.symbol, ctx, fnCtx)
@@ -839,7 +855,7 @@ export const compileFieldAccessExpr = (
       });
       const coerced = coerceValueToType({
         value: raw,
-        actualType: actualField.typeId,
+        actualType: actualFieldTypeId,
         targetType: expectedFieldTypeId,
         ctx,
         fnCtx,
@@ -898,7 +914,7 @@ export const compileFieldAccessExpr = (
     });
     const coerced = coerceValueToType({
       value: raw,
-      actualType: actualField.typeId,
+      actualType: actualFieldTypeId,
       targetType: expectedFieldTypeId,
       ctx,
       fnCtx,
@@ -977,7 +993,7 @@ export const compileFieldAccessExpr = (
 
   const coerced = coerceValueToType({
     value: raw,
-    actualType: actualField.typeId,
+    actualType: actualFieldTypeId,
     targetType: expectedFieldTypeId,
     ctx,
     fnCtx,

--- a/packages/compiler/src/codegen/functions.ts
+++ b/packages/compiler/src/codegen/functions.ts
@@ -1189,12 +1189,20 @@ export const compileFunctions = ({
           );
           const callee = ctx.module.hir.expressions.get(expr.callee);
           if (callee?.exprKind === "identifier") {
-            reachableFunctions.add(
-              ctx.program.symbols.canonicalIdOf(
-                ctx.moduleId,
-                callee.symbol,
-              ) as ProgramSymbolId,
-            );
+            const calleeId = ctx.program.symbols.canonicalIdOf(
+              ctx.moduleId,
+              callee.symbol,
+            ) as ProgramSymbolId;
+            reachableFunctions.add(calleeId);
+            if (
+              ctx.program.symbols.getIntrinsicName(calleeId) ===
+              "__boundary_shape_of"
+            ) {
+              markStringLiteralCtorReachable({
+                ctx,
+                reachable: reachableFunctions,
+              });
+            }
           }
           return;
         }

--- a/packages/compiler/src/codegen/intrinsics.ts
+++ b/packages/compiler/src/codegen/intrinsics.ts
@@ -49,7 +49,10 @@ import {
   stabilizeSerializedAbiResult,
 } from "./exports/serialized-abi.js";
 import { ensureLinearMemoryExport } from "./memory-exports.js";
-import { deriveBoundarySchema } from "./boundary/schema.js";
+import {
+  BoundarySchemaError,
+  deriveBoundarySchema,
+} from "./boundary/schema.js";
 import {
   packBoundaryValueAsMsgPack,
   unpackBoundaryValueFromMsgPack,
@@ -62,6 +65,12 @@ import {
 } from "./boundary-metadata.js";
 import { currentHandlerValue } from "./expressions/call/shared.js";
 import { compileExternalCall } from "./external/imports.js";
+import { emitBoundaryShape } from "./boundary/shape.js";
+import { buildInstanceSubstitution } from "./type-substitution.js";
+import {
+  DiagnosticError,
+  diagnosticFromCode,
+} from "../diagnostics/index.js";
 
 type NumericKind = "i32" | "i64" | "f32" | "f64";
 type EqualityKind = NumericKind | "bool";
@@ -1215,6 +1224,39 @@ export const compileIntrinsicCall = ({
         fnCtx,
       });
     }
+    case "__boundary_shape_of": {
+      assertArgCount(name, args, 0);
+      const [targetTypeId] = intrinsicCallTypeArgs({ call, ctx, instanceId });
+      if (targetTypeId === undefined) {
+        throw shapeReificationDiagnostic({
+          call,
+          message: "shape_of<T>() requires one resolved type argument",
+        });
+      }
+      if (ctx.program.types.getTypeDesc(targetTypeId).kind === "type-param-ref") {
+        throw shapeReificationDiagnostic({
+          call,
+          message:
+            "shape_of<T>() requires a closed, resolved type argument; unresolved type parameters cannot be reified",
+        });
+      }
+      try {
+        return emitBoundaryShape({
+          typeId: targetTypeId,
+          resultTypeId: getRequiredExprType(call.id, ctx, instanceId),
+          ctx,
+          fnCtx,
+        });
+      } catch (error) {
+        if (error instanceof DiagnosticError) {
+          throw error;
+        }
+        if (error instanceof BoundarySchemaError) {
+          throw shapeReificationDiagnostic({ call, message: error.message });
+        }
+        throw error;
+      }
+    }
     case "__shift_l":
     case "__shift_ru": {
       assertArgCount(name, args, 2);
@@ -1453,6 +1495,48 @@ export const compileIntrinsicCall = ({
     default:
       throw new Error(`unsupported intrinsic ${name}`);
   }
+};
+
+const shapeReificationDiagnostic = ({
+  call,
+  message,
+}: {
+  call: HirCallExpr;
+  message: string;
+}): DiagnosticError =>
+  new DiagnosticError(
+    diagnosticFromCode({
+      code: "CG0001",
+      params: { kind: "codegen-error", message },
+      span: call.span,
+    }),
+  );
+
+const intrinsicCallTypeArgs = ({
+  call,
+  ctx,
+  instanceId,
+}: {
+  call: HirCallExpr;
+  ctx: CodegenContext;
+  instanceId?: ProgramFunctionInstanceId;
+}): readonly TypeId[] => {
+  const callInfo = ctx.program.calls.getCallInfo(ctx.moduleId, call.id);
+  const raw =
+    (typeof instanceId === "number"
+      ? callInfo.typeArgs?.get(instanceId)
+      : undefined) ??
+    (callInfo.typeArgs?.size === 1
+      ? callInfo.typeArgs.values().next().value
+      : undefined) ??
+    [];
+  const substitution = buildInstanceSubstitution({
+    ctx,
+    typeInstanceId: instanceId,
+  });
+  return substitution
+    ? raw.map((typeId) => ctx.program.types.substitute(typeId, substitution))
+    : raw;
 };
 
 const emitArithmeticIntrinsic = ({

--- a/packages/compiler/src/codegen/module-lets.ts
+++ b/packages/compiler/src/codegen/module-lets.ts
@@ -142,12 +142,21 @@ const markInitializerDependenciesReachable = ({
           moduleId: ctx.moduleId,
           symbol: callee.symbol,
         });
-        reachable.add(
-          ctx.program.symbols.canonicalIdOf(
-            resolved.moduleId,
-            resolved.symbol,
-          ) as ProgramSymbolId,
-        );
+        const calleeId = ctx.program.symbols.canonicalIdOf(
+          resolved.moduleId,
+          resolved.symbol,
+        ) as ProgramSymbolId;
+        reachable.add(calleeId);
+        if (
+          ctx.program.symbols.getIntrinsicName(calleeId) ===
+          "__boundary_shape_of"
+        ) {
+          markDependencyFunctionReachable({
+            ctx,
+            dependency: "string-literal-constructor",
+            reachable,
+          });
+        }
       },
     },
   });

--- a/packages/compiler/src/optimize/passes/reachability.ts
+++ b/packages/compiler/src/optimize/passes/reachability.ts
@@ -36,6 +36,8 @@ export const BOUNDARY_MSGPACK_DEPENDENT_INTRINSICS = new Set([
   "__boundary_msgpack_to_value",
 ]);
 
+const SHAPE_REIFICATION_INTRINSICS = new Set(["__boundary_shape_of"]);
+
 export const resolveIntrinsicFunction = ({
   ir,
   intrinsicName,
@@ -763,6 +765,18 @@ export const wholeProgramSpecializationPruningPass: ProgramOptimizationPass = {
                   BOUNDARY_MSGPACK_DEPENDENT_INTRINSICS.has(intrinsicName)
                 ) {
                   enqueueMsgPackFunctions();
+                }
+                if (
+                  intrinsicName &&
+                  SHAPE_REIFICATION_INTRINSICS.has(intrinsicName)
+                ) {
+                  const dependency = resolveIntrinsicFunction({
+                    ir: ctx.ir,
+                    intrinsicName: "__string_new",
+                  });
+                  if (dependency) {
+                    enqueueKnownFunctionInstances(dependency);
+                  }
                 }
                 recordResolvedSymbolReachability({
                   moduleId,

--- a/packages/compiler/src/semantics/codegen-view/index.ts
+++ b/packages/compiler/src/semantics/codegen-view/index.ts
@@ -64,6 +64,7 @@ export type CodegenStructuralField = {
   visibility?: HirVisibility;
   owner?: SymbolId;
   packageId?: string;
+  documentation?: string;
 };
 
 export type CodegenFunctionParameter = {
@@ -882,6 +883,7 @@ export const buildProgramCodegenView = (
     visibility: "visibility" in field ? field.visibility : undefined,
     owner: "owner" in field ? field.owner : undefined,
     packageId: "packageId" in field ? field.packageId : undefined,
+    documentation: "documentation" in field ? field.documentation : undefined,
   });
 
   const toCodegenTypeDesc = (

--- a/packages/compiler/src/semantics/intrinsics.ts
+++ b/packages/compiler/src/semantics/intrinsics.ts
@@ -89,6 +89,10 @@ const VALUE_INTRINSICS = new Map<string, IntrinsicValueMetadata>([
     "__boundary_msgpack_to_value",
     { intrinsicUsesSignature: false, access: "std-only" },
   ],
+  [
+    "__boundary_shape_of",
+    { intrinsicUsesSignature: false, access: "std-only" },
+  ],
   ["__shift_l", { intrinsicUsesSignature: false, access: "std-only" }],
   ["__shift_ru", { intrinsicUsesSignature: false, access: "std-only" }],
   ["__bit_and", { intrinsicUsesSignature: false, access: "std-only" }],

--- a/packages/compiler/src/semantics/program-symbol-arena.ts
+++ b/packages/compiler/src/semantics/program-symbol-arena.ts
@@ -23,6 +23,7 @@ export type ProgramSymbolArena = {
   tryIdOf(ref: SymbolRef): ProgramSymbolId | undefined;
   refOf(id: ProgramSymbolId): SymbolRef;
   getName(id: ProgramSymbolId): string | undefined;
+  getDocumentation(id: ProgramSymbolId): string | undefined;
   getPackageId(id: ProgramSymbolId): string;
   getIntrinsicType(id: ProgramSymbolId): string | undefined;
   getStdIntrinsicTypeContract(
@@ -64,6 +65,7 @@ export const buildProgramSymbolArena = (
   const idsByModuleAndSymbol = new Map<string, Map<SymbolId, ProgramSymbolId>>();
   const refsById: SymbolRef[] = [];
   const namesById: (string | undefined)[] = [];
+  const documentationById: (string | undefined)[] = [];
   const packageIdsById: string[] = [];
   const intrinsicTypesById: (string | undefined)[] = [];
   const stdIntrinsicTypeContractsById: (
@@ -107,6 +109,9 @@ export const buildProgramSymbolArena = (
 
       refsById[id] = { moduleId: mod.moduleId, symbol };
       namesById[id] = mod.symbols.getName(symbol);
+      documentationById[id] =
+        mod.binding.decls.getObject(symbol)?.documentation ??
+        mod.binding.decls.getTypeAlias(symbol)?.documentation;
       packageIdsById[id] = mod.binding.packageId;
       intrinsicTypesById[id] = mod.symbols.getIntrinsicType(symbol);
       const stdIntrinsicTypeContract =
@@ -181,6 +186,7 @@ export const buildProgramSymbolArena = (
     tryIdOf,
     refOf,
     getName,
+    getDocumentation: (id) => documentationById[id],
     getPackageId,
     getIntrinsicType: (id) => intrinsicTypesById[id],
     getStdIntrinsicTypeContract: (id) => stdIntrinsicTypeContractsById[id],

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -508,6 +508,28 @@ export const typeCallExpr = (
         calleeExpr.id,
         applyCurrentSubstitution(calleeType, ctx, state),
       );
+      if (
+        intrinsicName === "__boundary_shape_of" &&
+        signature &&
+        instantiation &&
+        (signature.typeParams?.length ?? 0) > 0
+      ) {
+        const codegenTypeArgs = getAppliedTypeArguments({
+          signature,
+          substitution: instantiation.substitution,
+          symbol: calleeExpr.symbol,
+          ctx,
+          nameForSymbol: (symbol) => ctx.symbolTable.getSymbol(symbol).name,
+        });
+        const existingTypeArgs =
+          ctx.callResolution.typeArguments.get(expr.id) ?? new Map();
+        const callerInstanceKey = state.currentFunction?.instanceKey;
+        if (!callerInstanceKey) {
+          throw new Error(`missing function instance key for call ${expr.id}`);
+        }
+        existingTypeArgs.set(callerInstanceKey, codegenTypeArgs);
+        ctx.callResolution.typeArguments.set(expr.id, existingTypeArgs);
+      }
       return finalizeCall({
         returnType,
         latentEffectRow:
@@ -7392,6 +7414,18 @@ const typeIntrinsicCall = (
         args,
         typeArguments,
       });
+    case "__boundary_shape_of":
+      assertIntrinsicArgCount({
+        name: "__boundary_shape_of",
+        args,
+        expected: 0,
+      });
+      requireSingleTypeArgument({
+        name: "__boundary_shape_of",
+        typeArguments,
+        detail: "reified type",
+      });
+      return expectedReturnType ?? ctx.primitives.unknown;
     case "__shift_l":
     case "__shift_ru":
       return typeShiftIntrinsic({ name, args, ctx, state, typeArguments });

--- a/packages/compiler/src/semantics/typing/import-symbol-mapping.ts
+++ b/packages/compiler/src/semantics/typing/import-symbol-mapping.ts
@@ -510,6 +510,7 @@ export const registerImportedObjectTemplate = ({
     owner:
       typeof field.owner === "number" ? mapOwner(field.owner) : field.owner,
     packageId: field.packageId ?? dependency.packageId ?? ctx.packageId,
+    documentation: field.documentation,
   }));
 
   ctx.objects.registerTemplate({

--- a/packages/compiler/src/semantics/typing/type-system.ts
+++ b/packages/compiler/src/semantics/typing/type-system.ts
@@ -2221,6 +2221,11 @@ export const getObjectTemplate = (
             ? undefined
             : getNominalComponent(baseType, ctx);
 
+        const sourceFields = new Map(
+          ctx.decls
+            .getObject(symbol)
+            ?.fields.map((field) => [field.name, field]) ?? [],
+        );
         const ownFields = decl.fields.map((field) => {
           const type = resolveTypeExpr(
             field.type,
@@ -2237,6 +2242,7 @@ export const getObjectTemplate = (
             visibility: field.visibility,
             owner: decl.symbol,
             packageId: ctx.packageId,
+            documentation: sourceFields.get(field.name)?.documentation,
           };
         });
 
@@ -2387,6 +2393,7 @@ export const ensureObjectType = (
     visibility: field.visibility,
     owner: field.owner,
     packageId: field.packageId ?? ctx.packageId,
+    documentation: field.documentation,
   }));
   ensureFieldsSubstituted(fields, ctx, `object ${objectName} instantiation`);
   const baseNominal = template.baseNominal

--- a/packages/compiler/src/semantics/typing/types.ts
+++ b/packages/compiler/src/semantics/typing/types.ts
@@ -697,6 +697,7 @@ export interface ObjectFieldAccessMetadata {
   owner?: SymbolId;
   visibility?: HirVisibility;
   packageId?: string;
+  documentation?: string;
 }
 
 export type ObjectField = StructuralField & ObjectFieldAccessMetadata;
@@ -834,6 +835,7 @@ const cloneObjectField = (field: ObjectField): ObjectField => ({
   visibility: field.visibility ? { ...field.visibility } : undefined,
   owner: field.owner,
   packageId: field.packageId,
+  documentation: field.documentation,
 });
 
 const cloneObjectTypeInfo = (info: ObjectTypeInfo): ObjectTypeInfo => ({

--- a/packages/reference/docs/README.md
+++ b/packages/reference/docs/README.md
@@ -48,6 +48,7 @@ The installed command is `voyd`.
 - [Modules](./modules.md)
 - [External Packages](./external-packages.md)
 - [Types Overview](./types/overview.md)
+- [Type Shapes and Structural Codecs](./type-shapes-and-codecs.md)
 
 ## Feature map
 

--- a/packages/reference/docs/type-shapes-and-codecs.md
+++ b/packages/reference/docs/type-shapes-and-codecs.md
@@ -1,0 +1,113 @@
+---
+order: 205
+---
+
+# Type Shapes and Structural Codecs
+
+`std::meta::shape_of<T>()` reifies a closed Voyd type as a provider-neutral
+`Shape` value. A shape describes Voyd data directly; it does not expose
+compiler type IDs and does not depend on JSON Schema, MessagePack, or another
+wire-format vocabulary.
+
+```voyd
+use std::meta::{ RecordShape, shape_of }
+
+obj Profile {
+  /// Display name shown to other users.
+  name: String,
+  nickname?: String
+}
+
+let shape = shape_of<Profile>()
+shape.root.match(node)
+  RecordShape:
+    // node.fields preserves declaration order, optionality, and documentation.
+    node.fields
+```
+
+## Shape model
+
+`Shape::root` is a `ShapeNode`. Nodes cover boundary-compatible primitives,
+arrays, records, named unions, and references. Recursive types use `RefShape`
+entries whose graph-local keys resolve through `Shape::definitions`; compiler
+IDs never appear in the graph. Definition names remain available separately for
+display. Keys are deterministically disambiguated when distinct imported or
+generic types have the same source-level name. A key is meaningful only within
+the `Shape` value that contains it and should not be persisted independently.
+
+Record fields and union variants preserve declaration order. Documentation is
+available when a declaration or field has a doc comment. Missing comments are
+represented as `None` rather than synthesized text.
+
+Nominal records use their declaring object name and documentation. When an
+erased union has several aliases, Shape chooses the alias lexicographically by
+name and takes documentation from that same declaration. Alias display names
+are descriptive metadata rather than persistent identity; use graph-local keys
+to resolve references.
+
+The public names and meanings in `std::meta` are intended as stable standard
+library API. Consumers should still handle newly added `ShapeNode` variants
+when upgrading Voyd, because the supported boundary type set may expand.
+
+## Fallible decoding
+
+Wire-format or configuration providers can translate their own dynamic value
+model into `std::data::DataValue`, then use `decode<T>` for checked structural
+conversion.
+
+```voyd
+use std::array::Array
+use std::data::{ DataField, DataI32, DataObject, DecodeError, decode }
+use std::result::types::all
+
+obj Request { count: i32 }
+
+let ~fields = Array<DataField>::init()
+fields.push(DataField { name: "count", value: DataI32 { value: 3 } })
+
+match(decode<Request>(DataObject { fields }))
+  Ok<Request> { value }:
+    value.count
+  Err<DecodeError> { error }:
+    // error.kind and error.path are safe to report or map into provider errors.
+    0
+```
+
+Decoding validates the complete value before constructing `T`. Failures are
+returned as `DecodeError` values with a stable category and a rooted path such
+as `$.profile.age` or `$.items[2]`. Errors distinguish missing fields, unknown
+fields, duplicate fields, wrong value kinds, invalid union variants, and invalid shape
+references.
+
+Unknown fields are ignored by default. Pass `DecodeOptions` with
+`RejectUnknownFields {}` to reject them. This policy applies consistently to
+records and union payloads at every nesting level.
+
+## Supported types and limitations
+
+Shapes and codecs use the same boundary-compatible type rules as typed host
+boundaries:
+
+- `bool`, `i32`, `i64`, `f32`, `f64`, `String`, and unit
+- `Array<T>` when `T` is supported
+- records and objects whose non-private fields are supported
+- named unions and variants whose payload fields are supported
+- aliases, imported types, optional fields, and recursive references composed
+  from the categories above
+
+Unsupported inputs, including functions, traits, unresolved type parameters,
+and implementation-oriented containers such as `Dict`, produce a compile-time
+diagnostic at `shape_of<T>()`. This is intentional: generated structural codecs
+only operate on closed types with deterministic boundary representations.
+
+`shape_of<void>()` is supported and produces `UnitShape`, matching a boundary
+function's unit result. `decode<T>` accepts the value-bearing subset of the
+categories above; `void` is not a valid decoder target because `Result<T, E>`
+requires a concrete success payload. Providers should model an explicit unit
+value with a record or named variant when it must appear in dynamic data.
+
+`DataValue` is an interchange model, not a general reflection or mutation API.
+It does not preserve object identity, arbitrary runtime values, private state,
+or provider-specific number and metadata extensions. Providers remain
+responsible for mapping their own syntax and range rules into the exact
+`DataValue` kinds expected by the target shape.

--- a/packages/reference/docs/types/overview.md
+++ b/packages/reference/docs/types/overview.md
@@ -38,3 +38,4 @@ primitives and runtime-provided reference types.
 - [Traits](./traits.md)
 - [Effects](./effects.md)
 - [Value Types](./value-types.md)
+- [Type Shapes and Structural Codecs](../type-shapes-and-codecs.md)

--- a/packages/std/src/data.voyd
+++ b/packages/std/src/data.voyd
@@ -1,0 +1,460 @@
+//! Neutral dynamic values and checked structural decoding.
+//!
+//! Wire-format packages translate their own values to `DataValue`; the
+//! compiler-generated boundary codec performs the final typed conversion only
+//! after this module validates the matching provider-neutral `Shape`.
+
+use std::array::Array
+use std::dict::{ Dict, DictKey }
+use std::meta::{
+  ArrayShape,
+  BoolShape,
+  F32Shape,
+  F64Shape,
+  I32Shape,
+  I64Shape,
+  RecordShape,
+  RefShape,
+  Shape,
+  ShapeDefinition,
+  ShapeField,
+  ShapeNode,
+  ShapeVariant,
+  StringShape,
+  UnionShape,
+  UnitShape,
+  shape_of
+}
+use std::msgpack::{ MsgPack }
+use std::msgpack::self as msgpack
+use std::number::cast::self as cast
+use std::optional::types::all
+use std::result::types::all
+use std::string::type::{ String, StringSlice }
+
+/// Neutral null/unit value.
+pub obj DataNull {}
+
+/// Neutral boolean value.
+pub obj DataBool { api value: bool }
+
+/// Neutral signed 32-bit integer value.
+pub obj DataI32 { api value: i32 }
+
+/// Neutral signed 64-bit integer value.
+pub obj DataI64 { api value: i64 }
+
+/// Neutral 32-bit floating-point value.
+pub obj DataF32 { api value: f32 }
+
+/// Neutral 64-bit floating-point value.
+pub obj DataF64 { api value: f64 }
+
+/// Neutral owned string value.
+pub obj DataString { api value: String }
+
+/// Named field in a neutral object or variant payload.
+pub obj DataField {
+  api name: String,
+  api value: DataValue
+}
+
+/// Neutral ordered array value.
+pub obj DataArray { api values: Array<DataValue> }
+
+/// Neutral string-keyed object value.
+pub obj DataObject { api fields: Array<DataField> }
+
+/// Neutral named variant value.
+pub obj DataVariant {
+  api name: String,
+  api fields: Array<DataField>
+}
+
+/// Provider-neutral dynamic value accepted by structural codecs.
+pub type DataValue = DataNull
+  | DataBool
+  | DataI32
+  | DataI64
+  | DataF32
+  | DataF64
+  | DataString
+  | DataArray
+  | DataObject
+  | DataVariant
+
+/// Ignore object fields absent from the target Voyd type.
+pub obj IgnoreUnknownFields {}
+
+/// Reject object fields absent from the target Voyd type.
+pub obj RejectUnknownFields {}
+
+/// Policy for fields not present in a target record or variant.
+pub type UnknownFieldPolicy = IgnoreUnknownFields | RejectUnknownFields
+
+/// Structural decoder configuration.
+pub obj DecodeOptions {
+  api unknown_fields: UnknownFieldPolicy
+}
+
+/// A required field was absent.
+pub obj MissingField {}
+
+/// A field was not declared by the target shape.
+pub obj UnknownField {}
+
+/// A dynamic value had the wrong kind.
+pub obj TypeMismatch {}
+
+/// An object or variant payload repeated a field name.
+pub obj DuplicateField {}
+
+/// A union value named an unsupported variant.
+pub obj InvalidVariant {}
+
+/// A shape reference could not be resolved.
+pub obj InvalidShapeReference {}
+
+/// Stable categories of structural decode failures.
+pub type DecodeErrorKind = MissingField
+  | UnknownField
+  | TypeMismatch
+  | DuplicateField
+  | InvalidVariant
+  | InvalidShapeReference
+
+/// Precise, recoverable structural decode failure.
+pub obj DecodeError {
+  /// Failure category.
+  api kind: DecodeErrorKind,
+  /// Rooted value path such as `$.profile.age` or `$.items[2]`.
+  api path: String,
+  /// Expected shape/value kind.
+  api expected: String,
+  /// Observed dynamic value kind or name.
+  api actual: String
+}
+
+/// Returns decoder options that ignore unknown fields.
+pub fn default_decode_options() -> DecodeOptions
+  DecodeOptions { unknown_fields: IgnoreUnknownFields {} }
+
+/// Fallibly decodes a neutral value into a boundary-compatible Voyd type.
+pub fn decode<T>(value: DataValue): () -> Result<T, DecodeError>
+  decode<T>(value, options: default_decode_options())
+
+/// Fallibly decodes with an explicit unknown-field policy.
+pub fn decode<T>(value: DataValue, { options: DecodeOptions }): () -> Result<T, DecodeError>
+  let shape = shape_of<T>()
+  match(validate(value, shape.root, shape, options, "$".to_string()))
+    Ok<Unit>:
+      Ok<T> { value: boundary_data_to_value<T>(value) }
+    Err<DecodeError> { error }:
+      Err<DecodeError> { error }
+
+/// Constructs a neutral string value from owned text.
+pub fn string_value(value: String) -> DataValue
+  DataString { value }
+
+/// Constructs a neutral string value from a slice.
+pub fn string_value(value: StringSlice) -> DataValue
+  DataString { value: value.to_string() }
+
+fn validate(
+  value: DataValue,
+  shape: ShapeNode,
+  graph: Shape,
+  options: DecodeOptions,
+  path: String
+): () -> Result<Unit, DecodeError>
+  shape.match(active)
+    BoolShape:
+      value.match(decoded)
+        DataBool: valid()
+        else: mismatch(path, "bool", data_kind_name(value))
+    I32Shape:
+      value.match(decoded)
+        DataI32: valid()
+        else: mismatch(path, "i32", data_kind_name(value))
+    I64Shape:
+      value.match(decoded)
+        DataI64: valid()
+        else: mismatch(path, "i64", data_kind_name(value))
+    F32Shape:
+      value.match(decoded)
+        DataF32: valid()
+        else: mismatch(path, "f32", data_kind_name(value))
+    F64Shape:
+      value.match(decoded)
+        DataF64: valid()
+        else: mismatch(path, "f64", data_kind_name(value))
+    StringShape:
+      value.match(decoded)
+        DataString: valid()
+        else: mismatch(path, "string", data_kind_name(value))
+    UnitShape:
+      value.match(decoded)
+        DataNull: valid()
+        else: mismatch(path, "unit", data_kind_name(value))
+    ArrayShape:
+      value.match(decoded)
+        DataArray:
+          validate_array(decoded, active.element, graph, options, path)
+        else:
+          mismatch(path, "array", data_kind_name(value))
+    RecordShape:
+      value.match(decoded)
+        DataObject:
+          validate_fields(decoded.fields, active.fields, graph, options, path)
+        else:
+          mismatch(path, active.name, data_kind_name(value))
+    UnionShape:
+      value.match(decoded)
+        DataVariant:
+          validate_variant(decoded, active, graph, options, path)
+        else:
+          mismatch(path, active.name, data_kind_name(value))
+    RefShape:
+      match(find_definition(graph.definitions, active.key))
+        Some<ShapeNode> { value: target }:
+          validate(value, target, graph, options, path)
+        None:
+          Err<DecodeError> {
+            error: DecodeError {
+              kind: InvalidShapeReference {},
+              path,
+              expected: active.key,
+              actual: "unresolved shape reference".to_string()
+            }
+          }
+
+fn validate_array(
+  value: DataArray,
+  element: ShapeNode,
+  graph: Shape,
+  options: DecodeOptions,
+  path: String
+): () -> Result<Unit, DecodeError>
+  var index = 0
+  while index < value.values.len():
+    match(validate(value.values.at(index), element, graph, options, index_path(path, index)))
+      Ok<Unit>:
+        void
+      Err<DecodeError> { error }:
+        return Err<DecodeError> { error }
+    index = index + 1
+  valid()
+
+fn validate_variant(
+  value: DataVariant,
+  shape: UnionShape,
+  graph: Shape,
+  options: DecodeOptions,
+  path: String
+): () -> Result<Unit, DecodeError>
+  match(find_variant(shape.variants, value.name))
+    Some<ShapeVariant> { value: variant }:
+      validate_fields(value.fields, variant.fields, graph, options, path)
+    None:
+      Err<DecodeError> {
+        error: DecodeError {
+          kind: InvalidVariant {},
+          path,
+          expected: shape.name,
+          actual: value.name
+        }
+      }
+
+fn validate_fields(
+  values: Array<DataField>,
+  fields: Array<ShapeField>,
+  graph: Shape,
+  options: DecodeOptions,
+  path: String
+): () -> Result<Unit, DecodeError>
+  match(find_duplicate_field(values))
+    Some<String> { value: name }:
+      return Err<DecodeError> {
+        error: DecodeError {
+          kind: DuplicateField {},
+          path: field_path(path, name),
+          expected: "unique field".to_string(),
+          actual: name
+        }
+      }
+    None:
+      void
+
+  var shape_index = 0
+  while shape_index < fields.len():
+    let field = fields.at(shape_index)
+    let nested_path = field_path(path, field.name)
+    var found = false
+    var value_index = 0
+    while value_index < values.len():
+      let value_field = values.at(value_index)
+      if value_field.name == field.name:
+        found = true
+        match(validate(value_field.value, field.shape, graph, options, nested_path))
+          Ok<Unit>:
+            void
+          Err<DecodeError> { error }:
+            return Err<DecodeError> { error }
+      value_index = value_index + 1
+    if found == false and field.optional == false:
+      return Err<DecodeError> {
+        error: DecodeError {
+          kind: MissingField {},
+          path: nested_path,
+          expected: shape_kind_name(field.shape),
+          actual: "missing".to_string()
+        }
+      }
+    shape_index = shape_index + 1
+
+  if rejects_unknown_fields(options):
+    var value_index = 0
+    while value_index < values.len():
+      let field = values.at(value_index)
+      if contains_shape_field(fields, field.name) == false:
+        return Err<DecodeError> {
+          error: DecodeError {
+            kind: UnknownField {},
+            path: field_path(path, field.name),
+            expected: "declared field".to_string(),
+            actual: field.name
+          }
+        }
+      value_index = value_index + 1
+  valid()
+
+fn find_duplicate_field(fields: Array<DataField>) -> Optional<String>
+  var index = 0
+  while index < fields.len():
+    let name = fields.at(index).name
+    var candidate = index + 1
+    while candidate < fields.len():
+      if fields.at(candidate).name == name:
+        return Some<String> { value: name }
+      candidate = candidate + 1
+    index = index + 1
+  None {}
+
+fn contains_shape_field(fields: Array<ShapeField>, name: String) -> bool
+  var index = 0
+  while index < fields.len():
+    if fields.at(index).name == name:
+      return true
+    index = index + 1
+  false
+
+fn find_variant(variants: Array<ShapeVariant>, name: String) -> Optional<ShapeVariant>
+  var index = 0
+  while index < variants.len():
+    let variant = variants.at(index)
+    if variant.name == name:
+      return Some<ShapeVariant> { value: variant }
+    index = index + 1
+  None {}
+
+fn find_definition(definitions: Array<ShapeDefinition>, key: String) -> Optional<ShapeNode>
+  var index = 0
+  while index < definitions.len():
+    let definition = definitions.at(index)
+    if definition.key == key:
+      return Some<ShapeNode> { value: definition.shape }
+    index = index + 1
+  None {}
+
+fn rejects_unknown_fields(options: DecodeOptions) -> bool
+  match(options.unknown_fields)
+    RejectUnknownFields: true
+    IgnoreUnknownFields: false
+
+fn valid() -> Result<Unit, DecodeError>
+  Ok<Unit> { value: Unit {} }
+
+fn mismatch<T>(path: String, expected: String, actual: String): () -> Result<T, DecodeError>
+  Err<DecodeError> {
+    error: DecodeError {
+      kind: TypeMismatch {},
+      path,
+      expected,
+      actual
+    }
+  }
+
+fn field_path(path: String, name: String) -> String
+  path.concat(".").concat(name)
+
+fn index_path(path: String, index: i32) -> String
+  path.concat("[").concat(cast::to_string(index)).concat("]")
+
+fn shape_kind_name(shape: ShapeNode) -> String
+  shape.match(active)
+    BoolShape: "bool".to_string()
+    I32Shape: "i32".to_string()
+    I64Shape: "i64".to_string()
+    F32Shape: "f32".to_string()
+    F64Shape: "f64".to_string()
+    StringShape: "string".to_string()
+    UnitShape: "unit".to_string()
+    ArrayShape: "array".to_string()
+    RecordShape: active.name
+    UnionShape: active.name
+    RefShape: active.key
+
+fn data_kind_name(value: DataValue) -> String
+  value.match(active)
+    DataNull: "null".to_string()
+    DataBool: "bool".to_string()
+    DataI32: "i32".to_string()
+    DataI64: "i64".to_string()
+    DataF32: "f32".to_string()
+    DataF64: "f64".to_string()
+    DataString: "string".to_string()
+    DataArray: "array".to_string()
+    DataObject: "object".to_string()
+    DataVariant: active.name
+
+fn data_value_to_msgpack(value: DataValue): () -> MsgPack
+  value.match(active)
+    DataNull:
+      msgpack::make_null()
+    DataBool:
+      msgpack::make_bool(active.value)
+    DataI32:
+      msgpack::make_i32(active.value)
+    DataI64:
+      msgpack::make_i64(active.value)
+    DataF32:
+      msgpack::make_f32(active.value)
+    DataF64:
+      msgpack::make_f64(active.value)
+    DataString:
+      msgpack::make_string(active.value)
+    DataArray:
+      let ~values = Array<MsgPack>::with_capacity(active.values.len())
+      var index = 0
+      while index < active.values.len():
+        values.push(data_value_to_msgpack(active.values.at(index)))
+        index = index + 1
+      msgpack::make_array(values)
+    DataObject:
+      msgpack::make_map(data_fields_to_msgpack(active.fields))
+    DataVariant:
+      let ~fields = data_fields_to_msgpack(active.fields)
+      fields.set("$variant", msgpack::make_string(active.name))
+      msgpack::make_map(fields)
+
+fn data_fields_to_msgpack(fields: Array<DataField>): () -> Dict<String, MsgPack>
+  let ~out = Dict<String, MsgPack>::init()
+  var index = 0
+  while index < fields.len():
+    let field = fields.at(index)
+    out.set(field.name, data_value_to_msgpack(field.value))
+    index = index + 1
+  out
+
+fn boundary_data_to_value<T>(value: DataValue): () -> T
+  msgpack::unpack_boundary_value<T>(data_value_to_msgpack(value))

--- a/packages/std/src/data_decode_errors.test.voyd
+++ b/packages/std/src/data_decode_errors.test.voyd
@@ -1,0 +1,104 @@
+use std::array::Array
+use std::data::{
+  DataArray,
+  DataField,
+  DataI32,
+  DataObject,
+  DataString,
+  DataValue,
+  DecodeError,
+  DecodeOptions,
+  DuplicateField,
+  MissingField,
+  RejectUnknownFields,
+  TypeMismatch,
+  UnknownField,
+  decode
+}
+use std::optional::all
+use std::result::types::all
+use std::string::type::String
+use std::test::assertions::all
+
+obj DataErrorProfile {
+  age: i32,
+  nickname?: String
+}
+
+obj DataErrorRequest {
+  profile: DataErrorProfile,
+  tags: Array<String>
+}
+
+test "decode reports nested type mismatch paths":
+  let ~profile_fields = Array<DataField>::init()
+  profile_fields.push(DataField { name: "age", value: DataString { value: "old" } })
+  match(decode<DataErrorRequest>(request_value(profile_fields)))
+    Ok<DataErrorRequest>:
+      Test::fail()
+    Err<DecodeError> { error }:
+      assert(error.path, eq: "$.profile.age")
+      error.kind.match(kind)
+        TypeMismatch:
+          void
+        else:
+          Test::fail()
+
+test "decode rejects duplicate fields before conversion":
+  let ~profile_fields = Array<DataField>::init()
+  profile_fields.push(DataField { name: "age", value: DataI32 { value: 40 } })
+  profile_fields.push(DataField { name: "age", value: DataI32 { value: 41 } })
+  match(decode<DataErrorRequest>(request_value(profile_fields)))
+    Ok<DataErrorRequest>:
+      Test::fail()
+    Err<DecodeError> { error }:
+      assert(error.path, eq: "$.profile.age")
+      error.kind.match(kind)
+        DuplicateField:
+          void
+        else:
+          Test::fail()
+
+test "decode distinguishes missing and rejected unknown fields":
+  let ~missing_fields = Array<DataField>::init()
+  missing_fields.push(DataField {
+    name: "tags",
+    value: DataArray { values: Array<DataValue>::init() }
+  })
+  match(decode<DataErrorRequest>(DataObject { fields: missing_fields }))
+    Ok<DataErrorRequest>:
+      Test::fail()
+    Err<DecodeError> { error }:
+      assert(error.path, eq: "$.profile")
+      error.kind.match(kind)
+        MissingField:
+          void
+        else:
+          Test::fail()
+
+  let ~profile_fields = Array<DataField>::init()
+  profile_fields.push(DataField { name: "age", value: DataI32 { value: 1 } })
+  profile_fields.push(DataField { name: "extra", value: DataI32 { value: 2 } })
+  let options = DecodeOptions { unknown_fields: RejectUnknownFields {} }
+  match(decode<DataErrorRequest>(request_value(profile_fields), options: options))
+    Ok<DataErrorRequest>:
+      Test::fail()
+    Err<DecodeError> { error }:
+      assert(error.path, eq: "$.profile.extra")
+      error.kind.match(kind)
+        UnknownField:
+          void
+        else:
+          Test::fail()
+
+fn request_value(profile_fields: Array<DataField>) -> DataValue
+  let ~request_fields = Array<DataField>::init()
+  request_fields.push(DataField {
+    name: "profile",
+    value: DataObject { fields: profile_fields }
+  })
+  request_fields.push(DataField {
+    name: "tags",
+    value: DataArray { values: Array<DataValue>::init() }
+  })
+  DataObject { fields: request_fields }

--- a/packages/std/src/data_decode_success.test.voyd
+++ b/packages/std/src/data_decode_success.test.voyd
@@ -1,0 +1,87 @@
+use std::array::Array
+use std::data::{
+  DataArray,
+  DataField,
+  DataI32,
+  DataI64,
+  DataObject,
+  DataString,
+  DataValue,
+  DataVariant,
+  DecodeError,
+  decode
+}
+use std::optional::all
+use std::result::types::all
+use std::string::type::String
+use std::test::assertions::all
+
+obj DataSuccessProfile {
+  age: i32,
+  nickname?: String
+}
+
+obj DataSuccessRequest {
+  profile: DataSuccessProfile,
+  tags: Array<String>
+}
+
+obj DataSuccessCreated { id: i32 }
+obj DataSuccessDeleted { reason: String }
+type DataSuccessEvent = DataSuccessCreated | DataSuccessDeleted
+type DataSuccessId = i64
+
+test "decode converts valid nested values and permits missing optional fields":
+  let ~profile_fields = Array<DataField>::init()
+  profile_fields.push(DataField { name: "age", value: DataI32 { value: 42 } })
+  let ~tag_values = Array<DataValue>::init()
+  tag_values.push(DataString { value: "voyd" })
+  let ~request_fields = Array<DataField>::init()
+  request_fields.push(DataField {
+    name: "profile",
+    value: DataObject { fields: profile_fields }
+  })
+  request_fields.push(DataField {
+    name: "tags",
+    value: DataArray { values: tag_values }
+  })
+
+  match(decode<DataSuccessRequest>(DataObject { fields: request_fields }))
+    Ok<DataSuccessRequest> { value }:
+      assert(value.profile.age, eq: 42)
+      assert(value.tags.at(0), eq: "voyd")
+    Err<DecodeError>:
+      Test::fail()
+
+test "decode handles named variants":
+  let ~fields = Array<DataField>::init()
+  fields.push(DataField { name: "id", value: DataI32 { value: 7 } })
+  let source = DataVariant { name: "DataSuccessCreated", fields }
+  match(decode<DataSuccessEvent>(source))
+    Ok<DataSuccessEvent> { value }:
+      value.match(event)
+        DataSuccessCreated:
+          assert(event.id, eq: 7)
+        else:
+          Test::fail()
+    Err<DecodeError>:
+      Test::fail()
+
+test "decode handles primitive aliases and options":
+  match(decode<DataSuccessId>(DataI64 { value: 91i64 }))
+    Ok<DataSuccessId> { value }:
+      assert(value, eq: 91i64)
+    Err<DecodeError>:
+      Test::fail()
+
+  let ~fields = Array<DataField>::init()
+  fields.push(DataField { name: "value", value: DataString { value: "ready" } })
+  match(decode<Optional<String>>(DataVariant { name: "Some", fields }))
+    Ok<Optional<String>> { value }:
+      match(value)
+        Some<String> { value: decoded }:
+          assert(decoded, eq: "ready")
+        None:
+          Test::fail()
+    Err<DecodeError>:
+      Test::fail()

--- a/packages/std/src/data_decode_variants.test.voyd
+++ b/packages/std/src/data_decode_variants.test.voyd
@@ -1,0 +1,68 @@
+use std::array::Array
+use std::data::{
+  DataArray,
+  DataField,
+  DataI32,
+  DataObject,
+  DataString,
+  DataValue,
+  DataVariant,
+  DecodeError,
+  InvalidVariant,
+  TypeMismatch,
+  decode
+}
+use std::result::types::all
+use std::string::type::String
+use std::test::assertions::all
+
+obj DataPathProfile { age: i32 }
+obj DataPathRequest {
+  profile: DataPathProfile,
+  tags: Array<String>
+}
+
+obj DataPathStarted { id: i32 }
+obj DataPathStopped { reason: String }
+type DataPathEvent = DataPathStarted | DataPathStopped
+
+test "decode reports array indexes":
+  let ~profile_fields = Array<DataField>::init()
+  profile_fields.push(DataField { name: "age", value: DataI32 { value: 1 } })
+  let ~tag_values = Array<DataValue>::init()
+  tag_values.push(DataString { value: "valid" })
+  tag_values.push(DataI32 { value: 2 })
+  let ~request_fields = Array<DataField>::init()
+  request_fields.push(DataField {
+    name: "profile",
+    value: DataObject { fields: profile_fields }
+  })
+  request_fields.push(DataField {
+    name: "tags",
+    value: DataArray { values: tag_values }
+  })
+
+  match(decode<DataPathRequest>(DataObject { fields: request_fields }))
+    Ok<DataPathRequest>:
+      Test::fail()
+    Err<DecodeError> { error }:
+      assert(error.path, eq: "$.tags[1]")
+      error.kind.match(kind)
+        TypeMismatch:
+          void
+        else:
+          Test::fail()
+
+test "decode reports invalid variants":
+  match(decode<DataPathEvent>(DataVariant {
+    name: "DataPathPaused",
+    fields: Array<DataField>::init()
+  }))
+    Ok<DataPathEvent>:
+      Test::fail()
+    Err<DecodeError> { error }:
+      error.kind.match(kind)
+        InvalidVariant:
+          void
+        else:
+          Test::fail()

--- a/packages/std/src/meta.voyd
+++ b/packages/std/src/meta.voyd
@@ -1,0 +1,123 @@
+//! Provider-neutral reification of boundary-compatible Voyd types.
+//!
+//! `Shape` is a stable runtime graph. It describes Voyd structure without
+//! exposing compiler type ids or a schema dialect such as JSON Schema.
+
+use std::array::Array
+use std::optional::types::all
+use std::string::type::String
+
+/// A complete portable type graph.
+pub obj Shape {
+  /// Root node for the reified type.
+  api root: ShapeNode,
+  /// Named nodes referenced by `RefShape` entries.
+  api definitions: Array<ShapeDefinition>
+}
+
+/// A named node used to close recursive shape graphs.
+pub obj ShapeDefinition {
+  /// Graph-local, deterministic key used by references.
+  api key: String,
+  /// Source-level display name for the defined type.
+  api name: String,
+  /// Reified definition body.
+  api shape: ShapeNode,
+  /// Declaration documentation when available.
+  api documentation?: String
+}
+
+/// Boolean primitive shape.
+pub obj BoolShape {}
+
+/// Signed 32-bit integer primitive shape.
+pub obj I32Shape {}
+
+/// Signed 64-bit integer primitive shape.
+pub obj I64Shape {}
+
+/// 32-bit floating-point primitive shape.
+pub obj F32Shape {}
+
+/// 64-bit floating-point primitive shape.
+pub obj F64Shape {}
+
+/// String primitive shape.
+pub obj StringShape {}
+
+/// Void/unit boundary shape.
+pub obj UnitShape {}
+
+/// Growable-array shape.
+pub obj ArrayShape {
+  /// Shape of every array element.
+  api element: ShapeNode
+}
+
+/// Field in a record or variant payload.
+pub obj ShapeField {
+  /// Source field name.
+  api name: String,
+  /// Resolved field shape.
+  api shape: ShapeNode,
+  /// Whether the field may be omitted.
+  api optional: bool,
+  /// Field documentation when available.
+  api documentation?: String
+}
+
+/// Record or structural-object shape.
+pub obj RecordShape {
+  /// Stable source-level name, or a deterministic structural spelling.
+  api name: String,
+  /// Declaration documentation when available.
+  api documentation?: String,
+  /// Fields in declaration order.
+  api fields: Array<ShapeField>
+}
+
+/// One supported named union variant.
+pub obj ShapeVariant {
+  /// Variant name used by neutral data values.
+  api name: String,
+  /// Variant documentation when available.
+  api documentation?: String,
+  /// Variant payload fields in declaration order.
+  api fields: Array<ShapeField>
+}
+
+/// Named union/variant shape.
+pub obj UnionShape {
+  /// Stable source-level union name.
+  api name: String,
+  /// Union declaration documentation when available.
+  api documentation?: String,
+  /// Supported variants in declaration order.
+  api variants: Array<ShapeVariant>
+}
+
+/// Reference to a named entry in `Shape::definitions`.
+pub obj RefShape {
+  /// Graph-local definition key. Compiler-local ids are never exposed.
+  api key: String
+}
+
+/// One node in a portable shape graph.
+pub type ShapeNode = BoolShape
+  | I32Shape
+  | I64Shape
+  | F32Shape
+  | F64Shape
+  | StringShape
+  | UnitShape
+  | ArrayShape
+  | RecordShape
+  | UnionShape
+  | RefShape
+
+/// Reifies a closed boundary-compatible type as a portable runtime graph.
+///
+/// Unsupported or unresolved type arguments produce a compile-time diagnostic.
+@intrinsic(name: "__boundary_shape_of")
+pub fn shape_of<T>() -> Shape
+  __boundary_shape_of<T>()

--- a/packages/std/src/meta_shape.test.voyd
+++ b/packages/std/src/meta_shape.test.voyd
@@ -1,0 +1,159 @@
+use std::array::Array
+use std::error::HostError
+use std::meta::{
+  ArrayShape,
+  BoolShape,
+  F32Shape,
+  F64Shape,
+  I64Shape,
+  RecordShape,
+  StringShape,
+  UnionShape,
+  UnitShape,
+  shape_of
+}
+use std::optional::all
+use std::string::type::String
+use std::test::assertions::all
+
+/// Profile documentation.
+obj MetaShapeProfile {
+  /// Age documentation.
+  age: i32,
+  nickname?: String
+}
+
+obj MetaShapeRequest {
+  profile: MetaShapeProfile,
+  tags: Array<String>
+}
+
+obj MetaShapeCreated { id: i32 }
+obj MetaShapeDeleted { reason: String }
+type MetaShapeEvent = MetaShapeCreated | MetaShapeDeleted
+type MetaShapeId = i64
+
+obj MetaRecursiveNode<T> {
+  value: T,
+  next?: MetaRecursiveNode<T>
+}
+
+obj MetaRecursivePair {
+  numbers: MetaRecursiveNode<i32>,
+  names: MetaRecursiveNode<String>
+}
+
+/// Canonical record documentation.
+obj MetaCanonicalRecord { value: i32 }
+
+/// Alias documentation is not paired with the canonical record name.
+type MetaCanonicalAlias = MetaCanonicalRecord
+
+test "shape_of reifies nested records arrays optionality and documentation":
+  if request_shape_is_complete() == false:
+    Test::fail()
+
+fn request_shape_is_complete() -> bool
+  let shape = shape_of<MetaShapeRequest>()
+  shape.root.match(root)
+    RecordShape:
+      if root.fields.len() != 2:
+        return false
+      let profile = root.fields.at(0)
+      if profile.name != "profile":
+        return false
+      profile.shape.match(profile_shape)
+        RecordShape:
+          if profile_shape.name != "MetaShapeProfile":
+            return false
+          if profile_shape.fields.len() != 2:
+            return false
+          if profile_shape.fields.at(0).name != "age":
+            return false
+          match(profile_shape.fields.at(0).documentation)
+            Some<String> { value: documentation }:
+              assert(documentation, eq: " Age documentation.")
+            None:
+              return false
+          if profile_shape.fields.at(1).optional == false:
+            return false
+        else:
+          return false
+      let tags = root.fields.at(1)
+      tags.shape.match(tags_shape)
+        ArrayShape:
+          tags_shape.element.match(element)
+            StringShape:
+              true
+            else:
+              false
+        else:
+          false
+    else:
+      false
+
+test "shape_of reifies named unions":
+  let shape = shape_of<MetaShapeEvent>()
+  shape.root.match(root)
+    UnionShape:
+      assert(root.name, eq: "MetaShapeEvent")
+      assert(root.variants.len(), eq: 2)
+      assert(root.variants.at(0).name, eq: "MetaShapeCreated")
+      assert(root.variants.at(1).name, eq: "MetaShapeDeleted")
+    else:
+      Test::fail()
+
+test "shape_of supports primitive aliases options and imported types":
+  shape_of<MetaShapeId>().root.match(alias_shape)
+    I64Shape:
+      void
+    else:
+      Test::fail()
+
+  shape_of<Optional<String>>().root.match(option_shape)
+    UnionShape:
+      assert(option_shape.variants.len(), eq: 2)
+    else:
+      Test::fail()
+
+  shape_of<HostError>().root.match(imported_shape)
+    RecordShape:
+      assert(imported_shape.name, eq: "HostError")
+      match(imported_shape.fields.at(0).documentation)
+        Some<String> { value: documentation }:
+          assert(documentation, eq: " Machine-readable error code.")
+        None:
+          Test::fail()
+    else:
+      Test::fail()
+
+test "shape_of reifies every boundary primitive":
+  shape_of<bool>().root.match(node)
+    BoolShape: void
+    else: Test::fail()
+  shape_of<f32>().root.match(node)
+    F32Shape: void
+    else: Test::fail()
+  shape_of<f64>().root.match(node)
+    F64Shape: void
+    else: Test::fail()
+  shape_of<void>().root.match(node)
+    UnitShape: void
+    else: Test::fail()
+
+test "shape_of assigns unique graph keys to same-named recursive instances":
+  let shape = shape_of<MetaRecursivePair>()
+  assert(shape.definitions.len(), eq: 2)
+  assert(shape.definitions.at(0).key, neq: shape.definitions.at(1).key)
+
+test "shape_of keeps canonical names and documentation from one declaration":
+  shape_of<MetaCanonicalAlias>().root.match(node)
+    RecordShape:
+      assert(node.name, eq: "MetaCanonicalRecord")
+      match(node.documentation)
+        Some<String> { value: documentation }:
+          assert(documentation, eq: " Canonical record documentation.")
+        None:
+          Test::fail()
+    else:
+      Test::fail()

--- a/packages/std/src/pkg.voyd
+++ b/packages/std/src/pkg.voyd
@@ -41,6 +41,8 @@ pub self::path
 pub self::fs
 pub self::test
 pub self::task
+pub self::meta
+pub self::data
 pub std::output::print
 pub std::optional::types::{ Optional, Option, Some, None }
 pub std::optional::fns::all


### PR DESCRIPTION
## Summary
- add public std::meta Shape graph reification through shape_of<T>(), including docs, optionality, portable recursive keys, aliases, imports, arrays, and unions
- add std::data DataValue and fallible structural decoding with rooted errors, duplicate/missing/unknown/type/variant handling, and configurable unknown-field policy
- preserve the existing boundary ABI contract while sharing its compatibility rules, add call-site diagnostics and intrinsic reachability support, and document stability and limitations

## Validation
- npm test (18/18 tasks)
- npm run test:codegen (51 files, 301 tests)
- npm run typecheck (18/18 tasks)
- npm run test:audit
- agentic review loop: implementation-gap, architecture, and correctness stages all clean after repeated fresh reviews

## Test ownership and cost
- std behavior remains library-local and is split across focused native Voyd test files to stay under the typing budget
- one compiler-local compile-heavy group covers unsupported-type diagnostics and module-let reachability; final full codegen suite duration was about 154 seconds