### PR TITLE
Fix macro-generated declaration codegen

### DIFF
--- a/packages/compiler/src/__tests__/module-codegen.test.ts
+++ b/packages/compiler/src/__tests__/module-codegen.test.ts
@@ -182,6 +182,40 @@ pub fn main() -> i32
     expect(instantiations?.size ?? 0).toBeGreaterThan(0);
   });
 
+  it("uses the instantiated representation for imported generic match payloads", async () => {
+    const root = resolve("/proj/src");
+    const std = resolve("/proj/std");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `use std::util::all
+
+obj Arguments { left: i32, right: i32 }
+
+pub fn main() -> i32
+  match(wrap<Arguments>(Arguments { left: 20, right: 22 }))
+    Wrapped<Arguments> { value }:
+      value.left + value.right
+    Empty:
+      0`,
+      [`${std}${sep}pkg.voyd`]: "pub use std::util::all",
+      [`${std}${sep}util.voyd`]: `pub obj Wrapped<T> { api value: T }
+pub obj Empty {}
+pub type GenericResult<T> = Wrapped<T> | Empty
+
+pub fn wrap<T>(value: T) -> GenericResult<T>
+  Wrapped<T> { value }`,
+    });
+
+    const result = expectCompileSuccess(await compileProgram({
+      entryPath: `${root}${sep}main.voyd`,
+      roots: { src: root, std },
+      host,
+    }));
+
+    expect(result.wasm).toBeInstanceOf(Uint8Array);
+    const instance = getWasmInstance(result.wasm!);
+    expect((instance.exports.main as () => number)()).toBe(42);
+  });
+
   it("links multiple imported generic instantiations across modules", async () => {
     const root = resolve("/proj/src");
     const std = resolve("/proj/std");

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/array_function_element_coercion.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/array_function_element_coercion.voyd
@@ -1,0 +1,32 @@
+obj ArrayOwners { value: i32 }
+obj Array<T> {
+  storage: FixedArray<T>,
+  count: i32,
+  owners: ArrayOwners
+}
+
+pub fn new_array_unchecked<T>({ from source: FixedArray<T> }) -> Array<T>
+  Array<T> { storage: source, count: __array_len(source), owners: ArrayOwners { value: 1 } }
+
+impl<T> Array<T>
+  fn len(self) -> i32
+    self.count
+
+  fn at(self, index: i32) -> T
+    __array_get(self.storage, index)
+
+type Handler = fn(i32) -> i32
+
+fn add_one(value: i32) -> i32
+  value + 1
+
+fn add_two(value: i32) -> i32
+  value + 2
+
+fn invoke_all(handlers: Array<Handler>) -> i32
+  let first = handlers.at(0)
+  let second = handlers.at(1)
+  first(20) + second(19)
+
+pub fn main() -> i32
+  invoke_all([add_one, add_two])

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/generic_function_closure_coercion.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/generic_function_closure_coercion.voyd
@@ -1,0 +1,12 @@
+type Handler = fn(i32) : (open) -> i32
+type PureHandler = fn(i32) -> i32
+
+fn widen<T>(handler: T) -> Handler
+  handler
+
+fn add_one(value: i32) -> i32
+  value + 1
+
+pub fn main(): (open) -> i32
+  let handler = widen<PureHandler>(add_one)
+  handler(41)

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/generic_optional_injection.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/generic_optional_injection.voyd
@@ -1,0 +1,12 @@
+obj Some<T> { value: T }
+obj None {}
+type Optional<T> = Some<T> | None
+
+fn some<T>(value: T) -> Optional<T>
+  value
+
+pub fn main() -> i32
+  let result = some<i32>(42)
+  match(result)
+    Some<i32>: result.value
+    None: 0

--- a/packages/compiler/src/codegen/__tests__/codegen.test.ts
+++ b/packages/compiler/src/codegen/__tests__/codegen.test.ts
@@ -1151,6 +1151,21 @@ describe("next codegen", () => {
     expect(main()).toBe(2);
   });
 
+  it("coerces array literal function elements to the declared function type", () => {
+    const main = loadMain("array_function_element_coercion.voyd", { asStd: true });
+    expect(main()).toBe(42);
+  });
+
+  it("coerces specialized generic function values to open closures", () => {
+    const main = loadMain("generic_function_closure_coercion.voyd");
+    expect(main()).toBe(42);
+  });
+
+  it("injects specialized generic values into optional results", () => {
+    const main = loadMain("generic_optional_injection.voyd");
+    expect(main()).toBe(42);
+  });
+
   it("resumes correctly when multiple suspending call arguments exist", () => {
     const main = loadMain("effects-multi-arg-resume.voyd");
     expect(main()).toBe(30);

--- a/packages/compiler/src/codegen/__tests__/union-coercion-target.test.ts
+++ b/packages/compiler/src/codegen/__tests__/union-coercion-target.test.ts
@@ -29,4 +29,32 @@ pub fn main() -> i32
     const instance = getWasmInstance(module);
     expect((instance.exports.main as () => number)()).toBe(41);
   });
+
+  it("specializes generic payload fields before structural conversion", () => {
+    const source = `
+obj Wrapped<T> { value: T }
+obj Empty {}
+type GenericResult<T> = Wrapped<T> | Empty
+
+obj Arguments { left: i32, right: i32 }
+
+fn wrap<T>(value: T) -> GenericResult<T>
+  Wrapped<T> { value }
+
+pub fn main() -> i32
+  match(wrap<Arguments>(Arguments { left: 20, right: 22 }))
+    Wrapped<Arguments> { value }:
+      value.left + value.right
+    Empty:
+      0
+`;
+    const ast = parse(source, "generic_structural_coercion.voyd");
+    const semantics = semanticsPipeline(ast);
+    const { module, diagnostics } = codegen(semantics);
+    if (diagnostics.length > 0) {
+      throw new Error(JSON.stringify(diagnostics, null, 2));
+    }
+    const instance = getWasmInstance(module);
+    expect((instance.exports.main as () => number)()).toBe(42);
+  });
 });

--- a/packages/compiler/src/codegen/structural.ts
+++ b/packages/compiler/src/codegen/structural.ts
@@ -46,6 +46,7 @@ import {
   serializerKeyFor,
 } from "./serializer.js";
 import { captureMultivalueLanes } from "./multivalue.js";
+import { buildInstanceSubstitution } from "./type-substitution.js";
 
 const NON_REF_TYPES = new Set<number>([
   binaryen.none,
@@ -1000,6 +1001,50 @@ const shouldUseNominalFieldFastPath = (
 ): boolean =>
   Boolean(ctx.optimization && typeof structInfo.nominalId === "number");
 
+const typeRequiresClosureCoercion = (
+  actualType: TypeId,
+  targetType: TypeId,
+  ctx: CodegenContext,
+  seen = new Set<string>(),
+): boolean => {
+  if (actualType === targetType) return false;
+  const key = `${actualType}:${targetType}`;
+  if (seen.has(key)) return false;
+  seen.add(key);
+
+  const actualDesc = ctx.program.types.getTypeDesc(actualType);
+  const targetDesc = ctx.program.types.getTypeDesc(targetType);
+  if (actualDesc.kind === "function" && targetDesc.kind === "function") {
+    return true;
+  }
+  if (
+    actualDesc.kind === "fixed-array" &&
+    targetDesc.kind === "fixed-array"
+  ) {
+    return typeRequiresClosureCoercion(
+      actualDesc.element,
+      targetDesc.element,
+      ctx,
+      seen,
+    );
+  }
+  if (actualDesc.kind === "recursive") {
+    const unfolded = ctx.program.types.substitute(
+      actualDesc.body,
+      new Map([[actualDesc.binder, actualType]]),
+    );
+    return typeRequiresClosureCoercion(unfolded, targetType, ctx, seen);
+  }
+  if (targetDesc.kind === "recursive") {
+    const unfolded = ctx.program.types.substitute(
+      targetDesc.body,
+      new Map([[targetDesc.binder, targetType]]),
+    );
+    return typeRequiresClosureCoercion(actualType, unfolded, ctx, seen);
+  }
+  return false;
+};
+
 const fieldTypesMatchExactly = (
   actualType: TypeId,
   targetType: TypeId,
@@ -1007,6 +1052,9 @@ const fieldTypesMatchExactly = (
 ): boolean => {
   if (actualType === targetType) {
     return true;
+  }
+  if (typeRequiresClosureCoercion(actualType, targetType, ctx)) {
+    return false;
   }
 
   const cache = structuralMatchCache(ctx).fieldTypes;
@@ -1264,6 +1312,33 @@ export const coerceValueToType = ({
       fnCtx,
     });
   }
+
+  const substitution = buildInstanceSubstitution({
+    ctx,
+    typeInstanceId: fnCtx.typeInstanceId ?? fnCtx.instanceId,
+  });
+  if (substitution) {
+    const specializedActual = ctx.program.types.substitute(
+      actualType,
+      substitution,
+    );
+    const specializedTarget = ctx.program.types.substitute(
+      targetType,
+      substitution,
+    );
+    if (
+      specializedActual !== actualType ||
+      specializedTarget !== targetType
+    ) {
+      return coerceValueToType({
+        value,
+        actualType: specializedActual,
+        targetType: specializedTarget,
+        ctx,
+        fnCtx,
+      });
+    }
+  }
   if (actualType === targetType) {
     if (shouldInlineUnionLayout(actualType, ctx)) {
       return normalizeValueToInlineAbi({
@@ -1283,6 +1358,20 @@ export const coerceValueToType = ({
 
   const targetDesc = ctx.program.types.getTypeDesc(targetType);
   const actualDesc = ctx.program.types.getTypeDesc(actualType);
+  if (
+    actualDesc.kind === "type-param-ref" &&
+    binaryen.getExpressionType(value) === wasmTypeFor(targetType, ctx)
+  ) {
+    if (shouldInlineUnionLayout(targetType, ctx)) {
+      return normalizeValueToInlineAbi({
+        value,
+        typeId: targetType,
+        ctx,
+        fnCtx,
+      });
+    }
+    return cloneTransferredValue({ value, typeId: targetType, ctx, fnCtx });
+  }
   const actualSerializer = findUnambiguousSerializerForType(actualType, ctx);
   const targetSerializer = findUnambiguousSerializerForType(targetType, ctx);
   if (
@@ -2020,7 +2109,12 @@ export const coerceValueToType = ({
     const actualElementType = actualDesc.element;
     const actualArrayType = wasmTypeFor(actualType, ctx);
     const targetArrayType = wasmTypeFor(targetType, ctx);
-    if (actualArrayType === targetArrayType) {
+    const elementNeedsClosureCoercion = typeRequiresClosureCoercion(
+      actualElementType,
+      targetElementType,
+      ctx,
+    );
+    if (actualArrayType === targetArrayType && !elementNeedsClosureCoercion) {
       return value;
     }
     const valueType = binaryen.getExpressionType(value);
@@ -2180,6 +2274,7 @@ export const coerceValueToType = ({
       `cannot coerce non-structural value to structural type (actual=${actualType}:${actualDesc.kind}, target=${targetType}:${targetDesc.kind})`,
     );
   }
+
   if (structuralLayoutsMatchExactly(actualInfo, targetInfo, ctx)) {
     return value;
   }

--- a/packages/compiler/src/modules/__tests__/doc-comments.test.ts
+++ b/packages/compiler/src/modules/__tests__/doc-comments.test.ts
@@ -89,7 +89,7 @@ pub mod math
     1
 `);
 
-    expect(diagnostics.filter((entry) => entry.code === "MD0004")).toHaveLength(0);
+    expect(diagnostics).toEqual([]);
 
     const mainModule = graph.modules.get("src::main");
     expect(mainModule?.docs?.module).toBe(" Module docs.\n More module docs.");
@@ -239,5 +239,37 @@ pub fn documented(
       ?.binding.functions.find((fn) => fn.name === "documented");
     expect(documented?.documentation).toBe(" Documented function.");
     expect(documented?.params[0]?.documentation).toBe(" Documented parameter.");
+  });
+
+  it("preserves parameter docs when an attribute macro emits an object field", async () => {
+    const { diagnostics, semantics } = await compileSingleModule(`
+attribute macro arguments_object(args, declaration)
+  let signature = declaration.get(1)
+  let head = signature.get(1)
+  let labeled_group = head.get(1)
+  let labeled = labeled_group.get(1)
+  let parameter = labeled.get(1)
+  let field_name = labeled.get(0)
+  let field_type = parameter.get(2)
+  let field = \`(: $field_name $field_type)
+  let located_field = with_location(field, parameter.get(1))
+  \`(obj GeneratedArguments { $located_field })
+
+@arguments_object
+fn source(
+  /// Value passed to the generated declaration.
+  { external value: i32 }
+) -> i32
+  value
+`);
+
+    expect(diagnostics).toEqual([]);
+    const generated = semantics
+      .get("src::main")
+      ?.binding.objects.find((object) => object.name === "GeneratedArguments");
+    expect(generated?.fields[0]?.name).toBe("external");
+    expect(generated?.fields[0]?.documentation).toBe(
+      " Value passed to the generated declaration.",
+    );
   });
 });

--- a/packages/compiler/src/modules/__tests__/doc-comments.test.ts
+++ b/packages/compiler/src/modules/__tests__/doc-comments.test.ts
@@ -243,6 +243,9 @@ pub fn documented(
 
   it("preserves parameter docs when an attribute macro emits an object field", async () => {
     const { diagnostics, semantics } = await compileSingleModule(`
+macro locate(value, source)
+  with_location(value, source)
+
 attribute macro arguments_object(args, declaration)
   let signature = declaration.get(1)
   let head = signature.get(1)
@@ -252,7 +255,8 @@ attribute macro arguments_object(args, declaration)
   let field_name = labeled.get(0)
   let field_type = parameter.get(2)
   let field = \`(: $field_name $field_type)
-  let located_field = with_location(field, parameter.get(1))
+  let field_source = parameter.get(1)
+  let located_field = locate(field, field_source)
   \`(obj GeneratedArguments { $located_field })
 
 @arguments_object

--- a/packages/compiler/src/modules/macro-expansion.ts
+++ b/packages/compiler/src/modules/macro-expansion.ts
@@ -325,6 +325,7 @@ const remapExpandedDocumentation = ({
     const parameter = documentationByLocation.parameters.get(key);
     if (parameter !== undefined) {
       parameters.set(syntax.syntaxId, parameter);
+      declarations.set(syntax.syntaxId, parameter);
     }
   });
   module.docs = {
@@ -348,7 +349,6 @@ const documentationLocationKey = (syntax: Syntax): string | undefined => {
   const location = syntax.location;
   return location
     ? [
-        syntax.syntaxType,
         location.filePath,
         location.startIndex,
         location.endIndex,

--- a/packages/compiler/src/parser/syntax-macros/__tests__/functional-macros.test.ts
+++ b/packages/compiler/src/parser/syntax-macros/__tests__/functional-macros.test.ts
@@ -128,6 +128,21 @@ has_generics(Box<T>)
     expect(plain.at(-1)).toEqual("1");
   });
 
+  test("with_location transfers source provenance to generated syntax", () => {
+    const code = `\
+macro relabel(generated, source)
+  with_location(generated, source)
+relabel(output, original)
+`;
+    const ast = parse(code);
+    const output = ast.last;
+    expect(output?.toJSON()).toBe("output");
+    expect(output?.location?.startIndex).toBe(code.lastIndexOf("original"));
+    expect(output?.location?.endIndex).toBe(
+      code.lastIndexOf("original") + "original".length,
+    );
+  });
+
   test("supports clause-style if expressions in functional macros", () => {
     const code = `\
 macro choose(n)

--- a/packages/compiler/src/parser/syntax-macros/__tests__/functional-macros.test.ts
+++ b/packages/compiler/src/parser/syntax-macros/__tests__/functional-macros.test.ts
@@ -141,6 +141,25 @@ relabel(output, original)
     expect(output?.location?.endIndex).toBe(
       code.lastIndexOf("original") + "original".length,
     );
+    expect(output?.attributes).toBeUndefined();
+  });
+
+  test("with_location preserves source provenance through helper macros", () => {
+    const code = `\
+macro locate(generated, source)
+  with_location(generated, source)
+macro relabel(generated, source)
+  locate(generated, source)
+relabel(output, original)
+`;
+    const ast = parse(code);
+    const output = ast.last;
+    expect(output?.toJSON()).toBe("output");
+    expect(output?.location?.startIndex).toBe(code.lastIndexOf("original"));
+    expect(output?.location?.endIndex).toBe(
+      code.lastIndexOf("original") + "original".length,
+    );
+    expect(output?.attributes).toBeUndefined();
   });
 
   test("supports clause-style if expressions in functional macros", () => {

--- a/packages/compiler/src/parser/syntax-macros/functional-macro-expander/builtins.ts
+++ b/packages/compiler/src/parser/syntax-macros/functional-macro-expander/builtins.ts
@@ -600,6 +600,16 @@ export const createBuiltins = (
       return new Form([...list.toArray(), ...values].map(cloneExpr));
     },
     is_list: ({ args }) => bool(isForm(expectExpr(args.at(0)))),
+    with_location: ({ args }) => {
+      const value = cloneExpr(expectExpr(args.at(0)));
+      const source = expectExpr(args.at(1));
+      value.setLocation(source.location?.clone());
+      value.attributes = {
+        ...value.attributes,
+        __macroExplicitLocation: true,
+      };
+      return value;
+    },
     log: ({ args, scope }) => {
       const value = getMacroTimeValue(args.at(0), scope);
       console.error(JSON.stringify(value));

--- a/packages/compiler/src/parser/syntax-macros/functional-macro-expander/evaluator.ts
+++ b/packages/compiler/src/parser/syntax-macros/functional-macro-expander/evaluator.ts
@@ -166,7 +166,15 @@ const rebaseGeneratedSyntax = ({
   preservedLocations: ReadonlySet<string>;
 }): void => {
   const key = syntaxLocationKey(syntax);
-  if (!key || !preservedLocations.has(key)) {
+  const hasExplicitLocation =
+    syntax.attributes?.__macroExplicitLocation === true;
+  if (hasExplicitLocation && syntax.attributes) {
+    delete syntax.attributes.__macroExplicitLocation;
+    if (Object.keys(syntax.attributes).length === 0) {
+      syntax.attributes = undefined;
+    }
+  }
+  if (!hasExplicitLocation && (!key || !preservedLocations.has(key))) {
     syntax.setLocation(invocationLocation.clone());
   }
   if (isForm(syntax)) {

--- a/packages/compiler/src/parser/syntax-macros/functional-macro-expander/evaluator.ts
+++ b/packages/compiler/src/parser/syntax-macros/functional-macro-expander/evaluator.ts
@@ -23,11 +23,22 @@ import type {
 } from "./types.js";
 import { isMacroLambdaValue } from "./types.js";
 
+type ExpandMacroCallOptions = {
+  preserveExplicitLocationMarkers?: boolean;
+  resolveArgumentBindings?: boolean;
+};
+
 export function evalMacroExpr(
   expr: Expr,
   scope: MacroScope,
   opts: EvalOpts = {}
 ): MacroEvalResult {
+  // `with_location` returns syntax as an opaque macro value. Nested expansion
+  // must not evaluate that syntax before the outer expansion consumes it.
+  if (expr.attributes?.__macroExplicitLocation === true) {
+    return cloneExpr(expr);
+  }
+
   if (isIdentifierAtom(expr)) {
     const value = scope.getVariable(expr.value)?.value;
     return value ? cloneMacroEvalResult(value) : expr;
@@ -76,7 +87,10 @@ function evalCall(
   const id = head.value;
   const macro = scope.getMacro(id);
   if (macro) {
-    const expanded = expandMacroCall(form, macro, scope);
+    const expanded = expandMacroCall(form, macro, scope, {
+      preserveExplicitLocationMarkers: true,
+      resolveArgumentBindings: true,
+    });
     return evalMacroExpr(expanded, scope, opts);
   }
 
@@ -110,10 +124,19 @@ function evalCall(
 export function expandMacroCall(
   call: Form,
   macro: MacroDefinition,
-  _scope: MacroScope
+  scope: MacroScope,
+  options: ExpandMacroCallOptions = {},
 ): Expr {
   const invocationScope = new MacroScope(macro.scope);
-  const args = call.toArray().slice(1).map(cloneExpr);
+  const args = call.rest.map((argument) => {
+    if (options.resolveArgumentBindings && isIdentifierAtom(argument)) {
+      const binding = scope.getVariable(argument.value)?.value;
+      if (binding instanceof Syntax) {
+        return cloneExpr(binding);
+      }
+    }
+    return cloneExpr(argument);
+  });
   const preservedLocations = collectSyntaxLocationKeys(args);
   const bodyArguments = new Form({
     location: call.location?.clone(),
@@ -151,6 +174,8 @@ export function expandMacroCall(
       syntax: normalized,
       invocationLocation: call.location,
       preservedLocations,
+      preserveExplicitLocationMarkers:
+        options.preserveExplicitLocationMarkers === true,
     });
   }
   return normalized;
@@ -160,15 +185,21 @@ const rebaseGeneratedSyntax = ({
   syntax,
   invocationLocation,
   preservedLocations,
+  preserveExplicitLocationMarkers,
 }: {
   syntax: Syntax;
   invocationLocation: NonNullable<Syntax["location"]>;
   preservedLocations: ReadonlySet<string>;
+  preserveExplicitLocationMarkers: boolean;
 }): void => {
   const key = syntaxLocationKey(syntax);
   const hasExplicitLocation =
     syntax.attributes?.__macroExplicitLocation === true;
-  if (hasExplicitLocation && syntax.attributes) {
+  if (
+    hasExplicitLocation &&
+    syntax.attributes &&
+    !preserveExplicitLocationMarkers
+  ) {
     delete syntax.attributes.__macroExplicitLocation;
     if (Object.keys(syntax.attributes).length === 0) {
       syntax.attributes = undefined;
@@ -183,6 +214,7 @@ const rebaseGeneratedSyntax = ({
         syntax: entry,
         invocationLocation,
         preservedLocations,
+        preserveExplicitLocationMarkers,
       }),
     );
   }

--- a/packages/compiler/src/semantics/__tests__/binding.test.ts
+++ b/packages/compiler/src/semantics/__tests__/binding.test.ts
@@ -2330,10 +2330,11 @@ eff async_effect
     );
   });
 
-  it("validates hygienic generated type names using their source prefix", () => {
+  it("validates repeatedly hygienic generated type names using their source prefix", () => {
     const source = `
 attribute macro generate_type(arguments, declaration)
-  let generated = identifier(GeneratedType)
+  let first = identifier(GeneratedType)
+  let generated = identifier(first)
   emit_many(declaration, \`(type $generated = i32))
 
 @generate_type

--- a/packages/compiler/src/semantics/__tests__/binding.test.ts
+++ b/packages/compiler/src/semantics/__tests__/binding.test.ts
@@ -2330,6 +2330,24 @@ eff async_effect
     );
   });
 
+  it("validates hygienic generated type names using their source prefix", () => {
+    const source = `
+attribute macro generate_type(arguments, declaration)
+  let generated = identifier(GeneratedType)
+  emit_many(declaration, \`(type $generated = i32))
+
+@generate_type
+fn value() -> i32
+  1
+`;
+    const ast = parse(source, "main.voyd");
+    const symbolTable = new SymbolTable({ rootOwner: ast.syntaxId });
+    symbolTable.declare({ name: "main.voyd", kind: "module", declaredAt: ast.syntaxId });
+
+    const binding = runBindingPipeline({ moduleForm: ast, symbolTable });
+    expect(binding.diagnostics.filter((entry) => entry.code === "BD0007")).toHaveLength(0);
+  });
+
   it("reports unsupported mod declarations", () => {
     const source = "pub mod util";
     const ast = parse(source, "main.voyd");

--- a/packages/compiler/src/semantics/binding/binders/object.ts
+++ b/packages/compiler/src/semantics/binding/binders/object.ts
@@ -96,7 +96,9 @@ export const bindObjectDecl = (
         ast: field.ast,
         typeExpr: field.typeExpr,
         optional: field.optional,
-        documentation: declarationDocForSyntax(field.name, ctx),
+        documentation:
+          declarationDocForSyntax(field.name, ctx) ??
+          declarationDocForSyntax(field.ast, ctx),
         visibility: inheritMemberVisibility({
           ownerVisibility: decl.visibility,
           modifier: field.memberModifier,

--- a/packages/compiler/src/semantics/binding/type-name-convention.ts
+++ b/packages/compiler/src/semantics/binding/type-name-convention.ts
@@ -4,7 +4,7 @@ import { toSourceSpan } from "../../parser/surface/utils.js";
 import type { BindingContext } from "./types.js";
 
 const upperCamelNamePattern = /^[A-Z][A-Za-z0-9]*$/;
-const macroHygieneSuffixPattern = /\$macro_id\$\d+$/;
+const macroHygieneSuffixPattern = /(?:\$macro_id\$\d+)+$/;
 
 const isUpperCamelTypeName = (name: string): boolean =>
   upperCamelNamePattern.test(name.replace(macroHygieneSuffixPattern, ""));

--- a/packages/compiler/src/semantics/binding/type-name-convention.ts
+++ b/packages/compiler/src/semantics/binding/type-name-convention.ts
@@ -4,9 +4,10 @@ import { toSourceSpan } from "../../parser/surface/utils.js";
 import type { BindingContext } from "./types.js";
 
 const upperCamelNamePattern = /^[A-Z][A-Za-z0-9]*$/;
+const macroHygieneSuffixPattern = /\$macro_id\$\d+$/;
 
 const isUpperCamelTypeName = (name: string): boolean =>
-  upperCamelNamePattern.test(name);
+  upperCamelNamePattern.test(name.replace(macroHygieneSuffixPattern, ""));
 
 export const reportInvalidTypeDeclarationName = ({
   declarationKind,

--- a/packages/reference/docs/macros.md
+++ b/packages/reference/docs/macros.md
@@ -35,6 +35,11 @@ Macro bodies commonly build syntax with:
 The standard library uses this model to implement surface features such as
 `enum`, `for`, `??`, and `?.`.
 
+When a macro replaces syntax while preserving its source-level role, use
+`with_location(generated, source)` to transfer the source syntax location to
+the generated form. This also preserves documentation provenance when, for
+example, a function parameter becomes an object field.
+
 ## Exporting and importing macros
 
 `pub macro` exports a macro from a module. Macros can also be re-exported with


### PR DESCRIPTION
## Summary
- preserve source provenance for syntax synthesized by user macros
- support hygienic macro-generated type names and function coercions in generic arrays and unions
- specialize imported generic match payloads without bypassing optional or closure conversions
- add regressions for attribute docs, generic payloads, optional injection, and closure arrays

## Verification
- npm test
- npm run typecheck
- npm run test:audit
- npm run lint