### PR TITLE
[V-434] Fix generic conditional argument coercion

### DIFF
--- a/packages/compiler/src/codegen/__tests__/__fixtures__/generic_conditional_structural_optional.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/generic_conditional_structural_optional.voyd
@@ -1,0 +1,44 @@
+obj Some<T> { value: T }
+obj None {}
+type Optional<T> = Some<T> | None
+
+obj DefaultSize {}
+obj IconSmallSize {}
+type ButtonSize = DefaultSize | IconSmallSize
+
+obj Label { value: i32 }
+
+obj View<Msg> {
+  message: Msg,
+  code: i32
+}
+
+fn button<Msg>({
+  on_press: Msg,
+  size: ButtonSize,
+  aria_label: Optional<Label>
+}) -> View<Msg>
+  let size_code = match(size)
+    DefaultSize: 1
+    IconSmallSize: 10
+  let label_code = match(aria_label)
+    Some<Label> { value }: value.value
+    None: 0
+  View<Msg> { message: on_press, code: size_code + label_code }
+
+fn dialog_close<Msg>({
+  on_close: Msg,
+  size: ButtonSize = DefaultSize {},
+  icon_only: bool = false
+}) -> View<Msg>
+  button<Msg>(
+    on_press: on_close,
+    size: if icon_only then: IconSmallSize {} else: size,
+    aria_label: if icon_only then: Some<Label> { value: Label { value: 5 } } else: None {}
+  )
+
+fn dialog_close_icon<Msg>({ on_close: Msg }) -> View<Msg>
+  dialog_close<Msg>(on_close: on_close, icon_only: true)
+
+pub fn main() -> i32
+  dialog_close_icon<i32>(on_close: 42).code

--- a/packages/compiler/src/codegen/__tests__/codegen.test.ts
+++ b/packages/compiler/src/codegen/__tests__/codegen.test.ts
@@ -1075,6 +1075,11 @@ describe("next codegen", () => {
     expect(main()).toBe(17);
   });
 
+  it("coerces structural optionals in generic conditional arguments", () => {
+    const main = loadMain("generic_conditional_structural_optional.voyd");
+    expect(main()).toBe(15);
+  });
+
   it("dispatches trait objects with mixed pure/effectful impl ABIs", () => {
     const main = loadMain("trait_object_dispatch_mixed_effects.voyd");
     expect(main()).toBe(18);

--- a/packages/compiler/src/codegen/expressions/control-flow.ts
+++ b/packages/compiler/src/codegen/expressions/control-flow.ts
@@ -30,7 +30,6 @@ import {
   getRequiredExprType,
   getStructuralTypeInfo,
   getMatchPatternTypeId,
-  getTypeIdFromTypeExpr,
   getUnresolvedExprType,
   shouldInlineUnionLayout,
   wasmTypeFor,
@@ -152,20 +151,7 @@ const getValueSourceTypeId = (
   while (true) {
     const expr = ctx.module.hir.expressions.get(currentExprId);
     if (expr?.exprKind === "object-literal") {
-      if (expr.literalKind === "nominal" && typeof expr.targetSymbol === "number") {
-        const canonicalTarget = ctx.program.symbols.canonicalIdOf(
-          ctx.moduleId,
-          expr.targetSymbol,
-        );
-        const template = ctx.program.objects.getTemplate(canonicalTarget);
-        if (template) {
-          return template.type;
-        }
-      }
-      if (expr.literalKind === "nominal" && expr.target) {
-        return getTypeIdFromTypeExpr(expr.target, ctx);
-      }
-      return getRequiredExprType(currentExprId, ctx, instanceId);
+      return getUnresolvedExprType(currentExprId, ctx, instanceId);
     }
     if (!expr || expr.exprKind !== "block" || typeof expr.value !== "number") {
       return getUnresolvedExprType(currentExprId, ctx, instanceId);

--- a/tests/integration/fixtures/vx-generic-conditional-wrapper.voyd
+++ b/tests/integration/fixtures/vx-generic-conditional-wrapper.voyd
@@ -1,0 +1,61 @@
+use std::array::Array
+use std::msgpack::MsgPack
+use std::optional::types::all
+use std::string::type::String
+use std::vx::self as vx
+
+type View<Msg> = MsgPack
+type Child<Msg> = MsgPack
+
+enum ButtonSize
+  Default
+  IconSmall
+
+enum TestMsg
+  Clicked
+
+fn icon() -> MsgPack
+  vx::html_element(
+    tag: "span",
+    children: Array<MsgPack>::init()
+  )
+
+fn Button<Msg>({
+  children: Array<Child<Msg>>,
+  on_press: Msg,
+  size: ButtonSize = ButtonSize::Default {},
+  aria_label?: String
+}) -> View<Msg>
+  let size_class = match(size)
+    ButtonSize::Default: "default"
+    ButtonSize::IconSmall: "icon-small"
+  let ~attrs = [
+    vx::class(size_class),
+    vx::html_event_message(name: "click", message: on_press)
+  ]
+  if aria_label is Some:
+    attrs.push(vx::attr(name: "aria-label", value: aria_label.value))
+  vx::html_element(tag: "button", attrs: attrs, children: children)
+
+fn DialogClose<Msg>({
+  children: Array<Child<Msg>>,
+  on_close: Msg,
+  size: ButtonSize = ButtonSize::Default {},
+  icon_only: bool = false
+}) -> View<Msg>
+  Button<Msg>(
+    children: children,
+    on_press: on_close,
+    size: if icon_only then: ButtonSize::IconSmall {} else: size,
+    aria_label: if icon_only then: Some<String> { value: "Close" } else: None {}
+  )
+
+fn DialogCloseIcon<Msg>({ on_close: Msg }) -> View<Msg>
+  DialogClose<Msg>(
+    children: [icon()],
+    on_close: on_close,
+    icon_only: true
+  )
+
+pub fn main() -> View<TestMsg>
+  DialogCloseIcon<TestMsg>(on_close: TestMsg::Clicked {})

--- a/tests/integration/src/vx-dom.test.ts
+++ b/tests/integration/src/vx-dom.test.ts
@@ -54,6 +54,10 @@ const wideValueModelEntryPath = path.join(
   fixtureRoot,
   "vx-wide-value-model.voyd",
 );
+const genericConditionalWrapperEntryPath = path.join(
+  fixtureRoot,
+  "vx-generic-conditional-wrapper.voyd",
+);
 const markdownEntryPath = path.resolve(
   import.meta.dirname,
   "../../../examples/markdown.voyd",
@@ -229,6 +233,20 @@ pub fn multi_document() -> String
 
     renderer.dispose();
     expect(container.innerHTML).toBe("");
+  });
+
+  it("renders conditional arguments forwarded through a generic VX wrapper", async () => {
+    const result = expectCompileSuccess(
+      await createSdk().compile({
+        entryPath: genericConditionalWrapperEntryPath,
+      }),
+    );
+
+    await expect(result.run({ entryName: "main" })).resolves.toMatchObject({
+      kind: "element",
+      tag: "button",
+      attrs: { class: "icon-small", "aria-label": "Close" },
+    });
   });
 
   it("dispatches static event messages from compiled Voyd VX nodes", async () => {


### PR DESCRIPTION
## Summary

- use instantiated expression source types when coercing object-literal branches
- add a focused compiler regression for structural optional values forwarded through generic wrappers
- add an SDK/VX regression matching the DialogClose/DialogCloseIcon failure shape

## Root cause

Control-flow codegen identified nominal object-literal branches with the generic object template type. For a conditional such as `Some<String> ... else None {}`, this left the `Some` payload as an unresolved type parameter while coercing it to `Optional<String>`. The resulting structural conversion could emit an invalid runtime cast.

Using the unresolved expression type preserves the instantiated source type without replacing it with the context-resolved optional target.

## Impact

Generic VX component wrappers can safely forward conditional enum and optional arguments without trapping with `illegal cast` / `bad cast`.

## Validation

- `npx vitest packages/compiler/src/codegen/__tests__/codegen.test.ts -t "coerces structural optionals in generic conditional arguments"`
- `npx vitest tests/integration/src/vx-dom.test.ts -t "renders conditional arguments forwarded through a generic VX wrapper"`
- `npm run typecheck`
- `npm run test:audit`
- `npm test`
- single correctness-agent review: no production-impact findings