### PR TITLE
Add Phase 3 web streaming and OpenAPI

### DIFF
--- a/docs/proposals/web-framework/voyd-web-framework.md
+++ b/docs/proposals/web-framework/voyd-web-framework.md
@@ -1016,9 +1016,30 @@ Phase 2 implementation notes:
 
 - streaming request and response bodies
 - multipart forms
-- WebSocket or server-sent events if the effect model supports them cleanly
+- server-sent events
 - richer content negotiation
-- OpenAPI/schema generation from route declarations if DTO reflection supports it
+- OpenAPI/schema generation from reified DTO shapes
+
+Phase 3 implementation notes:
+
+- Response streams use explicit start/write/finish host operations. Writes wait
+  for host backpressure, and the Web SSE layer formats events over that general
+  stream contract. Transport chunks have a 16 KiB contract so MessagePack
+  effect payloads remain bounded. The host response timeout is refreshed by
+  successful writes and cleanly closes abandoned started streams.
+- Request streaming is opt-in through `ServerConfig::stream_request_bodies` and
+  `accept_streaming`; `pkg::web::serve_streaming` exposes the reader through
+  `Context::streaming_body` on routes marked `.streaming()`, while other routes
+  in the same app are buffered lazily for ordinary extractors.
+- Multipart parsing preserves binary part bodies and exposes checked UTF-8 only
+  as an explicit part operation.
+- OpenAPI 3.1 generation consumes `std::meta::Shape`, including declaration and
+  field documentation. Route behavior metadata remains explicit through
+  `OpenApiOperation`; `document_openapi_route` derives method and path from the
+  router entry instead of accepting an independent route identity. Component
+  names include deterministic full-schema fingerprints so same-named types do
+  not collide across modules.
+- WebSockets are intentionally outside this phase.
 
 ## Testing Direction
 

--- a/docs/specs/runtime-event-loop.md
+++ b/docs/specs/runtime-event-loop.md
@@ -234,7 +234,9 @@ Request payload (`tail` op argument):
 - `host: string | null`
 - `max_body_bytes: i32 | null` (default adapter default: `1048576`)
 - `max_pending_requests: i32 | null` (default adapter default: `100`)
-- `response_timeout_millis: i32 | null` (default adapter default: `30000`)
+- `response_timeout_millis: i32 | null` (default adapter default: `30000`;
+  idle watchdog refreshed by successful response-stream writes)
+- `stream_request_bodies: bool | null` (default adapter default: `false`)
 
 Success response payload:
 
@@ -252,7 +254,7 @@ Request payload (`resume` op argument):
 
 Success response payload:
 
-- `{ ok: true, value: { request_id: i32, method: string, path: string, query: string | null, headers: Array<{ name: string, value: string }>, body: Array<i32> } }`
+- `{ ok: true, value: { request_id: i32, method: string, path: string, query: string | null, headers: Array<{ name: string, value: string }>, body: Array<i32>, body_streaming: bool } }`
 
 Error response payload:
 
@@ -261,14 +263,47 @@ Error response payload:
 Lifecycle semantics:
 
 - `accept_raw` suspends until a request is available or the server closes.
-- Each `request_id` may be answered exactly once through `respond_raw`.
+- Each `request_id` may be answered exactly once through `respond_raw`, or by
+  the ordered `start_response_raw`, zero or more `write_response_raw`, and
+  `finish_response_raw` sequence.
 - Requests whose bodies exceed `max_body_bytes` are rejected with a host response
-  before they are accepted.
+  before they are accepted when `stream_request_bodies` is false. Streaming
+  bodies enforce the same cumulative limit while `read_request_raw` consumes
+  them.
 - Requests beyond `max_pending_requests` are rejected by the default adapter with
   `503`.
-- Accepted requests not completed before `response_timeout_millis` receive a
-  host-managed `500` and are released. A later `respond_raw` for that request
-  returns a host error.
+- Accepted requests not started before `response_timeout_millis` receive a
+  host-managed `500` and are released. Started streams use the timeout as an
+  idle watchdog refreshed after each successful write; timeout closes the body
+  without appending an error payload to already-written bytes. A later response
+  operation for a released request returns a host error.
+- Completing a response cancels an unread streaming request body. Runtime
+  adapters SHOULD propagate that cancellation to their native request reader.
+
+### `std::http::server::HttpServer.read_request_raw`
+
+Request payload (`resume` op argument):
+
+- `request_id: i32`
+
+Success response payload:
+
+- `{ ok: true, value: { chunk: Array<i32>, done: bool } }`
+
+Error response payload:
+
+- `{ ok: false, code: i32, message: string }`
+- Error code `3` identifies a request body that exceeded `max_body_bytes`.
+
+Lifecycle semantics:
+
+- The operation is valid only for an accepted request whose `body_streaming`
+  field is true.
+- Hosts split native input into transport-safe chunks no larger than 16 KiB and
+  await the underlying reader, providing request-body backpressure.
+- Each successful read refreshes the request's response idle watchdog so an
+  active upload is not mistaken for an abandoned handler.
+- `done: true` is terminal; subsequent reads return a host error.
 
 ### `std::http::server::HttpServer.respond_raw`
 
@@ -283,6 +318,56 @@ Success response payload:
 Error response payload:
 
 - `{ ok: false, code: i32, message: string }`
+
+### `std::http::server::HttpServer.start_response_raw`
+
+Request payload (`tail` op argument):
+
+- `{ request_id: i32, response: { status: i32, reason: string, headers: Array<{ name: string, value: string }>, body: Array<i32> } }`
+- `response.body` MUST be empty. Body bytes are sent by `write_response_raw`.
+
+Success response payload: `{ ok: true }`
+
+Error response payload: `{ ok: false, code: i32, message: string }`
+
+### `std::http::server::HttpServer.write_response_raw`
+
+Request payload (`tail` op argument):
+
+- `{ request_id: i32, chunk: Array<i32> }`
+- `chunk` MUST contain no more than 16384 bytes.
+
+Success response payload: `{ ok: true }`
+
+Error response payload: `{ ok: false, code: i32, message: string }`
+
+Lifecycle and transport semantics:
+
+- The operation is valid only after `start_response_raw` and before
+  `finish_response_raw` for the same request.
+- Completion means the host accepted the bytes according to its native
+  backpressure signal; implementations MUST NOT acknowledge before that point.
+- A host exposing this 16 KiB contract MUST allocate an effect transport large
+  enough for its encoded envelope. The default JS host requires at least
+  131072 bytes whenever `write_response_raw` is present and rejects adapter
+  registration otherwise.
+- Native disconnects and write failures return a host error.
+
+### `std::http::server::HttpServer.finish_response_raw`
+
+Request payload (`tail` op argument):
+
+- `request_id: i32`
+
+Success response payload: `{ ok: true }`
+
+Error response payload: `{ ok: false, code: i32, message: string }`
+
+Lifecycle semantics:
+
+- The operation closes a started response body and releases the request.
+- A second finish, a write after finish, or any streaming operation for an
+  unknown/released request returns a host error.
 
 ### `std::http::server::HttpServer.close_raw`
 
@@ -303,7 +388,8 @@ Lifecycle semantics:
 - `close_raw` stops new accepts and releases host resources.
 - Pending accepts resume with a host error.
 - Pending accepted responses receive a host-managed `500` before the adapter
-  waits for the underlying server to close.
+  waits for the underlying server to close. Started streams are ended without
+  injecting an error body.
 
 ### `std::input::Input.read_line`
 

--- a/docs/testing/ci.md
+++ b/docs/testing/ci.md
@@ -42,11 +42,13 @@ detection without making ordinary hosted-runner variance a required-check
 failure; tighten it once retained artifacts provide a credible p95 baseline.
 
 The first live hosted-runner integration baseline completed all 128 assertions
-in about 201 seconds, with the slowest file at about 132 seconds. Its initial
-budget is therefore 300 seconds for the lane and 180 seconds per file. This
-preserves meaningful regression detection while leaving headroom for ordinary
-hosted-runner variance; tighten it after enough successful runs exist to
-estimate p95 reliably.
+in about 201 seconds, with the slowest file at about 132 seconds. After the
+public web package gained request streaming, SSE, and OpenAPI generation,
+healthy runs completed in about 247 seconds with the expanded web fixture at
+183-193 seconds. The budget is therefore 300 seconds for the lane and 210
+seconds per file. This preserves the lane-wide regression guard while leaving
+headroom for ordinary runner variance; tighten it after enough successful runs
+exist to estimate p95 reliably.
 
 ## Runtime Selection
 

--- a/docs/testing/test-inventory.json
+++ b/docs/testing/test-inventory.json
@@ -2359,10 +2359,22 @@
     "rationale": "Keep co-located: protects one package or app implementation contract at the cheapest precise boundary."
   },
   {
+    "file": "packages/web/src/openapi.test.voyd",
+    "owner": "voyd-library",
+    "disposition": "library-local",
+    "rationale": "Keep co-located: protects pkg::web OpenAPI document building, type reification, and documentation propagation through the native Voyd test runner."
+  },
+  {
     "file": "packages/web/src/phase2.test.voyd",
     "owner": "voyd-library",
     "disposition": "library-local",
     "rationale": "Keep co-located: protects a Voyd source package or library contract through the native test runner."
+  },
+  {
+    "file": "packages/web/src/phase3.test.voyd",
+    "owner": "voyd-library",
+    "disposition": "library-local",
+    "rationale": "Keep co-located: protects pkg::web SSE formatting, multipart parsing, and content negotiation through the native Voyd test runner."
   },
   {
     "file": "packages/web/src/web.test.voyd",

--- a/packages/js-host/src/adapters/default.test.ts
+++ b/packages/js-host/src/adapters/default.test.ts
@@ -1716,6 +1716,70 @@ describe("registerDefaultHostAdapters", () => {
     expect(shutdown).toHaveBeenCalledTimes(1);
   });
 
+  it("clears web response stream timeouts when the server closes", async () => {
+    const table = buildTable([
+      { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },
+      { effectId: "voyd.std.http.server", opName: "accept_raw", opId: 1 },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "start_response_raw",
+        opId: 2,
+      },
+      { effectId: "voyd.std.http.server", opName: "close_raw", opId: 3 },
+    ]);
+    let serveHandler: ((request: Request) => Promise<Response>) | undefined;
+    const serve = vi.fn((_options: unknown, handler: typeof serveHandler) => {
+      serveHandler = handler;
+      return { shutdown: vi.fn() };
+    });
+    vi.stubGlobal("Deno", { serve });
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const { host, getHandler } = createFakeHost(table);
+
+    await registerDefaultHostAdapters({
+      host,
+      options: { runtime: "deno" },
+    });
+    const listenResult = await getHandler("voyd.std.http.server", "listen_raw")(
+      tailContinuation,
+      { port: 4548, host: "127.0.0.1", response_timeout_millis: 60_000 }
+    );
+    const serverId = (listenResult.value as { value: number }).value;
+    const responsePromise = serveHandler!(
+      new Request("http://127.0.0.1:4548/events")
+    );
+    const acceptResult = await getHandler("voyd.std.http.server", "accept_raw")(
+      tailContinuation,
+      serverId
+    );
+    const requestId = (
+      acceptResult.value as { value: { request_id: number } }
+    ).value.request_id;
+    await getHandler("voyd.std.http.server", "start_response_raw")(
+      tailContinuation,
+      {
+        request_id: requestId,
+        response: {
+          status: 200,
+          reason: "OK",
+          headers: [{ name: "content-type", value: "text/event-stream" }],
+          body: [],
+        },
+      }
+    );
+    await responsePromise;
+    const clearedBeforeClose = clearTimeoutSpy.mock.calls.length;
+
+    await expect(
+      getHandler("voyd.std.http.server", "close_raw")(
+        tailContinuation,
+        serverId
+      )
+    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(clearedBeforeClose + 1);
+    clearTimeoutSpy.mockRestore();
+  });
+
   it("omits Deno/Bun web response bodies for null-body statuses", async () => {
     const table = buildTable([
       { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },

--- a/packages/js-host/src/adapters/default.test.ts
+++ b/packages/js-host/src/adapters/default.test.ts
@@ -1703,6 +1703,83 @@ describe("registerDefaultHostAdapters", () => {
     expect(readRequest).toHaveBeenCalledOnce();
   });
 
+  it("drops buffered request remainders when the source times out", async () => {
+    const table = buildTable([
+      { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },
+      { effectId: "voyd.std.http.server", opName: "accept_raw", opId: 1 },
+      { effectId: "voyd.std.http.server", opName: "read_request_raw", opId: 2 },
+      { effectId: "voyd.std.http.server", opName: "close_raw", opId: 3 },
+    ]);
+    const { host, getHandler } = createFakeHost(table);
+    const port = await findFreePort();
+
+    await registerDefaultHostAdapters({
+      host,
+      options: { runtime: "node", effectBufferSize: 256 },
+    });
+    const listenResult = await getHandler("voyd.std.http.server", "listen_raw")(
+      tailContinuation,
+      {
+        port,
+        host: "127.0.0.1",
+        stream_request_bodies: true,
+        response_timeout_millis: 25,
+      }
+    );
+    const serverId = (listenResult.value as { value: number }).value;
+    const acceptPromise = getHandler("voyd.std.http.server", "accept_raw")(
+      tailContinuation,
+      serverId
+    );
+    const responsePromise = new Promise<string>((resolve, reject) => {
+      const request = http.request(
+        `http://127.0.0.1:${port}/timeout`,
+        { method: "POST" },
+        (response) => {
+          response.setEncoding("utf8");
+          let body = "";
+          response.on("data", (chunk: string) => {
+            body += chunk;
+          });
+          response.on("end", () => resolve(body));
+        }
+      );
+      request.once("error", reject);
+      request.end(Buffer.alloc(600, 1));
+    });
+    const acceptResult = await acceptPromise;
+    const requestId = (
+      acceptResult.value as { value: { request_id: number } }
+    ).value.request_id;
+
+    await expect(
+      getHandler("voyd.std.http.server", "read_request_raw")(
+        tailContinuation,
+        requestId
+      )
+    ).resolves.toMatchObject({
+      kind: "resume",
+      value: { ok: true, value: { done: false } },
+    });
+    await expect(responsePromise).resolves.toBe("server response timeout");
+    await expect(
+      getHandler("voyd.std.http.server", "read_request_raw")(
+        tailContinuation,
+        requestId
+      )
+    ).resolves.toMatchObject({
+      kind: "resume",
+      value: {
+        ok: false,
+        message: `request ${requestId} has no open request body stream`,
+      },
+    });
+    await getHandler("voyd.std.http.server", "close_raw")(
+      tailContinuation,
+      serverId
+    );
+  });
+
   it("rejects response streaming when the effect buffer cannot carry a full chunk", async () => {
     const table = buildTable([
       {
@@ -1817,7 +1894,12 @@ describe("registerDefaultHostAdapters", () => {
         opName: "start_response_raw",
         opId: 2,
       },
-      { effectId: "voyd.std.http.server", opName: "close_raw", opId: 3 },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "write_response_raw",
+        opId: 3,
+      },
+      { effectId: "voyd.std.http.server", opName: "close_raw", opId: 4 },
     ]);
     let serveHandler: ((request: Request) => Promise<Response>) | undefined;
     const serve = vi.fn((_options: unknown, handler: typeof serveHandler) => {
@@ -1859,7 +1941,15 @@ describe("registerDefaultHostAdapters", () => {
         },
       }
     );
-    await responsePromise;
+    const response = await responsePromise;
+    const bodyPromise = response.text();
+    await getHandler("voyd.std.http.server", "write_response_raw")(
+      tailContinuation,
+      {
+        request_id: requestId,
+        chunk: Array.from(new TextEncoder().encode("data: partial\n\n")),
+      }
+    );
     const clearedBeforeClose = clearTimeoutSpy.mock.calls.length;
 
     await expect(
@@ -1868,6 +1958,7 @@ describe("registerDefaultHostAdapters", () => {
         serverId
       )
     ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+    await expect(bodyPromise).resolves.toBe("data: partial\n\n");
     expect(clearTimeoutSpy).toHaveBeenCalledTimes(clearedBeforeClose + 1);
     clearTimeoutSpy.mockRestore();
   });

--- a/packages/js-host/src/adapters/default.test.ts
+++ b/packages/js-host/src/adapters/default.test.ts
@@ -1872,6 +1872,95 @@ describe("registerDefaultHostAdapters", () => {
     clearTimeoutSpy.mockRestore();
   });
 
+  it("finishes cleanly after a web response stream write detects disconnect", async () => {
+    const table = buildTable([
+      { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },
+      { effectId: "voyd.std.http.server", opName: "accept_raw", opId: 1 },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "start_response_raw",
+        opId: 2,
+      },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "write_response_raw",
+        opId: 3,
+      },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "finish_response_raw",
+        opId: 4,
+      },
+      { effectId: "voyd.std.http.server", opName: "close_raw", opId: 5 },
+    ]);
+    let serveHandler: ((request: Request) => Promise<Response>) | undefined;
+    const serve = vi.fn((_options: unknown, handler: typeof serveHandler) => {
+      serveHandler = handler;
+      return { shutdown: vi.fn() };
+    });
+    vi.stubGlobal("Deno", { serve });
+    const { host, getHandler } = createFakeHost(table);
+
+    await registerDefaultHostAdapters({
+      host,
+      options: { runtime: "deno" },
+    });
+    const listenResult = await getHandler("voyd.std.http.server", "listen_raw")(
+      tailContinuation,
+      { port: 4549, host: "127.0.0.1", response_timeout_millis: 60_000 }
+    );
+    const serverId = (listenResult.value as { value: number }).value;
+    const responsePromise = serveHandler!(
+      new Request("http://127.0.0.1:4549/events")
+    );
+    const acceptResult = await getHandler("voyd.std.http.server", "accept_raw")(
+      tailContinuation,
+      serverId
+    );
+    const requestId = (
+      acceptResult.value as { value: { request_id: number } }
+    ).value.request_id;
+    await getHandler("voyd.std.http.server", "start_response_raw")(
+      tailContinuation,
+      {
+        request_id: requestId,
+        response: {
+          status: 200,
+          reason: "OK",
+          headers: [{ name: "content-type", value: "text/event-stream" }],
+          body: [],
+        },
+      }
+    );
+    const response = await responsePromise;
+    await response.body!.cancel(new Error("client disconnected"));
+
+    await expect(
+      getHandler("voyd.std.http.server", "write_response_raw")(
+        tailContinuation,
+        {
+          request_id: requestId,
+          chunk: Array.from(new TextEncoder().encode("data: too late\n\n")),
+        }
+      )
+    ).resolves.toMatchObject({
+      kind: "tail",
+      value: { ok: false, message: "client disconnected" },
+    });
+    await expect(
+      getHandler("voyd.std.http.server", "finish_response_raw")(
+        tailContinuation,
+        requestId
+      )
+    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+    await expect(
+      getHandler("voyd.std.http.server", "close_raw")(
+        tailContinuation,
+        serverId
+      )
+    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+  });
+
   it("omits Deno/Bun web response bodies for null-body statuses", async () => {
     const table = buildTable([
       { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },

--- a/packages/js-host/src/adapters/default.test.ts
+++ b/packages/js-host/src/adapters/default.test.ts
@@ -1166,6 +1166,477 @@ describe("registerDefaultHostAdapters", () => {
     });
   });
 
+  it("streams node http-server response chunks before finishing the request", async () => {
+    const table = buildTable([
+      { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },
+      { effectId: "voyd.std.http.server", opName: "accept_raw", opId: 1 },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "start_response_raw",
+        opId: 2,
+      },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "write_response_raw",
+        opId: 3,
+      },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "finish_response_raw",
+        opId: 4,
+      },
+      { effectId: "voyd.std.http.server", opName: "close_raw", opId: 5 },
+    ]);
+    const { host, getHandler } = createFakeHost(table);
+    const port = await findFreePort();
+
+    await registerDefaultHostAdapters({
+      host,
+      options: { runtime: "node" },
+    });
+
+    const listenResult = await getHandler("voyd.std.http.server", "listen_raw")(
+      tailContinuation,
+      { port, host: "127.0.0.1" }
+    );
+    const serverId = (listenResult.value as { value: number }).value;
+    const acceptPromise = getHandler("voyd.std.http.server", "accept_raw")(
+      tailContinuation,
+      serverId
+    );
+
+    let resolveFirstChunk: ((chunk: string) => void) | undefined;
+    const firstChunk = new Promise<string>((resolve) => {
+      resolveFirstChunk = resolve;
+    });
+    const responsePromise = new Promise<{
+      status: number;
+      contentType?: string;
+      body: string;
+    }>((resolve, reject) => {
+      const request = http.get(`http://127.0.0.1:${port}/events`, (response) => {
+        response.setEncoding("utf8");
+        let body = "";
+        response.on("data", (chunk: string) => {
+          body += chunk;
+          resolveFirstChunk?.(chunk);
+          resolveFirstChunk = undefined;
+        });
+        response.on("end", () => {
+          resolve({
+            status: response.statusCode ?? 0,
+            contentType: response.headers["content-type"],
+            body,
+          });
+        });
+      });
+      request.once("error", reject);
+    });
+
+    const acceptResult = await acceptPromise;
+    const requestId = (
+      acceptResult.value as { value: { request_id: number } }
+    ).value.request_id;
+    await expect(
+      getHandler("voyd.std.http.server", "start_response_raw")(
+        tailContinuation,
+        {
+          request_id: requestId,
+          response: {
+            status: 200,
+            reason: "OK",
+            headers: [{ name: "content-type", value: "text/event-stream" }],
+            body: [],
+          },
+        }
+      )
+    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+    await expect(
+      getHandler("voyd.std.http.server", "write_response_raw")(
+        tailContinuation,
+        {
+          request_id: requestId,
+          chunk: Array.from(new TextEncoder().encode("data: one\n\n")),
+        }
+      )
+    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+    await expect(firstChunk).resolves.toBe("data: one\n\n");
+    await expect(
+      getHandler("voyd.std.http.server", "write_response_raw")(
+        tailContinuation,
+        {
+          request_id: requestId,
+          chunk: Array.from(new TextEncoder().encode("data: two\n\n")),
+        }
+      )
+    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+    await expect(
+      getHandler("voyd.std.http.server", "finish_response_raw")(
+        tailContinuation,
+        requestId
+      )
+    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+    await expect(responsePromise).resolves.toEqual({
+      status: 200,
+      contentType: "text/event-stream",
+      body: "data: one\n\ndata: two\n\n",
+    });
+    await expect(
+      getHandler("voyd.std.http.server", "close_raw")(
+        tailContinuation,
+        serverId
+      )
+    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+  });
+
+  it("closes an abandoned started response without corrupting streamed bytes", async () => {
+    const table = buildTable([
+      { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },
+      { effectId: "voyd.std.http.server", opName: "accept_raw", opId: 1 },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "start_response_raw",
+        opId: 2,
+      },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "write_response_raw",
+        opId: 3,
+      },
+      { effectId: "voyd.std.http.server", opName: "close_raw", opId: 4 },
+    ]);
+    const { host, getHandler } = createFakeHost(table);
+    const port = await findFreePort();
+
+    await registerDefaultHostAdapters({
+      host,
+      options: { runtime: "node" },
+    });
+    const listenResult = await getHandler("voyd.std.http.server", "listen_raw")(
+      tailContinuation,
+      {
+        port,
+        host: "127.0.0.1",
+        response_timeout_millis: 25,
+      }
+    );
+    const serverId = (listenResult.value as { value: number }).value;
+    const acceptPromise = getHandler("voyd.std.http.server", "accept_raw")(
+      tailContinuation,
+      serverId
+    );
+    const responsePromise = new Promise<{ status: number; body: string }>(
+      (resolve, reject) => {
+        const request = http.get(
+          `http://127.0.0.1:${port}/abandoned-stream`,
+          (response) => {
+            response.setEncoding("utf8");
+            let body = "";
+            response.on("data", (chunk: string) => {
+              body += chunk;
+            });
+            response.on("end", () => {
+              resolve({ status: response.statusCode ?? 0, body });
+            });
+          }
+        );
+        request.once("error", reject);
+      }
+    );
+
+    const acceptResult = await acceptPromise;
+    const requestId = (
+      acceptResult.value as { value: { request_id: number } }
+    ).value.request_id;
+    await getHandler("voyd.std.http.server", "start_response_raw")(
+      tailContinuation,
+      {
+        request_id: requestId,
+        response: {
+          status: 200,
+          reason: "OK",
+          headers: [{ name: "content-type", value: "text/event-stream" }],
+          body: [],
+        },
+      }
+    );
+    await getHandler("voyd.std.http.server", "write_response_raw")(
+      tailContinuation,
+      {
+        request_id: requestId,
+        chunk: Array.from(new TextEncoder().encode("data: before panic\n\n")),
+      }
+    );
+
+    await expect(responsePromise).resolves.toEqual({
+      status: 200,
+      body: "data: before panic\n\n",
+    });
+    await expect(
+      getHandler("voyd.std.http.server", "close_raw")(
+        tailContinuation,
+        serverId
+      )
+    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+  });
+
+  it("accepts node request headers before consuming a streamed request body", async () => {
+    const table = buildTable([
+      { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },
+      { effectId: "voyd.std.http.server", opName: "accept_raw", opId: 1 },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "read_request_raw",
+        opId: 2,
+      },
+      { effectId: "voyd.std.http.server", opName: "respond_raw", opId: 3 },
+      { effectId: "voyd.std.http.server", opName: "close_raw", opId: 4 },
+    ]);
+    const { host, getHandler } = createFakeHost(table);
+    const port = await findFreePort();
+
+    await registerDefaultHostAdapters({
+      host,
+      options: { runtime: "node" },
+    });
+    const listenResult = await getHandler("voyd.std.http.server", "listen_raw")(
+      tailContinuation,
+      {
+        port,
+        host: "127.0.0.1",
+        stream_request_bodies: true,
+        response_timeout_millis: 75,
+      }
+    );
+    const serverId = (listenResult.value as { value: number }).value;
+    const acceptPromise = getHandler("voyd.std.http.server", "accept_raw")(
+      tailContinuation,
+      serverId
+    );
+    const responsePromise = new Promise<string>((resolve, reject) => {
+      const request = http.request(
+        `http://127.0.0.1:${port}/stream-upload`,
+        { method: "POST" },
+        (response) => {
+          response.setEncoding("utf8");
+          let body = "";
+          response.on("data", (chunk: string) => {
+            body += chunk;
+          });
+          response.on("end", () => resolve(body));
+        }
+      );
+      request.once("error", reject);
+      request.write("first-");
+      void Promise.resolve(acceptPromise).then(() => {
+        setTimeout(() => request.write("second-"), 50);
+        setTimeout(() => request.end("third"), 100);
+      });
+    });
+
+    const acceptResult = await acceptPromise;
+    expect(acceptResult).toMatchObject({
+      kind: "resume",
+      value: {
+        ok: true,
+        value: {
+          path: "/stream-upload",
+          body: [],
+          body_streaming: true,
+        },
+      },
+    });
+    const requestId = (
+      acceptResult.value as { value: { request_id: number } }
+    ).value.request_id;
+    const chunks: number[] = [];
+    let done = false;
+    while (!done) {
+      const readResult = await getHandler(
+        "voyd.std.http.server",
+        "read_request_raw"
+      )(tailContinuation, requestId);
+      const value = (
+        readResult.value as {
+          value: { chunk: number[]; done: boolean };
+        }
+      ).value;
+      chunks.push(...value.chunk);
+      done = value.done;
+    }
+    expect(new TextDecoder().decode(Uint8Array.from(chunks))).toBe(
+      "first-second-third"
+    );
+    await getHandler("voyd.std.http.server", "respond_raw")(
+      tailContinuation,
+      {
+        request_id: requestId,
+        response: { status: 200, reason: "OK", headers: [], body: [111, 107] },
+      }
+    );
+    await expect(responsePromise).resolves.toBe("ok");
+    await getHandler("voyd.std.http.server", "close_raw")(
+      tailContinuation,
+      serverId
+    );
+  });
+
+  it("cancels an unread web request body when the response completes", async () => {
+    const table = buildTable([
+      { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },
+      { effectId: "voyd.std.http.server", opName: "accept_raw", opId: 1 },
+      { effectId: "voyd.std.http.server", opName: "respond_raw", opId: 2 },
+      { effectId: "voyd.std.http.server", opName: "close_raw", opId: 3 },
+    ]);
+    let serveHandler: ((request: Request) => Promise<Response>) | undefined;
+    const serve = vi.fn((_options: unknown, handler: typeof serveHandler) => {
+      serveHandler = handler;
+      return { shutdown: vi.fn() };
+    });
+    vi.stubGlobal("Deno", { serve });
+    const { host, getHandler } = createFakeHost(table);
+    const cancelBody = vi.fn();
+
+    await registerDefaultHostAdapters({
+      host,
+      options: { runtime: "deno" },
+    });
+    const listenResult = await getHandler("voyd.std.http.server", "listen_raw")(
+      tailContinuation,
+      {
+        port: 4545,
+        host: "127.0.0.1",
+        stream_request_bodies: true,
+      }
+    );
+    const serverId = (listenResult.value as { value: number }).value;
+    const requestBody = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        controller.enqueue(new TextEncoder().encode("unused"));
+      },
+      cancel: cancelBody,
+    });
+    const requestPromise = serveHandler!(
+      new Request("http://127.0.0.1:4545/upload", {
+        method: "POST",
+        body: requestBody,
+        duplex: "half",
+      } as RequestInit)
+    );
+    const acceptResult = await getHandler("voyd.std.http.server", "accept_raw")(
+      tailContinuation,
+      serverId
+    );
+    const requestId = (
+      acceptResult.value as { value: { request_id: number } }
+    ).value.request_id;
+
+    await getHandler("voyd.std.http.server", "respond_raw")(
+      tailContinuation,
+      {
+        request_id: requestId,
+        response: { status: 204, reason: "No Content", headers: [], body: [] },
+      }
+    );
+    await requestPromise;
+    expect(cancelBody).toHaveBeenCalledOnce();
+    await getHandler("voyd.std.http.server", "close_raw")(
+      tailContinuation,
+      serverId
+    );
+  });
+
+  it("splits streamed request chunks to fit the effect transport", async () => {
+    const table = buildTable([
+      { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },
+      { effectId: "voyd.std.http.server", opName: "accept_raw", opId: 1 },
+      { effectId: "voyd.std.http.server", opName: "read_request_raw", opId: 2 },
+      { effectId: "voyd.std.http.server", opName: "respond_raw", opId: 3 },
+      { effectId: "voyd.std.http.server", opName: "close_raw", opId: 4 },
+    ]);
+    const { host, getHandler } = createFakeHost(table);
+    const readRequest = vi.fn(async () => ({
+      requestId: 7,
+      chunk: Uint8Array.from({ length: 600 }, (_, index) => index % 256),
+      done: true,
+    }));
+
+    await registerDefaultHostAdapters({
+      host,
+      options: {
+        runtime: "unknown",
+        effectBufferSize: 256,
+        runtimeHooks: {
+          httpServerListen: async () => 1,
+          httpServerAccept: async () => ({
+            requestId: 7,
+            method: "POST",
+            path: "/upload",
+            headers: [],
+            body: new Uint8Array(),
+            bodyStreaming: true,
+          }),
+          httpServerReadRequest: readRequest,
+          httpServerRespond: async () => {},
+          httpServerClose: async () => {},
+        },
+      },
+    });
+
+    await getHandler("voyd.std.http.server", "listen_raw")(
+      tailContinuation,
+      { port: 1, stream_request_bodies: true }
+    );
+    await getHandler("voyd.std.http.server", "accept_raw")(
+      tailContinuation,
+      1
+    );
+    const received: number[] = [];
+    let done = false;
+    while (!done) {
+      const result = await getHandler(
+        "voyd.std.http.server",
+        "read_request_raw"
+      )(tailContinuation, 7);
+      const value = (
+        result.value as { value: { chunk: number[]; done: boolean } }
+      ).value;
+      received.push(...value.chunk);
+      done = value.done;
+    }
+
+    expect(received).toEqual(
+      Array.from({ length: 600 }, (_, index) => index % 256)
+    );
+    expect(readRequest).toHaveBeenCalledOnce();
+  });
+
+  it("rejects response streaming when the effect buffer cannot carry a full chunk", async () => {
+    const table = buildTable([
+      {
+        effectId: "voyd.std.http.server",
+        opName: "write_response_raw",
+        opId: 0,
+      },
+    ]);
+    const { host } = createFakeHost(table);
+
+    await expect(
+      registerDefaultHostAdapters({
+        host,
+        options: {
+          runtime: "unknown",
+          effectBufferSize: 256,
+          runtimeHooks: {
+            httpServerWriteResponse: async () => {},
+          },
+        },
+      })
+    ).rejects.toThrow(
+      "http-server response streaming requires an effect buffer of at least 131072 bytes"
+    );
+  });
+
   it("serves requests through Deno.serve when runtime is deno", async () => {
     const table = buildTable([
       { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },

--- a/packages/js-host/src/adapters/default.test.ts
+++ b/packages/js-host/src/adapters/default.test.ts
@@ -1973,6 +1973,80 @@ describe("registerDefaultHostAdapters", () => {
     expect(shutdown).toHaveBeenCalledTimes(1);
   });
 
+  it("closes timed-out web response streams without corrupting written bytes", async () => {
+    const table = buildTable([
+      { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },
+      { effectId: "voyd.std.http.server", opName: "accept_raw", opId: 1 },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "start_response_raw",
+        opId: 2,
+      },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "write_response_raw",
+        opId: 3,
+      },
+      { effectId: "voyd.std.http.server", opName: "close_raw", opId: 4 },
+    ]);
+    let serveHandler: ((request: Request) => Promise<Response>) | undefined;
+    const serve = vi.fn((_options: unknown, handler: typeof serveHandler) => {
+      serveHandler = handler;
+      return { shutdown: vi.fn() };
+    });
+    vi.stubGlobal("Deno", { serve });
+    const { host, getHandler } = createFakeHost(table);
+
+    await registerDefaultHostAdapters({
+      host,
+      options: { runtime: "deno" },
+    });
+    const listenResult = await getHandler("voyd.std.http.server", "listen_raw")(
+      tailContinuation,
+      { port: 4547, host: "127.0.0.1", response_timeout_millis: 25 }
+    );
+    const serverId = (listenResult.value as { value: number }).value;
+    const responsePromise = serveHandler!(
+      new Request("http://127.0.0.1:4547/events")
+    );
+    const acceptResult = await getHandler("voyd.std.http.server", "accept_raw")(
+      tailContinuation,
+      serverId
+    );
+    const requestId = (
+      acceptResult.value as { value: { request_id: number } }
+    ).value.request_id;
+    await getHandler("voyd.std.http.server", "start_response_raw")(
+      tailContinuation,
+      {
+        request_id: requestId,
+        response: {
+          status: 200,
+          reason: "OK",
+          headers: [{ name: "content-type", value: "text/event-stream" }],
+          body: [],
+        },
+      }
+    );
+    const response = await responsePromise;
+    const bodyPromise = response.text();
+    await getHandler("voyd.std.http.server", "write_response_raw")(
+      tailContinuation,
+      {
+        request_id: requestId,
+        chunk: Array.from(new TextEncoder().encode("data: partial\n\n")),
+      }
+    );
+
+    await expect(bodyPromise).resolves.toBe("data: partial\n\n");
+    await expect(
+      getHandler("voyd.std.http.server", "close_raw")(
+        tailContinuation,
+        serverId
+      )
+    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+  });
+
   it("clears web response stream timeouts when the server closes", async () => {
     const table = buildTable([
       { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },
@@ -2363,7 +2437,7 @@ describe("registerDefaultHostAdapters", () => {
       kind: "tail",
       value: { ok: true },
     });
-    expect(stop).toHaveBeenCalledWith(true);
+    expect(stop).toHaveBeenCalledWith(false);
   });
 
   it("registers input handlers from runtime hooks", async () => {

--- a/packages/js-host/src/adapters/default.test.ts
+++ b/packages/js-host/src/adapters/default.test.ts
@@ -1275,7 +1275,7 @@ describe("registerDefaultHostAdapters", () => {
         tailContinuation,
         requestId
       )
-    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+    ).resolves.toEqual({ kind: "resume", value: { ok: true } });
     await expect(responsePromise).resolves.toEqual({
       status: 200,
       contentType: "text/event-stream",
@@ -1372,7 +1372,95 @@ describe("registerDefaultHostAdapters", () => {
         tailContinuation,
         requestId
       )
+    ).resolves.toEqual({ kind: "resume", value: { ok: true } });
+    await expect(
+      getHandler("voyd.std.http.server", "close_raw")(
+        tailContinuation,
+        serverId
+      )
     ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+  });
+
+  it("finishes cleanly when a client disconnects after the final stream write", async () => {
+    const table = buildTable([
+      { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },
+      { effectId: "voyd.std.http.server", opName: "accept_raw", opId: 1 },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "start_response_raw",
+        opId: 2,
+      },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "write_response_raw",
+        opId: 3,
+      },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "finish_response_raw",
+        opId: 4,
+      },
+      { effectId: "voyd.std.http.server", opName: "close_raw", opId: 5 },
+    ]);
+    const { host, getHandler } = createFakeHost(table);
+    const port = await findFreePort();
+
+    await registerDefaultHostAdapters({
+      host,
+      options: { runtime: "node" },
+    });
+    const listenResult = await getHandler("voyd.std.http.server", "listen_raw")(
+      tailContinuation,
+      { port, host: "127.0.0.1", response_timeout_millis: 60_000 }
+    );
+    const serverId = (listenResult.value as { value: number }).value;
+    const acceptPromise = getHandler("voyd.std.http.server", "accept_raw")(
+      tailContinuation,
+      serverId
+    );
+    const disconnected = new Promise<void>((resolve) => {
+      const request = http.get(
+        `http://127.0.0.1:${port}/disconnect-after-write`,
+        (response) => {
+          response.once("data", () => response.destroy());
+          response.once("close", resolve);
+        }
+      );
+      request.once("error", () => resolve());
+    });
+    const acceptResult = await acceptPromise;
+    const requestId = (
+      acceptResult.value as { value: { request_id: number } }
+    ).value.request_id;
+    await getHandler("voyd.std.http.server", "start_response_raw")(
+      tailContinuation,
+      {
+        request_id: requestId,
+        response: {
+          status: 200,
+          reason: "OK",
+          headers: [{ name: "content-type", value: "text/event-stream" }],
+          body: [],
+        },
+      }
+    );
+    await expect(
+      getHandler("voyd.std.http.server", "write_response_raw")(
+        tailContinuation,
+        {
+          request_id: requestId,
+          chunk: Array.from(new TextEncoder().encode("data: final\n\n")),
+        }
+      )
+    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+    await disconnected;
+
+    await expect(
+      getHandler("voyd.std.http.server", "finish_response_raw")(
+        tailContinuation,
+        requestId
+      )
+    ).resolves.toEqual({ kind: "resume", value: { ok: true } });
     await expect(
       getHandler("voyd.std.http.server", "close_raw")(
         tailContinuation,
@@ -2043,7 +2131,7 @@ describe("registerDefaultHostAdapters", () => {
         tailContinuation,
         requestId
       )
-    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+    ).resolves.toEqual({ kind: "resume", value: { ok: true } });
     await expect(
       getHandler("voyd.std.http.server", "close_raw")(
         tailContinuation,

--- a/packages/js-host/src/adapters/default.test.ts
+++ b/packages/js-host/src/adapters/default.test.ts
@@ -1289,6 +1289,98 @@ describe("registerDefaultHostAdapters", () => {
     ).resolves.toEqual({ kind: "tail", value: { ok: true } });
   });
 
+  it("finishes cleanly after a streamed response write detects disconnect", async () => {
+    const table = buildTable([
+      { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },
+      { effectId: "voyd.std.http.server", opName: "accept_raw", opId: 1 },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "start_response_raw",
+        opId: 2,
+      },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "write_response_raw",
+        opId: 3,
+      },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "finish_response_raw",
+        opId: 4,
+      },
+      { effectId: "voyd.std.http.server", opName: "close_raw", opId: 5 },
+    ]);
+    const { host, getHandler } = createFakeHost(table);
+    const port = await findFreePort();
+
+    await registerDefaultHostAdapters({
+      host,
+      options: { runtime: "node" },
+    });
+    const listenResult = await getHandler("voyd.std.http.server", "listen_raw")(
+      tailContinuation,
+      { port, host: "127.0.0.1", response_timeout_millis: 60_000 }
+    );
+    const serverId = (listenResult.value as { value: number }).value;
+    const acceptPromise = getHandler("voyd.std.http.server", "accept_raw")(
+      tailContinuation,
+      serverId
+    );
+    const disconnected = new Promise<void>((resolve) => {
+      const request = http.get(
+        `http://127.0.0.1:${port}/disconnect`,
+        (response) => {
+          response.once("close", resolve);
+          response.destroy();
+        }
+      );
+      request.once("error", () => resolve());
+    });
+    const acceptResult = await acceptPromise;
+    const requestId = (
+      acceptResult.value as { value: { request_id: number } }
+    ).value.request_id;
+    await getHandler("voyd.std.http.server", "start_response_raw")(
+      tailContinuation,
+      {
+        request_id: requestId,
+        response: {
+          status: 200,
+          reason: "OK",
+          headers: [{ name: "content-type", value: "text/event-stream" }],
+          body: [],
+        },
+      }
+    );
+    await disconnected;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    await expect(
+      getHandler("voyd.std.http.server", "write_response_raw")(
+        tailContinuation,
+        {
+          request_id: requestId,
+          chunk: Array.from(new TextEncoder().encode("data: too late\n\n")),
+        }
+      )
+    ).resolves.toMatchObject({
+      kind: "tail",
+      value: { ok: false, message: "client disconnected during streamed response" },
+    });
+    await expect(
+      getHandler("voyd.std.http.server", "finish_response_raw")(
+        tailContinuation,
+        requestId
+      )
+    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+    await expect(
+      getHandler("voyd.std.http.server", "close_raw")(
+        tailContinuation,
+        serverId
+      )
+    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+  });
+
   it("closes an abandoned started response without corrupting streamed bytes", async () => {
     const table = buildTable([
       { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },

--- a/packages/js-host/src/adapters/default.test.ts
+++ b/packages/js-host/src/adapters/default.test.ts
@@ -2140,6 +2140,95 @@ describe("registerDefaultHostAdapters", () => {
     ).resolves.toEqual({ kind: "tail", value: { ok: true } });
   });
 
+  it("finishes cleanly when a web client disconnects after the final stream write", async () => {
+    const table = buildTable([
+      { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },
+      { effectId: "voyd.std.http.server", opName: "accept_raw", opId: 1 },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "start_response_raw",
+        opId: 2,
+      },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "write_response_raw",
+        opId: 3,
+      },
+      {
+        effectId: "voyd.std.http.server",
+        opName: "finish_response_raw",
+        opId: 4,
+      },
+      { effectId: "voyd.std.http.server", opName: "close_raw", opId: 5 },
+    ]);
+    let serveHandler: ((request: Request) => Promise<Response>) | undefined;
+    const serve = vi.fn((_options: unknown, handler: typeof serveHandler) => {
+      serveHandler = handler;
+      return { shutdown: vi.fn() };
+    });
+    vi.stubGlobal("Deno", { serve });
+    const { host, getHandler } = createFakeHost(table);
+
+    await registerDefaultHostAdapters({
+      host,
+      options: { runtime: "deno" },
+    });
+    const listenResult = await getHandler("voyd.std.http.server", "listen_raw")(
+      tailContinuation,
+      { port: 4550, host: "127.0.0.1", response_timeout_millis: 60_000 }
+    );
+    const serverId = (listenResult.value as { value: number }).value;
+    const responsePromise = serveHandler!(
+      new Request("http://127.0.0.1:4550/events")
+    );
+    const acceptResult = await getHandler("voyd.std.http.server", "accept_raw")(
+      tailContinuation,
+      serverId
+    );
+    const requestId = (
+      acceptResult.value as { value: { request_id: number } }
+    ).value.request_id;
+    await getHandler("voyd.std.http.server", "start_response_raw")(
+      tailContinuation,
+      {
+        request_id: requestId,
+        response: {
+          status: 200,
+          reason: "OK",
+          headers: [{ name: "content-type", value: "text/event-stream" }],
+          body: [],
+        },
+      }
+    );
+    const response = await responsePromise;
+    const reader = response.body!.getReader();
+    const firstChunk = reader.read();
+    await expect(
+      getHandler("voyd.std.http.server", "write_response_raw")(
+        tailContinuation,
+        {
+          request_id: requestId,
+          chunk: Array.from(new TextEncoder().encode("data: final\n\n")),
+        }
+      )
+    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+    await expect(firstChunk).resolves.toMatchObject({ done: false });
+    await reader.cancel(new Error("client disconnected"));
+
+    await expect(
+      getHandler("voyd.std.http.server", "finish_response_raw")(
+        tailContinuation,
+        requestId
+      )
+    ).resolves.toEqual({ kind: "resume", value: { ok: true } });
+    await expect(
+      getHandler("voyd.std.http.server", "close_raw")(
+        tailContinuation,
+        serverId
+      )
+    ).resolves.toEqual({ kind: "tail", value: { ok: true } });
+  });
+
   it("omits Deno/Bun web response bodies for null-body statuses", async () => {
     const table = buildTable([
       { effectId: "voyd.std.http.server", opName: "listen_raw", opId: 0 },

--- a/packages/js-host/src/adapters/default/capabilities/http-server.ts
+++ b/packages/js-host/src/adapters/default/capabilities/http-server.ts
@@ -56,6 +56,7 @@ type PendingNodeResponse = {
   response: NodeHttpServerResponse;
   completed: boolean;
   started: boolean;
+  streamWriteFailed: boolean;
   timeoutHandle?: ReturnType<typeof setTimeout>;
 };
 
@@ -695,6 +696,7 @@ const addPendingNodeResponse = ({
     response,
     completed: false,
     started: false,
+    streamWriteFailed: false,
   };
   state.pendingResponses.set(requestId, pending);
   resetPendingNodeResponseTimeout({ state, requestId, pending });
@@ -1201,7 +1203,17 @@ const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
         if (!pending.started || pending.completed) {
           throw new Error(`request ${requestId} has no open response stream`);
         }
-        await writeNodeResponseChunk({ target: pending.response, chunk });
+        try {
+          await writeNodeResponseChunk({ target: pending.response, chunk });
+        } catch (error) {
+          pending.completed = true;
+          pending.streamWriteFailed = true;
+          if (pending.timeoutHandle !== undefined) {
+            clearTimeout(pending.timeoutHandle);
+          }
+          cancelRequestBody(state.requestBodies, requestId);
+          throw error;
+        }
         resetPendingNodeResponseTimeout({ state, requestId, pending });
         return;
       }
@@ -1212,6 +1224,10 @@ const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
         const pending = state.pendingResponses.get(requestId);
         if (!pending) {
           continue;
+        }
+        if (pending.streamWriteFailed) {
+          state.pendingResponses.delete(requestId);
+          return;
         }
         if (!pending.started || pending.completed) {
           throw new Error(`request ${requestId} has no open response stream`);

--- a/packages/js-host/src/adapters/default/capabilities/http-server.ts
+++ b/packages/js-host/src/adapters/default/capabilities/http-server.ts
@@ -3,6 +3,7 @@ import {
   hostError,
   hostOk,
   httpServerAcceptSuccessPayload,
+  maxTransportSafeHttpServerChunkBytes,
   isRecord,
   readField,
   toNumberOrUndefined,
@@ -25,19 +26,48 @@ import {
   type CapabilityDefinition,
   type DefaultAdapterHttpHeader,
   type DefaultAdapterHttpRequest,
+  type DefaultAdapterHttpRequestChunk,
   type DefaultAdapterHttpResponse,
+  type DefaultAdapterHttpResponseChunk,
+  type DefaultAdapterHttpResponseHead,
   type DefaultAdapterHttpServerConfig,
 } from "../types.js";
+import { MIN_EFFECT_BUFFER_SIZE } from "../../../runtime/constants.js";
 
 const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
 const DEFAULT_MAX_PENDING_REQUESTS = 100;
 const DEFAULT_RESPONSE_TIMEOUT_MILLIS = 30_000;
 const NULL_BODY_STATUSES = new Set([204, 205, 304]);
+const HTTP_SERVER_PAYLOAD_TOO_LARGE_ERROR_CODE = 3;
+
+class HttpServerPayloadTooLargeError extends Error {
+  readonly code = HTTP_SERVER_PAYLOAD_TOO_LARGE_ERROR_CODE;
+}
+
+const httpServerErrorPayload = (error: unknown): Record<string, unknown> => {
+  const code = toNumberOrUndefined(readField(error, "code"));
+  return hostError(
+    error instanceof Error ? error.message : String(error),
+    code === undefined ? 1 : Math.trunc(code)
+  );
+};
 
 type PendingNodeResponse = {
   response: NodeHttpServerResponse;
   completed: boolean;
+  started: boolean;
   timeoutHandle?: ReturnType<typeof setTimeout>;
+};
+
+type NodeRequestBodySource = {
+  iterator: AsyncIterator<unknown>;
+  bytesRead: number;
+  cancel: () => Promise<void>;
+};
+
+type WebRequestBodySource = {
+  read: () => Promise<DefaultAdapterHttpRequestChunk>;
+  cancel: () => Promise<void>;
 };
 
 type NodeServerState = {
@@ -48,10 +78,12 @@ type NodeServerState = {
     reject: (error: Error) => void;
   }>;
   pendingResponses: Map<number, PendingNodeResponse>;
+  requestBodies: Map<number, NodeRequestBodySource>;
   closed: boolean;
   maxBodyBytes: number;
   maxPendingRequests: number;
   responseTimeoutMillis: number;
+  streamRequestBodies: boolean;
 };
 
 type RequestQueueState = {
@@ -66,15 +98,23 @@ type RequestQueueState = {
 type WebPendingResponse = {
   resolve: (response: unknown) => void;
   completed: boolean;
+  started: boolean;
+  writer?: {
+    write: (chunk: Uint8Array) => Promise<void>;
+    close: () => Promise<void>;
+    abort: (reason?: unknown) => Promise<void>;
+  };
   timeoutHandle?: ReturnType<typeof setTimeout>;
 };
 
 type WebServerState = RequestQueueState & {
   closeRuntime: () => Promise<void>;
   pendingResponses: Map<number, WebPendingResponse>;
+  requestBodies: Map<number, WebRequestBodySource>;
   closed: boolean;
   maxBodyBytes: number;
   responseTimeoutMillis: number;
+  streamRequestBodies: boolean;
 };
 
 type WebServerHandle = {
@@ -88,8 +128,78 @@ type HttpServerSource = {
   unavailableReason: string;
   listen: (config: DefaultAdapterHttpServerConfig) => Promise<number>;
   accept: (serverId: number) => Promise<DefaultAdapterHttpRequest>;
+  readRequest: (requestId: number) => Promise<DefaultAdapterHttpRequestChunk>;
   respond: (response: DefaultAdapterHttpResponse) => Promise<void>;
+  startResponse: (response: DefaultAdapterHttpResponseHead) => Promise<void>;
+  writeResponse: (response: DefaultAdapterHttpResponseChunk) => Promise<void>;
+  finishResponse: (requestId: number) => Promise<void>;
   close: (serverId: number) => Promise<void>;
+};
+
+const transportSafeHttpServerSource = ({
+  source,
+  maxChunkBytes,
+}: {
+  source: HttpServerSource;
+  maxChunkBytes: number;
+}): HttpServerSource => {
+  const remainder = new Map<number, DefaultAdapterHttpRequestChunk>();
+  const serverRequests = new Map<number, Set<number>>();
+  const clearRequest = (requestId: number): void => {
+    remainder.delete(requestId);
+    for (const requests of serverRequests.values()) {
+      requests.delete(requestId);
+    }
+  };
+  const nextChunk = (value: DefaultAdapterHttpRequestChunk): DefaultAdapterHttpRequestChunk => {
+    if (maxChunkBytes <= 0) {
+      throw new Error("http server effect buffer is too small for request streaming");
+    }
+    if (value.chunk.byteLength <= maxChunkBytes) {
+      clearRequest(value.done ? value.requestId : -1);
+      return value;
+    }
+    const head = value.chunk.slice(0, maxChunkBytes);
+    remainder.set(value.requestId, {
+      requestId: value.requestId,
+      chunk: value.chunk.slice(maxChunkBytes),
+      done: value.done,
+    });
+    return { requestId: value.requestId, chunk: head, done: false };
+  };
+  return {
+    ...source,
+    accept: async (serverId) => {
+      const request = await source.accept(serverId);
+      const requests = serverRequests.get(serverId) ?? new Set<number>();
+      requests.add(request.requestId);
+      serverRequests.set(serverId, requests);
+      return request;
+    },
+    readRequest: async (requestId) => {
+      const pending = remainder.get(requestId);
+      if (pending) {
+        remainder.delete(requestId);
+        return nextChunk(pending);
+      }
+      return nextChunk(await source.readRequest(requestId));
+    },
+    respond: async (response) => {
+      clearRequest(response.requestId);
+      await source.respond(response);
+    },
+    finishResponse: async (requestId) => {
+      clearRequest(requestId);
+      await source.finishResponse(requestId);
+    },
+    close: async (serverId) => {
+      for (const requestId of serverRequests.get(serverId) ?? []) {
+        remainder.delete(requestId);
+      }
+      serverRequests.delete(serverId);
+      await source.close(serverId);
+    },
+  };
 };
 
 const toByteArray = (value: unknown): Uint8Array => {
@@ -201,6 +311,9 @@ const decodeConfig = (payload: unknown): DefaultAdapterHttpServerConfig => {
     readField(payload, "response_timeout_millis") ??
       readField(payload, "responseTimeoutMillis")
   );
+  const streamRequestBodies =
+    readField(payload, "stream_request_bodies") === true ||
+    readField(payload, "streamRequestBodies") === true;
   return {
     port: Math.trunc(port),
     host: toStringOrUndefined(readField(payload, "host")) || undefined,
@@ -214,6 +327,7 @@ const decodeConfig = (payload: unknown): DefaultAdapterHttpServerConfig => {
       responseTimeoutMillis === undefined
         ? undefined
         : Math.max(1, Math.trunc(responseTimeoutMillis)),
+    streamRequestBodies,
   };
 };
 
@@ -236,6 +350,29 @@ const decodeResponsePayload = (payload: unknown): DefaultAdapterHttpResponse => 
       "",
     headers: decodeHeaders(readField(response, "headers")),
     body: toByteArray(readField(response, "body")),
+  };
+};
+
+const decodeResponseHeadPayload = (
+  payload: unknown
+): DefaultAdapterHttpResponseHead => {
+  const { body: _body, ...head } = decodeResponsePayload(payload);
+  if (NULL_BODY_STATUSES.has(head.status)) {
+    throw new Error(`status ${head.status} cannot open a response body stream`);
+  }
+  return head;
+};
+
+const decodeResponseChunkPayload = (
+  payload: unknown
+): DefaultAdapterHttpResponseChunk => {
+  const requestId = toNumberOrUndefined(readField(payload, "request_id"));
+  if (requestId === undefined) {
+    throw new Error("http server response chunk must include request_id");
+  }
+  return {
+    requestId: Math.trunc(requestId),
+    chunk: toByteArray(readField(payload, "chunk")),
   };
 };
 
@@ -276,7 +413,9 @@ const readRequestBody = async ({
       typeof chunk === "string" ? new TextEncoder().encode(chunk) : toByteArray(chunk);
     total += bytes.byteLength;
     if (total > maxBodyBytes) {
-      throw new Error(`request body exceeds max_body_bytes (${maxBodyBytes})`);
+      throw new HttpServerPayloadTooLargeError(
+        `request body exceeds max_body_bytes (${maxBodyBytes})`
+      );
     }
     chunks.push(bytes);
   }
@@ -318,11 +457,11 @@ const webResponse = ({
   status: number;
   reason?: string;
   headers?: DefaultAdapterHttpHeader[];
-  body: string | Uint8Array;
+  body: unknown;
 }): unknown => {
   const ResponseCtor = globalRecord.Response as
     | (new (
-        body?: string | Uint8Array,
+        body?: unknown,
         init?: {
           status?: number;
           statusText?: string;
@@ -340,37 +479,154 @@ const webResponse = ({
   });
 };
 
+const applyNodeResponseHead = ({
+  target,
+  response,
+}: {
+  target: NodeHttpServerResponse;
+  response: DefaultAdapterHttpResponseHead;
+}): void => {
+  const headers = new Map<string, string[]>();
+  for (const header of response.headers) {
+    const existing = headers.get(header.name) ?? [];
+    existing.push(header.value);
+    headers.set(header.name, existing);
+  }
+  for (const [name, values] of headers) {
+    target.setHeader(name, values.length === 1 ? values[0] ?? "" : values);
+  }
+
+  target.statusCode = response.status;
+  target.statusMessage = response.reason;
+};
+
 const writeNodeResponse = ({
   target,
   response,
 }: {
   target: NodeHttpServerResponse;
   response: DefaultAdapterHttpResponse;
+}): Promise<void> => {
+  applyNodeResponseHead({ target, response });
+  return endNodeResponse({
+    target,
+    chunk: response.body,
+    disconnectedMessage: "client disconnected before response completed",
+  });
+};
+
+const endNodeResponse = ({
+  target,
+  chunk,
+  disconnectedMessage,
+}: {
+  target: NodeHttpServerResponse;
+  chunk?: string | Uint8Array;
+  disconnectedMessage: string;
 }): Promise<void> =>
   new Promise((resolve, reject) => {
     if (target.destroyed || target.writableEnded) {
-      reject(new Error("client disconnected before response"));
+      reject(new Error(disconnectedMessage));
       return;
     }
 
-    const headers = new Map<string, string[]>();
-    for (const header of response.headers) {
-      const existing = headers.get(header.name) ?? [];
-      existing.push(header.value);
-      headers.set(header.name, existing);
-    }
-    for (const [name, values] of headers) {
-      target.setHeader(name, values.length === 1 ? values[0] ?? "" : values);
-    }
-
-    target.statusCode = response.status;
-    target.statusMessage = response.reason;
-    target.once("error", reject);
-    target.end(response.body, () => {
-      target.off("error", reject);
+    let settled = false;
+    const cleanup = (): void => {
+      target.off("error", onError);
+      target.off("close", onClose);
+    };
+    const onError = (error: Error): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onClose = (): void => onError(new Error(disconnectedMessage));
+    target.once("error", onError);
+    target.once("close", onClose);
+    target.end(chunk, () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
       resolve();
     });
   });
+
+const writeNodeResponseChunk = ({
+  target,
+  chunk,
+}: {
+  target: NodeHttpServerResponse;
+  chunk: Uint8Array;
+}): Promise<void> =>
+  new Promise((resolve, reject) => {
+    if (target.destroyed || target.writableEnded) {
+      reject(new Error("client disconnected during streamed response"));
+      return;
+    }
+
+    let settled = false;
+    const cleanup = (): void => {
+      target.off("error", onError);
+      target.off("close", onClose);
+      target.off("drain", onDrain);
+    };
+    const resolveOnce = (): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve();
+    };
+    const rejectOnce = (error: Error): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onError = (error: Error): void => rejectOnce(error);
+    const onClose = (): void =>
+      rejectOnce(new Error("client disconnected during streamed response"));
+    const onDrain = (): void => resolveOnce();
+
+    target.once("error", onError);
+    target.once("close", onClose);
+    const accepted = target.write(chunk, () => {
+      if (accepted) {
+        resolveOnce();
+      }
+    });
+    if (!accepted) {
+      target.once("drain", onDrain);
+    }
+  });
+
+const cancelRequestBody = <T extends { cancel: () => Promise<void> }>(
+  requestBodies: Map<number, T>,
+  requestId: number
+): void => {
+  const source = requestBodies.get(requestId);
+  if (!source) {
+    return;
+  }
+  requestBodies.delete(requestId);
+  void source.cancel().catch(() => undefined);
+};
+
+const cancelAllRequestBodies = <T extends { cancel: () => Promise<void> }>(
+  requestBodies: Map<number, T>
+): void => {
+  for (const requestId of requestBodies.keys()) {
+    cancelRequestBody(requestBodies, requestId);
+  }
+};
 
 const completePendingNodeResponse = ({
   state,
@@ -392,11 +648,38 @@ const completePendingNodeResponse = ({
     clearTimeout(pending.timeoutHandle);
   }
   state.pendingResponses.delete(requestId);
+  cancelRequestBody(state.requestBodies, requestId);
   state.queue = state.queue.filter((request) => request.requestId !== requestId);
   if (!pending.response.destroyed && !pending.response.writableEnded) {
+    if (pending.started) {
+      pending.response.end();
+      return;
+    }
     pending.response.statusCode = status;
     pending.response.end(body);
   }
+};
+
+const resetPendingNodeResponseTimeout = ({
+  state,
+  requestId,
+  pending,
+}: {
+  state: NodeServerState;
+  requestId: number;
+  pending: PendingNodeResponse;
+}): void => {
+  if (pending.timeoutHandle !== undefined) {
+    clearTimeout(pending.timeoutHandle);
+  }
+  pending.timeoutHandle = setTimeout(() => {
+    completePendingNodeResponse({
+      state,
+      requestId,
+      status: 500,
+      body: "server response timeout",
+    });
+  }, state.responseTimeoutMillis);
 };
 
 const addPendingNodeResponse = ({
@@ -408,16 +691,13 @@ const addPendingNodeResponse = ({
   requestId: number;
   response: NodeHttpServerResponse;
 }): void => {
-  const pending: PendingNodeResponse = { response, completed: false };
-  pending.timeoutHandle = setTimeout(() => {
-    completePendingNodeResponse({
-      state,
-      requestId,
-      status: 500,
-      body: "server response timeout",
-    });
-  }, state.responseTimeoutMillis);
+  const pending: PendingNodeResponse = {
+    response,
+    completed: false,
+    started: false,
+  };
   state.pendingResponses.set(requestId, pending);
+  resetPendingNodeResponseTimeout({ state, requestId, pending });
 };
 
 const releasePendingNodeResponses = ({
@@ -434,17 +714,19 @@ const releasePendingNodeResponses = ({
     if (pending.timeoutHandle !== undefined) {
       clearTimeout(pending.timeoutHandle);
     }
-    if (
-      !pending.completed &&
-      !pending.response.destroyed &&
-      !pending.response.writableEnded
-    ) {
-      pending.completed = true;
+    if (pending.completed || pending.response.destroyed || pending.response.writableEnded) {
+      continue;
+    }
+    pending.completed = true;
+    if (pending.started) {
+      pending.response.end();
+    } else {
       pending.response.statusCode = 500;
       pending.response.end("server closed before response");
     }
   }
   state.pendingResponses.clear();
+  cancelAllRequestBodies(state.requestBodies);
   state.queue = [];
 };
 
@@ -459,7 +741,9 @@ const readWebRequestBody = async ({
   if (typeof arrayBuffer === "function") {
     const body = toByteArray(await (arrayBuffer as () => Promise<unknown>).call(request));
     if (body.byteLength > maxBodyBytes) {
-      throw new Error(`request body exceeds max_body_bytes (${maxBodyBytes})`);
+      throw new HttpServerPayloadTooLargeError(
+        `request body exceeds max_body_bytes (${maxBodyBytes})`
+      );
     }
     return body;
   }
@@ -468,16 +752,71 @@ const readWebRequestBody = async ({
   if (typeof text === "function") {
     const body = toByteArray(await (text as () => Promise<unknown>).call(request));
     if (body.byteLength > maxBodyBytes) {
-      throw new Error(`request body exceeds max_body_bytes (${maxBodyBytes})`);
+      throw new HttpServerPayloadTooLargeError(
+        `request body exceeds max_body_bytes (${maxBodyBytes})`
+      );
     }
     return body;
   }
 
   const body = toByteArray(readField(request, "body"));
   if (body.byteLength > maxBodyBytes) {
-    throw new Error(`request body exceeds max_body_bytes (${maxBodyBytes})`);
+    throw new HttpServerPayloadTooLargeError(
+      `request body exceeds max_body_bytes (${maxBodyBytes})`
+    );
   }
   return body;
+};
+
+const createWebRequestBodySource = ({
+  request,
+  requestId,
+  maxBodyBytes,
+}: {
+  request: unknown;
+  requestId: number;
+  maxBodyBytes: number;
+}): WebRequestBodySource => {
+  const body = readField(request, "body");
+  const getReader = readField(body, "getReader");
+  let bytesRead = 0;
+  if (typeof getReader === "function") {
+    const reader = (
+      getReader as () => {
+        read: () => Promise<{ done?: boolean; value?: unknown }>;
+        cancel?: (reason?: unknown) => Promise<void>;
+      }
+    ).call(body);
+    return {
+      read: async () => {
+        const next = await reader.read();
+        const chunk = next.done ? new Uint8Array() : toByteArray(next.value);
+        bytesRead += chunk.byteLength;
+        if (bytesRead > maxBodyBytes) {
+          throw new HttpServerPayloadTooLargeError(
+            `request body exceeds max_body_bytes (${maxBodyBytes})`
+          );
+        }
+        return { requestId, chunk, done: next.done === true };
+      },
+      cancel: async () => {
+        await reader.cancel?.("HTTP response completed before request body");
+      },
+    };
+  }
+
+  let emitted = false;
+  return {
+    read: async () => {
+      if (emitted) {
+        return { requestId, chunk: new Uint8Array(), done: true };
+      }
+      emitted = true;
+      const chunk = await readWebRequestBody({ request, maxBodyBytes });
+      return { requestId, chunk, done: true };
+    },
+    cancel: async () => undefined,
+  };
 };
 
 const completeWebPendingResponse = ({
@@ -498,8 +837,37 @@ const completeWebPendingResponse = ({
     clearTimeout(pending.timeoutHandle);
   }
   state.pendingResponses.delete(requestId);
+  cancelRequestBody(state.requestBodies, requestId);
   state.queue = state.queue.filter((request) => request.requestId !== requestId);
+  if (pending.started && pending.writer) {
+    void pending.writer.abort(new Error("server response timeout"));
+    return;
+  }
   pending.resolve(response);
+};
+
+const resetPendingWebResponseTimeout = ({
+  state,
+  requestId,
+  pending,
+}: {
+  state: WebServerState;
+  requestId: number;
+  pending: WebPendingResponse;
+}): void => {
+  if (pending.timeoutHandle !== undefined) {
+    clearTimeout(pending.timeoutHandle);
+  }
+  pending.timeoutHandle = setTimeout(() => {
+    completeWebPendingResponse({
+      state,
+      requestId,
+      response: webResponse({
+        status: 500,
+        body: "server response timeout",
+      }),
+    });
+  }, state.responseTimeoutMillis);
 };
 
 const addWebPendingResponse = ({
@@ -511,18 +879,13 @@ const addWebPendingResponse = ({
   requestId: number;
   resolve: (response: unknown) => void;
 }): void => {
-  const pending: WebPendingResponse = { resolve, completed: false };
-  pending.timeoutHandle = setTimeout(() => {
-    completeWebPendingResponse({
-      state,
-      requestId,
-      response: webResponse({
-        status: 500,
-        body: "server response timeout",
-      }),
-    });
-  }, state.responseTimeoutMillis);
+  const pending: WebPendingResponse = {
+    resolve,
+    completed: false,
+    started: false,
+  };
   state.pendingResponses.set(requestId, pending);
+  resetPendingWebResponseTimeout({ state, requestId, pending });
 };
 
 const releasePendingWebResponses = ({
@@ -535,7 +898,12 @@ const releasePendingWebResponses = ({
   for (const waiter of state.waiters.splice(0)) {
     waiter.reject(new Error(`http server ${serverId} closed`));
   }
-  for (const [requestId] of state.pendingResponses) {
+  for (const [requestId, pending] of state.pendingResponses) {
+    if (pending.started && pending.writer) {
+      pending.completed = true;
+      void pending.writer.abort(new Error("server closed during streamed response"));
+      continue;
+    }
     completeWebPendingResponse({
       state,
       requestId,
@@ -546,6 +914,7 @@ const releasePendingWebResponses = ({
     });
   }
   state.pendingResponses.clear();
+  cancelAllRequestBodies(state.requestBodies);
   state.queue = [];
 };
 
@@ -559,6 +928,38 @@ const responseFromDefaultAdapterResponse = (
     body: response.body,
   });
 
+const streamingWebResponse = ({
+  response,
+  pending,
+}: {
+  response: DefaultAdapterHttpResponseHead;
+  pending: WebPendingResponse;
+}): unknown => {
+  const TransformStreamCtor = globalRecord.TransformStream as
+    | (new () => {
+        readable: unknown;
+        writable: {
+          getWriter: () => {
+            write: (chunk: Uint8Array) => Promise<void>;
+            close: () => Promise<void>;
+            abort: (reason?: unknown) => Promise<void>;
+          };
+        };
+      })
+    | undefined;
+  if (typeof TransformStreamCtor !== "function") {
+    throw new Error("streaming HTTP responses require TransformStream support");
+  }
+  const stream = new TransformStreamCtor();
+  pending.writer = stream.writable.getWriter();
+  return webResponse({
+    status: response.status,
+    reason: response.reason,
+    headers: response.headers,
+    body: NULL_BODY_STATUSES.has(response.status) ? undefined : stream.readable,
+  });
+};
+
 const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
   const nodeHttp = await maybeNodeHttp();
   if (!nodeHttp) {
@@ -571,7 +972,19 @@ const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
       accept: async () => {
         throw new Error("Node HTTP module is unavailable");
       },
+      readRequest: async () => {
+        throw new Error("Node HTTP module is unavailable");
+      },
       respond: async () => {
+        throw new Error("Node HTTP module is unavailable");
+      },
+      startResponse: async () => {
+        throw new Error("Node HTTP module is unavailable");
+      },
+      writeResponse: async () => {
+        throw new Error("Node HTTP module is unavailable");
+      },
+      finishResponse: async () => {
         throw new Error("Node HTTP module is unavailable");
       },
       close: async () => {
@@ -601,12 +1014,14 @@ const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
         queue: [],
         waiters: [],
         pendingResponses: new Map(),
+        requestBodies: new Map(),
         closed: false,
         maxBodyBytes: config.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
         maxPendingRequests:
           config.maxPendingRequests ?? DEFAULT_MAX_PENDING_REQUESTS,
         responseTimeoutMillis:
           config.responseTimeoutMillis ?? DEFAULT_RESPONSE_TIMEOUT_MILLIS,
+        streamRequestBodies: config.streamRequestBodies ?? false,
       };
 
       const server = nodeHttp.createServer(async (request, response) => {
@@ -619,12 +1034,24 @@ const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
             return;
           }
 
-          const body = await readRequestBody({
-            request,
-            maxBodyBytes: state.maxBodyBytes,
-          });
           const requestId = nextRequestId++;
           const url = new URL(request.url ?? "/", "http://localhost");
+          const body = state.streamRequestBodies
+            ? new Uint8Array()
+            : await readRequestBody({
+                request,
+                maxBodyBytes: state.maxBodyBytes,
+              });
+          if (state.streamRequestBodies) {
+            const iterator = request[Symbol.asyncIterator]();
+            state.requestBodies.set(requestId, {
+              iterator,
+              bytesRead: 0,
+              cancel: async () => {
+                await iterator.return?.();
+              },
+            });
+          }
           addPendingNodeResponse({ state, requestId, response });
           const queued = enqueueRequest({
             state,
@@ -635,6 +1062,7 @@ const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
               query: url.search.length > 1 ? url.search.slice(1) : undefined,
               headers: headersFromNodeRequest(request),
               body,
+              bodyStreaming: state.streamRequestBodies,
             },
           });
           if (!queued) {
@@ -683,6 +1111,41 @@ const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
         state.waiters.push({ resolve, reject });
       });
     },
+    readRequest: async (requestId) => {
+      for (const state of servers.values()) {
+        const source = state.requestBodies.get(requestId);
+        if (!source) {
+          continue;
+        }
+        try {
+          const next = await source.iterator.next();
+          const pending = state.pendingResponses.get(requestId);
+          if (pending && !pending.completed) {
+            resetPendingNodeResponseTimeout({ state, requestId, pending });
+          }
+          if (next.done) {
+            state.requestBodies.delete(requestId);
+            return { requestId, chunk: new Uint8Array(), done: true };
+          }
+          const chunk =
+            typeof next.value === "string"
+              ? new TextEncoder().encode(next.value)
+              : toByteArray(next.value);
+          source.bytesRead += chunk.byteLength;
+          if (source.bytesRead <= state.maxBodyBytes) {
+            return { requestId, chunk, done: false };
+          }
+          cancelRequestBody(state.requestBodies, requestId);
+          throw new HttpServerPayloadTooLargeError(
+            `request body exceeds max_body_bytes (${state.maxBodyBytes})`
+          );
+        } catch (error) {
+          cancelRequestBody(state.requestBodies, requestId);
+          throw error;
+        }
+      }
+      throw new Error(`request ${requestId} has no open request body stream`);
+    },
     respond: async (response) => {
       for (const state of servers.values()) {
         const pending = state.pendingResponses.get(response.requestId);
@@ -697,10 +1160,70 @@ const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
           clearTimeout(pending.timeoutHandle);
         }
         state.pendingResponses.delete(response.requestId);
+        cancelRequestBody(state.requestBodies, response.requestId);
         await writeNodeResponse({ target: pending.response, response });
         return;
       }
       throw new Error(`request ${response.requestId} is closed or unknown`);
+    },
+    startResponse: async (response) => {
+      for (const state of servers.values()) {
+        const pending = state.pendingResponses.get(response.requestId);
+        if (!pending) {
+          continue;
+        }
+        if (pending.completed || pending.started) {
+          throw new Error(`request ${response.requestId} was already responded to`);
+        }
+        pending.started = true;
+        resetPendingNodeResponseTimeout({
+          state,
+          requestId: response.requestId,
+          pending,
+        });
+        applyNodeResponseHead({ target: pending.response, response });
+        pending.response.flushHeaders?.();
+        return;
+      }
+      throw new Error(`request ${response.requestId} is closed or unknown`);
+    },
+    writeResponse: async ({ requestId, chunk }) => {
+      for (const state of servers.values()) {
+        const pending = state.pendingResponses.get(requestId);
+        if (!pending) {
+          continue;
+        }
+        if (!pending.started || pending.completed) {
+          throw new Error(`request ${requestId} has no open response stream`);
+        }
+        await writeNodeResponseChunk({ target: pending.response, chunk });
+        resetPendingNodeResponseTimeout({ state, requestId, pending });
+        return;
+      }
+      throw new Error(`request ${requestId} is closed or unknown`);
+    },
+    finishResponse: async (requestId) => {
+      for (const state of servers.values()) {
+        const pending = state.pendingResponses.get(requestId);
+        if (!pending) {
+          continue;
+        }
+        if (!pending.started || pending.completed) {
+          throw new Error(`request ${requestId} has no open response stream`);
+        }
+        pending.completed = true;
+        if (pending.timeoutHandle !== undefined) {
+          clearTimeout(pending.timeoutHandle);
+        }
+        state.pendingResponses.delete(requestId);
+        cancelRequestBody(state.requestBodies, requestId);
+        await endNodeResponse({
+          target: pending.response,
+          disconnectedMessage: "client disconnected before response stream finished",
+        });
+        return;
+      }
+      throw new Error(`request ${requestId} is closed or unknown`);
     },
     close: async (serverId) => {
       const state = servers.get(serverId);
@@ -742,7 +1265,19 @@ const createWebHttpServerSource = ({
       accept: async () => {
         throw new Error(unavailableReason);
       },
+      readRequest: async () => {
+        throw new Error(unavailableReason);
+      },
       respond: async () => {
+        throw new Error(unavailableReason);
+      },
+      startResponse: async () => {
+        throw new Error(unavailableReason);
+      },
+      writeResponse: async () => {
+        throw new Error(unavailableReason);
+      },
+      finishResponse: async () => {
         throw new Error(unavailableReason);
       },
       close: async () => {
@@ -773,12 +1308,14 @@ const createWebHttpServerSource = ({
         queue: [],
         waiters: [],
         pendingResponses: new Map(),
+        requestBodies: new Map(),
         closed: false,
         maxBodyBytes: config.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
         maxPendingRequests:
           config.maxPendingRequests ?? DEFAULT_MAX_PENDING_REQUESTS,
         responseTimeoutMillis:
           config.responseTimeoutMillis ?? DEFAULT_RESPONSE_TIMEOUT_MILLIS,
+        streamRequestBodies: config.streamRequestBodies ?? false,
       };
 
       const handler: WebServerHandler = async (request) => {
@@ -795,11 +1332,23 @@ const createWebHttpServerSource = ({
             });
           }
 
-          const body = await readWebRequestBody({
-            request,
-            maxBodyBytes: state.maxBodyBytes,
-          });
           const requestId = nextRequestId++;
+          const body = state.streamRequestBodies
+            ? new Uint8Array()
+            : await readWebRequestBody({
+                request,
+                maxBodyBytes: state.maxBodyBytes,
+              });
+          if (state.streamRequestBodies) {
+            state.requestBodies.set(
+              requestId,
+              createWebRequestBodySource({
+                request,
+                requestId,
+                maxBodyBytes: state.maxBodyBytes,
+              })
+            );
+          }
           const rawUrl = toStringOrUndefined(readField(request, "url")) ?? "/";
           const url = new URL(rawUrl, "http://localhost");
           const responsePromise = new Promise<unknown>((resolve) => {
@@ -815,6 +1364,7 @@ const createWebHttpServerSource = ({
               query: url.search.length > 1 ? url.search.slice(1) : undefined,
               headers: headersFromWebHeaders(readField(request, "headers")),
               body,
+              bodyStreaming: state.streamRequestBodies,
             },
           });
           if (!queued) {
@@ -854,6 +1404,29 @@ const createWebHttpServerSource = ({
         state.waiters.push({ resolve, reject });
       });
     },
+    readRequest: async (requestId) => {
+      for (const state of servers.values()) {
+        const source = state.requestBodies.get(requestId);
+        if (!source) {
+          continue;
+        }
+        try {
+          const chunk = await source.read();
+          const pending = state.pendingResponses.get(requestId);
+          if (pending && !pending.completed) {
+            resetPendingWebResponseTimeout({ state, requestId, pending });
+          }
+          if (chunk.done) {
+            state.requestBodies.delete(requestId);
+          }
+          return chunk;
+        } catch (error) {
+          cancelRequestBody(state.requestBodies, requestId);
+          throw error;
+        }
+      }
+      throw new Error(`request ${requestId} has no open request body stream`);
+    },
     respond: async (response) => {
       for (const state of servers.values()) {
         const pending = state.pendingResponses.get(response.requestId);
@@ -871,6 +1444,61 @@ const createWebHttpServerSource = ({
         return;
       }
       throw new Error(`request ${response.requestId} is closed or unknown`);
+    },
+    startResponse: async (response) => {
+      for (const state of servers.values()) {
+        const pending = state.pendingResponses.get(response.requestId);
+        if (!pending) {
+          continue;
+        }
+        if (pending.completed || pending.started) {
+          throw new Error(`request ${response.requestId} was already responded to`);
+        }
+        pending.started = true;
+        resetPendingWebResponseTimeout({
+          state,
+          requestId: response.requestId,
+          pending,
+        });
+        pending.resolve(streamingWebResponse({ response, pending }));
+        return;
+      }
+      throw new Error(`request ${response.requestId} is closed or unknown`);
+    },
+    writeResponse: async ({ requestId, chunk }) => {
+      for (const state of servers.values()) {
+        const pending = state.pendingResponses.get(requestId);
+        if (!pending) {
+          continue;
+        }
+        if (!pending.started || pending.completed || !pending.writer) {
+          throw new Error(`request ${requestId} has no open response stream`);
+        }
+        await pending.writer.write(chunk);
+        resetPendingWebResponseTimeout({ state, requestId, pending });
+        return;
+      }
+      throw new Error(`request ${requestId} is closed or unknown`);
+    },
+    finishResponse: async (requestId) => {
+      for (const state of servers.values()) {
+        const pending = state.pendingResponses.get(requestId);
+        if (!pending) {
+          continue;
+        }
+        if (!pending.started || pending.completed || !pending.writer) {
+          throw new Error(`request ${requestId} has no open response stream`);
+        }
+        pending.completed = true;
+        if (pending.timeoutHandle !== undefined) {
+          clearTimeout(pending.timeoutHandle);
+        }
+        state.pendingResponses.delete(requestId);
+        cancelRequestBody(state.requestBodies, requestId);
+        await pending.writer.close();
+        return;
+      }
+      throw new Error(`request ${requestId} is closed or unknown`);
     },
     close: async (serverId) => {
       const state = servers.get(serverId);
@@ -965,12 +1593,20 @@ const createBunHttpServerSource = (): HttpServerSource => {
 const createHookHttpServerSource = ({
   listen,
   accept,
+  readRequest,
   respond,
+  startResponse,
+  writeResponse,
+  finishResponse,
   close,
 }: {
   listen?: (config: DefaultAdapterHttpServerConfig) => Promise<number>;
   accept?: (serverId: number) => Promise<DefaultAdapterHttpRequest>;
+  readRequest?: (requestId: number) => Promise<DefaultAdapterHttpRequestChunk>;
   respond?: (response: DefaultAdapterHttpResponse) => Promise<void>;
+  startResponse?: (response: DefaultAdapterHttpResponseHead) => Promise<void>;
+  writeResponse?: (response: DefaultAdapterHttpResponseChunk) => Promise<void>;
+  finishResponse?: (requestId: number) => Promise<void>;
   close?: (serverId: number) => Promise<void>;
 }): HttpServerSource | undefined => {
   if (listen && accept && respond && close) {
@@ -979,7 +1615,27 @@ const createHookHttpServerSource = ({
       unavailableReason: "",
       listen,
       accept,
+      readRequest:
+        readRequest ??
+        (async () => {
+          throw new Error("http server request streaming hooks are unavailable");
+        }),
       respond,
+      startResponse:
+        startResponse ??
+        (async () => {
+          throw new Error("http server streaming hooks are unavailable");
+        }),
+      writeResponse:
+        writeResponse ??
+        (async () => {
+          throw new Error("http server streaming hooks are unavailable");
+        }),
+      finishResponse:
+        finishResponse ??
+        (async () => {
+          throw new Error("http server streaming hooks are unavailable");
+        }),
       close,
     };
   }
@@ -994,7 +1650,11 @@ const createHttpServerSource = async ({
   hooks: {
     listen?: (config: DefaultAdapterHttpServerConfig) => Promise<number>;
     accept?: (serverId: number) => Promise<DefaultAdapterHttpRequest>;
+    readRequest?: (requestId: number) => Promise<DefaultAdapterHttpRequestChunk>;
     respond?: (response: DefaultAdapterHttpResponse) => Promise<void>;
+    startResponse?: (response: DefaultAdapterHttpResponseHead) => Promise<void>;
+    writeResponse?: (response: DefaultAdapterHttpResponseChunk) => Promise<void>;
+    finishResponse?: (requestId: number) => Promise<void>;
     close?: (serverId: number) => Promise<void>;
   };
 }): Promise<HttpServerSource> => {
@@ -1026,7 +1686,19 @@ const createHttpServerSource = async ({
     accept: async () => {
       throw new Error(unavailableReason);
     },
+    readRequest: async () => {
+      throw new Error(unavailableReason);
+    },
     respond: async () => {
+      throw new Error(unavailableReason);
+    },
+    startResponse: async () => {
+      throw new Error(unavailableReason);
+    },
+    writeResponse: async () => {
+      throw new Error(unavailableReason);
+    },
+    finishResponse: async () => {
       throw new Error(unavailableReason);
     },
     close: async () => {
@@ -1049,15 +1721,34 @@ export const httpServerCapabilityDefinition: CapabilityDefinition = {
     if (entries.length === 0) {
       return 0;
     }
+    if (
+      entries.some((entry) => entry.opName === "write_response_raw") &&
+      effectBufferSize < MIN_EFFECT_BUFFER_SIZE
+    ) {
+      throw new Error(
+        `http-server response streaming requires an effect buffer of at least ${MIN_EFFECT_BUFFER_SIZE} bytes`
+      );
+    }
 
-    const httpServerSource = await createHttpServerSource({
+    const rawHttpServerSource = await createHttpServerSource({
       runtime,
       hooks: {
         listen: runtimeHooks.httpServerListen,
         accept: runtimeHooks.httpServerAccept,
+        readRequest: runtimeHooks.httpServerReadRequest,
         respond: runtimeHooks.httpServerRespond,
+        startResponse: runtimeHooks.httpServerStartResponse,
+        writeResponse: runtimeHooks.httpServerWriteResponse,
+        finishResponse: runtimeHooks.httpServerFinishResponse,
         close: runtimeHooks.httpServerClose,
       },
+    });
+    const httpServerSource = transportSafeHttpServerSource({
+      source: rawHttpServerSource,
+      maxChunkBytes: Math.min(
+        16_384,
+        maxTransportSafeHttpServerChunkBytes({ effectBufferSize })
+      ),
     });
     if (!httpServerSource.isAvailable) {
       return registerUnsupportedHandlers({
@@ -1116,13 +1807,37 @@ export const httpServerCapabilityDefinition: CapabilityDefinition = {
           }
           return resume(payload);
         } catch (error) {
-          return resume(
-            hostError(error instanceof Error ? error.message : String(error))
-          );
+          return resume(httpServerErrorPayload(error));
         }
       },
     });
     implementedOps.add("accept_raw");
+
+    registered += registerOpHandler({
+      host,
+      effectId: HTTP_SERVER_EFFECT_ID,
+      opName: "read_request_raw",
+      handler: async ({ resume }, requestId) => {
+        try {
+          const parsedRequestId = toNumberOrUndefined(requestId);
+          if (parsedRequestId === undefined) {
+            throw new Error("http server request read requires a request id");
+          }
+          const result = await httpServerSource.readRequest(
+            Math.trunc(parsedRequestId)
+          );
+          return resume(
+            hostOk({
+              chunk: Array.from(result.chunk.values()),
+              done: result.done,
+            })
+          );
+        } catch (error) {
+          return resume(httpServerErrorPayload(error));
+        }
+      },
+    });
+    implementedOps.add("read_request_raw");
 
     registered += registerOpHandler({
       host,
@@ -1138,6 +1853,55 @@ export const httpServerCapabilityDefinition: CapabilityDefinition = {
       },
     });
     implementedOps.add("respond_raw");
+
+    registered += registerOpHandler({
+      host,
+      effectId: HTTP_SERVER_EFFECT_ID,
+      opName: "start_response_raw",
+      handler: async ({ tail }, payload) => {
+        try {
+          await httpServerSource.startResponse(decodeResponseHeadPayload(payload));
+          return tail(hostOk());
+        } catch (error) {
+          return tail(hostError(error instanceof Error ? error.message : String(error)));
+        }
+      },
+    });
+    implementedOps.add("start_response_raw");
+
+    registered += registerOpHandler({
+      host,
+      effectId: HTTP_SERVER_EFFECT_ID,
+      opName: "write_response_raw",
+      handler: async ({ tail }, payload) => {
+        try {
+          await httpServerSource.writeResponse(decodeResponseChunkPayload(payload));
+          return tail(hostOk());
+        } catch (error) {
+          return tail(hostError(error instanceof Error ? error.message : String(error)));
+        }
+      },
+    });
+    implementedOps.add("write_response_raw");
+
+    registered += registerOpHandler({
+      host,
+      effectId: HTTP_SERVER_EFFECT_ID,
+      opName: "finish_response_raw",
+      handler: async ({ tail }, requestId) => {
+        try {
+          const parsedRequestId = toNumberOrUndefined(requestId);
+          if (parsedRequestId === undefined) {
+            throw new Error("http server finish response requires a request id");
+          }
+          await httpServerSource.finishResponse(Math.trunc(parsedRequestId));
+          return tail(hostOk());
+        } catch (error) {
+          return tail(hostError(error instanceof Error ? error.message : String(error)));
+        }
+      },
+    });
+    implementedOps.add("finish_response_raw");
 
     registered += registerOpHandler({
       host,

--- a/packages/js-host/src/adapters/default/capabilities/http-server.ts
+++ b/packages/js-host/src/adapters/default/capabilities/http-server.ts
@@ -1556,7 +1556,12 @@ const createWebHttpServerSource = ({
         state.pendingResponses.delete(requestId);
         state.requestClosed(requestId);
         cancelRequestBody(state.requestBodies, requestId);
-        await pending.writer.close();
+        try {
+          await pending.writer.close();
+        } catch {
+          // The readable side may have been canceled after the final chunk.
+          // Treat that client disconnect as a completed response stream.
+        }
         return;
       }
       throw new Error(`request ${requestId} is closed or unknown`);

--- a/packages/js-host/src/adapters/default/capabilities/http-server.ts
+++ b/packages/js-host/src/adapters/default/capabilities/http-server.ts
@@ -1252,10 +1252,15 @@ const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
         state.pendingResponses.delete(requestId);
         state.requestClosed(requestId);
         cancelRequestBody(state.requestBodies, requestId);
-        await endNodeResponse({
-          target: pending.response,
-          disconnectedMessage: "client disconnected before response stream finished",
-        });
+        try {
+          await endNodeResponse({
+            target: pending.response,
+            disconnectedMessage: "client disconnected before response stream finished",
+          });
+        } catch {
+          // The response was already started and all producer writes succeeded.
+          // A socket failure while ending it is a normal client disconnect.
+        }
         return;
       }
       throw new Error(`request ${requestId} is closed or unknown`);
@@ -1944,16 +1949,16 @@ export const httpServerCapabilityDefinition: CapabilityDefinition = {
       host,
       effectId: HTTP_SERVER_EFFECT_ID,
       opName: "finish_response_raw",
-      handler: async ({ tail }, requestId) => {
+      handler: async ({ resume }, requestId) => {
         try {
           const parsedRequestId = toNumberOrUndefined(requestId);
           if (parsedRequestId === undefined) {
             throw new Error("http server finish response requires a request id");
           }
           await httpServerSource.finishResponse(Math.trunc(parsedRequestId));
-          return tail(hostOk());
+          return resume(hostOk());
         } catch (error) {
-          return tail(hostError(error instanceof Error ? error.message : String(error)));
+          return resume(hostError(error instanceof Error ? error.message : String(error)));
         }
       },
     });

--- a/packages/js-host/src/adapters/default/capabilities/http-server.ts
+++ b/packages/js-host/src/adapters/default/capabilities/http-server.ts
@@ -901,7 +901,12 @@ const releasePendingWebResponses = ({
   for (const [requestId, pending] of state.pendingResponses) {
     if (pending.started && pending.writer) {
       pending.completed = true;
-      void pending.writer.abort(new Error("server closed during streamed response"));
+      if (pending.timeoutHandle !== undefined) {
+        clearTimeout(pending.timeoutHandle);
+      }
+      void pending.writer
+        .abort(new Error("server closed during streamed response"))
+        .catch(() => undefined);
       continue;
     }
     completeWebPendingResponse({

--- a/packages/js-host/src/adapters/default/capabilities/http-server.ts
+++ b/packages/js-host/src/adapters/default/capabilities/http-server.ts
@@ -100,6 +100,7 @@ type WebPendingResponse = {
   resolve: (response: unknown) => void;
   completed: boolean;
   started: boolean;
+  streamWriteFailed: boolean;
   writer?: {
     write: (chunk: Uint8Array) => Promise<void>;
     close: () => Promise<void>;
@@ -885,6 +886,7 @@ const addWebPendingResponse = ({
     resolve,
     completed: false,
     started: false,
+    streamWriteFailed: false,
   };
   state.pendingResponses.set(requestId, pending);
   resetPendingWebResponseTimeout({ state, requestId, pending });
@@ -1495,7 +1497,17 @@ const createWebHttpServerSource = ({
         if (!pending.started || pending.completed || !pending.writer) {
           throw new Error(`request ${requestId} has no open response stream`);
         }
-        await pending.writer.write(chunk);
+        try {
+          await pending.writer.write(chunk);
+        } catch (error) {
+          pending.completed = true;
+          pending.streamWriteFailed = true;
+          if (pending.timeoutHandle !== undefined) {
+            clearTimeout(pending.timeoutHandle);
+          }
+          cancelRequestBody(state.requestBodies, requestId);
+          throw error;
+        }
         resetPendingWebResponseTimeout({ state, requestId, pending });
         return;
       }
@@ -1506,6 +1518,10 @@ const createWebHttpServerSource = ({
         const pending = state.pendingResponses.get(requestId);
         if (!pending) {
           continue;
+        }
+        if (pending.streamWriteFailed) {
+          state.pendingResponses.delete(requestId);
+          return;
         }
         if (!pending.started || pending.completed || !pending.writer) {
           throw new Error(`request ${requestId} has no open response stream`);

--- a/packages/js-host/src/adapters/default/capabilities/http-server.ts
+++ b/packages/js-host/src/adapters/default/capabilities/http-server.ts
@@ -85,6 +85,7 @@ type NodeServerState = {
   maxPendingRequests: number;
   responseTimeoutMillis: number;
   streamRequestBodies: boolean;
+  requestClosed: (requestId: number) => void;
 };
 
 type RequestQueueState = {
@@ -117,6 +118,7 @@ type WebServerState = RequestQueueState & {
   maxBodyBytes: number;
   responseTimeoutMillis: number;
   streamRequestBodies: boolean;
+  requestClosed: (requestId: number) => void;
 };
 
 type WebServerHandle = {
@@ -136,6 +138,7 @@ type HttpServerSource = {
   writeResponse: (response: DefaultAdapterHttpResponseChunk) => Promise<void>;
   finishResponse: (requestId: number) => Promise<void>;
   close: (serverId: number) => Promise<void>;
+  onRequestClosed?: (listener: (requestId: number) => void) => void;
 };
 
 const transportSafeHttpServerSource = ({
@@ -153,6 +156,7 @@ const transportSafeHttpServerSource = ({
       requests.delete(requestId);
     }
   };
+  source.onRequestClosed?.(clearRequest);
   const nextChunk = (value: DefaultAdapterHttpRequestChunk): DefaultAdapterHttpRequestChunk => {
     if (maxChunkBytes <= 0) {
       throw new Error("http server effect buffer is too small for request streaming");
@@ -650,6 +654,7 @@ const completePendingNodeResponse = ({
     clearTimeout(pending.timeoutHandle);
   }
   state.pendingResponses.delete(requestId);
+  state.requestClosed(requestId);
   cancelRequestBody(state.requestBodies, requestId);
   state.queue = state.queue.filter((request) => request.requestId !== requestId);
   if (!pending.response.destroyed && !pending.response.writableEnded) {
@@ -840,6 +845,7 @@ const completeWebPendingResponse = ({
     clearTimeout(pending.timeoutHandle);
   }
   state.pendingResponses.delete(requestId);
+  state.requestClosed(requestId);
   cancelRequestBody(state.requestBodies, requestId);
   state.queue = state.queue.filter((request) => request.requestId !== requestId);
   if (pending.started && pending.writer) {
@@ -908,9 +914,7 @@ const releasePendingWebResponses = ({
       if (pending.timeoutHandle !== undefined) {
         clearTimeout(pending.timeoutHandle);
       }
-      void pending.writer
-        .abort(new Error("server closed during streamed response"))
-        .catch(() => undefined);
+      void pending.writer.close().catch(() => undefined);
       continue;
     }
     completeWebPendingResponse({
@@ -1004,6 +1008,7 @@ const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
   const servers = new Map<number, NodeServerState>();
   let nextServerId = 1;
   let nextRequestId = 1;
+  let requestClosed = (_requestId: number): void => {};
 
   const serverFor = (serverId: number): NodeServerState => {
     const state = servers.get(serverId);
@@ -1016,6 +1021,9 @@ const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
   return {
     isAvailable: true,
     unavailableReason: "",
+    onRequestClosed: (listener) => {
+      requestClosed = listener;
+    },
     listen: async (config) => {
       const serverId = nextServerId++;
       const state: NodeServerState = {
@@ -1031,6 +1039,7 @@ const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
         responseTimeoutMillis:
           config.responseTimeoutMillis ?? DEFAULT_RESPONSE_TIMEOUT_MILLIS,
         streamRequestBodies: config.streamRequestBodies ?? false,
+        requestClosed: (requestId) => requestClosed(requestId),
       };
 
       const server = nodeHttp.createServer(async (request, response) => {
@@ -1169,6 +1178,7 @@ const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
           clearTimeout(pending.timeoutHandle);
         }
         state.pendingResponses.delete(response.requestId);
+        state.requestClosed(response.requestId);
         cancelRequestBody(state.requestBodies, response.requestId);
         await writeNodeResponse({ target: pending.response, response });
         return;
@@ -1229,6 +1239,7 @@ const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
         }
         if (pending.streamWriteFailed) {
           state.pendingResponses.delete(requestId);
+          state.requestClosed(requestId);
           return;
         }
         if (!pending.started || pending.completed) {
@@ -1239,6 +1250,7 @@ const createNodeHttpServerSource = async (): Promise<HttpServerSource> => {
           clearTimeout(pending.timeoutHandle);
         }
         state.pendingResponses.delete(requestId);
+        state.requestClosed(requestId);
         cancelRequestBody(state.requestBodies, requestId);
         await endNodeResponse({
           target: pending.response,
@@ -1312,6 +1324,7 @@ const createWebHttpServerSource = ({
   const servers = new Map<number, WebServerState>();
   let nextServerId = 1;
   let nextRequestId = 1;
+  let requestClosed = (_requestId: number): void => {};
 
   const serverFor = (serverId: number): WebServerState => {
     const state = servers.get(serverId);
@@ -1324,6 +1337,9 @@ const createWebHttpServerSource = ({
   return {
     isAvailable: true,
     unavailableReason: "",
+    onRequestClosed: (listener) => {
+      requestClosed = listener;
+    },
     listen: async (config) => {
       const serverId = nextServerId++;
       const state: WebServerState = {
@@ -1339,6 +1355,7 @@ const createWebHttpServerSource = ({
         responseTimeoutMillis:
           config.responseTimeoutMillis ?? DEFAULT_RESPONSE_TIMEOUT_MILLIS,
         streamRequestBodies: config.streamRequestBodies ?? false,
+        requestClosed: (requestId) => requestClosed(requestId),
       };
 
       const handler: WebServerHandler = async (request) => {
@@ -1521,6 +1538,7 @@ const createWebHttpServerSource = ({
         }
         if (pending.streamWriteFailed) {
           state.pendingResponses.delete(requestId);
+          state.requestClosed(requestId);
           return;
         }
         if (!pending.started || pending.completed || !pending.writer) {
@@ -1531,6 +1549,7 @@ const createWebHttpServerSource = ({
           clearTimeout(pending.timeoutHandle);
         }
         state.pendingResponses.delete(requestId);
+        state.requestClosed(requestId);
         cancelRequestBody(state.requestBodies, requestId);
         await pending.writer.close();
         return;

--- a/packages/js-host/src/adapters/default/capabilities/http-server.ts
+++ b/packages/js-host/src/adapters/default/capabilities/http-server.ts
@@ -105,7 +105,6 @@ type WebPendingResponse = {
   writer?: {
     write: (chunk: Uint8Array) => Promise<void>;
     close: () => Promise<void>;
-    abort: (reason?: unknown) => Promise<void>;
   };
   timeoutHandle?: ReturnType<typeof setTimeout>;
 };
@@ -849,7 +848,7 @@ const completeWebPendingResponse = ({
   cancelRequestBody(state.requestBodies, requestId);
   state.queue = state.queue.filter((request) => request.requestId !== requestId);
   if (pending.started && pending.writer) {
-    void pending.writer.abort(new Error("server response timeout"));
+    void pending.writer.close().catch(() => undefined);
     return;
   }
   pending.resolve(response);
@@ -955,7 +954,6 @@ const streamingWebResponse = ({
           getWriter: () => {
             write: (chunk: Uint8Array) => Promise<void>;
             close: () => Promise<void>;
-            abort: (reason?: unknown) => Promise<void>;
           };
         };
       })
@@ -1647,7 +1645,7 @@ const createBunHttpServerSource = (): HttpServerSource => {
           if (typeof stop === "function") {
             await (stop as (force?: boolean) => Promise<void> | void).call(
               runtimeServer,
-              true
+              false
             );
           }
         },

--- a/packages/js-host/src/adapters/default/helpers.ts
+++ b/packages/js-host/src/adapters/default/helpers.ts
@@ -251,11 +251,31 @@ export const httpServerAcceptSuccessPayload = ({
       value: header.value,
     })),
     body: Array.from(request.body.values()),
+    body_streaming: request.bodyStreaming ?? false,
   });
   if (payloadFitsEffectTransport({ payload, effectBufferSize })) {
     return payload;
   }
   return httpServerAcceptTransportOverflowError({ effectBufferSize });
+};
+
+export const maxTransportSafeHttpServerChunkBytes = ({
+  effectBufferSize,
+}: {
+  effectBufferSize: number;
+}): number => {
+  let low = 0;
+  let high = effectBufferSize;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    const payload = hostOk({ chunk: Array.from({ length: mid }, () => 255), done: false });
+    if (payloadFitsEffectTransport({ payload, effectBufferSize })) {
+      low = mid;
+      continue;
+    }
+    high = mid - 1;
+  }
+  return low;
 };
 
 export const inputTransportOverflowError = ({

--- a/packages/js-host/src/adapters/default/runtime-imports.ts
+++ b/packages/js-host/src/adapters/default/runtime-imports.ts
@@ -13,8 +13,16 @@ export type NodeHttpServerResponse = {
   statusCode: number;
   statusMessage: string;
   setHeader: (name: string, value: string | string[]) => void;
-  once: (event: "error", listener: (error: Error) => void) => void;
-  off: (event: "error", listener: (error: Error) => void) => void;
+  once: (
+    event: "error" | "drain" | "close",
+    listener: ((error: Error) => void) | (() => void)
+  ) => void;
+  off: (
+    event: "error" | "drain" | "close",
+    listener: ((error: Error) => void) | (() => void)
+  ) => void;
+  flushHeaders?: () => void;
+  write: (chunk: string | Uint8Array, callback?: () => void) => boolean;
   end: (chunk?: string | Uint8Array, callback?: () => void) => void;
 };
 

--- a/packages/js-host/src/adapters/default/types.ts
+++ b/packages/js-host/src/adapters/default/types.ts
@@ -59,6 +59,7 @@ export type DefaultAdapterHttpServerConfig = {
   maxBodyBytes?: number;
   maxPendingRequests?: number;
   responseTimeoutMillis?: number;
+  streamRequestBodies?: boolean;
 };
 
 export type DefaultAdapterHttpRequest = {
@@ -68,6 +69,13 @@ export type DefaultAdapterHttpRequest = {
   query?: string;
   headers: DefaultAdapterHttpHeader[];
   body: Uint8Array;
+  bodyStreaming?: boolean;
+};
+
+export type DefaultAdapterHttpRequestChunk = {
+  requestId: number;
+  chunk: Uint8Array;
+  done: boolean;
 };
 
 export type DefaultAdapterHttpResponse = {
@@ -76,6 +84,16 @@ export type DefaultAdapterHttpResponse = {
   reason: string;
   headers: DefaultAdapterHttpHeader[];
   body: Uint8Array;
+};
+
+export type DefaultAdapterHttpResponseHead = Omit<
+  DefaultAdapterHttpResponse,
+  "body"
+>;
+
+export type DefaultAdapterHttpResponseChunk = {
+  requestId: number;
+  chunk: Uint8Array;
 };
 
 export type DefaultAdapterOutputTarget = "stdout" | "stderr";
@@ -107,9 +125,19 @@ export type DefaultAdapterRuntimeHooks = {
     config: DefaultAdapterHttpServerConfig
   ) => Promise<number>;
   httpServerAccept?: (serverId: number) => Promise<DefaultAdapterHttpRequest>;
+  httpServerReadRequest?: (
+    requestId: number
+  ) => Promise<DefaultAdapterHttpRequestChunk>;
   httpServerRespond?: (
     response: DefaultAdapterHttpResponse
   ) => Promise<void>;
+  httpServerStartResponse?: (
+    response: DefaultAdapterHttpResponseHead
+  ) => Promise<void>;
+  httpServerWriteResponse?: (
+    response: DefaultAdapterHttpResponseChunk
+  ) => Promise<void>;
+  httpServerFinishResponse?: (requestId: number) => Promise<void>;
   httpServerClose?: (serverId: number) => Promise<void>;
   readLine?: (prompt: string | null) => Promise<string | null>;
   readBytes?: (maxBytes: number) => Promise<Uint8Array | null>;

--- a/packages/reference/docs/web.md
+++ b/packages/reference/docs/web.md
@@ -86,8 +86,8 @@ runtime effects. Any effects used by your handlers also remain visible in the
 entrypoint's effect row.
 
 Most applications should import `pkg::web::all`. For tighter imports, the public
-modules are `router`, `routes`, `extract`, `response`, `html`, `middleware`, and
-`static_files`.
+modules are `router`, `routes`, `extract`, `response`, `html`, `middleware`,
+`static_files`, `streaming`, `sse`, `multipart`, `negotiate`, and `openapi`.
 
 ## Routes
 
@@ -198,6 +198,181 @@ get("/api/articles/:slug") do(params: ArticleParams):
 Use `response_dto_json(Response::created(), value:)` to choose the status,
 `result_dto_json` for a `Result`, and `option_dto_json` when absence should be a 404. Use `response_json(value)` for an existing `JsonValue`; the root-level
 `json()` name is reserved for the JSON request-body policy.
+
+## Streaming Responses And SSE
+
+`stream` opens the response before running its body producer. Each
+`write_stream` waits for host backpressure, and returning from the producer
+closes the body:
+
+```voyd
+use pkg::web::all
+use std::result::types::all
+
+get("/chunks") do:
+  stream(Response::ok().with(
+    header: "content-type".as_slice(),
+    value: "text/plain; charset=utf-8".as_slice()
+  ), body: () =>
+    let _ = write_stream("first\n".as_slice())
+    let _ = write_stream("second\n".as_slice())
+  )
+```
+
+Use `sse_response` for Server-Sent Events. It supplies the required response headers and
+formats data, event names, ids, retry delays, and comments according to the SSE
+wire format:
+
+```voyd
+use std::http::server::ResponseWriter
+
+fn publish_events(sender: SseSender): ResponseWriter -> void
+  let data_event = make_sse_event("ready".as_slice())
+  let status_event = data_event.with(event: "status".as_slice())
+  let identified_event = status_event.with(id: "1".as_slice())
+  let retry_event = identified_event.with(retry_millis: 2000)
+  let _ = sender.send(retry_event)
+  let _ = sender.comment("keepalive".as_slice())
+
+get("/events") do:
+  sse_response(publish_events)
+```
+
+`send` and `comment` return `Result<Unit, HostError>`. Long-lived producers
+should stop after an error because it normally means the client disconnected.
+The server closes the stream automatically when the producer returns. SSE uses
+ordinary HTTP streaming; the framework does not expose a WebSocket API.
+The server response timeout is an idle watchdog: each successful stream write
+refreshes it. Send periodic SSE comments more frequently than that timeout so a
+healthy but otherwise quiet connection stays open; an abandoned producer is
+closed without appending an error payload to bytes already sent.
+
+Streaming transport chunks are capped at 16 KiB so every chunk fits the host
+effect buffer. Request readers apply this cap automatically. Response producers
+should split larger byte values before calling `write`; an oversized write
+returns `HostError` without partially writing the value.
+
+Use `serve_streaming(app, port: ...)` when routes need lazy request bodies. A
+handler on a route marked `.streaming()` can retrieve the one-shot reader with
+`ctx.streaming_body()` and read backpressure-aware chunks with `next()`. Other
+routes are buffered lazily, so ordinary JSON, text, and multipart extractors can
+coexist in the same app:
+
+```voyd
+use std::http::server::{ HttpServer, RequestBody }
+
+fn upload(ctx: Context): HttpServer -> Response
+  match(ctx.streaming_body())
+    None:
+      Response::bad_request().text("missing stream".as_slice())
+    Some<RequestBody> { value }:
+      let ~body = value
+      let first_chunk = body.next()
+      first_chunk
+      Response::ok().text("received".as_slice())
+
+let uploads = app().post("/upload".as_slice(), handler: upload).streaming()
+let _ = serve_streaming(uploads, port: 3000)
+```
+
+The lower-level `std::http::server` equivalents are
+`ServerConfig::init(stream_request_bodies: true)`, `accept_streaming`, and
+`serve_each_streaming`. With streaming disabled, ordinary `accept` and Web body
+extractors retain their buffered behavior. Successful request-chunk reads
+refresh the response idle watchdog, so active uploads can run longer than one
+timeout interval.
+
+## Multipart Forms
+
+Use the `multipart_body()` body policy for `multipart/form-data`. Part bodies remain
+bytes, so uploaded files are not forced through UTF-8:
+
+```voyd
+post("/upload", body: multipart_body()) do(form: MultipartForm):
+  match(form.get("asset".as_slice()))
+    Some<MultipartPart> { value: asset }:
+      asset.body
+      Response::ok().text("uploaded")
+    None:
+      Response::bad_request().text("missing asset")
+```
+
+Each part exposes its headers, form name, optional filename, optional content
+type, and body. `part.text()` provides checked UTF-8 decoding for text fields.
+
+## Content Negotiation
+
+`negotiate_content(ctx, supported)` chooses the best representation from `Accept`,
+including quality values and wildcards. `accepts(ctx, media_type)` handles a
+single candidate, and `best_match` works directly with an Accept header value.
+A missing Accept header selects the first supported representation.
+
+## OpenAPI 3.1
+
+OpenAPI schemas use `std::meta::shape_of<T>()`. Type and field `///` doc comments
+become schema descriptions, including path/query/header parameter descriptions
+and request/response body field descriptions. Operation summaries,
+descriptions, ids, tags, response statuses, and response descriptions are
+explicit so API behavior is documented at its route boundary:
+
+```voyd
+/// Parameters identifying an article.
+obj ArticlePath {
+  /// Stable article identifier.
+  id: i32
+}
+
+/// New article fields.
+obj CreateArticle {
+  /// Reader-visible title.
+  title: String,
+  /// Optional summary shown in lists.
+  summary?: String
+}
+
+/// Stored article.
+obj Article {
+  /// Stable article identifier.
+  id: i32,
+  /// Reader-visible title.
+  title: String
+}
+
+let create_article = openapi_operation(
+  summary: "Create an article".as_slice().to_string(),
+  description: "Creates and returns one article.".as_slice().to_string(),
+  operation_id: "createArticle".as_slice().to_string(),
+  response_status: 201,
+  response_description: "Article created".as_slice().to_string()
+)
+  .with_path_params<ArticlePath>()
+  .with_json_body<CreateArticle>()
+  .responds_json<Article>()
+
+let base_app = app().route(
+    "/articles/:id".as_slice(),
+    method: Method::Post {},
+    handler: create_article_handler
+  )
+let web_app = base_app
+let empty_docs = openapi_document(openapi_info(
+  title: "Articles".as_slice(),
+  version: "1.0.0".as_slice()
+))
+let api_docs = document_openapi_route(web_app, empty_docs, create_article)
+
+let documented_app = expose_openapi(web_app, api_docs, at: "/openapi.json".as_slice())
+```
+
+`document_openapi_route` derives the method and path from the most recently
+added real route, preventing docs for a nonexistent endpoint. Use
+`.with_query<T>()`, `.with_headers<T>()`, and `.tagged(...)` for additional
+operation metadata. `.responds_sse<T>()` documents `text/event-stream` and
+includes the reified event payload under the `x-voyd-event-schema` extension.
+Recursive DTO references are emitted through OpenAPI components. Component
+identities include a deterministic fingerprint of the full reified schema and
+its documentation, so same-named DTOs from separate modules cannot overwrite
+one another.
 
 ## Typed Request Data
 

--- a/packages/std/src/http/server.voyd
+++ b/packages/std/src/http/server.voyd
@@ -5,6 +5,7 @@
 //! request task policy.
 
 use std::error::{ HostError, panic }
+use std::bytes::{ ByteBuffer, Bytes }
 use std::host_dto::HostDto
 use std::http::self as http
 use std::http::wire::self as wire
@@ -28,17 +29,47 @@ pub obj ServerConfig {
   api host?: String,
   api max_body_bytes?: i32,
   api max_pending_requests?: i32,
-  api response_timeout_millis?: i32
+  /// Maximum idle time before an unanswered or stalled response is released.
+  api response_timeout_millis?: i32,
+  api stream_request_bodies?: bool
 }
 
 pub obj PendingRequest {
   api handle: RequestHandle,
-  api request: http::IncomingRequest
+  api request: http::IncomingRequest,
+  body_streaming: bool
+}
+
+/// A request accepted with a lazily read body.
+pub obj StreamingPendingRequest {
+  api handle: RequestHandle,
+  api request: http::IncomingRequest,
+  api body: RequestBody
+}
+
+/// Backpressure-aware request body reader.
+pub obj RequestBody {
+  handle: RequestHandle,
+  buffered: Bytes,
+  emitted_buffer: bool,
+  streaming: bool,
+  done: bool
 }
 
 pub obj ServeTaskPolicy {
   kind: i32
 }
+
+/// Dynamically scoped response-stream request used by `stream`.
+@effect(id: "voyd.std.http.response-stream")
+pub eff ResponseStream
+  begin_stream(resume, response: MsgPack) -> MsgPack
+  finish_stream(resume, payload: MsgPack) -> MsgPack
+
+/// Dynamically scoped writer available while a response stream is open.
+@effect(id: "voyd.std.http.response-writer")
+pub eff ResponseWriter
+  write_chunk(tail, chunk: MsgPack) -> MsgPack
 
 impl Server
   fn raw_id(self) -> i32
@@ -64,32 +95,52 @@ pub eff HttpServer
   listen_raw(tail, payload: MsgPack) -> MsgPack
   /// Suspends until a request is available or the server closes.
   accept_raw(resume, server_id: i32) -> MsgPack
+  /// Reads the next chunk for a streaming request.
+  read_request_raw(resume, request_id: i32) -> MsgPack
   /// Sends one response for a request handle.
   respond_raw(tail, payload: MsgPack) -> MsgPack
+  /// Starts a streaming response for a request handle.
+  start_response_raw(tail, payload: MsgPack) -> MsgPack
+  /// Writes one streaming response chunk.
+  write_response_raw(tail, payload: MsgPack) -> MsgPack
+  /// Finishes a streaming response.
+  finish_response_raw(tail, request_id: i32) -> MsgPack
   /// Closes a server and releases host resources.
   close_raw(tail, server_id: i32) -> MsgPack
 
 impl ServerConfig
   /// Creates a server configuration with common defaults.
+  ///
+  /// `response_timeout_millis` is an idle watchdog. Successful streaming body
+  /// reads and response writes refresh it, and finishing cancels it.
   api fn init({
     port: i32,
     host?: String,
     max_body_bytes?: i32,
     max_pending_requests?: i32,
-    response_timeout_millis?: i32
+    response_timeout_millis?: i32,
+    stream_request_bodies?: bool
   }) -> ServerConfig
     ServerConfig {
       port: port,
       host: host,
       max_body_bytes: rebox_optional_i32(max_body_bytes),
       max_pending_requests: rebox_optional_i32(max_pending_requests),
-      response_timeout_millis: rebox_optional_i32(response_timeout_millis)
+      response_timeout_millis: rebox_optional_i32(response_timeout_millis),
+      stream_request_bodies: rebox_optional_bool(stream_request_bodies)
     }
 
 fn rebox_optional_i32(value: Option<i32>) -> Option<i32>
   match(value)
     Some<i32> { value }:
       Some<i32> { value: value }
+    None:
+      None {}
+
+fn rebox_optional_bool(value: Option<bool>) -> Option<bool>
+  match(value)
+    Some<bool> { value }:
+      Some<bool> { value: value }
     None:
       None {}
 
@@ -104,15 +155,87 @@ pub fn listen(config: ServerConfig): HttpServer -> Result<Server, HostError>
 /// Accepts the next pending request.
 pub fn accept(server: Server): HttpServer -> Result<PendingRequest, HostError>
   match(wire::decode_pending_request_result(HttpServer::accept_raw(server.raw_id())))
-    Ok<(i32, http::IncomingRequest)> { value }:
+    Ok<(i32, http::IncomingRequest, bool)> { value }:
       Ok<PendingRequest> {
         value: PendingRequest {
           handle: RequestHandle { id: value.0 },
-          request: value.1
+          request: value.1,
+          body_streaming: value.2
         }
       }
     Err<HostError> { error }:
       Err<HostError> { error: error }
+
+/// Accepts a request whose body can be consumed incrementally.
+///
+/// Configure the server with `stream_request_bodies: true` to avoid buffering
+/// in the host. Buffered hook implementations remain compatible and are
+/// exposed as the reader's first chunk.
+pub fn accept_streaming(server: Server): HttpServer -> Result<StreamingPendingRequest, HostError>
+  match(accept(server))
+    Err<HostError> { error }:
+      Err<HostError> { error: error }
+    Ok<PendingRequest> { value }:
+      let request = value.request
+      Ok<StreamingPendingRequest> {
+        value: StreamingPendingRequest {
+          handle: value.handle,
+          request: http::IncomingRequest {
+            method: request.method,
+            path: request.path,
+            query: request.query,
+            headers: request.headers,
+            body: http::Body::empty()
+          },
+          body: RequestBody {
+            handle: value.handle,
+            buffered: request.body.as_bytes(),
+            emitted_buffer: false,
+            streaming: value.body_streaming,
+            done: false
+          }
+        }
+      }
+
+impl RequestBody
+  /// Reads the next body chunk, or `None` after end-of-stream.
+  api fn next(~self): HttpServer -> Result<Option<Bytes>, HostError>
+    if self.done:
+      return Ok<Option<Bytes>> { value: None {} }
+    if not self.emitted_buffer and not self.buffered.is_empty():
+      self.emitted_buffer = true
+      if not self.streaming:
+        self.done = true
+      return Ok<Option<Bytes>> { value: Some<Bytes> { value: self.buffered } }
+    self.emitted_buffer = true
+    if not self.streaming:
+      self.done = true
+      return Ok<Option<Bytes>> { value: None {} }
+    match(wire::decode_request_chunk_result(HttpServer::read_request_raw(self.handle.raw_id())))
+      Err<HostError> { error }:
+        Err<HostError> { error: error }
+      Ok<(Bytes, bool)> { value }:
+        self.done = value.1
+        if value.0.is_empty() and value.1:
+          Ok<Option<Bytes>> { value: None {} }
+        else:
+          Ok<Option<Bytes>> { value: Some<Bytes> { value: value.0 } }
+
+  /// Buffers all remaining chunks while preserving the host body limit.
+  api fn read_all(~self): HttpServer -> Result<Bytes, HostError>
+    let ~buffer = ByteBuffer::init()
+    var reading = true
+    while reading:
+      match(self.next())
+        Err<HostError> { error }:
+          return Err<HostError> { error: error }
+        Ok<Option<Bytes>> { value }:
+          match(value)
+            None:
+              reading = false
+            Some<Bytes> { value: chunk }:
+              buffer.extend(chunk)
+    Ok<Bytes> { value: buffer.as_bytes() }
 
 /// Responds to one pending request.
 pub fn respond(
@@ -120,6 +243,53 @@ pub fn respond(
   response: http::Response
 ): HttpServer -> Result<Unit, HostError>
   wire::decode_unit_result(HttpServer::respond_raw(encode_respond_payload(handle, response)))
+
+/// Starts a response without ending its body.
+pub fn start_response(
+  handle: RequestHandle,
+  response: http::Response
+): HttpServer -> Result<Unit, HostError>
+  wire::decode_unit_result(HttpServer::start_response_raw(encode_respond_payload(handle, response)))
+
+/// Writes a chunk to an open response stream with host backpressure.
+pub fn write_response(
+  handle: RequestHandle,
+  chunk: Bytes
+): HttpServer -> Result<Unit, HostError>
+  if chunk.len() > 16384:
+    return stream_chunk_too_large()
+  wire::decode_unit_result(HttpServer::write_response_raw(encode_chunk_payload(handle, chunk)))
+
+/// Finishes an open response stream.
+pub fn finish_response(handle: RequestHandle): HttpServer -> Result<Unit, HostError>
+  wire::decode_unit_result(HttpServer::finish_response_raw(handle.raw_id()))
+
+/// Produces a streaming response from an ordinary Web handler.
+///
+/// The enclosing server loop binds the stream to the current request. Calling
+/// this outside `serve_each` leaves `ResponseStream` visible to the caller.
+pub fn stream(
+  response: http::Response,
+  { body: fn() : (ResponseWriter, open) -> void }
+): (ResponseStream, open) -> http::Response
+  let _ = ResponseStream::begin_stream(wire::encode_response(response))
+  body()
+  let _ = ResponseStream::finish_stream(msgpack::make_null())
+  response
+
+/// Writes one byte chunk from a streaming response producer.
+pub fn write(chunk: Bytes): ResponseWriter -> Result<Unit, HostError>
+  if chunk.len() > 16384:
+    return stream_chunk_too_large()
+  wire::decode_unit_result(ResponseWriter::write_chunk(wire::encode_bytes(chunk)))
+
+fn stream_chunk_too_large() -> Result<Unit, HostError>
+  Err<HostError> {
+    error: HostError {
+      code: 1,
+      message: "HTTP stream chunks may not exceed 16384 bytes".as_slice().to_string()
+    }
+  }
 
 /// Closes a server.
 pub fn close(server: Server): HttpServer -> Result<Unit, HostError>
@@ -140,6 +310,20 @@ pub fn serve_each({
     return serve_each_detached(config: config, handle: handle)
   serve_each_sequential(config: config, handle: handle)
 
+/// Listens and handles requests with lazily consumed request bodies.
+///
+/// Set `config.stream_request_bodies` to true so the host accepts requests
+/// after their headers arrive. The handler receives the request head and a
+/// backpressure-aware body reader separately.
+pub fn serve_each_streaming({
+  config: ServerConfig,
+  policy: ServeTaskPolicy,
+  handle: fn(http::IncomingRequest, RequestBody) : (open) -> http::Response
+}): (HttpServer, task::TaskRuntime, open) -> Result<Unit, HostError>
+  if policy.kind == 1:
+    return serve_each_streaming_detached(config: config, handle: handle)
+  serve_each_streaming_sequential(config: config, handle: handle)
+
 fn serve_each_sequential({
   config: ServerConfig,
   handle: fn(http::IncomingRequest) : (open) -> http::Response
@@ -154,8 +338,8 @@ fn serve_each_sequential({
             let _ = close(server)
             return Err<HostError> { error: error }
           Ok<PendingRequest> { value: pending }:
-            let response = handle(pending.request)
-            match(respond(pending.handle, response))
+            let request = pending.request
+            match(respond_request(pending.handle, () => handle(request)))
               Err<HostError> { error }:
                 let _ = close(server)
                 return Err<HostError> { error: error }
@@ -180,20 +364,91 @@ fn serve_each_detached({
             let request_handle = pending.handle
             let request = pending.request
             let _ = task::detach do:
-              respond_or_panic(request_handle, handle(request))
+              respond_or_panic(request_handle, () => handle(request))
+            let _ = task::yield_now()
+      Ok<Unit> { value: Unit {} }
+
+fn serve_each_streaming_sequential({
+  config: ServerConfig,
+  handle: fn(http::IncomingRequest, RequestBody) : (open) -> http::Response
+}): (HttpServer, task::TaskRuntime, open) -> Result<Unit, HostError>
+  match(listen(config))
+    Err<HostError> { error }:
+      Err<HostError> { error: error }
+    Ok<Server> { value: server }:
+      while true:
+        match(accept_streaming(server))
+          Err<HostError> { error }:
+            let _ = close(server)
+            return Err<HostError> { error: error }
+          Ok<StreamingPendingRequest> { value: pending }:
+            let request = pending.request
+            let body = pending.body
+            match(respond_request(pending.handle, () => handle(request, body)))
+              Err<HostError> { error }:
+                let _ = close(server)
+                return Err<HostError> { error: error }
+              Ok<Unit>:
+                let _ = task::yield_now()
+      Ok<Unit> { value: Unit {} }
+
+fn serve_each_streaming_detached({
+  config: ServerConfig,
+  handle: fn(http::IncomingRequest, RequestBody) : (open) -> http::Response
+}): (HttpServer, task::TaskRuntime, open) -> Result<Unit, HostError>
+  match(listen(config))
+    Err<HostError> { error }:
+      Err<HostError> { error: error }
+    Ok<Server> { value: server }:
+      while true:
+        match(accept_streaming(server))
+          Err<HostError> { error }:
+            let _ = close(server)
+            return Err<HostError> { error: error }
+          Ok<StreamingPendingRequest> { value: pending }:
+            let request_handle = pending.handle
+            let request = pending.request
+            let body = pending.body
+            let _ = task::detach do:
+              respond_or_panic(request_handle, () => handle(request, body))
             let _ = task::yield_now()
       Ok<Unit> { value: Unit {} }
 
 fn respond_or_panic(
   handle: RequestHandle,
-  response: http::Response
-): HttpServer -> Unit
-  match(respond(handle, response))
+  work: fn() : (ResponseStream, open) -> http::Response
+): (HttpServer, open) -> Unit
+  match(respond_request(handle, work))
     Ok<Unit>:
       Unit {}
     Err<HostError> { error }:
       panic(error.message)
       Unit {}
+
+fn respond_request(
+  handle: RequestHandle,
+  work: fn() : (ResponseStream, open) -> http::Response
+): (HttpServer, open) -> Result<Unit, HostError>
+  try open
+    respond(handle, work())
+  ResponseStream::begin_stream(resume, payload):
+    match(wire::decode_response(payload))
+      Err<HostError> { error }:
+        Err<HostError> { error: error }
+      Ok<http::Response> { value: response }:
+        match(start_response(handle, response))
+          Err<HostError> { error }:
+            Err<HostError> { error: error }
+          Ok<Unit>:
+            resume(msgpack::make_null())
+  ResponseWriter::write_chunk(tail, payload):
+    match(wire::decode_body(payload))
+      Err<HostError> { error }:
+        tail(encode_unit_result(Err<HostError> { error: error }))
+      Ok<http::Body> { value }:
+        tail(encode_unit_result(write_response(handle, value.as_bytes())))
+  ResponseStream::finish_stream(_resume, _payload):
+    finish_response(handle)
 
 fn encode_config(config: ServerConfig): () -> MsgPack
   HostDto::init()
@@ -202,10 +457,38 @@ fn encode_config(config: ServerConfig): () -> MsgPack
     .set("max_body_bytes", wire::encode_optional_i32(config.max_body_bytes))
     .set("max_pending_requests", wire::encode_optional_i32(config.max_pending_requests))
     .set("response_timeout_millis", wire::encode_optional_i32(config.response_timeout_millis))
+    .set("stream_request_bodies", encode_optional_bool(config.stream_request_bodies))
     .pack()
+
+fn encode_optional_bool(value: Option<bool>) -> MsgPack
+  match(value)
+    Some<bool> { value }:
+      msgpack::make_bool(value)
+    None:
+      msgpack::make_null()
+
+fn encode_unit_result(result: Result<Unit, HostError>) -> MsgPack
+  match(result)
+    Ok<Unit>:
+      HostDto::init()
+        .set("ok", msgpack::make_bool(true))
+        .pack()
+    Err<HostError> { error }:
+      HostDto::init()
+        .set("ok", msgpack::make_bool(false))
+        .set("code", msgpack::make_i32(error.code))
+        .set("message", msgpack::make_string(error.message))
+        .pack()
+
 
 fn encode_respond_payload(handle: RequestHandle, response: http::Response): () -> MsgPack
   HostDto::init()
     .set("request_id", msgpack::make_i32(handle.raw_id()))
     .set("response", wire::encode_response(response))
+    .pack()
+
+fn encode_chunk_payload(handle: RequestHandle, chunk: Bytes): () -> MsgPack
+  HostDto::init()
+    .set("request_id", msgpack::make_i32(handle.raw_id()))
+    .set("chunk", wire::encode_bytes(chunk))
     .pack()

--- a/packages/std/src/http/server.voyd
+++ b/packages/std/src/http/server.voyd
@@ -249,7 +249,7 @@ pub fn start_response(
   handle: RequestHandle,
   response: http::Response
 ): HttpServer -> Result<Unit, HostError>
-  wire::decode_unit_result(HttpServer::start_response_raw(encode_respond_payload(handle, response)))
+  wire::decode_unit_result(HttpServer::start_response_raw(encode_respond_payload(handle, response.empty())))
 
 /// Writes a chunk to an open response stream with host backpressure.
 pub fn write_response(

--- a/packages/std/src/http/server.voyd
+++ b/packages/std/src/http/server.voyd
@@ -60,6 +60,10 @@ pub obj ServeTaskPolicy {
   kind: i32
 }
 
+obj RespondRequestState {
+  streamed: bool
+}
+
 /// Dynamically scoped response-stream request used by `stream`.
 @effect(id: "voyd.std.http.response-stream")
 pub eff ResponseStream
@@ -104,7 +108,7 @@ pub eff HttpServer
   /// Writes one streaming response chunk.
   write_response_raw(tail, payload: MsgPack) -> MsgPack
   /// Finishes a streaming response.
-  finish_response_raw(tail, request_id: i32) -> MsgPack
+  finish_response_raw(resume, request_id: i32) -> MsgPack
   /// Closes a server and releases host resources.
   close_raw(tail, server_id: i32) -> MsgPack
 
@@ -429,8 +433,13 @@ fn respond_request(
   handle: RequestHandle,
   work: fn() : (ResponseStream, open) -> http::Response
 ): (HttpServer, open) -> Result<Unit, HostError>
+  let ~state = RespondRequestState { streamed: false }
   try open
-    respond(handle, work())
+    let response = work()
+    if state.streamed:
+      Ok<Unit> { value: Unit {} }
+    else:
+      respond(handle, response)
   ResponseStream::begin_stream(resume, payload):
     match(wire::decode_response(payload))
       Err<HostError> { error }:
@@ -440,6 +449,7 @@ fn respond_request(
           Err<HostError> { error }:
             Err<HostError> { error: error }
           Ok<Unit>:
+            state.streamed = true
             resume(msgpack::make_null())
   ResponseWriter::write_chunk(tail, payload):
     match(wire::decode_body(payload))
@@ -447,8 +457,12 @@ fn respond_request(
         tail(encode_unit_result(Err<HostError> { error: error }))
       Ok<http::Body> { value }:
         tail(encode_unit_result(write_response(handle, value.as_bytes())))
-  ResponseStream::finish_stream(_resume, _payload):
-    finish_response(handle)
+  ResponseStream::finish_stream(resume, _payload):
+    match(finish_response(handle))
+      Err<HostError> { error }:
+        Err<HostError> { error: error }
+      Ok<Unit>:
+        resume(msgpack::make_null())
 
 fn encode_config(config: ServerConfig): () -> MsgPack
   HostDto::init()

--- a/packages/std/src/http/wire.voyd
+++ b/packages/std/src/http/wire.voyd
@@ -133,8 +133,8 @@ pub fn decode_unit_result(payload: MsgPack) -> Result<Unit, HostError>
           else:
             decode_host_error_result<Unit>(decoded)
 
-/// Decodes an inbound pending request host result.
-pub fn decode_pending_request_result(payload: MsgPack) -> Result<(i32, IncomingRequest), HostError>
+/// Decodes one streamed request-body chunk.
+pub fn decode_request_chunk_result(payload: MsgPack) -> Result<(Bytes, bool), HostError>
   match(HostDto::unpack(payload))
     Err<HostError> { error }:
       Err<HostError> { error: error }
@@ -144,7 +144,42 @@ pub fn decode_pending_request_result(payload: MsgPack) -> Result<(i32, IncomingR
           Err<HostError> { error: error }
         Ok<bool> { value }:
           if value == false:
-            decode_host_error_result<(i32, IncomingRequest)>(decoded)
+            decode_host_error_result<(Bytes, bool)>(decoded)
+          else:
+            match(decoded.read_msgpack("value".as_slice().to_string()))
+              Err<HostError> { error }:
+                Err<HostError> { error: error }
+              Ok<MsgPack> { value }:
+                match(HostDto::unpack(value))
+                  Err<HostError> { error }:
+                    Err<HostError> { error: error }
+                  Ok<HostDto> { value: chunk }:
+                    match(chunk.read_msgpack("chunk".as_slice().to_string()))
+                      Err<HostError> { error }:
+                        Err<HostError> { error: error }
+                      Ok<MsgPack> { value: bytes }:
+                        match(decode_bytes(bytes))
+                          Err<HostError> { error }:
+                            Err<HostError> { error: error }
+                          Ok<Bytes> { value }:
+                            match(chunk.read_bool("done".as_slice().to_string()))
+                              Err<HostError> { error }:
+                                Err<HostError> { error: error }
+                              Ok<bool> { value: done }:
+                                Ok<(Bytes, bool)> { value: (value, done) }
+
+/// Decodes an inbound pending request host result.
+pub fn decode_pending_request_result(payload: MsgPack) -> Result<(i32, IncomingRequest, bool), HostError>
+  match(HostDto::unpack(payload))
+    Err<HostError> { error }:
+      Err<HostError> { error: error }
+    Ok<HostDto> { value: decoded }:
+      match(decoded.read_bool("ok".as_slice().to_string()))
+        Err<HostError> { error }:
+          Err<HostError> { error: error }
+        Ok<bool> { value }:
+          if value == false:
+            decode_host_error_result<(i32, IncomingRequest, bool)>(decoded)
           else:
             match(decoded.read_msgpack("value".as_slice().to_string()))
               Err<HostError> { error }:
@@ -198,7 +233,8 @@ fn decode_header(payload: MsgPack): () -> Result<Header, HostError>
                     }
                   }
 
-fn encode_bytes(bytes: Bytes): () -> MsgPack
+/// Encodes raw bytes for streaming host operations.
+pub fn encode_bytes(bytes: Bytes) -> MsgPack
   let source = bytes.to_array()
   let ~encoded = Array<MsgPack>::with_capacity(source.len())
   var index = 0
@@ -231,7 +267,8 @@ fn decode_bytes(payload: MsgPack): () -> Result<Bytes, HostError>
         index = index + 1
       Ok<Bytes> { value: buffer.as_bytes() }
 
-fn decode_response(payload: MsgPack): () -> Result<Response, HostError>
+/// Decodes an HTTP response from its raw MessagePack representation.
+pub fn decode_response(payload: MsgPack): () -> Result<Response, HostError>
   match(HostDto::unpack(payload))
     Err<HostError> { error }:
       Err<HostError> { error: error }
@@ -272,7 +309,7 @@ fn decode_response(payload: MsgPack): () -> Result<Response, HostError>
                                     }
                                   }
 
-fn decode_pending_request(payload: MsgPack): () -> Result<(i32, IncomingRequest), HostError>
+fn decode_pending_request(payload: MsgPack): () -> Result<(i32, IncomingRequest, bool), HostError>
   match(HostDto::unpack(payload))
     Err<HostError> { error }:
       Err<HostError> { error: error }
@@ -309,7 +346,7 @@ fn decode_pending_request(payload: MsgPack): () -> Result<(i32, IncomingRequest)
                                     Err<HostError> { error }:
                                       Err<HostError> { error: error }
                                     Ok<Body> { value: body }:
-                                      Ok<(i32, IncomingRequest)> {
+                                      Ok<(i32, IncomingRequest, bool)> {
                                         value: (
                                           request_id,
                                           IncomingRequest {
@@ -318,9 +355,17 @@ fn decode_pending_request(payload: MsgPack): () -> Result<(i32, IncomingRequest)
                                             query: query,
                                             headers: headers,
                                             body: body
-                                          }
+                                          },
+                                          decode_bool_or_false(decoded, "body_streaming".as_slice())
                                         )
                                       }
+
+fn decode_bool_or_false(payload: HostDto, key: StringSlice) -> bool
+  match(payload.read_bool(key.to_string()))
+    Ok<bool> { value }:
+      value
+    Err:
+      false
 
 fn decode_optional_query(payload: HostDto): () -> Result<Option<QueryString>, HostError>
   match(payload.read_msgpack("query".as_slice().to_string()))

--- a/packages/web/src/all.voyd
+++ b/packages/web/src/all.voyd
@@ -7,6 +7,8 @@ use super::extract::{
   required_session as required_session_policy,
   text as text_policy
 }
+pub use super::openapi_expose::expose as expose_openapi
+pub use super::openapi_routes::document_route as document_openapi_route
 use super::response::{ json as response_json_value }
 use std::json::JsonValue
 
@@ -52,6 +54,17 @@ pub use super::html::{
   render
 }
 pub use super::middleware::request_id_required
+pub use super::multipart::{ Form as MultipartForm, MultipartBody, Part as MultipartPart, multipart as multipart_body }
+pub use super::negotiate::{ accepts, best_match, negotiate as negotiate_content }
+pub use super::openapi::{
+  Document as OpenApi,
+  Info as OpenApiInfo,
+  Operation as OpenApiOperation,
+  document as openapi_document,
+  info as openapi_info,
+  operation as openapi_operation
+}
+pub use super::request_streaming::serve as serve_streaming
 pub use super::response::{
   Body,
   Header,
@@ -165,6 +178,8 @@ pub use super::routes::{
   timeout_millis
 }
 pub use super::static_files::serve_dir
+pub use super::streaming::{ stream, write as write_stream }
+pub use super::sse::{ Event as SseEvent, Sender as SseSender, response as sse_response, make_sse_event }
 
 pub fn json() -> JsonBody
   json_policy()
@@ -177,6 +192,7 @@ pub fn response_json(value: JsonValue) -> Response
 
 pub fn response_json(response: Response, value: JsonValue) -> Response
   response_json_value(response, value)
+
 
 pub fn text() -> TextBody
   text_policy()

--- a/packages/web/src/multipart.voyd
+++ b/packages/web/src/multipart.voyd
@@ -1,0 +1,262 @@
+//! Buffered `multipart/form-data` parsing with binary-safe part bodies.
+
+use std::array::Array
+use std::bytes::{ ByteBuffer, Bytes }
+use std::http::{ Body, Headers, IncomingRequest }
+use std::optional::types::all
+use std::result::types::all
+use std::string::type::{ String, StringSlice }
+use super::extract::{ FromBody, Rejection }
+
+/// One multipart field or uploaded file.
+pub obj Part {
+  api headers: Headers,
+  api name?: String,
+  api filename?: String,
+  api content_type?: String,
+  api body: Bytes
+}
+
+/// Parsed multipart form in source order.
+pub obj Form {
+  api parts: Array<Part>
+}
+
+/// Route body policy for `multipart/form-data`.
+pub obj MultipartBody {}
+
+impl Form
+  /// Returns the first part with `name`.
+  api fn get(self, name: StringSlice) -> Option<Part>
+    var index = 0
+    while index < self.parts.len():
+      let part = self.parts.at(index)
+      match(part.name)
+        Some<String> { value }:
+          if value.equals(name.to_string()):
+            return Some<Part> { value: part }
+        None:
+          void
+      index = index + 1
+    None {}
+
+  /// Returns the first part with `name`.
+  api fn get(self, name: String) -> Option<Part>
+    self.get(name.as_slice())
+
+impl Part
+  /// Decodes this part body as UTF-8.
+  api fn text(self) -> Result<String, Rejection>
+    match(Body::bytes(self.body).as_text())
+      Ok<String> { value }:
+        Ok<String> { value: value }
+      Err:
+        Err<Rejection> { error: Rejection::bad_request("multipart field is not valid UTF-8".as_slice()) }
+
+impl FromBody<Form> for MultipartBody
+  fn extract_body(self, request: IncomingRequest) : (open) -> Result<Form, Rejection>
+    self
+    parse(request)
+
+pub fn multipart() -> MultipartBody
+  MultipartBody {}
+
+/// Parses a `multipart/form-data` request.
+pub fn parse(request: IncomingRequest) -> Result<Form, Rejection>
+  match(request.header("content-type".as_slice()))
+    None:
+      Err<Rejection> { error: Rejection::unsupported_media_type("expected multipart/form-data request body".as_slice()) }
+    Some<String> { value }:
+      match(boundary_from(value.as_slice()))
+        None:
+          Err<Rejection> { error: Rejection::unsupported_media_type("multipart/form-data requires a boundary".as_slice()) }
+        Some<String> { value: boundary }:
+          parse_bytes(request.body_bytes(), boundary.as_slice())
+
+fn parse_bytes(source: Bytes, boundary: StringSlice) -> Result<Form, Rejection>
+  let delimiter = Body::text("--".concat(boundary)).as_bytes()
+  let ~separator_buffer = ByteBuffer::with_capacity(delimiter.len() + 2)
+  separator_buffer.push(13)
+  separator_buffer.push(10)
+  separator_buffer.extend(delimiter)
+  let separator = separator_buffer.as_bytes()
+  if not starts_with_bytes(source, delimiter, at: 0):
+    return malformed("multipart body does not start with its boundary")
+
+  let ~parts = Array<Part>::init()
+  var cursor = delimiter.len()
+  while cursor < source.len():
+    if has_pair(source, cursor, 45, 45):
+      if valid_closing_boundary_suffix(source, cursor + 2):
+        return Ok<Form> { value: Form { parts: parts } }
+      return malformed("multipart closing boundary has an invalid suffix")
+    cursor = skip_transport_padding(source, cursor)
+    if not has_pair(source, cursor, 13, 10):
+      return malformed("multipart boundary must be followed by CRLF")
+    cursor = cursor + 2
+    let headers_end = find_four(source, cursor, 13, 10, 13, 10)
+    if headers_end < 0:
+      return malformed("multipart part is missing its header terminator")
+    match(parse_headers(source.slice(cursor..headers_end)))
+      Err<Rejection> { error }:
+        return Err<Rejection> { error: error }
+      Ok<Headers> { value }:
+        let body_start = headers_end + 4
+        let body_end = find_boundary(source, separator, from: body_start)
+        if body_end < 0:
+          return malformed("multipart part is missing a closing boundary")
+        parts.push(part_from(value, source.slice(body_start..body_end)))
+        cursor = body_end + separator.len()
+  malformed("multipart body is missing its final boundary")
+
+fn parse_headers(source: Bytes) -> Result<Headers, Rejection>
+  match(Body::bytes(source).as_text())
+    Err:
+      malformed_headers("multipart headers are not valid UTF-8")
+    Ok<String> { value }:
+      let lines = value.lines()
+      var headers = Headers::empty()
+      var index = 0
+      while index < lines.len():
+        match(lines.at(index).split_once(on: 58))
+          None:
+            return malformed_headers("multipart header is missing ':'")
+          Some<(StringSlice, StringSlice)> { value: header }:
+            let name = header.0.trimmed()
+            if name.is_empty():
+              return malformed_headers("multipart header name is empty")
+            headers = headers.append(header: name, value: header.1.trimmed())
+        index = index + 1
+      Ok<Headers> { value: headers }
+
+fn part_from(headers: Headers, body: Bytes) -> Part
+  let disposition = headers.get("content-disposition".as_slice())
+  Part {
+    headers: headers,
+    name: disposition_parameter(disposition, "name".as_slice()),
+    filename: disposition_parameter(disposition, "filename".as_slice()),
+    content_type: headers.get("content-type".as_slice()),
+    body: body
+  }
+
+fn disposition_parameter(header: Option<String>, name: StringSlice) -> Option<String>
+  match(header)
+    None:
+      None {}
+    Some<String> { value }:
+      let parts = split_parameters(value.as_slice())
+      var index = 1
+      while index < parts.len():
+        match(parts.at(index).as_slice().trimmed().split_once(on: 61))
+          Some<(StringSlice, StringSlice)> { value: parameter }:
+            if parameter.0.trimmed().lowered().equals(name.to_string()):
+              return Some<String> { value: unquote(parameter.1.trimmed()) }
+          None:
+            void
+        index = index + 1
+      None {}
+
+fn boundary_from(content_type: StringSlice) -> Option<String>
+  let parts = split_parameters(content_type)
+  if parts.is_empty() or not parts.at(0).as_slice().trimmed().lowered().equals("multipart/form-data"):
+    return None {}
+  var index = 1
+  while index < parts.len():
+    match(parts.at(index).as_slice().trimmed().split_once(on: 61))
+      Some<(StringSlice, StringSlice)> { value }:
+        if value.0.trimmed().lowered().equals("boundary"):
+          let boundary = unquote(value.1.trimmed())
+          if not boundary.is_empty():
+            return Some<String> { value: boundary }
+      None:
+        void
+    index = index + 1
+  None {}
+
+fn split_parameters(value: StringSlice) -> Array<String>
+  let ~parts = Array<String>::init()
+  let quote_parts = value.split(on: 34, keep_empty: true)
+  var current = String::init()
+  var index = 0
+  while index < quote_parts.len():
+    let quote_part = quote_parts.at(index)
+    if index - (index / 2) * 2 == 1:
+      current = current.concat("\"".as_slice()).concat(quote_part).concat("\"".as_slice())
+    else:
+      let semicolon_parts = quote_part.split(on: 59, keep_empty: true)
+      if not semicolon_parts.is_empty():
+        current = current.concat(semicolon_parts.at(0))
+      var part_index = 1
+      while part_index < semicolon_parts.len():
+        parts.push(current)
+        current = semicolon_parts.at(part_index).to_string()
+        part_index = part_index + 1
+    index = index + 1
+  parts.push(current)
+  parts
+
+fn unquote(value: StringSlice) -> String
+  if value.byte_len() >= 2 and value.starts_with("\"".as_slice()) and value.ends_with("\"".as_slice()):
+    value.slice(bytes: 1, len: value.byte_len() - 2).to_string()
+  else:
+    value.to_string()
+
+fn find_boundary(source: Bytes, needle: Bytes, { from start: i32 }) -> i32
+  if needle.is_empty():
+    return start
+  var index = start
+  while index + needle.len() <= source.len():
+    if starts_with_bytes(source, needle, at: index):
+      let suffix = index + needle.len()
+      let has_closing_marker = has_pair(source, suffix, 45, 45)
+      let closing = has_closing_marker and valid_closing_boundary_suffix(source, suffix + 2)
+      if closing or valid_regular_boundary_suffix(source, suffix):
+        return index
+    index = index + 1
+  -1
+
+fn valid_closing_boundary_suffix(source: Bytes, start: i32) -> bool
+  let index = skip_transport_padding(source, start)
+  index == source.len() or has_pair(source, index, 13, 10)
+
+fn valid_regular_boundary_suffix(source: Bytes, start: i32) -> bool
+  has_pair(source, skip_transport_padding(source, start), 13, 10)
+
+fn skip_transport_padding(source: Bytes, start: i32) -> i32
+  var index = start
+  while index < source.len() and (source.at(index) == 32 or source.at(index) == 9):
+    index = index + 1
+  index
+
+fn starts_with_bytes(source: Bytes, expected: Bytes, { at start: i32 }) -> bool
+  if start < 0 or start + expected.len() > source.len():
+    return false
+  var index = 0
+  while index < expected.len():
+    if source.at(start + index) != expected.at(index):
+      return false
+    index = index + 1
+  true
+
+fn find_four(source: Bytes, start: i32, a: i32, b: i32, c: i32, d: i32) -> i32
+  var index = start
+  while index + 3 < source.len():
+    if source.at(index) == a and source.at(index + 1) == b and source.at(index + 2) == c and source.at(index + 3) == d:
+      return index
+    index = index + 1
+  -1
+
+fn has_pair(source: Bytes, index: i32, first: i32, second: i32) -> bool
+  index >= 0 and index + 1 < source.len() and source.at(index) == first and source.at(index + 1) == second
+
+fn malformed(message: StringSlice) -> Result<Form, Rejection>
+  Err<Rejection> { error: Rejection::bad_request(message) }
+
+fn malformed(message: String) -> Result<Form, Rejection>
+  malformed(message.as_slice())
+
+fn malformed_headers(message: StringSlice) -> Result<Headers, Rejection>
+  Err<Rejection> { error: Rejection::bad_request(message) }
+
+fn malformed_headers(message: String) -> Result<Headers, Rejection>
+  malformed_headers(message.as_slice())

--- a/packages/web/src/negotiate.voyd
+++ b/packages/web/src/negotiate.voyd
@@ -32,6 +32,10 @@ pub fn best_match(accept: StringSlice, supported: Array<String>) -> Option<Strin
   else:
     None {}
 
+/// Selects the best supported media type for an `Accept` header.
+pub fn best_match(accept: String, supported: Array<String>) -> Option<String>
+  best_match(accept.as_slice(), supported)
+
 /// Selects a representation for the current request.
 ///
 /// A missing `Accept` header is treated as `*/*`.

--- a/packages/web/src/negotiate.voyd
+++ b/packages/web/src/negotiate.voyd
@@ -1,0 +1,174 @@
+//! HTTP content negotiation helpers.
+
+use std::array::Array
+use std::optional::types::all
+use std::string::type::{ String, StringSlice }
+use super::router::Context
+
+obj MatchScore {
+  quality: i32,
+  specificity: i32
+}
+
+/// Selects the best supported media type for an `Accept` header.
+///
+/// Quality values, exact types, subtype wildcards, and `*/*` are supported.
+/// The supported list order breaks otherwise equal matches.
+pub fn best_match(accept: StringSlice, supported: Array<String>) -> Option<String>
+  let ranges = accept.split(on: 44, keep_empty: false)
+  var best_index = -1
+  var best_quality = -1
+  var best_specificity = -1
+  var candidate_index = 0
+  while candidate_index < supported.len():
+    let score = score_candidate(supported.at(candidate_index).as_slice(), ranges)
+    if score.quality > best_quality or (score.quality == best_quality and score.specificity > best_specificity):
+      best_index = candidate_index
+      best_quality = score.quality
+      best_specificity = score.specificity
+    candidate_index = candidate_index + 1
+  if best_index >= 0 and best_quality > 0:
+    Some<String> { value: supported.at(best_index) }
+  else:
+    None {}
+
+/// Selects a representation for the current request.
+///
+/// A missing `Accept` header is treated as `*/*`.
+pub fn negotiate(ctx: Context, supported: Array<String>) -> Option<String>
+  match(ctx.header("accept".as_slice()))
+    Some<String> { value }:
+      best_match(value.as_slice(), supported)
+    None:
+      match(supported.get(0))
+        Some<String> { value }:
+          Some<String> { value: value }
+        None:
+          None {}
+
+/// Returns whether the current request accepts `media_type`.
+pub fn accepts(ctx: Context, media_type: StringSlice) -> bool
+  let ~supported = Array<String>::with_capacity(1)
+  supported.push(media_type.to_string())
+  match(negotiate(ctx, supported))
+    Some<String>:
+      true
+    None:
+      false
+
+/// Returns whether the current request accepts `media_type`.
+pub fn accepts(ctx: Context, media_type: String) -> bool
+  accepts(ctx, media_type.as_slice())
+
+fn score_candidate(candidate: StringSlice, ranges: Array<StringSlice>) -> MatchScore
+  var best = MatchScore { quality: 0, specificity: -1 }
+  var index = 0
+  while index < ranges.len():
+    let score = score_range(ranges.at(index), candidate)
+    if score.specificity > best.specificity or (score.specificity == best.specificity and score.quality > best.quality):
+      best = score
+    index = index + 1
+  best
+
+fn score_range(range: StringSlice, candidate: StringSlice) -> MatchScore
+  let parts = split_media_value(range)
+  let candidate_parts = split_media_value(candidate)
+  if parts.is_empty() or candidate_parts.is_empty():
+    return MatchScore { quality: 0, specificity: -1 }
+  let media = parts.at(0).as_slice().trimmed().lowered()
+  let target = candidate_parts.at(0).as_slice().trimmed().lowered()
+  let media_score = media_specificity(media.as_slice(), target.as_slice())
+  if media_score < 0:
+    return MatchScore { quality: 0, specificity: -1 }
+  var quality = 1000
+  var media_parameters = 0
+  var index = 1
+  while index < parts.len():
+    let parameter = parts.at(index).as_slice().trimmed()
+    match(parameter.split_once(on: 61))
+      Some<(StringSlice, StringSlice)> { value }:
+        let name = value.0.trimmed().lowered()
+        if name.equals("q"):
+          quality = parse_quality(value.1.trimmed())
+          index = parts.len()
+        if not name.equals("q"):
+          if not media_parameter_matches(candidate, parameter):
+            return MatchScore { quality: 0, specificity: -1 }
+          media_parameters = media_parameters + 1
+      None:
+        void
+    index = index + 1
+  MatchScore { quality: quality, specificity: media_score * 100 + media_parameters }
+
+fn media_parameter_matches(candidate: StringSlice, parameter: StringSlice) -> bool
+  match(parameter.split_once(on: 61))
+    None:
+      false
+    Some<(StringSlice, StringSlice)> { value: expected }:
+      let expected_name = expected.0.trimmed().lowered()
+      let expected_value = expected.1.trimmed().to_string()
+      let candidate_parts = split_media_value(candidate)
+      var index = 1
+      while index < candidate_parts.len():
+        match(candidate_parts.at(index).as_slice().trimmed().split_once(on: 61))
+          Some<(StringSlice, StringSlice)> { value: actual }:
+            let actual_name = actual.0.trimmed().lowered()
+            let actual_value = actual.1.trimmed().to_string()
+            let name_matches = actual_name.equals(expected_name)
+            let value_matches = actual_value.equals(expected_value)
+            if name_matches and value_matches:
+              return true
+          None:
+            void
+        index = index + 1
+      false
+
+fn split_media_value(value: StringSlice) -> Array<String>
+  let slices = value.split(on: 59, keep_empty: false)
+  let ~parts = Array<String>::with_capacity(slices.len())
+  var index = 0
+  while index < slices.len():
+    parts.push(slices.at(index).to_string())
+    index = index + 1
+  parts
+
+fn media_specificity(range: StringSlice, candidate: StringSlice) -> i32
+  if range.to_string().equals(candidate.to_string()):
+    return 2
+  if range.to_string().equals("*/*"):
+    return 0
+  match(range.split_once(on: 47))
+    Some<(StringSlice, StringSlice)> { value }:
+      if value.1.to_string().equals("*"):
+        match(candidate.split_once(on: 47))
+          Some<(StringSlice, StringSlice)> { value: target }:
+            if value.0.to_string().equals(target.0.to_string()) then: 1 else: -1
+          None:
+            -1
+      else:
+        -1
+    None:
+      -1
+
+fn parse_quality(value: StringSlice) -> i32
+  let text = value.to_string()
+  if text.equals("1") or text.equals("1.0") or text.equals("1.00") or text.equals("1.000"):
+    return 1000
+  if text.equals("0"):
+    return 0
+  if not value.starts_with("0.".as_slice()):
+    return 0
+  var result = 0
+  var place = 100
+  var index = 2
+  while index < value.byte_len() and place > 0:
+    match(value.slice(bytes: index, len: 1).parse_i32())
+      Err:
+        return 0
+      Ok<i32> { value: digit }:
+        if digit < 0 or digit > 9:
+          return 0
+        result = result + digit * place
+    place = place / 10
+    index = index + 1
+  result

--- a/packages/web/src/openapi.test.voyd
+++ b/packages/web/src/openapi.test.voyd
@@ -1,0 +1,70 @@
+use src::openapi::{ document, info, operation }
+use src::phase3_openapi_types::{
+  DocumentedArticle,
+  DocumentedArticlePath,
+  DocumentedArticleQuery,
+  DocumentedCreateArticle,
+  DocumentedEvent,
+  DocumentedRecursivePair
+}
+use std::http::Method
+use std::json::stringify
+use std::error::panic
+use std::optional::types::all
+use std::result::types::all
+use std::string::type::{ String, StringSlice }
+use std::test::assertions::all
+
+test "OpenAPI reflects DTO fields and doc comments":
+  let base_operation = operation(
+    summary: "Create an article".as_slice().to_string(),
+    description: "Creates and returns one article.".as_slice().to_string(),
+    operation_id: "createArticle".as_slice().to_string(),
+    response_status: 201,
+    response_description: "Article created".as_slice().to_string()
+  )
+  let with_path = base_operation.with_path_params<DocumentedArticlePath>()
+  let with_query = with_path.with_query<DocumentedArticleQuery>()
+  let with_body = with_query.with_json_body<DocumentedCreateArticle>()
+  let create_operation = with_body.responds_json<DocumentedArticle>()
+  let events_base = operation(summary: "Watch events".as_slice().to_string())
+  let events_operation = events_base.responds_sse<DocumentedEvent>()
+  let spec_base = document(info(
+    title: "Article API".as_slice(),
+    version: "1.0.0".as_slice(),
+    description: "Example API".as_slice().to_string()
+  ))
+  let article_spec = spec_base.route(
+    "/articles/:id".as_slice(), method: Method::Post {}, operation: create_operation
+  )
+  let events_spec = article_spec.route(
+    "/events".as_slice(), method: Method::Get {}, operation: events_operation
+  )
+  let spec = events_spec.route(
+    "/recursive".as_slice(),
+    method: Method::Get {},
+    operation: operation().responds_json<DocumentedRecursivePair>()
+  )
+
+  match(stringify(spec.json()))
+    Err:
+      Test::fail()
+    Ok<String> { value }:
+      require_contains(value, "\"openapi\":\"3.1.0\"".as_slice(), "missing version")
+      require_contains(value, "\"/articles/{id}\"".as_slice(), "missing path")
+      require_contains(value, "\"operationId\":\"createArticle\"".as_slice(), "missing operation id")
+      require_contains(value, "Stable article identifier.".as_slice(), "missing path documentation")
+      require_contains(value, "Reader-visible article title.".as_slice(), "missing field documentation")
+      require_contains(value, "\"required\":[\"title\"]".as_slice(), "missing required field")
+      require_contains(value, "\"text/event-stream\"".as_slice(), "missing SSE content")
+      require_contains(value, "\"x-voyd-event-schema\"".as_slice(), "missing SSE event schema")
+      require_contains(value, "%23".as_slice(), "recursive component ref is not URI escaped")
+      require_contains(
+        value,
+        "DocumentedRecursivePair_".as_slice(),
+        "recursive component identity is not type based"
+      )
+
+fn require_contains(value: String, needle: StringSlice, message: String) -> void
+  if not value.contains(needle):
+    panic(message)

--- a/packages/web/src/openapi.voyd
+++ b/packages/web/src/openapi.voyd
@@ -1,0 +1,717 @@
+//! OpenAPI 3.1 documents generated from reified Voyd type shapes.
+
+use std::array::Array
+use std::dict::Dict
+use std::http::{ Method, Response, method_as_string }
+use std::json::{
+  JsonArray,
+  JsonBool,
+  JsonObject,
+  JsonString,
+  JsonValue
+}
+use std::meta::{
+  ArrayShape,
+  BoolShape,
+  F32Shape,
+  F64Shape,
+  I32Shape,
+  I64Shape,
+  RecordShape,
+  RefShape,
+  Shape,
+  ShapeNode,
+  StringShape,
+  UnionShape,
+  UnitShape,
+  shape_of
+}
+use std::number::cast::to_string
+use std::optional::types::all
+use std::result::types::all
+use std::string::type::{ String, StringSlice, Utf8Error, from_utf8 }
+use super::response::response_json
+
+/// Top-level API information.
+pub obj Info {
+  api title: String,
+  api version: String,
+  api description?: String
+}
+
+/// Documentation for one HTTP operation.
+pub obj Operation {
+  api summary?: String,
+  api description?: String,
+  api operation_id?: String,
+  api tags: Array<String>,
+  path_params?: Shape,
+  query_params?: Shape,
+  header_params?: Shape,
+  request_body?: Shape,
+  request_content_type: String,
+  response_body?: Shape,
+  response_content_type: String,
+  response_status: i32,
+  response_description: String
+}
+
+obj RouteDocument {
+  method: Method,
+  path: String,
+  operation: Operation
+}
+
+/// Immutable OpenAPI document builder.
+pub obj Document {
+  api info: Info,
+  routes: Array<RouteDocument>
+}
+
+impl Info
+  api fn init({ title: StringSlice, version: StringSlice, description?: String }) -> Info
+    Info {
+      title: title.to_string(),
+      version: version.to_string(),
+      description: description
+    }
+
+  api fn init({ title: String, version: String, description?: String }) -> Info
+    Info::init(title: title.as_slice(), version: version.as_slice(), description: description)
+
+impl Operation
+  /// Creates operation metadata. DTO field comments supply schema descriptions.
+  api fn init({
+    summary?: String,
+    description?: String,
+    operation_id?: String,
+    response_status?: i32,
+    response_description?: String
+  }) -> Operation
+    Operation {
+      summary: summary,
+      description: description,
+      operation_id: operation_id,
+      tags: Array<String>::init(),
+      path_params: None {},
+      query_params: None {},
+      header_params: None {},
+      request_body: None {},
+      request_content_type: "application/json".as_slice().to_string(),
+      response_body: None {},
+      response_content_type: "application/json".as_slice().to_string(),
+      response_status: response_status ?? 200,
+      response_description: response_description ?? "Successful response".as_slice().to_string()
+    }
+
+  /// Adds a grouping tag.
+  api fn tagged(self, tag: StringSlice) -> Operation
+    let ~tags = self.tags.copied(1)
+    tags.push(tag.to_string())
+    copy_operation(self, tags: tags)
+
+  /// Adds a grouping tag.
+  api fn tagged(self, tag: String) -> Operation
+    self.tagged(tag.as_slice())
+
+  /// Documents path parameters from a reified record type.
+  api fn with_path_params<T>(self) -> Operation
+    copy_operation(self, path_params: shape_of<T>())
+
+  /// Documents query parameters from a reified record type.
+  api fn with_query<T>(self) -> Operation
+    copy_operation(self, query_params: shape_of<T>())
+
+  /// Documents request headers from a reified record type.
+  api fn with_headers<T>(self) -> Operation
+    copy_operation(self, header_params: shape_of<T>())
+
+  /// Documents a JSON request body from a reified type.
+  api fn with_json_body<T>(self) -> Operation
+    copy_operation(
+      self,
+      request_body: shape_of<T>(),
+      request_content_type: "application/json".as_slice().to_string()
+    )
+
+  /// Documents a response body from a reified type.
+  api fn responds_json<T>(self) -> Operation
+    copy_operation(
+      self,
+      response_body: shape_of<T>(),
+      response_content_type: "application/json".as_slice().to_string()
+    )
+
+  /// Documents an SSE stream and its reified event payload type.
+  api fn responds_sse<T>(self) -> Operation
+    copy_operation(
+      self,
+      response_body: shape_of<T>(),
+      response_content_type: "text/event-stream".as_slice().to_string()
+    )
+
+impl Document
+  api fn init(info: Info) -> Document
+    Document { info: info, routes: Array<RouteDocument>::init() }
+
+  api fn route(self, path: StringSlice, { method: Method, operation: Operation }) -> Document
+    let ~routes = self.routes.copied(1)
+    routes.push(RouteDocument {
+      method: method,
+      path: openapi_path(path),
+      operation: operation
+    })
+    Document { info: self.info, routes: routes }
+
+  api fn route(self, path: String, { method: Method, operation: Operation }) -> Document
+    self.route(path.as_slice(), method: method, operation: operation)
+
+  /// Materializes this document as an OpenAPI 3.1 JSON value.
+  api fn json(self) -> JsonValue
+    document_json(self)
+
+  /// Returns this document as an HTTP JSON response.
+  api fn response(self) -> Response
+    response_json(self.json())
+
+pub fn info({ title: StringSlice, version: StringSlice, description?: String }) -> Info
+  Info::init(title: title, version: version, description: description)
+
+pub fn info({ title: String, version: String, description?: String }) -> Info
+  Info::init(title: title, version: version, description: description)
+
+pub fn document(info: Info) -> Document
+  Document::init(info)
+
+pub fn operation({
+  summary?: String,
+  description?: String,
+  operation_id?: String,
+  response_status?: i32,
+  response_description?: String
+}) -> Operation
+  Operation::init(
+    summary: summary,
+    description: description,
+    operation_id: operation_id,
+    response_status: response_status,
+    response_description: response_description
+  )
+
+fn copy_operation(
+  source: Operation,
+  {
+    tags?: Array<String>,
+    path_params?: Shape,
+    query_params?: Shape,
+    header_params?: Shape,
+    request_body?: Shape,
+    request_content_type?: String,
+    response_body?: Shape,
+    response_content_type?: String
+  }
+) -> Operation
+  Operation {
+    summary: source.summary,
+    description: source.description,
+    operation_id: source.operation_id,
+    tags: tags ?? source.tags,
+    path_params: shape_override(path_params, source.path_params),
+    query_params: shape_override(query_params, source.query_params),
+    header_params: shape_override(header_params, source.header_params),
+    request_body: shape_override(request_body, source.request_body),
+    request_content_type: request_content_type ?? source.request_content_type,
+    response_body: shape_override(response_body, source.response_body),
+    response_content_type: response_content_type ?? source.response_content_type,
+    response_status: source.response_status,
+    response_description: source.response_description
+  }
+
+fn shape_override(value: Option<Shape>, fallback: Option<Shape>) -> Option<Shape>
+  match(value)
+    Some<Shape> { value }:
+      Some<Shape> { value: value }
+    None:
+      fallback
+
+fn document_json(spec: Document) -> JsonValue
+  let ~root = Dict<String, JsonValue>::init()
+  root.set("openapi", json_string("3.1.0"))
+  root.set("info", info_json(spec.info))
+
+  let ~paths = Dict<String, JsonValue>::init()
+  let ~components = Dict<String, JsonValue>::init()
+  var index = 0
+  while index < spec.routes.len():
+    let route = spec.routes.at(index)
+    let ~existing = match(paths.get(route.path))
+      Some<JsonValue> { value }:
+        value.match(active)
+          JsonObject:
+            active.value
+          else:
+            Dict<String, JsonValue>::init()
+      None:
+        Dict<String, JsonValue>::init()
+    existing.set(
+      method_name(route.method),
+      operation_json(route.operation, prefix: "Operation".concat(to_string(index).as_slice()), components: components)
+    )
+    paths.set(route.path, JsonObject { value: existing })
+    index = index + 1
+  root.set("paths", JsonObject { value: paths })
+
+  if not components.is_empty():
+    let ~component_root = Dict<String, JsonValue>::init()
+    component_root.set("schemas", JsonObject { value: components })
+    root.set("components", JsonObject { value: component_root })
+  JsonObject { value: root }
+
+fn info_json(value: Info) -> JsonValue
+  let ~out = Dict<String, JsonValue>::init()
+  out.set("title", JsonString { value: value.title })
+  out.set("version", JsonString { value: value.version })
+  set_optional_string(out, "description", value.description)
+  JsonObject { value: out }
+
+fn operation_json(
+  operation: Operation,
+  { prefix: String, ~components: Dict<String, JsonValue> }
+) -> JsonValue
+  let ~out = Dict<String, JsonValue>::init()
+  set_optional_string(out, "summary", operation.summary)
+  set_optional_string(out, "description", operation.description)
+  set_optional_string(out, "operationId", operation.operation_id)
+  if not operation.tags.is_empty():
+    let ~tags = Array<JsonValue>::with_capacity(operation.tags.len())
+    var tag_index = 0
+    while tag_index < operation.tags.len():
+      tags.push(JsonString { value: operation.tags.at(tag_index) })
+      tag_index = tag_index + 1
+    out.set("tags", JsonArray { value: tags })
+
+  let ~parameters = Array<JsonValue>::init()
+  append_parameters(parameters, operation.path_params, location: "path".as_slice(), required: true, prefix: prefix.concat("Path".as_slice()), components: components)
+  append_parameters(parameters, operation.query_params, location: "query".as_slice(), required: false, prefix: prefix.concat("Query".as_slice()), components: components)
+  append_parameters(parameters, operation.header_params, location: "header".as_slice(), required: false, prefix: prefix.concat("Header".as_slice()), components: components)
+  if not parameters.is_empty():
+    out.set("parameters", JsonArray { value: parameters })
+
+  match(operation.request_body)
+    Some<Shape> { value }:
+      let ~body = Dict<String, JsonValue>::init()
+      body.set("required", JsonBool { value: true })
+      body.set(
+        "content",
+        content_json(
+          operation.request_content_type,
+          schema_for(value, prefix: prefix.concat("Request".as_slice()), components: components)
+        )
+      )
+      out.set("requestBody", JsonObject { value: body })
+    None:
+      void
+
+  let ~responses = Dict<String, JsonValue>::init()
+  let ~response = Dict<String, JsonValue>::init()
+  response.set("description", JsonString { value: operation.response_description })
+  match(operation.response_body)
+    Some<Shape> { value }:
+      let schema = schema_for(value, prefix: prefix.concat("Response".as_slice()), components: components)
+      if operation.response_content_type.equals("text/event-stream"):
+        let ~stream_schema = Dict<String, JsonValue>::init()
+        stream_schema.set("type", json_string("string"))
+        stream_schema.set("x-voyd-event-schema", schema)
+        response.set("content", content_json(operation.response_content_type, JsonObject { value: stream_schema }))
+      else:
+        response.set("content", content_json(operation.response_content_type, schema))
+    None:
+      void
+  responses.set(to_string(operation.response_status), JsonObject { value: response })
+  out.set("responses", JsonObject { value: responses })
+  JsonObject { value: out }
+
+fn append_parameters(
+  ~out: Array<JsonValue>,
+  shape: Option<Shape>,
+  {
+    location: StringSlice,
+    required: bool,
+    prefix: String,
+    ~components: Dict<String, JsonValue>
+  }
+) -> void
+  match(shape)
+    None:
+      void
+    Some<Shape> { value }:
+      let _ = schema_for(value, prefix: prefix, components: components)
+      let stable_prefix = schema_identity_prefix(value, fallback: prefix)
+      value.root.match(root)
+        RecordShape:
+          var index = 0
+          while index < root.fields.len():
+            let field = root.fields.at(index)
+            let ~parameter = Dict<String, JsonValue>::init()
+            parameter.set("name", JsonString { value: field.name })
+            parameter.set("in", json_string(location))
+            let parameter_required = required or not field.optional
+            parameter.set("required", JsonBool { value: parameter_required })
+            set_optional_string(parameter, "description", field.documentation)
+            parameter.set(
+              "schema",
+              schema_node(field.shape, prefix: stable_prefix, components: components)
+            )
+            out.push(JsonObject { value: parameter })
+            index = index + 1
+        else:
+          void
+
+fn schema_for(
+  shape: Shape,
+  { prefix: String, ~components: Dict<String, JsonValue> }
+) -> JsonValue
+  let stable_prefix = schema_identity_prefix(shape, fallback: prefix)
+  var index = 0
+  while index < shape.definitions.len():
+    let definition = shape.definitions.at(index)
+    components.set(
+      component_name(stable_prefix, definition.key.as_slice()),
+      schema_node(definition.shape, prefix: stable_prefix, components: components)
+    )
+    index = index + 1
+  schema_node(shape.root, prefix: stable_prefix, components: components)
+
+fn schema_node(
+  node: ShapeNode,
+  { prefix: String, ~components: Dict<String, JsonValue> }
+) -> JsonValue
+  node.match(active)
+    BoolShape:
+      typed_schema("boolean")
+    I32Shape:
+      formatted_schema("integer", "int32")
+    I64Shape:
+      formatted_schema("integer", "int64")
+    F32Shape:
+      formatted_schema("number", "float")
+    F64Shape:
+      formatted_schema("number", "double")
+    StringShape:
+      typed_schema("string")
+    UnitShape:
+      typed_schema("null")
+    RefShape:
+      let ~out = Dict<String, JsonValue>::init()
+      out.set("$ref", JsonString { value: component_reference(prefix, active.key.as_slice()) })
+      JsonObject { value: out }
+    ArrayShape:
+      let ~out = Dict<String, JsonValue>::init()
+      out.set("type", json_string("array"))
+      out.set("items", schema_node(active.element, prefix: prefix, components: components))
+      JsonObject { value: out }
+    RecordShape:
+      record_schema(active, prefix: prefix, components: components)
+    UnionShape:
+      union_schema(active, prefix: prefix, components: components)
+
+fn record_schema(
+  record: RecordShape,
+  { prefix: String, ~components: Dict<String, JsonValue> }
+) -> JsonValue
+  let ~out = Dict<String, JsonValue>::init()
+  out.set("type", json_string("object"))
+  set_optional_string(out, "description", record.documentation)
+  let ~properties = Dict<String, JsonValue>::init()
+  let ~required = Array<JsonValue>::init()
+  var index = 0
+  while index < record.fields.len():
+    let field = record.fields.at(index)
+    let property = schema_node(field.shape, prefix: prefix, components: components)
+    properties.set(field.name, with_description(property, field.documentation))
+    if not field.optional:
+      required.push(JsonString { value: field.name })
+    index = index + 1
+  out.set("properties", JsonObject { value: properties })
+  if not required.is_empty():
+    out.set("required", JsonArray { value: required })
+  out.set("additionalProperties", JsonBool { value: false })
+  JsonObject { value: out }
+
+fn union_schema(
+  union: UnionShape,
+  { prefix: String, ~components: Dict<String, JsonValue> }
+) -> JsonValue
+  let ~out = Dict<String, JsonValue>::init()
+  set_optional_string(out, "description", union.documentation)
+  let ~variants = Array<JsonValue>::with_capacity(union.variants.len())
+  var variant_index = 0
+  while variant_index < union.variants.len():
+    let variant = union.variants.at(variant_index)
+    let ~variant_schema = Dict<String, JsonValue>::init()
+    variant_schema.set("type", json_string("object"))
+    set_optional_string(variant_schema, "description", variant.documentation)
+    let ~properties = Dict<String, JsonValue>::init()
+    let ~tag = Dict<String, JsonValue>::init()
+    tag.set("const", JsonString { value: variant.name })
+    properties.set("$variant", JsonObject { value: tag })
+    let ~required = Array<JsonValue>::init()
+    required.push(json_string("$variant"))
+    var field_index = 0
+    while field_index < variant.fields.len():
+      let field = variant.fields.at(field_index)
+      let property = schema_node(
+        field.shape,
+        prefix: prefix,
+        components: components
+      )
+      properties.set(field.name, with_description(property, field.documentation))
+      if not field.optional:
+        required.push(JsonString { value: field.name })
+      field_index = field_index + 1
+    variant_schema.set("properties", JsonObject { value: properties })
+    variant_schema.set("required", JsonArray { value: required })
+    variant_schema.set("additionalProperties", JsonBool { value: false })
+    variants.push(JsonObject { value: variant_schema })
+    variant_index = variant_index + 1
+  out.set("oneOf", JsonArray { value: variants })
+  JsonObject { value: out }
+
+fn content_json(content_type: String, schema: JsonValue) -> JsonValue
+  let ~media = Dict<String, JsonValue>::init()
+  media.set("schema", schema)
+  let ~content = Dict<String, JsonValue>::init()
+  content.set(content_type, JsonObject { value: media })
+  JsonObject { value: content }
+
+fn typed_schema(kind: StringSlice) -> JsonValue
+  let ~out = Dict<String, JsonValue>::init()
+  out.set("type", json_string(kind))
+  JsonObject { value: out }
+
+fn typed_schema(kind: String) -> JsonValue
+  typed_schema(kind.as_slice())
+
+fn formatted_schema(kind: StringSlice, format: StringSlice) -> JsonValue
+  let ~out = Dict<String, JsonValue>::init()
+  out.set("type", json_string(kind))
+  out.set("format", json_string(format))
+  JsonObject { value: out }
+
+fn formatted_schema(kind: String, format: String) -> JsonValue
+  formatted_schema(kind.as_slice(), format.as_slice())
+
+fn with_description(value: JsonValue, description: Option<String>) -> JsonValue
+  match(description)
+    None:
+      value
+    Some<String> { value: documentation }:
+      value.match(active)
+        JsonObject:
+          let entries = active.value.entries()
+          let ~fields = Dict<String, JsonValue>::with_capacity(entries.len() + 1)
+          var index = 0
+          while index < entries.len():
+            let entry = entries.at(index)
+            fields.set(entry.0, entry.1)
+            index = index + 1
+          fields.set("description", JsonString { value: documentation })
+          JsonObject { value: fields }
+        else:
+          value
+
+fn set_optional_string(~target: Dict<String, JsonValue>, key: StringSlice, value: Option<String>) -> void
+  match(value)
+    Some<String> { value }:
+      target.set(key.to_string(), JsonString { value: value })
+    None:
+      void
+
+fn set_optional_string(~target: Dict<String, JsonValue>, key: String, value: Option<String>) -> void
+  set_optional_string(target, key.as_slice(), value)
+
+fn json_string(value: StringSlice) -> JsonValue
+  JsonString { value: value.to_string() }
+
+fn json_string(value: String) -> JsonValue
+  JsonString { value: value }
+
+fn component_name(prefix: String, key: StringSlice) -> String
+  prefix.concat("_".as_slice()).concat(key)
+
+fn schema_prefix(node: ShapeNode, { fallback: String }) -> String
+  node.match(active)
+    RecordShape:
+      active.name
+    UnionShape:
+      active.name
+    else:
+      fallback
+
+fn schema_identity_prefix(shape: Shape, { fallback: String }) -> String
+  schema_prefix(shape.root, fallback: fallback)
+    .concat("_".as_slice())
+    .concat(shape_fingerprint(shape).as_slice())
+
+fn shape_fingerprint(shape: Shape) -> String
+  var signature = signature_part(shape_node_signature(shape.root))
+  var index = 0
+  while index < shape.definitions.len():
+    let definition = shape.definitions.at(index)
+    signature = signature
+      .concat("definition".as_slice())
+      .concat(signature_part(definition.key).as_slice())
+      .concat(signature_part(shape_node_signature(definition.shape)).as_slice())
+    index = index + 1
+  signature_hash(signature)
+
+fn shape_node_signature(node: ShapeNode) -> String
+  node.match(active)
+    BoolShape:
+      "bool".as_slice().to_string()
+    I32Shape:
+      "i32".as_slice().to_string()
+    I64Shape:
+      "i64".as_slice().to_string()
+    F32Shape:
+      "f32".as_slice().to_string()
+    F64Shape:
+      "f64".as_slice().to_string()
+    StringShape:
+      "string".as_slice().to_string()
+    UnitShape:
+      "unit".as_slice().to_string()
+    RefShape:
+      "ref".as_slice().to_string().concat(signature_part(active.key).as_slice())
+    ArrayShape:
+      "array".as_slice().to_string()
+        .concat(signature_part(shape_node_signature(active.element)).as_slice())
+    RecordShape:
+      record_signature(active)
+    UnionShape:
+      union_signature(active)
+
+fn record_signature(record: RecordShape) -> String
+  var signature = "record".as_slice().to_string()
+    .concat(signature_part(record.name).as_slice())
+    .concat(signature_part(optional_signature(record.documentation)).as_slice())
+  var index = 0
+  while index < record.fields.len():
+    let field = record.fields.at(index)
+    signature = signature
+      .concat("field".as_slice())
+      .concat(signature_part(field.name).as_slice())
+      .concat(if field.optional: "optional".as_slice() else: "required".as_slice())
+      .concat(signature_part(optional_signature(field.documentation)).as_slice())
+      .concat(signature_part(shape_node_signature(field.shape)).as_slice())
+    index = index + 1
+  signature
+
+fn union_signature(union: UnionShape) -> String
+  var signature = "union".as_slice().to_string()
+    .concat(signature_part(union.name).as_slice())
+    .concat(signature_part(optional_signature(union.documentation)).as_slice())
+  var variant_index = 0
+  while variant_index < union.variants.len():
+    let variant = union.variants.at(variant_index)
+    signature = signature
+      .concat("variant".as_slice())
+      .concat(signature_part(variant.name).as_slice())
+      .concat(signature_part(optional_signature(variant.documentation)).as_slice())
+    var field_index = 0
+    while field_index < variant.fields.len():
+      let field = variant.fields.at(field_index)
+      signature = signature
+        .concat("field".as_slice())
+        .concat(signature_part(field.name).as_slice())
+        .concat(if field.optional: "optional".as_slice() else: "required".as_slice())
+        .concat(signature_part(optional_signature(field.documentation)).as_slice())
+        .concat(signature_part(shape_node_signature(field.shape)).as_slice())
+      field_index = field_index + 1
+    variant_index = variant_index + 1
+  signature
+
+fn optional_signature(value: Option<String>) -> String
+  match(value)
+    Some<String> { value }:
+      value
+    None:
+      String::init()
+
+fn signature_part(value: String) -> String
+  to_string(value.byte_len())
+    .concat(":".as_slice())
+    .concat(value.as_slice())
+
+fn signature_hash(value: String) -> String
+  let bytes = value.to_utf8()
+  var first = 17
+  var second = 29
+  var index = 0
+  while index < bytes.len():
+    let byte = bytes.at(index)
+    let first_mixed = first * 31 + byte
+    let second_mixed = second * 37 + byte
+    first = first_mixed - (first_mixed / 1000003) * 1000003
+    second = second_mixed - (second_mixed / 1000033) * 1000033
+    index = index + 1
+  to_string(bytes.len())
+    .concat("_".as_slice())
+    .concat(to_string(first).as_slice())
+    .concat("_".as_slice())
+    .concat(to_string(second).as_slice())
+
+fn component_reference(prefix: String, key: StringSlice) -> String
+  let component = component_name(prefix, key)
+  let pointer_segment = component
+    .replaced(old: "~".as_slice().to_string(), with: "~0".as_slice().to_string())
+    .replaced(old: "/".as_slice().to_string(), with: "~1".as_slice().to_string())
+  "#/components/schemas/".concat(uri_fragment(pointer_segment.as_slice()).as_slice())
+
+fn uri_fragment(value: StringSlice) -> String
+  let source = value.to_string().to_utf8()
+  let ~encoded = Array<i32>::with_capacity(source.len())
+  var index = 0
+  while index < source.len():
+    let byte = source.at(index)
+    if is_uri_unreserved(byte):
+      encoded.push(byte)
+    else:
+      encoded.push(37)
+      encoded.push(hex_digit(byte / 16))
+      encoded.push(hex_digit(byte - (byte / 16) * 16))
+    index = index + 1
+  match(from_utf8(encoded))
+    Ok<String> { value }:
+      value
+    Err<Utf8Error>:
+      String::init()
+
+fn is_uri_unreserved(byte: i32) -> bool
+  (byte >= 65 and byte <= 90) or
+    (byte >= 97 and byte <= 122) or
+    (byte >= 48 and byte <= 57) or
+    byte == 45 or byte == 46 or byte == 95 or byte == 126
+
+fn hex_digit(value: i32) -> i32
+  if value < 10:
+    return 48 + value
+  65 + value - 10
+
+fn method_name(method: Method) -> String
+  method_as_string(method).lowered()
+
+fn openapi_path(path: StringSlice) -> String
+  let segments = path.split(on: 47, keep_empty: true)
+  var out = String::init()
+  var index = 0
+  while index < segments.len():
+    if index > 0:
+      out = out.concat("/".as_slice())
+    let segment = segments.at(index)
+    if segment.byte_len() > 1 and segment.starts_with(":".as_slice()):
+      out = out.concat("{".as_slice()).concat(segment.slice(bytes: 1, len: segment.byte_len() - 1)).concat("}".as_slice())
+    else:
+      out = out.concat(segment)
+    index = index + 1
+  out

--- a/packages/web/src/openapi_expose.voyd
+++ b/packages/web/src/openapi_expose.voyd
@@ -1,0 +1,12 @@
+//! Serving generated OpenAPI documents through the router.
+
+use std::http::Response
+use std::string::type::{ String, StringSlice }
+use super::openapi::Document
+use super::router::App
+
+pub fn expose(app: App, spec: Document, { at path: StringSlice }) -> App
+  app.get(path, handler: () -> Response => spec.response())
+
+pub fn expose(app: App, spec: Document, { at path: String }) -> App
+  expose(app, spec, at: path.as_slice())

--- a/packages/web/src/openapi_routes.voyd
+++ b/packages/web/src/openapi_routes.voyd
@@ -1,0 +1,14 @@
+//! Router integration for OpenAPI documents.
+
+use std::optional::types::all
+use super::openapi::{ Document, Operation }
+use super::router::App
+
+/// Documents the most recently added real route using its router-owned method
+/// and path, preventing documentation for a nonexistent endpoint.
+pub fn document_route(app: App, spec: Document, operation: Operation) -> Document
+  match(app.last_route())
+    Some { value: route }:
+      spec.route(route.path, method: route.method, operation: operation)
+    None:
+      spec

--- a/packages/web/src/phase3.test.voyd
+++ b/packages/web/src/phase3.test.voyd
@@ -100,7 +100,7 @@ test "content negotiation honors quality and wildcard specificity":
   let ~supported = Array<String>::init()
   supported.push("application/json".as_slice().to_string())
   supported.push("text/html".as_slice().to_string())
-  match(best_match("text/*;q=0.5, application/json;q=0.9".as_slice(), supported))
+  match(best_match("text/*;q=0.5, application/json;q=0.9".as_slice().to_string(), supported))
     Some<String> { value }:
       assert(value, eq: "application/json")
     None:

--- a/packages/web/src/phase3.test.voyd
+++ b/packages/web/src/phase3.test.voyd
@@ -1,0 +1,181 @@
+use src::sse::{ Event as SseEvent, response as sse }
+use src::multipart::parse as parse_multipart
+use src::negotiate::best_match
+use std::array::Array
+use std::http::{ Body, Headers, IncomingRequest, Method, Response }
+use std::http::server::self as server
+use std::http::wire::self as wire
+use std::host_dto::HostDto
+use std::msgpack::MsgPack
+use std::msgpack::self as msgpack
+use std::optional::types::all
+use std::result::types::all
+use std::string::type::String
+use std::test::assertions::all
+
+obj StreamCapture {
+  body: String,
+  response?: Response
+}
+
+test "SSE formats fields and multiline data into streamed chunks":
+  let ~capture = StreamCapture { body: String::init(), response: None {} }
+  let response = capture_sse(capture)
+  assert(response.status.code(), eq: 200)
+  match(response.header("content-type".as_slice()))
+    Some<String> { value }:
+      assert(value, eq: "text/event-stream; charset=utf-8")
+    None:
+      Test::fail()
+
+  let expected_prefix = "event: update\nid: 42\nretry: 1500\ndata: first\ndata: second\ndata: third\n\n: alive\n\n".as_slice()
+  assert(capture.body.starts_with(expected_prefix), eq: true)
+  let expected_suffix = "data: ".as_slice().to_string()
+    .concat("x".as_slice().to_string().repeat(17000).as_slice())
+    .concat("\n\n".as_slice())
+  assert(capture.body.ends_with(expected_suffix.as_slice()), eq: true)
+
+test "multipart parses field metadata and binary-safe bodies":
+  let request = IncomingRequest {
+    method: Method::Post {},
+    path: "/upload".as_slice().to_string(),
+    query: None {},
+    headers: Headers::empty().append(
+      header: "content-type".as_slice(),
+      value: "multipart/form-data; boundary=voyd-boundary".as_slice()
+    ),
+    body: Body::text(
+      "--voyd-boundary\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\nHello\r\n--voyd-boundary \t\r\nContent-Disposition: form-data; name=\"asset\"; filename=\"quarter;final.csv\"\r\nContent-Type: text/plain\r\n\r\nfile\r\n--voyd-boundary--not-a-delimiter\r\n--voyd-boundaryX bytes\r\n--voyd-boundary--\t\r\n"
+    )
+  }
+  match(parse_multipart(request))
+    Err:
+      Test::fail()
+    Ok { value }:
+      assert(value.parts.len(), eq: 2)
+      match(value.get("title".as_slice()))
+        None:
+          Test::fail()
+        Some { value: title }:
+          match(title.text())
+            Ok<String> { value }:
+              assert(value, eq: "Hello")
+            Err:
+              Test::fail()
+      match(value.get("asset".as_slice()))
+        None:
+          Test::fail()
+        Some { value: asset }:
+          match(asset.filename)
+            Some<String> { value }:
+              assert(value, eq: "quarter;final.csv")
+            None:
+              Test::fail()
+          match(asset.text())
+            Ok<String> { value }:
+              assert(value, eq: "file\r\n--voyd-boundary--not-a-delimiter\r\n--voyd-boundaryX bytes")
+            Err:
+              Test::fail()
+
+test "multipart rejects closing boundaries with arbitrary suffixes":
+  let request = IncomingRequest {
+    method: Method::Post {},
+    path: "/upload".as_slice().to_string(),
+    query: None {},
+    headers: Headers::empty().append(
+      header: "content-type".as_slice(),
+      value: "multipart/form-data; boundary=voyd-boundary".as_slice()
+    ),
+    body: Body::text(
+      "--voyd-boundary\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\nHello\r\n--voyd-boundary--evil"
+    )
+  }
+  match(parse_multipart(request))
+    Ok:
+      Test::fail()
+    Err:
+      void
+
+test "content negotiation honors quality and wildcard specificity":
+  let ~supported = Array<String>::init()
+  supported.push("application/json".as_slice().to_string())
+  supported.push("text/html".as_slice().to_string())
+  match(best_match("text/*;q=0.5, application/json;q=0.9".as_slice(), supported))
+    Some<String> { value }:
+      assert(value, eq: "application/json")
+    None:
+      Test::fail()
+
+test "content negotiation lets an exact exclusion override a wildcard":
+  let ~supported = Array<String>::init()
+  supported.push("text/html".as_slice().to_string())
+  match(best_match("text/*;q=1, text/html;q=0".as_slice(), supported))
+    Some<String>:
+      Test::fail()
+    None:
+      void
+
+test "content negotiation matches parameterized representations by base media type":
+  let ~supported = Array<String>::init()
+  supported.push("text/event-stream; charset=utf-8".as_slice().to_string())
+  match(best_match("text/event-stream".as_slice(), supported))
+    Some<String> { value }:
+      assert(value, eq: "text/event-stream; charset=utf-8")
+    None:
+      Test::fail()
+
+  let ~parameterized = Array<String>::init()
+  parameterized.push("text/event-stream; charset=utf-8".as_slice().to_string())
+  match(best_match("text/event-stream; charset=iso-8859-1".as_slice(), parameterized))
+    Some<String>:
+      Test::fail()
+    None:
+      void
+
+  let ~case_sensitive = Array<String>::init()
+  case_sensitive.push("application/json; profile=Live".as_slice().to_string())
+  match(best_match("application/json; profile=live".as_slice(), case_sensitive))
+    Some<String>:
+      Test::fail()
+    None:
+      void
+
+fn capture_sse(~capture: StreamCapture) -> Response
+  try open
+    sse do(sender):
+      let event_data = SseEvent::data("first\rsecond\r\nthird".as_slice())
+      let event_type = event_data.with(event: "update\rinjected".as_slice())
+      let event_id = event_type.with(id: "42\rignored".as_slice())
+      let event_retry = event_id.with(retry_millis: 1500)
+      let _ = sender.send(event_retry)
+      let _ = sender.comment("alive\rinjected".as_slice())
+      let _ = sender.send(SseEvent::data("x".as_slice().to_string().repeat(17000)))
+  server::ResponseStream::begin_stream(resume, payload):
+    match(wire::decode_response(payload))
+      Ok<Response> { value }:
+        capture.response = Some<Response> { value: value }
+      Err:
+        void
+    resume(msgpack::make_null())
+  server::ResponseWriter::write_chunk(tail, payload):
+    match(wire::decode_body(payload))
+      Ok<Body> { value }:
+        match(value.as_text())
+          Ok<String> { value }:
+            capture.body = capture.body.concat(value.as_slice())
+          Err:
+            void
+      Err:
+        void
+    tail(test_host_ok())
+  server::ResponseStream::finish_stream(_resume, _payload):
+    match(capture.response)
+      Some<Response> { value }:
+        value
+      None:
+        Response::ok()
+
+fn test_host_ok() -> MsgPack
+  HostDto::init()
+    .set("ok", msgpack::make_bool(true))
+    .pack()

--- a/packages/web/src/phase3_openapi_types.voyd
+++ b/packages/web/src/phase3_openapi_types.voyd
@@ -1,0 +1,46 @@
+//! Documented fixture DTOs used to verify OpenAPI reification.
+
+use std::string::type::String
+
+pub obj DocumentedRecursiveNode<T> {
+  api value: T,
+  api next?: DocumentedRecursiveNode<T>
+}
+
+pub obj DocumentedRecursivePair {
+  api numbers: DocumentedRecursiveNode<i32>,
+  api names: DocumentedRecursiveNode<String>
+}
+
+/// Path parameters for an article.
+pub obj DocumentedArticlePath {
+  /// Stable article identifier.
+  api id: i32
+}
+
+/// Filters accepted by article search.
+pub obj DocumentedArticleQuery {
+  /// Include unpublished articles when true.
+  api drafts?: bool
+}
+
+/// A request to create an article.
+pub obj DocumentedCreateArticle {
+  /// Reader-visible article title.
+  api title: String,
+  /// Optional article summary.
+  api summary?: String
+}
+
+/// Article returned by the API.
+pub obj DocumentedArticle {
+  /// Stable article identifier.
+  api id: i32,
+  /// Reader-visible article title.
+  api title: String
+}
+
+pub obj DocumentedEvent {
+  /// Monotonic event sequence.
+  api sequence: i64
+}

--- a/packages/web/src/pkg.voyd
+++ b/packages/web/src/pkg.voyd
@@ -4,10 +4,18 @@ pub src::all
 pub src::extract
 pub src::html
 pub src::middleware
+pub src::multipart
+pub src::negotiate
+pub src::openapi
+pub src::openapi_expose
+pub src::openapi_routes
 pub src::response
+pub src::request_streaming
 pub src::router
 pub src::routes
 pub src::static_files
+pub src::streaming
+pub src::sse
 
 pub use src::extract::{
   AuthExtractor,
@@ -48,6 +56,8 @@ pub use src::extract::{
   text,
   text_body
 }
+pub use src::openapi_expose::expose as expose_openapi
+pub use src::openapi_routes::document_route as document_openapi_route
 pub use src::html::{
   Hydration,
   append_hydration,
@@ -62,6 +72,17 @@ pub use src::html::{
 }
 
 pub use src::middleware::request_id_required
+pub use src::multipart::{ Form as MultipartForm, MultipartBody, Part as MultipartPart, multipart as multipart_body }
+pub use src::negotiate::{ accepts, best_match, negotiate as negotiate_content }
+pub use src::openapi::{
+  Document as OpenApi,
+  Info as OpenApiInfo,
+  Operation as OpenApiOperation,
+  document as openapi_document,
+  info as openapi_info,
+  operation as openapi_operation
+}
+pub use src::request_streaming::serve as serve_streaming
 pub use src::response::{
   Body,
   Header,
@@ -176,3 +197,5 @@ pub use src::routes::{
   timeout_millis
 }
 pub use src::static_files::serve_dir
+pub use src::streaming::{ stream, write as write_stream }
+pub use src::sse::{ Event as SseEvent, Sender as SseSender, response as sse_response, make_sse_event }

--- a/packages/web/src/request_streaming.voyd
+++ b/packages/web/src/request_streaming.voyd
@@ -1,0 +1,39 @@
+//! Web server entrypoint for lazy request bodies.
+
+use std::error::HostError
+use std::http::{ IncomingRequest, Response }
+use std::http::server::self as server
+use std::optional::types::all
+use std::result::types::all
+use std::string::type::String
+use std::task::self as task
+use super::router::App
+
+/// Serves a Web app with request-body streaming enabled.
+///
+/// Routes marked `.streaming()` can access the one-shot reader with
+/// `ctx.streaming_body()`. Other routes are buffered lazily so ordinary body
+/// extractors can coexist in the same app.
+pub fn serve(
+  app: App,
+  {
+    port: i32,
+    host?: String,
+    shutdown_timeout?: i32,
+    max_body_bytes?: i32,
+    max_pending_requests?: i32
+  }
+): (server::HttpServer, task::TaskRuntime, open) -> Result<Unit, HostError>
+  server::serve_each_streaming(
+    config: server::ServerConfig::init(
+      port: port,
+      host: host,
+      max_body_bytes: max_body_bytes,
+      max_pending_requests: max_pending_requests,
+      response_timeout_millis: shutdown_timeout,
+      stream_request_bodies: true
+    ),
+    policy: server::ServeTaskPolicy::detached(),
+    handle: (request: IncomingRequest, body: server::RequestBody) -> Response =>
+      app.handle_streaming(request, body)
+  )

--- a/packages/web/src/router.voyd
+++ b/packages/web/src/router.voyd
@@ -4,8 +4,9 @@ use std::array::Array
 use std::bytes::Bytes
 use std::error::HostError
 use std::http::self as http
-use std::http::{ IncomingRequest, Method, Response }
+use std::http::{ Body, IncomingRequest, Method, Response }
 use std::http::server::self as server
+use std::http::server::RequestBody
 use std::json::JsonValue
 use std::optional::types::all
 use std::result::types::all
@@ -69,6 +70,7 @@ pub obj MatchedRoute {
 pub obj Context {
   api request: IncomingRequest,
   api route: MatchedRoute,
+  request_body_stream?: RequestBody,
   error_handler: ErrorHandler
 }
 
@@ -88,7 +90,14 @@ pub obj Route {
   middleware: Array<Middleware>,
   handler: Handler,
   error_handler: ErrorHandler,
+  streaming_request: bool,
   order: i32
+}
+
+/// Method and path of one concrete router entry.
+pub obj RouteIdentity {
+  api method: Method,
+  api path: String
 }
 
 obj RouteMatch {
@@ -157,6 +166,13 @@ impl Context
 
   api fn body_bytes(self) -> Bytes
     self.request.body_bytes()
+
+  /// Returns the lazy request body when the Web server enabled streaming.
+  ///
+  /// Buffered Web servers return `None`. The reader can be consumed once with
+  /// `next()` and requires the `HttpServer` effect.
+  api fn streaming_body(self) -> Option<RequestBody>
+    self.request_body_stream
 
   api fn text(self) -> Result<String, http::HttpError>
     self.request.text()
@@ -858,20 +874,61 @@ impl App
   api fn on_rejection(self, handler: ErrorHandler) -> App
     self.on_error(handler)
 
+  /// Marks the most recently added route as request-streaming.
+  api fn streaming(self) -> App
+    self.mark_last_streaming()
+
+  /// Returns the most recently added concrete route.
+  api fn last_route(self) -> Option<RouteIdentity>
+    if self.routes.is_empty():
+      return None {}
+    let route = self.routes.at(self.routes.len() - 1)
+    Some<RouteIdentity> { value: RouteIdentity { method: route.method, path: route.path } }
+
   api fn handle(self, request: IncomingRequest): (open) -> Response
+    self.handle_request(request, body: None {})
+
+  /// Routes a request whose body is supplied as a lazy stream.
+  api fn handle_streaming(
+    self,
+    request: IncomingRequest,
+    body: RequestBody
+  ): (open) -> Response
+    self.handle_request(request, body: Some<RequestBody> { value: body })
+
+  fn handle_request(
+    self,
+    request: IncomingRequest,
+    { body: Option<RequestBody> }
+  ): (open) -> Response
     let path = normalized_request_path(request.path, self.trailing_slash_policy)
     match(best_match(self.routes, request.method, path.as_slice(), self.trailing_slash_policy))
       Some<RouteMatch> { value }:
-        let ctx = Context {
-          request: request,
-          route: MatchedRoute { path: value.route.path, params: value.params },
-          error_handler: value.route.error_handler
-        }
-        run_middleware(value.route.middleware, 0, ctx, value.route.handler)
+        if value.route.streaming_request:
+          let ctx = Context {
+            request: request,
+            route: MatchedRoute { path: value.route.path, params: value.params },
+            request_body_stream: body,
+            error_handler: value.route.error_handler
+          }
+          run_middleware(value.route.middleware, 0, ctx, value.route.handler)
+        else:
+          match(buffer_streaming_request(request, body))
+            Err<HostError> { error }:
+              streaming_body_read_error(error)
+            Ok<IncomingRequest> { value: buffered_request }:
+              let ctx = Context {
+                request: buffered_request,
+                route: MatchedRoute { path: value.route.path, params: value.params },
+                request_body_stream: None {},
+                error_handler: value.route.error_handler
+              }
+              run_middleware(value.route.middleware, 0, ctx, value.route.handler)
       None:
         let ctx = Context {
           request: request,
           route: MatchedRoute { path: path, params: RouteParams::empty() },
+          request_body_stream: body,
           error_handler: self.error_handler
         }
         if path_matches_different_method(self.routes, path.as_slice(), self.trailing_slash_policy):
@@ -1073,6 +1130,7 @@ impl App
       middleware: self.current_middleware.copied(),
       handler: handler,
       error_handler: self.error_handler,
+      streaming_request: false,
       order: self.next_order
     }
     let ~routes = self.routes.copied(1)
@@ -1118,6 +1176,7 @@ impl App
       middleware: combine_middleware(self.current_middleware, route.middleware),
       handler: route.handler,
       error_handler: route.error_handler,
+      streaming_request: route.streaming_request,
       order: self.next_order
     }
     let ~routes = self.routes.copied(1)
@@ -1127,6 +1186,34 @@ impl App
       current_middleware: self.current_middleware,
       prefix: self.prefix,
       next_order: self.next_order + 1,
+      not_found_handler: self.not_found_handler,
+      method_not_allowed_handler: self.method_not_allowed_handler,
+      error_handler: self.error_handler,
+    trailing_slash_policy: self.trailing_slash_policy
+    }
+
+  fn mark_last_streaming(self) -> App
+    if self.routes.is_empty():
+      return self
+    let ~routes = self.routes.copied()
+    let index = routes.len() - 1
+    let route = routes.at(index)
+    let next = Route {
+      method: route.method,
+      path: route.path,
+      segments: route.segments,
+      middleware: route.middleware,
+      handler: route.handler,
+      error_handler: route.error_handler,
+      streaming_request: true,
+      order: route.order
+    }
+    let _ = routes.replace(index, with: next)
+    App {
+      routes: routes,
+      current_middleware: self.current_middleware,
+      prefix: self.prefix,
+      next_order: self.next_order,
       not_found_handler: self.not_found_handler,
       method_not_allowed_handler: self.method_not_allowed_handler,
       error_handler: self.error_handler,
@@ -1502,8 +1589,21 @@ impl Router
   api fn on_rejection(self, handler: ErrorHandler) -> Router
     Router { app: self.app.on_rejection(handler) }
 
+  api fn streaming(self) -> Router
+    Router { app: self.app.streaming() }
+
+  api fn last_route(self) -> Option<RouteIdentity>
+    self.app.last_route()
+
   api fn handle(self, request: IncomingRequest): (open) -> Response
     self.app.handle(request)
+
+  api fn handle_streaming(
+    self,
+    request: IncomingRequest,
+    body: RequestBody
+  ): (open) -> Response
+    self.app.handle_streaming(request, body)
 
 pub fn app() -> App
   App::init()
@@ -1553,7 +1653,13 @@ pub fn serve_build({
 
 pub fn serve(
   app: App,
-  { port: i32, host?: String, shutdown_timeout?: i32, max_body_bytes?: i32, max_pending_requests?: i32 }
+  {
+    port: i32,
+    host?: String,
+    shutdown_timeout?: i32,
+    max_body_bytes?: i32,
+    max_pending_requests?: i32
+  }
 ): (server::HttpServer, task::TaskRuntime, open) -> Result<Unit, HostError>
   serve_app(
     app,
@@ -1566,16 +1672,23 @@ pub fn serve(
 
 pub fn serve_app(
   app: App,
-  { port: i32, host?: String, shutdown_timeout?: i32, max_body_bytes?: i32, max_pending_requests?: i32 }
+  {
+    port: i32,
+    host?: String,
+    shutdown_timeout?: i32,
+    max_body_bytes?: i32,
+    max_pending_requests?: i32
+  }
 ): (server::HttpServer, task::TaskRuntime, open) -> Result<Unit, HostError>
+  let config = server::ServerConfig::init(
+    port: port,
+    host: host,
+    max_body_bytes: max_body_bytes,
+    max_pending_requests: max_pending_requests,
+    response_timeout_millis: shutdown_timeout
+  )
   server::serve_each(
-    config: server::ServerConfig::init(
-      port: port,
-      host: host,
-      max_body_bytes: max_body_bytes,
-      max_pending_requests: max_pending_requests,
-      response_timeout_millis: shutdown_timeout
-    ),
+    config: config,
     policy: server::ServeTaskPolicy::detached(),
     handle: (request: IncomingRequest) -> Response => app.handle(request)
   )
@@ -1766,8 +1879,41 @@ pub fn make_route(path: StringSlice, method: Method, handler: Handler): () -> Ro
     middleware: Array<Middleware>::init(),
     handler: handler,
     error_handler: (rejection: Rejection, ctx: Context) -> Response => default_rejection(rejection, ctx),
+    streaming_request: false,
     order: 0
   }
+
+fn buffer_streaming_request(
+  request: IncomingRequest,
+  body: Option<RequestBody>
+): server::HttpServer -> Result<IncomingRequest, HostError>
+  match(body)
+    None:
+      Ok<IncomingRequest> { value: request }
+    Some<RequestBody> { value }:
+      let ~reader = value
+      match(reader.read_all())
+        Err<HostError> { error }:
+          Err<HostError> { error: error }
+        Ok<Bytes> { value: bytes }:
+          Ok<IncomingRequest> {
+            value: IncomingRequest {
+              method: request.method,
+              path: request.path,
+              query: request.query,
+              headers: request.headers,
+              body: Body::bytes(bytes)
+            }
+          }
+
+fn streaming_body_read_error(error: HostError) -> Response
+  if error.code == 3:
+    match(http::Status::from(413))
+      Ok<http::Status> { value }:
+        return Response::new(status: value).text(error.message)
+      Err:
+        void
+  Response::internal_server_error().text(error.message)
 
 fn run_middleware(middleware: Array<Middleware>, index: i32, ctx: Context, handler: Handler): (open) -> Response
   if index >= middleware.len():

--- a/packages/web/src/sse.voyd
+++ b/packages/web/src/sse.voyd
@@ -1,0 +1,173 @@
+//! Server-Sent Events over Web response streaming.
+
+use std::array::Array
+use std::error::HostError
+use std::http::{ Body, Headers, Response }
+use std::http::server::self as server
+use std::number::cast::to_string
+use std::optional::types::all
+use std::result::types::all
+use std::string::type::{ String, StringSlice }
+use super::streaming
+
+/// One event in an SSE stream.
+pub obj Event {
+  api data: String,
+  api event?: String,
+  api id?: String,
+  api retry_millis?: i32
+}
+
+/// Sender scoped to one open SSE response.
+pub obj Sender {}
+
+impl Event
+  /// Creates a data-only event.
+  api fn data(value: StringSlice) -> Event
+    Event {
+      data: value.to_string(),
+      event: None {},
+      id: None {},
+      retry_millis: None {}
+    }
+
+  /// Creates a data-only event.
+  api fn data(value: String) -> Event
+    Event::data(value.as_slice())
+
+  /// Returns a copy with an event type.
+  api fn with(self, { event: StringSlice }) -> Event
+    Event {
+      data: self.data,
+      event: Some<String> { value: event.to_string() },
+      id: self.id,
+      retry_millis: self.retry_millis
+    }
+
+  /// Returns a copy with an event type.
+  api fn with(self, { event: String }) -> Event
+    self.with(event: event.as_slice())
+
+  /// Returns a copy with an event id.
+  api fn with(self, { id: StringSlice }) -> Event
+    Event {
+      data: self.data,
+      event: self.event,
+      id: Some<String> { value: id.to_string() },
+      retry_millis: self.retry_millis
+    }
+
+  /// Returns a copy with an event id.
+  api fn with(self, { id: String }) -> Event
+    self.with(id: id.as_slice())
+
+  /// Returns a copy with a browser reconnection delay.
+  api fn with(self, { retry_millis: i32 }) -> Event
+    Event {
+      data: self.data,
+      event: self.event,
+      id: self.id,
+      retry_millis: Some<i32> { value: retry_millis }
+    }
+
+impl Sender
+  /// Sends one event and waits for host backpressure.
+  api fn send(self, event: Event): server::ResponseWriter -> Result<Unit, HostError>
+    write_encoded(encode_event(event))
+
+  /// Sends an SSE comment, useful as a connection keepalive.
+  api fn comment(self, value: StringSlice): server::ResponseWriter -> Result<Unit, HostError>
+    write_encoded(": ".concat(sanitize_field(value)).concat("\n\n".as_slice()))
+
+  /// Sends an SSE comment, useful as a connection keepalive.
+  api fn comment(self, value: String): server::ResponseWriter -> Result<Unit, HostError>
+    self.comment(value.as_slice())
+
+/// Creates a data-only SSE event.
+pub fn event(data: StringSlice) -> Event
+  Event::data(data)
+
+/// Creates a data-only SSE event.
+pub fn event(data: String) -> Event
+  Event::data(data)
+
+/// Creates a data-only SSE event.
+pub fn make_sse_event(data: StringSlice) -> Event
+  event(data)
+
+/// Creates a data-only SSE event.
+pub fn make_sse_event(data: String) -> Event
+  event(data)
+
+/// Creates an SSE response. The stream closes when `body` returns.
+pub fn response(
+  body: fn(Sender) : (server::ResponseWriter, open) -> void
+): (server::ResponseStream, open) -> Response
+  var headers = Headers::empty()
+  headers = headers.set(header: "content-type".as_slice(), value: "text/event-stream; charset=utf-8".as_slice())
+  headers = headers.set(header: "cache-control".as_slice(), value: "no-cache".as_slice())
+  headers = headers.set(header: "connection".as_slice(), value: "keep-alive".as_slice())
+  headers = headers.set(header: "x-accel-buffering".as_slice(), value: "no".as_slice())
+  streaming::stream(
+    Response::ok().with(headers: headers),
+    body: () => body(Sender {})
+  )
+
+fn encode_event(event: Event) -> String
+  var encoded = String::init()
+  match(event.event)
+    Some<String> { value }:
+      encoded = encoded.concat("event: ".as_slice()).concat(sanitize_field(value.as_slice())).concat("\n".as_slice())
+    None:
+      void
+  match(event.id)
+    Some<String> { value }:
+      encoded = encoded.concat("id: ".as_slice()).concat(sanitize_field(value.as_slice())).concat("\n".as_slice())
+    None:
+      void
+  match(event.retry_millis)
+    Some<i32> { value }:
+      if value >= 0:
+        encoded = encoded.concat("retry: ".as_slice()).concat(to_string(value).as_slice()).concat("\n".as_slice())
+    None:
+      void
+
+  let lines = sse_lines(event.data.as_slice())
+  var index = 0
+  while index < lines.len():
+    let line = lines.at(index)
+    encoded = encoded.concat("data: ".as_slice()).concat(line.as_slice()).concat("\n".as_slice())
+    index = index + 1
+  encoded.concat("\n".as_slice())
+
+fn write_encoded(value: String): server::ResponseWriter -> Result<Unit, HostError>
+  let bytes = Body::text(value).as_bytes()
+  var start = 0
+  while start < bytes.len():
+    let remaining = bytes.len() - start
+    let length = if remaining > 16384 then: 16384 else: remaining
+    match(streaming::write(bytes.slice(start..start + length)))
+      Err<HostError> { error }:
+        return Err<HostError> { error: error }
+      Ok<Unit>:
+        void
+    start = start + length
+  Ok<Unit> { value: Unit {} }
+
+fn sanitize_field(value: StringSlice) -> String
+  let lines = sse_lines(value)
+  if lines.is_empty():
+    return String::init()
+  lines.at(0)
+
+fn sse_lines(value: StringSlice) -> Array<String>
+  let normalized = value.to_string()
+    .replaced(old: "\r\n".as_slice().to_string(), with: "\n".as_slice().to_string())
+    .replaced(old: "\r".as_slice().to_string(), with: "\n".as_slice().to_string())
+  let source = normalized.as_slice().split(on: 10, keep_empty: true)
+  let ~lines = Array<String>::with_capacity(source.len())
+  var index = 0
+  while index < source.len():
+    lines.push(source.at(index).to_string())
+    index = index + 1
+  lines

--- a/packages/web/src/streaming.voyd
+++ b/packages/web/src/streaming.voyd
@@ -1,0 +1,31 @@
+//! General streaming-response helpers.
+
+use std::bytes::Bytes
+use std::error::HostError
+use std::http::{ Body, Response }
+use std::http::server::self as server
+use std::result::types::Result
+use std::string::type::{ String, StringSlice }
+
+/// Opens a response and runs `body` while its body stream remains writable.
+///
+/// Each `write` waits for host backpressure. The server closes the stream when
+/// the callback returns. A producer should stop when a write reports that the
+/// client disconnected.
+pub fn stream(
+  response: Response,
+  { body: fn() : (server::ResponseWriter, open) -> void }
+): (server::ResponseStream, open) -> Response
+  server::stream(response.with(body: Body::empty()), body: body)
+
+/// Writes one byte chunk to the current response stream.
+pub fn write(chunk: Bytes): server::ResponseWriter -> Result<Unit, HostError>
+  server::write(chunk)
+
+/// Writes one UTF-8 chunk to the current response stream.
+pub fn write(chunk: StringSlice): server::ResponseWriter -> Result<Unit, HostError>
+  server::write(Body::text(chunk).as_bytes())
+
+/// Writes one UTF-8 chunk to the current response stream.
+pub fn write(chunk: String): server::ResponseWriter -> Result<Unit, HostError>
+  write(chunk.as_slice())

--- a/scripts/testing/timing-budgets.json
+++ b/scripts/testing/timing-budgets.json
@@ -9,6 +9,6 @@
   },
   "integration": {
     "maxWallMs": 300000,
-    "maxFileMs": 180000
+    "maxFileMs": 210000
   }
 }

--- a/tests/integration/fixtures/std-http.voyd
+++ b/tests/integration/fixtures/std-http.voyd
@@ -1,6 +1,6 @@
 use std::env::self as env
 use std::error::HostError
-use std::http::{ IncomingRequest, Response, method_as_string }
+use std::http::{ Body, IncomingRequest, Response, method_as_string }
 use std::http::client::self as client
 use std::http::client::{ ClientRequest, HttpClient }
 use std::http::server::self as server
@@ -98,6 +98,35 @@ pub fn serve_detached_static_from_env(): (HttpServer, task::TaskRuntime, env::En
       0
     Err<HostError> { error }:
       -error.code
+
+pub fn serve_streaming_head_from_env(): (HttpServer, task::TaskRuntime, env::Env) -> i32
+  let port = smoke_port()
+  if port <= 0:
+    return -10
+
+  let result = server::serve_each(
+    config: ServerConfig::init(
+      port: port,
+      host: "127.0.0.1".as_slice().to_string(),
+      response_timeout_millis: 2000
+    ),
+    policy: ServeTaskPolicy::sequential(),
+    handle: stream_head_response
+  )
+  match(result)
+    Ok<Unit>:
+      0
+    Err<HostError> { error }:
+      -error.code
+
+fn stream_head_response(_request: IncomingRequest): (server::ResponseStream, open) -> Response
+  server::stream(
+    Response::ok().text("x".as_slice().to_string().repeat(150000)),
+    body: write_streaming_body
+  )
+
+fn write_streaming_body(): server::ResponseWriter -> void
+  let _ = server::write(Body::text("streamed".as_slice()).as_bytes())
 
 fn handle_detached_request(request: IncomingRequest): Time -> Response
   if request.path.equals("/slow".as_slice().to_string()):

--- a/tests/integration/fixtures/std-http.voyd
+++ b/tests/integration/fixtures/std-http.voyd
@@ -12,6 +12,10 @@ use std::task::self as task
 use std::time::self as time
 use std::time::{ Duration, Time }
 
+obj StreamProbe {
+  complete: bool
+}
+
 fn status_or_error(result: Result<Response, HostError>): () -> i32
   match(result)
     Ok<Response> { value }:
@@ -104,6 +108,7 @@ pub fn serve_streaming_head_from_env(): (HttpServer, task::TaskRuntime, env::Env
   if port <= 0:
     return -10
 
+  let ~probe = StreamProbe { complete: false }
   let result = server::serve_each(
     config: ServerConfig::init(
       port: port,
@@ -111,7 +116,7 @@ pub fn serve_streaming_head_from_env(): (HttpServer, task::TaskRuntime, env::Env
       response_timeout_millis: 2000
     ),
     policy: ServeTaskPolicy::sequential(),
-    handle: stream_head_response
+    handle: (request: IncomingRequest) -> Response => stream_head_response(request, probe)
   )
   match(result)
     Ok<Unit>:
@@ -119,11 +124,16 @@ pub fn serve_streaming_head_from_env(): (HttpServer, task::TaskRuntime, env::Env
     Err<HostError> { error }:
       -error.code
 
-fn stream_head_response(_request: IncomingRequest): (server::ResponseStream, open) -> Response
-  server::stream(
+fn stream_head_response(request: IncomingRequest, ~probe: StreamProbe): (server::ResponseStream, open) -> Response
+  if request.path.equals("/status".as_slice().to_string()):
+    let status = if probe.complete then: "complete".as_slice() else: "pending".as_slice()
+    return Response::ok().text(status)
+  let response = server::stream(
     Response::ok().text("x".as_slice().to_string().repeat(150000)),
     body: write_streaming_body
   )
+  probe.complete = true
+  response
 
 fn write_streaming_body(): server::ResponseWriter -> void
   let _ = server::write(Body::text("streamed".as_slice()).as_bytes())

--- a/tests/integration/fixtures/web-framework.voyd
+++ b/tests/integration/fixtures/web-framework.voyd
@@ -366,18 +366,10 @@ pub fn serve_ssr_callback_scope_probe(): (HttpServer, tasks::TaskRuntime) -> i32
       -1
 
 pub fn serve_sse_probe(): (HttpServer, tasks::TaskRuntime) -> i32
-  let events = app()
-    .get(
-      "/events".as_slice(),
-      handler: () -> Response => sse_response(write_sse_probe)
-    )
-    .get(
-      "/stream-head".as_slice(),
-      handler: () -> Response => server::stream(
-        Response::ok().text("x".as_slice().to_string().repeat(150000)),
-        body: write_streaming_head_probe
-      )
-    )
+  let events = app().get(
+    "/events".as_slice(),
+    handler: () -> Response => sse_response(write_sse_probe)
+  )
   let result = server::serve_each(
     config: ServerConfig::init(port: 41235),
     policy: ServeTaskPolicy::detached(),
@@ -388,9 +380,6 @@ pub fn serve_sse_probe(): (HttpServer, tasks::TaskRuntime) -> i32
       0
     Err:
       -1
-
-fn write_streaming_head_probe(): server::ResponseWriter -> void
-  let _ = server::write(Body::text("streamed".as_slice()).as_bytes())
 
 fn write_sse_probe(sender: SseSender): server::ResponseWriter -> void
   let event_value = SseEvent {

--- a/tests/integration/fixtures/web-framework.voyd
+++ b/tests/integration/fixtures/web-framework.voyd
@@ -366,29 +366,22 @@ pub fn serve_ssr_callback_scope_probe(): (HttpServer, tasks::TaskRuntime) -> i32
       -1
 
 pub fn serve_sse_probe(): (HttpServer, tasks::TaskRuntime) -> i32
-  let events = app().get(
-    "/events".as_slice(),
-    handler: () -> Response => sse_response(write_sse_probe)
-  )
+  let events = app()
+    .get(
+      "/events".as_slice(),
+      handler: () -> Response => sse_response(write_sse_probe)
+    )
+    .get(
+      "/stream-head".as_slice(),
+      handler: () -> Response => server::stream(
+        Response::ok().text("x".as_slice().to_string().repeat(150000)),
+        body: write_streaming_head_probe
+      )
+    )
   let result = server::serve_each(
     config: ServerConfig::init(port: 41235),
     policy: ServeTaskPolicy::detached(),
     handle: (request: IncomingRequest) -> Response => events.handle(request)
-  )
-  match(result)
-    Ok<Unit>:
-      0
-    Err:
-      -1
-
-pub fn serve_streaming_head_probe(): (HttpServer, tasks::TaskRuntime) -> i32
-  let result = server::serve_each(
-    config: ServerConfig::init(port: 41236),
-    policy: ServeTaskPolicy::detached(),
-    handle: (_request: IncomingRequest) -> Response => server::stream(
-      Response::ok().text("x".as_slice().to_string().repeat(150000)),
-      body: write_streaming_head_probe
-    )
   )
   match(result)
     Ok<Unit>:

--- a/tests/integration/fixtures/web-framework.voyd
+++ b/tests/integration/fixtures/web-framework.voyd
@@ -381,6 +381,24 @@ pub fn serve_sse_probe(): (HttpServer, tasks::TaskRuntime) -> i32
     Err:
       -1
 
+pub fn serve_streaming_head_probe(): (HttpServer, tasks::TaskRuntime) -> i32
+  let result = server::serve_each(
+    config: ServerConfig::init(port: 41236),
+    policy: ServeTaskPolicy::detached(),
+    handle: (_request: IncomingRequest) -> Response => server::stream(
+      Response::ok().text("x".as_slice().to_string().repeat(150000)),
+      body: write_streaming_head_probe
+    )
+  )
+  match(result)
+    Ok<Unit>:
+      0
+    Err:
+      -1
+
+fn write_streaming_head_probe(): server::ResponseWriter -> void
+  let _ = server::write(Body::text("streamed".as_slice()).as_bytes())
+
 fn write_sse_probe(sender: SseSender): server::ResponseWriter -> void
   let event_value = SseEvent {
     data: "ready".as_slice().to_string(),

--- a/tests/integration/fixtures/web-framework.voyd
+++ b/tests/integration/fixtures/web-framework.voyd
@@ -4,14 +4,15 @@ use pkg::web::html::self as server_html
 use pkg::web::router
 use std::http::{ Body, Headers, HttpError, IncomingRequest, Method, QueryString, Response }
 use std::http::{ Response as HttpResponse }
-use std::json::{ JsonBool, JsonValue }
+use std::json::{ JsonBool, JsonValue, stringify }
 use std::msgpack::MsgPack
 use std::msgpack::self as msgpack
+use std::number::cast::to_string
 use std::optional::types::all
 use std::result::types::all
 use std::string::type::String
 use std::http::server::self as server
-use std::http::server::{ HttpServer, ServeTaskPolicy, ServerConfig }
+use std::http::server::{ HttpServer, RequestBody, ServeTaskPolicy, ServerConfig }
 use std::error::panic
 use std::task::self as tasks
 use std::vx::all
@@ -35,6 +36,20 @@ type CookieProbe = {
 
 type InvalidHydrationModel = {
   value: f64
+}
+
+/// Request path for the documented article endpoint.
+obj OpenApiArticlePath {
+  /// Stable article identifier.
+  id: i32
+}
+
+/// Body accepted by the documented article endpoint.
+obj OpenApiCreateArticle {
+  /// Reader-visible article title.
+  title: String,
+  /// Optional article summary.
+  summary?: String
 }
 
 enum SsrMsg
@@ -349,6 +364,98 @@ pub fn serve_ssr_callback_scope_probe(): (HttpServer, tasks::TaskRuntime) -> i32
       0
     Err:
       -1
+
+pub fn serve_sse_probe(): (HttpServer, tasks::TaskRuntime) -> i32
+  let events = app().get(
+    "/events".as_slice(),
+    handler: () -> Response => sse_response(write_sse_probe)
+  )
+  let result = server::serve_each(
+    config: ServerConfig::init(port: 41235),
+    policy: ServeTaskPolicy::detached(),
+    handle: (request: IncomingRequest) -> Response => events.handle(request)
+  )
+  match(result)
+    Ok<Unit>:
+      0
+    Err:
+      -1
+
+fn write_sse_probe(sender: SseSender): server::ResponseWriter -> void
+  let event_value = SseEvent {
+    data: "ready".as_slice().to_string(),
+    event: Some<String> { value: "status".as_slice().to_string() },
+    id: Some<String> { value: "1".as_slice().to_string() },
+    retry_millis: None {}
+  }
+  let _ = sender.send(event_value)
+
+pub fn openapi_schema_probe() -> String
+  let base = openapi_operation(
+    summary: "Create article".as_slice().to_string(),
+    description: "Creates one article.".as_slice().to_string()
+  )
+  let with_path = base.with_path_params<OpenApiArticlePath>()
+  let operation = with_path.with_json_body<OpenApiCreateArticle>()
+  let base_app = app().route(
+    "/articles/:id".as_slice(),
+    method: Method::Post {},
+    handler: (_ctx: Context) -> Response => Response::no_content()
+  )
+  let base_document = openapi_document(openapi_info(
+    title: "Article API".as_slice(),
+    version: "1.0.0".as_slice()
+  ))
+  let document = document_openapi_route(base_app, base_document, operation)
+  match(stringify(document.json()))
+    Ok<String> { value }:
+      value
+    Err:
+      "serialization failed".as_slice().to_string()
+
+pub fn serve_streaming_body_probe(): (HttpServer, tasks::TaskRuntime) -> i32
+  let uploads = app().post(
+    "/upload".as_slice(),
+    handler: (ctx: Context) -> Response => streaming_body_response(ctx)
+  ).streaming()
+  let result = serve_streaming(uploads, port: 41236)
+  match(result)
+    Ok<Unit>:
+      0
+    Err:
+      -1
+
+pub fn serve_streaming_buffered_body_probe(): (HttpServer, tasks::TaskRuntime) -> i32
+  let buffered = app().post(
+    "/buffered".as_slice(),
+    handler: (_ctx: Context) -> Response => Response::no_content()
+  )
+  let result = serve_streaming(buffered, port: 41238, max_body_bytes: 4)
+  match(result)
+    Ok<Unit>:
+      0
+    Err:
+      -1
+
+fn streaming_body_response(ctx: Context): HttpServer -> Response
+  match(ctx.streaming_body())
+    None:
+      Response::bad_request().text("missing stream".as_slice())
+    Some<RequestBody> { value }:
+      let ~body = value
+      var length = 0
+      var reading = true
+      while reading:
+        match(body.next())
+          Err:
+            return Response::bad_request().text("stream error".as_slice())
+          Ok { value: chunk }:
+            match(chunk)
+              Some { value }:
+                length = length + value.len()
+              None:
+                reading = false
+      Response::ok().text(to_string(length))
 
 pub fn direct_ssr_callback_scope_probe() -> String
   document<MsgPack>(retained_ssr_view(false))

--- a/tests/integration/src/std-http.test.ts
+++ b/tests/integration/src/std-http.test.ts
@@ -256,6 +256,8 @@ describe("integration: std http", () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toBe("streamed");
+    const status = await retryHttpGet(`http://127.0.0.1:${port}/status`);
+    expect(status.body).toBe("complete");
     expect(run.cancel("test complete")).toBe(true);
     await expect(run.outcome).resolves.toMatchObject({ kind: "cancelled" });
   });

--- a/tests/integration/src/std-http.test.ts
+++ b/tests/integration/src/std-http.test.ts
@@ -241,4 +241,22 @@ describe("integration: std http", () => {
     expect(run.cancel("test complete")).toBe(true);
     await expect(run.outcome).resolves.toMatchObject({ kind: "cancelled" });
   });
+
+  it("omits buffered bodies from streaming response heads", async () => {
+    const port = await findFreePort();
+    process.env.VOYD_HTTP_SMOKE_PORT = String(port);
+    const host = await createVoydHost({
+      wasm: compiled.wasm,
+      bufferSize: 131_072,
+      defaultAdapters: { runtime: "node" },
+    });
+
+    const run = host.runManaged<number>("serve_streaming_head_from_env");
+    const response = await retryHttpGet(`http://127.0.0.1:${port}/stream`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("streamed");
+    expect(run.cancel("test complete")).toBe(true);
+    await expect(run.outcome).resolves.toMatchObject({ kind: "cancelled" });
+  });
 });

--- a/tests/integration/src/web-framework.test.ts
+++ b/tests/integration/src/web-framework.test.ts
@@ -56,6 +56,7 @@ type HookRequest = {
   path: string;
   headers: Array<{ name: string; value: string }>;
   body: Uint8Array;
+  bodyStreaming?: boolean;
 };
 
 type HookResponse = {
@@ -64,14 +65,30 @@ type HookResponse = {
   body: Uint8Array;
 };
 
+type HookResponseHead = Omit<HookResponse, "body"> & {
+  headers: Array<{ name: string; value: string }>;
+};
+
 const createHttpServerHarness = (): {
   enqueueRequest: (requestId: number, requestPath: string) => void;
+  enqueueStreamingRequest: (
+    requestId: number,
+    requestPath: string,
+    chunks: Uint8Array[],
+  ) => void;
   responses: HookResponse[];
+  responseHeads: HookResponseHead[];
+  responseChunks: Array<{ requestId: number; chunk: Uint8Array }>;
+  finishedResponses: number[];
   runtimeHooks: DefaultAdapterRuntimeHooks;
 } => {
   const queuedRequests: HookRequest[] = [];
   const acceptWaiters: Array<(request: HookRequest) => void> = [];
   const responses: HookResponse[] = [];
+  const responseHeads: HookResponseHead[] = [];
+  const responseChunks: Array<{ requestId: number; chunk: Uint8Array }> = [];
+  const finishedResponses: number[] = [];
+  const requestChunks = new Map<number, Uint8Array[]>();
   const enqueueRequest = (requestId: number, requestPath: string): void => {
     const request = {
       requestId,
@@ -87,10 +104,35 @@ const createHttpServerHarness = (): {
     }
     queuedRequests.push(request);
   };
+  const enqueueStreamingRequest = (
+    requestId: number,
+    requestPath: string,
+    chunks: Uint8Array[],
+  ): void => {
+    requestChunks.set(requestId, [...chunks]);
+    const request: HookRequest = {
+      requestId,
+      method: "POST",
+      path: requestPath,
+      headers: [],
+      body: new Uint8Array(),
+      bodyStreaming: true,
+    };
+    const waiter = acceptWaiters.shift();
+    if (waiter) {
+      waiter(request);
+      return;
+    }
+    queuedRequests.push(request);
+  };
 
   return {
     enqueueRequest,
+    enqueueStreamingRequest,
     responses,
+    responseHeads,
+    responseChunks,
+    finishedResponses,
     runtimeHooks: {
       httpServerListen: async () => 1,
       httpServerAccept: async () => {
@@ -102,8 +144,26 @@ const createHttpServerHarness = (): {
           acceptWaiters.push(resolve),
         );
       },
+      httpServerReadRequest: async (requestId) => {
+        const chunks = requestChunks.get(requestId) ?? [];
+        const chunk = chunks.shift() ?? new Uint8Array();
+        const done = chunks.length === 0;
+        if (done) {
+          requestChunks.delete(requestId);
+        }
+        return { requestId, chunk, done };
+      },
       httpServerRespond: async (response) => {
         responses.push(response);
+      },
+      httpServerStartResponse: async (response) => {
+        responseHeads.push(response);
+      },
+      httpServerWriteResponse: async (response) => {
+        responseChunks.push(response);
+      },
+      httpServerFinishResponse: async (requestId) => {
+        finishedResponses.push(requestId);
       },
       httpServerClose: async () => undefined,
     },
@@ -111,6 +171,112 @@ const createHttpServerHarness = (): {
 };
 
 describe("integration: pkg::web", () => {
+  it("streams request bodies through Web Context when opted in", async () => {
+    const result = await compileWebFrameworkFixture();
+    const server = createHttpServerHarness();
+    const host = await createVoydHost({
+      wasm: result.wasm,
+      defaultAdapters: {
+        runtime: "node",
+        runtimeHooks: server.runtimeHooks,
+      },
+    });
+    const run = host.runManaged<number>("serve_streaming_body_probe");
+    server.enqueueStreamingRequest(2, "/upload", [
+      new TextEncoder().encode("first-"),
+      new TextEncoder().encode("second"),
+    ]);
+    await waitFor(() => server.responses.length === 1, "streaming upload response");
+
+    expect(new TextDecoder().decode(server.responses[0]!.body)).toBe("12");
+
+    expect(run.cancel("test complete")).toBe(true);
+    await expect(run.outcome).resolves.toMatchObject({ kind: "cancelled" });
+  });
+
+  it("preserves payload-too-large status while lazily buffering ordinary routes", async () => {
+    const result = await compileWebFrameworkFixture();
+    const server = createHttpServerHarness();
+    const host = await createVoydHost({
+      wasm: result.wasm,
+      defaultAdapters: {
+        runtime: "node",
+        runtimeHooks: {
+          ...server.runtimeHooks,
+          httpServerReadRequest: async () => {
+            throw Object.assign(new Error("request body exceeds max_body_bytes (4)"), {
+              code: 3,
+            });
+          },
+        },
+      },
+    });
+    const run = host.runManaged<number>("serve_streaming_buffered_body_probe");
+    server.enqueueStreamingRequest(3, "/buffered", [
+      new TextEncoder().encode("oversized"),
+    ]);
+    await waitFor(() => server.responses.length === 1, "buffered body rejection");
+
+    expect(server.responses[0]).toMatchObject({
+      requestId: 3,
+      status: 413,
+    });
+
+    expect(run.cancel("test complete")).toBe(true);
+    await expect(run.outcome).resolves.toMatchObject({ kind: "cancelled" });
+  });
+
+  it("generates documented OpenAPI schemas through the public package API", async () => {
+    const result = await compileWebFrameworkFixture();
+    const schema = await result.run<string>({ entryName: "openapi_schema_probe" });
+
+    expect(schema).toContain('"/articles/{id}"');
+    expect(schema).toContain('"required":["title"]');
+    expect(schema).toContain("Stable article identifier.");
+    expect(schema).toContain("Reader-visible article title.");
+  });
+
+  it("serves formatted SSE through the Web router and host stream lifecycle", async () => {
+    const result = await compileWebFrameworkFixture();
+    const server = createHttpServerHarness();
+    const host = await createVoydHost({
+      wasm: result.wasm,
+      defaultAdapters: {
+        runtime: "node",
+        runtimeHooks: server.runtimeHooks,
+      },
+    });
+    const run = host.runManaged<number>("serve_sse_probe");
+    server.enqueueRequest(1, "/events");
+    await waitFor(
+      () => server.finishedResponses.includes(1),
+      "SSE stream completion",
+    );
+
+    expect(server.responseHeads).toEqual([
+      expect.objectContaining({
+        requestId: 1,
+        status: 200,
+        headers: expect.arrayContaining([
+          {
+            name: "content-type",
+            value: "text/event-stream; charset=utf-8",
+          },
+        ]),
+      }),
+    ]);
+    expect(
+      new TextDecoder().decode(
+        Uint8Array.from(
+          server.responseChunks.flatMap((entry) => [...entry.chunk]),
+        ),
+      ),
+    ).toBe("event: status\nid: 1\ndata: ready\n\n");
+
+    expect(run.cancel("test complete")).toBe(true);
+    await expect(run.outcome).resolves.toMatchObject({ kind: "cancelled" });
+  });
+
   it("releases server-rendered callbacks after success and failure", async () => {
     const result = await compileWebFrameworkFixture();
     const server = createHttpServerHarness();

--- a/tests/integration/src/web-framework.test.ts
+++ b/tests/integration/src/web-framework.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { createSdk, type CompileResult } from "@voyd-lang/sdk";
 import { createVoydHost } from "@voyd-lang/sdk/js-host";
 import {
@@ -171,6 +171,10 @@ const createHttpServerHarness = (): {
 };
 
 describe("integration: pkg::web", () => {
+  beforeAll(async () => {
+    await compileWebFrameworkFixture();
+  }, 180_000);
+
   it("streams request bodies through Web Context when opted in", async () => {
     const result = await compileWebFrameworkFixture();
     const server = createHttpServerHarness();

--- a/tests/integration/src/web-framework.test.ts
+++ b/tests/integration/src/web-framework.test.ts
@@ -241,6 +241,7 @@ describe("integration: pkg::web", () => {
     const server = createHttpServerHarness();
     const host = await createVoydHost({
       wasm: result.wasm,
+      bufferSize: 131_072,
       defaultAdapters: {
         runtime: "node",
         runtimeHooks: server.runtimeHooks,
@@ -273,33 +274,17 @@ describe("integration: pkg::web", () => {
       ),
     ).toBe("event: status\nid: 1\ndata: ready\n\n");
 
-    expect(run.cancel("test complete")).toBe(true);
-    await expect(run.outcome).resolves.toMatchObject({ kind: "cancelled" });
-  });
-
-  it("omits buffered bodies from streaming response heads", async () => {
-    const result = await compileWebFrameworkFixture();
-    const server = createHttpServerHarness();
-    const host = await createVoydHost({
-      wasm: result.wasm,
-      bufferSize: 131_072,
-      defaultAdapters: {
-        runtime: "node",
-        runtimeHooks: server.runtimeHooks,
-      },
-    });
-    const run = host.runManaged<number>("serve_streaming_head_probe");
-    server.enqueueRequest(2, "/stream");
+    server.enqueueRequest(2, "/stream-head");
     await waitFor(
       () => server.finishedResponses.includes(2),
       "streaming response completion",
     );
 
-    expect(server.responseHeads).toEqual([
+    expect(server.responseHeads[1]).toEqual(
       expect.objectContaining({ requestId: 2, status: 200 }),
-    ]);
+    );
     expect(
-      new TextDecoder().decode(server.responseChunks[0]?.chunk),
+      new TextDecoder().decode(server.responseChunks[1]?.chunk),
     ).toBe("streamed");
 
     expect(run.cancel("test complete")).toBe(true);

--- a/tests/integration/src/web-framework.test.ts
+++ b/tests/integration/src/web-framework.test.ts
@@ -241,7 +241,6 @@ describe("integration: pkg::web", () => {
     const server = createHttpServerHarness();
     const host = await createVoydHost({
       wasm: result.wasm,
-      bufferSize: 131_072,
       defaultAdapters: {
         runtime: "node",
         runtimeHooks: server.runtimeHooks,
@@ -273,19 +272,6 @@ describe("integration: pkg::web", () => {
         ),
       ),
     ).toBe("event: status\nid: 1\ndata: ready\n\n");
-
-    server.enqueueRequest(2, "/stream-head");
-    await waitFor(
-      () => server.finishedResponses.includes(2),
-      "streaming response completion",
-    );
-
-    expect(server.responseHeads[1]).toEqual(
-      expect.objectContaining({ requestId: 2, status: 200 }),
-    );
-    expect(
-      new TextDecoder().decode(server.responseChunks[1]?.chunk),
-    ).toBe("streamed");
 
     expect(run.cancel("test complete")).toBe(true);
     await expect(run.outcome).resolves.toMatchObject({ kind: "cancelled" });

--- a/tests/integration/src/web-framework.test.ts
+++ b/tests/integration/src/web-framework.test.ts
@@ -277,6 +277,35 @@ describe("integration: pkg::web", () => {
     await expect(run.outcome).resolves.toMatchObject({ kind: "cancelled" });
   });
 
+  it("omits buffered bodies from streaming response heads", async () => {
+    const result = await compileWebFrameworkFixture();
+    const server = createHttpServerHarness();
+    const host = await createVoydHost({
+      wasm: result.wasm,
+      bufferSize: 131_072,
+      defaultAdapters: {
+        runtime: "node",
+        runtimeHooks: server.runtimeHooks,
+      },
+    });
+    const run = host.runManaged<number>("serve_streaming_head_probe");
+    server.enqueueRequest(2, "/stream");
+    await waitFor(
+      () => server.finishedResponses.includes(2),
+      "streaming response completion",
+    );
+
+    expect(server.responseHeads).toEqual([
+      expect.objectContaining({ requestId: 2, status: 200 }),
+    ]);
+    expect(
+      new TextDecoder().decode(server.responseChunks[0]?.chunk),
+    ).toBe("streamed");
+
+    expect(run.cancel("test complete")).toBe(true);
+    await expect(run.outcome).resolves.toMatchObject({ kind: "cancelled" });
+  });
+
   it("releases server-rendered callbacks after success and failure", async () => {
     const result = await compileWebFrameworkFixture();
     const server = createHttpServerHarness();


### PR DESCRIPTION
## Summary

- add backpressure-aware request and response streaming across std, the JS host, and `pkg::web`
- add SSE helpers, binary-safe multipart parsing, and richer `Accept` negotiation
- generate OpenAPI 3.1 documents from reified DTO shapes, including type/field doc comments for schemas and parameter/body descriptions
- derive documented route identity from the router and serve generated specs through a Web route
- document the expanded host protocol and Phase 3 public APIs

WebSockets are intentionally not included.

## Validation

- `npm test` (18/18 package tasks)
- `npm run typecheck` (18/18 tasks)
- `npm run test:audit`
- `npm test --workspace @voyd-lang/web` (76 tests)
- JS-host HTTP adapter suite (47 tests)
- Web framework integration suite

## Review

Completed the requested agentic review loop with clean final Implementation Gap, Architecture, and Correctness reviews.
