### PR TITLE
[V-435] Support selective effect namespace imports

### DIFF
--- a/packages/compiler/src/__tests__/module-codegen.test.ts
+++ b/packages/compiler/src/__tests__/module-codegen.test.ts
@@ -86,6 +86,36 @@ pub fn main() -> i32
     expect((instance.exports.main as () => number)()).toBe(42);
   });
 
+  it("prefers a selected external operation over an unselected local handler operation", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}effects.voyd`]: `pub eff External
+  save(tail, value: i32) -> i32
+`,
+      [`${root}${sep}main.voyd`]: `use src::effects::External::{ save }
+
+eff Local
+  save(tail, value: i32) -> i32
+
+pub fn main() -> i32
+  try
+    save(41)
+  save(tail, value):
+    tail(value + 1)
+`,
+    });
+
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root },
+        host,
+      }),
+    );
+    const instance = getWasmInstance(result.wasm!);
+    expect((instance.exports.main as () => number)()).toBe(42);
+  });
+
   it("links imported functions across modules and exports only entry functions", async () => {
     const root = resolve("/proj/src");
     const host = createMemoryHost({

--- a/packages/compiler/src/__tests__/module-codegen.test.ts
+++ b/packages/compiler/src/__tests__/module-codegen.test.ts
@@ -59,6 +59,33 @@ pub fn main() -> i32
     },
   );
 
+  it("uses a local effect operation alias in calls and handler heads", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `eff Store
+  save(tail, value: i32) -> i32
+
+use Store::save as persist
+
+pub fn main() -> i32
+  try
+    persist(41)
+  persist(tail, value):
+    tail(value + 1)
+`,
+    });
+
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root },
+        host,
+      }),
+    );
+    const instance = getWasmInstance(result.wasm!);
+    expect((instance.exports.main as () => number)()).toBe(42);
+  });
+
   it("links imported functions across modules and exports only entry functions", async () => {
     const root = resolve("/proj/src");
     const host = createMemoryHost({

--- a/packages/compiler/src/__tests__/module-codegen.test.ts
+++ b/packages/compiler/src/__tests__/module-codegen.test.ts
@@ -22,6 +22,43 @@ const expectCompileSuccess = (
 };
 
 describe("module codegen", () => {
+  it.each([
+    ["imported effect then all", "use src::effects::Store\nuse Store::all"],
+    ["qualified all", "use src::effects::Store::all"],
+    ["grouped qualified all", "use src::effects::{ Store::all }"],
+    ["grouped selective operation", "use src::effects::{ Store::{ save } }"],
+    ["qualified selective operation", "use src::effects::Store::{ save }"],
+  ])(
+    "executes an unqualified effect operation through %s",
+    async (_name, useDecl) => {
+      const root = resolve("/proj/src");
+      const host = createMemoryHost({
+        [`${root}${sep}main.voyd`]: `${useDecl}
+
+pub fn main() -> i32
+  try
+    save(41)
+  save(tail, value):
+    tail(value + 1)
+`,
+        [`${root}${sep}effects.voyd`]: `pub eff Store
+  save(tail, value: i32) -> i32
+  load(tail, value: i32) -> i32
+`,
+      });
+
+      const result = expectCompileSuccess(
+        await compileProgram({
+          entryPath: `${root}${sep}main.voyd`,
+          roots: { src: root },
+          host,
+        }),
+      );
+      const instance = getWasmInstance(result.wasm!);
+      expect((instance.exports.main as () => number)()).toBe(42);
+    },
+  );
+
   it("links imported functions across modules and exports only entry functions", async () => {
     const root = resolve("/proj/src");
     const host = createMemoryHost({
@@ -43,11 +80,13 @@ pub fn sub(a: i32, b: i32) -> i32
   a - b`,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -82,11 +121,13 @@ impl Box
 `,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root, std },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root, std },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -126,11 +167,13 @@ impl Sequence for Array
 `,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root, std },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root, std },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -150,11 +193,13 @@ pub fn main() -> i32
   value`,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root, std },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root, std },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -205,11 +250,13 @@ pub fn wrap<T>(value: T) -> GenericResult<T>
   Wrapped<T> { value }`,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root, std },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root, std },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -230,11 +277,13 @@ pub fn main() -> i32
   value`,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root, std },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root, std },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -261,11 +310,13 @@ pub fn assert<T>(value: T, { neq expected: T }) -> i32
   if value != expected then: 1 else: 0`,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -281,11 +332,13 @@ pub fn assert<T>(value: T, { neq expected: T }) -> i32
   o.a`,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -301,11 +354,13 @@ pub fn assert<T>(value: T, { neq expected: T }) -> i32
   o.a.b`,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -338,11 +393,13 @@ impl Animal
     Animal { id: 2, name: value }`,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -359,11 +416,13 @@ pub fn main() -> i32
   base + addend`,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -380,11 +439,13 @@ pub fn main() -> i32
       [`${root}${sep}constants.voyd`]: `pub let answer = 41`,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -406,11 +467,13 @@ pub fn main() -> i32
   a + c`,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -435,11 +498,13 @@ pub fn new_string(from_bytes: FixedArray<i32>): () -> String
 `,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root, std },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root, std },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -465,11 +530,13 @@ pub fn new_array_unchecked<T>({ from source: FixedArray<T> }) -> Array<T>
 `,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root, std },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root, std },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -489,11 +556,13 @@ pub let plus_one = base + 1`,
       [`${root}${sep}zeta.voyd`]: `pub let base = 41`,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);
@@ -517,11 +586,13 @@ pub fn main() -> i32
   computed`,
     });
 
-    const result = expectCompileSuccess(await compileProgram({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root },
-      host,
-    }));
+    const result = expectCompileSuccess(
+      await compileProgram({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root },
+        host,
+      }),
+    );
 
     expect(result.wasm).toBeInstanceOf(Uint8Array);
     const instance = getWasmInstance(result.wasm!);

--- a/packages/compiler/src/__tests__/module-imports.test.ts
+++ b/packages/compiler/src/__tests__/module-imports.test.ts
@@ -9,6 +9,330 @@ const createMemoryHost = (files: Record<string, string>): ModuleHost =>
   createMemoryModuleHost({ files, pathAdapter: createNodePathAdapter() });
 
 describe("module imports", () => {
+  it("imports effect operations through an effect re-export", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}origin.voyd`]: `pub eff ArticleStorage
+  save(tail, value: i32) -> i32
+`,
+      [`${root}${sep}api.voyd`]: "pub use src::origin::{ ArticleStorage }",
+      [`${root}${sep}main.voyd`]: `use src::api::ArticleStorage::all
+
+pub fn main() -> i32
+  try
+    save(1)
+  save(tail, value):
+    tail(value)
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      roots: { src: root },
+      host,
+    });
+    const { semantics, diagnostics } = analyzeModules({ graph });
+    const imported = semantics
+      .get("src::main")
+      ?.binding.imports.find((entry) => entry.name === "save");
+
+    expect([...graph.diagnostics, ...diagnostics]).toHaveLength(0);
+    expect(imported?.target?.moduleId).toBe("src::origin");
+    expect(imported).toBeDefined();
+  });
+
+  it("keeps unselected effect operations out of unqualified scope", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}effects.voyd`]: `pub eff Store
+  save(tail, value: i32) -> i32
+  load(tail, value: i32) -> i32
+`,
+      [`${root}${sep}main.voyd`]: `use src::effects::Store::{ save }
+
+pub fn main() -> i32
+  load(1)
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      roots: { src: root },
+      host,
+    });
+    const { diagnostics } = analyzeModules({ graph });
+
+    expect([...graph.diagnostics, ...diagnostics]).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "TY0006" })]),
+    );
+  });
+
+  it("does not make operations unqualified when only the effect is imported", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}effects.voyd`]: `pub eff Store
+  save(tail, value: i32) -> i32
+`,
+      [`${root}${sep}main.voyd`]: `use src::effects::Store
+
+pub fn qualified() -> i32
+  try
+    Store::save(1)
+  Store::save(tail, value):
+    tail(value)
+
+pub fn unqualified() -> i32
+  save(1)
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      roots: { src: root },
+      host,
+    });
+    const { diagnostics } = analyzeModules({ graph });
+
+    expect([...graph.diagnostics, ...diagnostics]).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "TY0006" })]),
+    );
+  });
+
+  it("imports every operation from Effect::all without changing module::all", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}effects.voyd`]: `pub eff Store
+  save(tail, value: i32) -> i32
+  load(tail, value: i32) -> i32
+`,
+      [`${root}${sep}main.voyd`]: "use src::effects::Store::all",
+      [`${root}${sep}module_all.voyd`]: "use src::effects::all",
+    });
+
+    const effectGraph = await loadModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      roots: { src: root },
+      host,
+    });
+    const effectAnalysis = analyzeModules({ graph: effectGraph });
+    const effectImports = effectAnalysis.semantics
+      .get("src::main")
+      ?.binding.imports.map((entry) => entry.name);
+
+    const moduleGraph = await loadModuleGraph({
+      entryPath: `${root}${sep}module_all.voyd`,
+      roots: { src: root },
+      host,
+    });
+    const moduleAnalysis = analyzeModules({ graph: moduleGraph });
+    const moduleImports = moduleAnalysis.semantics
+      .get("src::module_all")
+      ?.binding.imports.map((entry) => entry.name);
+
+    expect([
+      ...effectGraph.diagnostics,
+      ...effectAnalysis.diagnostics,
+    ]).toHaveLength(0);
+    expect(effectImports).toEqual(expect.arrayContaining(["save", "load"]));
+    expect([
+      ...moduleGraph.diagnostics,
+      ...moduleAnalysis.diagnostics,
+    ]).toHaveLength(0);
+    expect(moduleImports).not.toEqual(expect.arrayContaining(["save", "load"]));
+  });
+
+  it("enforces effect visibility for namespace imports", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}effects.voyd`]: `eff HiddenStore
+  save(tail, value: i32) -> i32
+`,
+      [`${root}${sep}main.voyd`]: "use src::effects::HiddenStore::all",
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      roots: { src: root },
+      host,
+    });
+    const { diagnostics } = analyzeModules({ graph });
+
+    expect([...graph.diagnostics, ...diagnostics]).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "BD0001" })]),
+    );
+  });
+
+  it("imports effect operations across a package boundary", async () => {
+    const srcRoot = resolve("/proj/src");
+    const pkgDir = resolve("/proj/node_modules");
+    const packageRoot = `${pkgDir}${sep}storage${sep}src`;
+    const host = createMemoryHost({
+      [`${srcRoot}${sep}main.voyd`]: "use pkg::storage::ArticleStorage::all",
+      [`${packageRoot}${sep}pkg.voyd`]:
+        "pub use self::effects::{ ArticleStorage }",
+      [`${packageRoot}${sep}effects.voyd`]: `pub eff ArticleStorage
+  save(tail, value: i32) -> i32
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${srcRoot}${sep}main.voyd`,
+      roots: { src: srcRoot, pkgDirs: [pkgDir] },
+      host,
+    });
+    const { semantics, diagnostics } = analyzeModules({ graph });
+    const imported = semantics
+      .get("src::main")
+      ?.binding.imports.find((entry) => entry.name === "save");
+
+    expect([...graph.diagnostics, ...diagnostics]).toHaveLength(0);
+    expect(imported?.target?.moduleId).toBe("pkg:storage::effects");
+  });
+
+  it("reports a deterministic conflict between imported values and effect operations", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}effects.voyd`]: `pub eff Store
+  save(tail, value: i32) -> i32
+`,
+      [`${root}${sep}values.voyd`]: "pub fn save(value: i32) -> i32\n  value",
+      [`${root}${sep}main.voyd`]: `use src::values::{ save }
+use src::effects::Store::{ save }
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      roots: { src: root },
+      host,
+    });
+    const { diagnostics } = analyzeModules({ graph });
+    const conflicts = [...graph.diagnostics, ...diagnostics].filter(
+      (diagnostic) =>
+        diagnostic.code === "BD0001" && diagnostic.message.includes("save"),
+    );
+
+    expect(conflicts).toHaveLength(1);
+  });
+
+  it("preserves overloaded operations selected from an effect namespace", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}effects.voyd`]: `pub eff Store
+  fetch(tail, value: i32) -> i32
+  fetch(tail, value: bool) -> bool
+`,
+      [`${root}${sep}main.voyd`]: `use src::effects::Store
+use Store::{ fetch }
+
+pub fn fetch_number(): Store -> i32
+  fetch(1)
+
+pub fn fetch_flag(): Store -> bool
+  fetch(true)
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      roots: { src: root },
+      host,
+    });
+    const { semantics, diagnostics } = analyzeModules({ graph });
+    const fetchImports =
+      semantics
+        .get("src::main")
+        ?.binding.imports.filter((entry) => entry.name === "fetch") ?? [];
+
+    expect([...graph.diagnostics, ...diagnostics]).toHaveLength(0);
+    expect(fetchImports).toHaveLength(2);
+  });
+
+  it("exposes only the alias for a locally selected effect operation", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `eff Store
+  save(tail, value: i32) -> i32
+
+use Store::save as persist
+
+fn accepted(): Store -> i32
+  persist(1)
+
+fn rejected(): Store -> i32
+  save(1)
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      roots: { src: root },
+      host,
+    });
+    const { diagnostics } = analyzeModules({ graph });
+    const undefinedFunctions = [...graph.diagnostics, ...diagnostics].filter(
+      (diagnostic) => diagnostic.code === "TY0006",
+    );
+
+    expect(undefinedFunctions).toHaveLength(1);
+    expect(undefinedFunctions[0]?.message).toContain("save");
+  });
+
+  it("reports conflicts between local values and selected local operations", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `fn save(value: i32) -> i32
+  value
+
+eff Store
+  save(tail, value: i32) -> i32
+
+use Store::{ save }
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      roots: { src: root },
+      host,
+    });
+    const { diagnostics } = analyzeModules({ graph });
+    const conflicts = [...graph.diagnostics, ...diagnostics].filter(
+      (diagnostic) =>
+        diagnostic.code === "BD0001" && diagnostic.message.includes("save"),
+    );
+
+    expect(conflicts).toHaveLength(1);
+  });
+
+  it("reports conflicts between selected operations from local effects", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}main.voyd`]: `eff FirstStore
+  save(tail, value: i32) -> i32
+
+eff SecondStore
+  save(tail, value: i32) -> i32
+
+use FirstStore::{ save }
+use SecondStore::{ save }
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      roots: { src: root },
+      host,
+    });
+    const { diagnostics } = analyzeModules({ graph });
+    const conflicts = [...graph.diagnostics, ...diagnostics].filter(
+      (diagnostic) =>
+        diagnostic.code === "BD0001" && diagnostic.message.includes("save"),
+    );
+
+    expect(conflicts).toHaveLength(1);
+  });
+
   it("binds imports across modules using the module graph exports", async () => {
     const root = resolve("/proj/src");
     const host = createMemoryHost({
@@ -27,7 +351,7 @@ describe("module imports", () => {
     const mathSemantics = semantics.get("src::util::math");
 
     expect(mainSemantics?.binding.imports.map((imp) => imp.name)).toContain(
-      "add"
+      "add",
     );
     expect(mathSemantics?.exports.has("add")).toBe(true);
     expect([...graph.diagnostics, ...diagnostics]).toHaveLength(0);
@@ -385,7 +709,9 @@ describe("module imports", () => {
 
     expect(semantics.has("src::a")).toBe(true);
     expect(semantics.has("src::b")).toBe(true);
-    expect(combinedDiagnostics.some((diag) => diag.code === "TY0006")).toBe(true);
+    expect(combinedDiagnostics.some((diag) => diag.code === "TY0006")).toBe(
+      true,
+    );
     expect(
       combinedDiagnostics.some(
         (diag) =>
@@ -614,7 +940,8 @@ pub fn main() -> i32
         "use src::msgpack::fns::marker\npub fn top() -> i32\n  marker()",
       [`${stdRoot}${sep}msgpack${sep}fns.voyd`]:
         "use std::fixed_array::fns::hidden\npub fn marker() -> i32\n  hidden()",
-      [`${stdRoot}${sep}fixed_array${sep}fns.voyd`]: "pub fn hidden() -> i32\n  1",
+      [`${stdRoot}${sep}fixed_array${sep}fns.voyd`]:
+        "pub fn hidden() -> i32\n  1",
     });
 
     const graph = await loadModuleGraph({
@@ -655,7 +982,8 @@ pub fn main() -> i32
     const { semantics, diagnostics } = analyzeModules({ graph });
     const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
     const msgpackSemantics = semantics.get("std::msgpack");
-    const msgpackUses = msgpackSemantics?.binding.uses.flatMap((decl) => decl.entries) ?? [];
+    const msgpackUses =
+      msgpackSemantics?.binding.uses.flatMap((decl) => decl.entries) ?? [];
     const localMarkerImport = msgpackUses.find(
       (entry) => entry.path.join("::") === "src::msgpack::fns::marker",
     );
@@ -734,7 +1062,9 @@ pub fn main() -> i32
     const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
 
     expect(combinedDiagnostics).toHaveLength(0);
-    expect(mainSemantics?.binding.imports.map((entry) => entry.name)).toContain("Coffee");
+    expect(mainSemantics?.binding.imports.map((entry) => entry.name)).toContain(
+      "Coffee",
+    );
   });
 
   it("supports generic enum namespace single-member imports via use Drink::Coffee", async () => {
@@ -773,7 +1103,9 @@ pub fn main() -> i32
     const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
 
     expect(combinedDiagnostics).toHaveLength(0);
-    expect(mainSemantics?.binding.imports.map((entry) => entry.name)).toContain("Coffee");
+    expect(mainSemantics?.binding.imports.map((entry) => entry.name)).toContain(
+      "Coffee",
+    );
   });
 
   it("supports generic enum namespace grouped member imports", async () => {
@@ -1334,8 +1666,11 @@ pub fn main() -> i32
       true,
     );
     expect(
-      Array.from(semantics.get("src::main")?.hir.expressions.values() ?? []).some(
-        (expr) => expr.exprKind === "object-literal" && expr.literalKind === "nominal",
+      Array.from(
+        semantics.get("src::main")?.hir.expressions.values() ?? [],
+      ).some(
+        (expr) =>
+          expr.exprKind === "object-literal" && expr.literalKind === "nominal",
       ),
     ).toBe(false);
   });
@@ -1372,7 +1707,10 @@ pub fn main() -> i32
 
     const { diagnostics } = analyzeModules({ graph });
     const combinedDiagnostics = [...graph.diagnostics, ...diagnostics];
-    expect(combinedDiagnostics, JSON.stringify(combinedDiagnostics)).toHaveLength(0);
+    expect(
+      combinedDiagnostics,
+      JSON.stringify(combinedDiagnostics),
+    ).toHaveLength(0);
   });
 
   it("does not infer inaccessible imported union members in match patterns", async () => {
@@ -1623,8 +1961,7 @@ pub fn main() -> i32
     expect(
       combinedDiagnostics.some(
         (diag) =>
-          diag.code === "BD0001" &&
-          diag.message.includes("not visible here"),
+          diag.code === "BD0001" && diag.message.includes("not visible here"),
       ),
     ).toBe(false);
   });
@@ -1687,8 +2024,7 @@ pub fn main() -> Drink
     expect(
       combinedDiagnostics.some(
         (diag) =>
-          diag.code === "BD0001" &&
-          diag.message.includes("not visible here"),
+          diag.code === "BD0001" && diag.message.includes("not visible here"),
       ),
     ).toBe(true);
   });

--- a/packages/compiler/src/__tests__/module-imports.test.ts
+++ b/packages/compiler/src/__tests__/module-imports.test.ts
@@ -189,15 +189,54 @@ pub fn unqualified() -> i32
     expect(imported?.target?.moduleId).toBe("pkg:storage::effects");
   });
 
-  it("reports a deterministic conflict between imported values and effect operations", async () => {
+  it.each([
+    [
+      "value first",
+      `use src::values::{ save }
+use src::effects::Store::{ save }`,
+    ],
+    [
+      "effect operation first",
+      `use src::effects::Store::{ save }
+use src::values::{ save }`,
+    ],
+  ])(
+    "reports a deterministic conflict between imported values and effect operations with the %s",
+    async (_name, imports) => {
+      const root = resolve("/proj/src");
+      const host = createMemoryHost({
+        [`${root}${sep}effects.voyd`]: `pub eff Store
+  save(tail, value: i32) -> i32
+`,
+        [`${root}${sep}values.voyd`]: "pub fn save(value: i32) -> i32\n  value",
+        [`${root}${sep}main.voyd`]: imports,
+      });
+
+      const graph = await loadModuleGraph({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root },
+        host,
+      });
+      const { diagnostics } = analyzeModules({ graph });
+      const conflicts = [...graph.diagnostics, ...diagnostics].filter(
+        (diagnostic) =>
+          diagnostic.code === "BD0001" && diagnostic.message.includes("save"),
+      );
+
+      expect(conflicts).toHaveLength(1);
+    },
+  );
+
+  it("reports a conflict when an external effect operation selection precedes a local value", async () => {
     const root = resolve("/proj/src");
     const host = createMemoryHost({
       [`${root}${sep}effects.voyd`]: `pub eff Store
   save(tail, value: i32) -> i32
 `,
-      [`${root}${sep}values.voyd`]: "pub fn save(value: i32) -> i32\n  value",
-      [`${root}${sep}main.voyd`]: `use src::values::{ save }
-use src::effects::Store::{ save }
+      [`${root}${sep}main.voyd`]: `use src::effects::Store::{ save }
+
+fn save(value: i32) -> i32
+  value
 `,
     });
 
@@ -278,32 +317,49 @@ fn rejected(): Store -> i32
     expect(undefinedFunctions[0]?.message).toContain("save");
   });
 
-  it("reports conflicts between local values and selected local operations", async () => {
-    const root = resolve("/proj/src");
-    const host = createMemoryHost({
-      [`${root}${sep}main.voyd`]: `fn save(value: i32) -> i32
+  it.each([
+    [
+      "value first",
+      `fn save(value: i32) -> i32
   value
 
 eff Store
   save(tail, value: i32) -> i32
 
+use Store::{ save }`,
+    ],
+    [
+      "effect operation first",
+      `eff Store
+  save(tail, value: i32) -> i32
+
 use Store::{ save }
-`,
-    });
 
-    const graph = await loadModuleGraph({
-      entryPath: `${root}${sep}main.voyd`,
-      roots: { src: root },
-      host,
-    });
-    const { diagnostics } = analyzeModules({ graph });
-    const conflicts = [...graph.diagnostics, ...diagnostics].filter(
-      (diagnostic) =>
-        diagnostic.code === "BD0001" && diagnostic.message.includes("save"),
-    );
+fn save(value: i32) -> i32
+  value`,
+    ],
+  ])(
+    "reports conflicts between local values and selected local operations with the %s",
+    async (_name, source) => {
+      const root = resolve("/proj/src");
+      const host = createMemoryHost({
+        [`${root}${sep}main.voyd`]: source,
+      });
 
-    expect(conflicts).toHaveLength(1);
-  });
+      const graph = await loadModuleGraph({
+        entryPath: `${root}${sep}main.voyd`,
+        roots: { src: root },
+        host,
+      });
+      const { diagnostics } = analyzeModules({ graph });
+      const conflicts = [...graph.diagnostics, ...diagnostics].filter(
+        (diagnostic) =>
+          diagnostic.code === "BD0001" && diagnostic.message.includes("save"),
+      );
+
+      expect(conflicts).toHaveLength(1);
+    },
+  );
 
   it("reports conflicts between selected operations from local effects", async () => {
     const root = resolve("/proj/src");

--- a/packages/compiler/src/__tests__/module-imports.test.ts
+++ b/packages/compiler/src/__tests__/module-imports.test.ts
@@ -361,6 +361,34 @@ fn save(value: i32) -> i32
     },
   );
 
+  it("reports conflicts between module aliases and selected local operations", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryHost({
+      [`${root}${sep}util.voyd`]: "pub fn value() -> i32\n  1",
+      [`${root}${sep}main.voyd`]: `use src::util as save
+
+eff Store
+  save(tail, value: i32) -> i32
+
+use Store::{ save }
+`,
+    });
+
+    const graph = await loadModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      roots: { src: root },
+      host,
+    });
+    const { diagnostics } = analyzeModules({ graph });
+    const conflicts = [...graph.diagnostics, ...diagnostics].filter(
+      (diagnostic) =>
+        diagnostic.code === "BD0001" && diagnostic.message.includes("save"),
+    );
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]?.message).toContain("module");
+  });
+
   it("reports conflicts between selected operations from local effects", async () => {
     const root = resolve("/proj/src");
     const host = createMemoryHost({

--- a/packages/compiler/src/modules/__tests__/graph.test.ts
+++ b/packages/compiler/src/modules/__tests__/graph.test.ts
@@ -368,6 +368,42 @@ pub macro declare_helper()
     );
   });
 
+  it("reports fallback module resolution errors as diagnostics", async () => {
+    const root = resolve("/proj/src");
+    const memoryHost = createMemoryHost({
+      [`${root}${sep}main.voyd`]: "use src::foo::Fx::all",
+    });
+    const fallbackCandidate = `${root}${sep}foo.voyd`;
+    let fallbackCandidateChecks = 0;
+    const host: ModuleHost = {
+      ...memoryHost,
+      fileExists: async (path) => {
+        if (path === fallbackCandidate) {
+          fallbackCandidateChecks += 1;
+          if (fallbackCandidateChecks === 2) {
+            throw new Error("fallback lookup failed");
+          }
+        }
+        return memoryHost.fileExists(path);
+      },
+    };
+
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      host,
+      roots: { src: root },
+    });
+
+    expect(graph.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "MD0002",
+          message: expect.stringContaining("fallback lookup failed"),
+        }),
+      ])
+    );
+  });
+
   it("loads dependencies via bare pub module-expression exports", async () => {
     const root = resolve("/proj/src");
     const host = createMemoryHost({

--- a/packages/compiler/src/modules/dependency-snapshot-cache.ts
+++ b/packages/compiler/src/modules/dependency-snapshot-cache.ts
@@ -9,9 +9,7 @@ import {
   type TypeArenaSnapshot,
 } from "../semantics/typing/type-arena.js";
 import { incrementCompilerPerfCounter } from "../perf.js";
-import {
-  cloneSemanticsMapForTypingState,
-} from "./semantic-snapshot.js";
+import { cloneSemanticsMapForTypingState } from "./semantic-snapshot.js";
 import type {
   ModuleDependency,
   ModuleGraph,
@@ -19,9 +17,7 @@ import type {
   ModulePath,
   ModuleRoots,
 } from "./types.js";
-import type {
-  ReusableDependencySemanticsSnapshot,
-} from "./semantic-analysis.js";
+import type { ReusableDependencySemanticsSnapshot } from "./semantic-analysis.js";
 
 const COMPILER_DEPENDENCY_SNAPSHOT_VERSION =
   "0.2.0:v375-dependency-snapshot-v2";
@@ -137,7 +133,9 @@ export const commitDependencySnapshot = ({
   }
 
   const arena = createTypeArena(dependencySnapshot.arena);
-  const effectInterner = createEffectInterner(dependencySnapshot.effectInterner);
+  const effectInterner = createEffectInterner(
+    dependencySnapshot.effectInterner,
+  );
   const semantics = cloneSemanticsMapForTypingState({
     semantics: dependencySnapshot.semantics,
     arena,
@@ -161,9 +159,11 @@ const dependencyModuleFingerprintsFor = (
   new Map(
     Array.from(graph.modules.entries())
       .filter(([, module]) => module.path.namespace !== "src")
-      .sort(([left], [right]) => left.localeCompare(right, undefined, {
-        numeric: true,
-      }))
+      .sort(([left], [right]) =>
+        left.localeCompare(right, undefined, {
+          numeric: true,
+        }),
+      )
       .map(([moduleId, module]) => [moduleId, moduleFingerprint(module)]),
   );
 
@@ -186,6 +186,9 @@ const moduleFingerprint = (module: ModuleNode): string =>
 const serializableDependency = (dependency: ModuleDependency) => ({
   kind: dependency.kind,
   path: serializableModulePath(dependency.path),
+  namespaceFallbackPath: dependency.namespaceFallbackPath
+    ? serializableModulePath(dependency.namespaceFallbackPath)
+    : undefined,
 });
 
 const serializableModulePath = (modulePath: ModulePath) => ({
@@ -222,4 +225,4 @@ const sortForStableSerialization = (value: unknown): unknown => {
 };
 
 const moduleNamespaceForId = (moduleId: string): string =>
-  moduleId.startsWith("pkg:") ? "pkg" : moduleId.split("::")[0] ?? "unknown";
+  moduleId.startsWith("pkg:") ? "pkg" : (moduleId.split("::")[0] ?? "unknown");

--- a/packages/compiler/src/modules/graph.ts
+++ b/packages/compiler/src/modules/graph.ts
@@ -460,9 +460,11 @@ export const buildModuleGraph = async ({
             missingModules.delete(existing.id);
           }
           if (existing?.origin.kind === "file") {
-            (existing.sourceFiles ?? [
-              { filePath: existing.origin.filePath, source: existing.source },
-            ]).forEach(({ filePath }) => inactiveModuleFiles.add(filePath));
+            (
+              existing.sourceFiles ?? [
+                { filePath: existing.origin.filePath, source: existing.source },
+              ]
+            ).forEach(({ filePath }) => inactiveModuleFiles.add(filePath));
           }
           modules.set(inlineModule.id, inlineModule);
           modulesByPath.set(
@@ -552,6 +554,20 @@ export const buildModuleGraph = async ({
     }
 
     if (!resolved) {
+      const fallbackPath = dependency.namespaceFallbackPath;
+      if (fallbackPath) {
+        const fallback = await resolveModuleFile(fallbackPath, roots, host);
+        if (fallback) {
+          dependency.path = fallbackPath;
+          pending.push({ dependency, importerId, importerFilePath });
+          updateNestedPrefixCounts({
+            counts: pendingNestedPrefixCounts,
+            pathKey: modulePathToString(fallbackPath),
+            delta: 1,
+          });
+          continue;
+        }
+      }
       moduleDiagnostics.push({
         kind: "missing-module",
         requested: requestedPath,
@@ -567,6 +583,12 @@ export const buildModuleGraph = async ({
     const resolvedPath = resolved.filePath;
     const resolvedModulePath = resolved.modulePath;
     const resolvedKey = modulePathToString(resolvedModulePath);
+    if (
+      dependency.namespaceFallbackPath &&
+      resolvedKey === modulePathToString(dependency.namespaceFallbackPath)
+    ) {
+      dependency.path = dependency.namespaceFallbackPath;
+    }
     const resolvedExtendsRequested =
       resolvedModulePath.namespace === requestedPath.namespace &&
       resolvedModulePath.packageName === requestedPath.packageName &&
@@ -726,9 +748,7 @@ export const buildModuleGraph = async ({
   const baseDiagnostics = unresolvedModuleDiagnostics.map(
     moduleDiagnosticToDiagnostic,
   );
-  const macroDiagnostics = Array.from(
-    macroDiagnosticsByModule.values(),
-  ).flat();
+  const macroDiagnostics = Array.from(macroDiagnosticsByModule.values()).flat();
   const surfaceDiagnostics = Array.from(
     surfaceDiagnosticsByModule.values(),
   ).flat();
@@ -1043,7 +1063,7 @@ const collectModuleInfo = ({
             typeof firstSegment === "string" &&
             inlineModuleNames.has(firstSegment);
 
-          return resolveModuleRequest(
+          const path = resolveModuleRequest(
             { segments: entryPath.moduleSegments, span: entryPath.span },
             modulePath,
             {
@@ -1053,12 +1073,30 @@ const collectModuleInfo = ({
                 moduleIsPackageRoot && !preservesInlinePkgScope,
             },
           );
+          const namespaceFallbackPath =
+            entryPath.moduleSegments.length > 1
+              ? resolveModuleRequest(
+                  {
+                    segments: entryPath.moduleSegments.slice(0, -1),
+                    span: entryPath.span,
+                  },
+                  modulePath,
+                  {
+                    anchorToSelf: entryPath.anchorToSelf === true,
+                    parentHops: entryPath.parentHops ?? 0,
+                    importerIsPackageRoot:
+                      moduleIsPackageRoot && !preservesInlinePkgScope,
+                  },
+                )
+              : undefined;
+          return { path, namespaceFallbackPath };
         });
-      resolvedEntries.forEach((path) => {
+      resolvedEntries.forEach(({ path, namespaceFallbackPath }) => {
         if (!path.segments.length && !path.packageName) return;
         dependencies.push({
           kind: "use",
           path,
+          namespaceFallbackPath,
           span,
         });
         if (

--- a/packages/compiler/src/modules/graph.ts
+++ b/packages/compiler/src/modules/graph.ts
@@ -539,6 +539,22 @@ export const buildModuleGraph = async ({
     let resolved: Awaited<ReturnType<typeof resolveModuleFile>>;
     try {
       resolved = await resolveModuleFile(requestedPath, roots, host);
+      if (!resolved) {
+        const fallbackPath = dependency.namespaceFallbackPath;
+        if (fallbackPath) {
+          const fallback = await resolveModuleFile(fallbackPath, roots, host);
+          if (fallback) {
+            dependency.path = fallbackPath;
+            pending.push({ dependency, importerId, importerFilePath });
+            updateNestedPrefixCounts({
+              counts: pendingNestedPrefixCounts,
+              pathKey: modulePathToString(fallbackPath),
+              delta: 1,
+            });
+            continue;
+          }
+        }
+      }
     } catch (error) {
       moduleDiagnostics.push({
         kind: "io-error",
@@ -554,20 +570,6 @@ export const buildModuleGraph = async ({
     }
 
     if (!resolved) {
-      const fallbackPath = dependency.namespaceFallbackPath;
-      if (fallbackPath) {
-        const fallback = await resolveModuleFile(fallbackPath, roots, host);
-        if (fallback) {
-          dependency.path = fallbackPath;
-          pending.push({ dependency, importerId, importerFilePath });
-          updateNestedPrefixCounts({
-            counts: pendingNestedPrefixCounts,
-            pathKey: modulePathToString(fallbackPath),
-            delta: 1,
-          });
-          continue;
-        }
-      }
       moduleDiagnostics.push({
         kind: "missing-module",
         requested: requestedPath,

--- a/packages/compiler/src/modules/types.ts
+++ b/packages/compiler/src/modules/types.ts
@@ -61,6 +61,11 @@ export type ModuleDependencyKind = "use" | "export";
 export interface ModuleDependency {
   kind: ModuleDependencyKind;
   path: ModulePath;
+  /**
+   * Alternate module path for a use whose final namespace segment may name a
+   * type or effect rather than a child module (for example `Fx::all`).
+   */
+  namespaceFallbackPath?: ModulePath;
   span?: SourceSpan;
 }
 

--- a/packages/compiler/src/semantics/binding/binders/expressions.ts
+++ b/packages/compiler/src/semantics/binding/binders/expressions.ts
@@ -59,6 +59,7 @@ import {
   collectTryHandlerClauses,
   isTryHandlerClause,
 } from "../../try-handler-clauses.js";
+import { resolveUnqualifiedEffectOperation } from "../../effect-operation-resolution.js";
 
 export const bindExpr = (
   expr: Expr | undefined,
@@ -163,9 +164,11 @@ const bindTry = (
           expr: entry,
           scope: tracker.current(),
           resolveBareHandlerHead: ({ name, scope }) =>
-            typeof ctx.symbolTable.resolveByKinds(name, scope, [
-              "effect-op",
-            ]) === "number",
+            typeof resolveUnqualifiedEffectOperation({
+              name,
+              scope,
+              symbolTable: ctx.symbolTable,
+            }) === "number",
         }) &&
         isForm(entry)
       ) {
@@ -178,8 +181,11 @@ const bindTry = (
       expr: body,
       scope: tracker.current(),
       resolveBareHandlerHead: ({ name, scope }) =>
-        typeof ctx.symbolTable.resolveByKinds(name, scope, ["effect-op"]) ===
-        "number",
+        typeof resolveUnqualifiedEffectOperation({
+          name,
+          scope,
+          symbolTable: ctx.symbolTable,
+        }) === "number",
     }),
   );
   bindExpr(body, ctx, tracker);

--- a/packages/compiler/src/semantics/binding/binders/module.ts
+++ b/packages/compiler/src/semantics/binding/binders/module.ts
@@ -205,6 +205,16 @@ const resolveUseEntry = ({
   }
 
   let dependencyPath = resolveDependencyPath({ entry, ctx });
+  if (!dependencyPath) {
+    const effectNamespaceUse = resolveQualifiedEffectNamespaceUseEntry({
+      entry,
+      decl,
+      ctx,
+    });
+    if (effectNamespaceUse) {
+      return effectNamespaceUse;
+    }
+  }
   let blockedStdImport = false;
 
   if (dependencyPath && isStdImportBlocked({ dependencyPath, entry, ctx })) {
@@ -329,6 +339,15 @@ const resolveImplicitNamespaceUseEntry = ({
     };
   }
 
+  if (namespaceRecord.kind === "effect") {
+    return resolveEffectNamespaceUseEntry({
+      namespaceSymbol,
+      entry,
+      decl,
+      ctx,
+    });
+  }
+
   if (namespaceRecord.kind !== "type") {
     return undefined;
   }
@@ -352,18 +371,21 @@ const resolveImplicitNamespaceUseEntry = ({
   const dependency = ctx.dependencies.get(importedTarget.moduleId);
   const variantMembers = new Map(
     Array.from(ctx.staticMethods.get(namespaceSymbol)?.entries() ?? [])
-      .map(([name, symbols]) => [
-        name,
-        new Set(
-          Array.from(symbols).filter((symbol) => {
-            const record = ctx.symbolTable.getSymbol(symbol);
-            const entity = (
-              record.metadata as { entity?: unknown } | undefined
-            )?.entity;
-            return record.kind === "type" && entity === "object";
-          }),
-        ),
-      ] as const)
+      .map(
+        ([name, symbols]) =>
+          [
+            name,
+            new Set(
+              Array.from(symbols).filter((symbol) => {
+                const record = ctx.symbolTable.getSymbol(symbol);
+                const entity = (
+                  record.metadata as { entity?: unknown } | undefined
+                )?.entity;
+                return record.kind === "type" && entity === "object";
+              }),
+            ),
+          ] as const,
+      )
       .filter(([, symbols]) => symbols.size > 0),
   );
   if (!dependency || variantMembers.size === 0) {
@@ -385,7 +407,10 @@ const resolveImplicitNamespaceUseEntry = ({
           symbol,
           binding: ctx,
         });
-        return [`${canonical.moduleId}:${canonical.symbol}`, canonical] as const;
+        return [
+          `${canonical.moduleId}:${canonical.symbol}`,
+          canonical,
+        ] as const;
       }),
     );
     if (canonicalCandidates.size > 1) {
@@ -497,6 +522,366 @@ const resolveImplicitNamespaceUseEntry = ({
     alias: entry.alias,
     imports,
   };
+};
+
+const resolveQualifiedEffectNamespaceUseEntry = ({
+  entry,
+  decl,
+  ctx,
+}: {
+  entry: ParsedUseEntry;
+  decl: ParsedUseDecl;
+  ctx: BindingContext;
+}): BoundUseEntry | undefined => {
+  if (entry.moduleSegments.length < 2) {
+    return undefined;
+  }
+  const namespaceName = entry.moduleSegments.at(-1);
+  if (!namespaceName) {
+    return undefined;
+  }
+  const parentSegments = entry.moduleSegments.slice(0, -1);
+  const parentEntry = {
+    ...entry,
+    moduleSegments: parentSegments,
+    path: parentSegments,
+    targetName: undefined,
+    alias: parentSegments.at(-1),
+    selectionKind: "module" as const,
+  };
+  const dependencyPath = resolveDependencyPath({ entry: parentEntry, ctx });
+  if (!dependencyPath) {
+    return undefined;
+  }
+  const moduleId = modulePathToString(dependencyPath);
+  const exportedEffect = ctx.moduleExports.get(moduleId)?.get(namespaceName);
+  if (!exportedEffect || exportedEffect.kind !== "effect") {
+    return undefined;
+  }
+  const explicitlyTargetsStdSubmodule =
+    isExplicitStdSubmoduleEntry(parentEntry);
+  if (
+    !canAccessExport({
+      exported: exportedEffect,
+      moduleId,
+      ctx,
+      explicitlyTargetsStdSubmodule,
+    })
+  ) {
+    recordImportDiagnostic({
+      params: {
+        kind: "out-of-scope-export",
+        moduleId,
+        target: namespaceName,
+        visibility: exportedEffect.visibility.level,
+      },
+      span: entry.span,
+      ctx,
+    });
+    return {
+      path: entry.path,
+      moduleId,
+      span: entry.span,
+      selectionKind: entry.selectionKind,
+      targetName: entry.targetName,
+      alias: entry.alias,
+      imports: [],
+    };
+  }
+
+  const importedTarget = canonicalExportTarget({
+    exported: exportedEffect,
+    ctx,
+  });
+  if (!importedTarget) {
+    return undefined;
+  }
+  const imports = bindEffectNamespaceOperations({
+    effectModuleId: importedTarget.moduleId,
+    effectSymbol: importedTarget.symbol,
+    entry,
+    declaredAt: decl.form,
+    visibility: decl.visibility,
+    explicitlyTargetsStdSubmodule,
+    ctx,
+  });
+  return {
+    path: entry.path,
+    moduleId,
+    span: entry.span,
+    selectionKind: entry.selectionKind,
+    targetName: entry.targetName,
+    alias: entry.alias,
+    imports,
+  };
+};
+
+const resolveEffectNamespaceUseEntry = ({
+  namespaceSymbol,
+  entry,
+  decl,
+  ctx,
+}: {
+  namespaceSymbol: SymbolId;
+  entry: ParsedUseEntry;
+  decl: ParsedUseDecl;
+  ctx: BindingContext;
+}): BoundUseEntry | undefined => {
+  const namespaceRecord = ctx.symbolTable.getSymbol(namespaceSymbol);
+  const importedTarget = importedSymbolTargetFromMetadata(
+    namespaceRecord.metadata as Record<string, unknown> | undefined,
+  );
+  const effectModuleId = importedTarget?.moduleId ?? ctx.module.id;
+  const effectSymbol = importedTarget?.symbol ?? namespaceSymbol;
+  const imports = bindEffectNamespaceOperations({
+    effectModuleId,
+    effectSymbol,
+    entry,
+    declaredAt: decl.form,
+    visibility: decl.visibility,
+    explicitlyTargetsStdSubmodule:
+      importedModuleExplicitStdSubmoduleFrom(
+        namespaceRecord.metadata as Record<string, unknown> | undefined,
+      ) ?? false,
+    ctx,
+  });
+  if (
+    imports.length === 0 &&
+    !effectDeclFor({ effectModuleId, effectSymbol, ctx })
+  ) {
+    return undefined;
+  }
+  return {
+    path: entry.path,
+    moduleId: effectModuleId,
+    span: entry.span,
+    selectionKind: entry.selectionKind,
+    targetName: entry.targetName,
+    alias: entry.alias,
+    imports,
+  };
+};
+
+const bindEffectNamespaceOperations = ({
+  effectModuleId,
+  effectSymbol,
+  entry,
+  declaredAt,
+  visibility,
+  explicitlyTargetsStdSubmodule,
+  ctx,
+}: {
+  effectModuleId: string;
+  effectSymbol: SymbolId;
+  entry: ParsedUseEntry;
+  declaredAt: Form;
+  visibility: HirVisibility;
+  explicitlyTargetsStdSubmodule: boolean;
+  ctx: BindingContext;
+}): BoundImport[] => {
+  const effect = effectDeclFor({ effectModuleId, effectSymbol, ctx });
+  if (!effect) {
+    return [];
+  }
+  const selectedNames =
+    entry.selectionKind === "all"
+      ? Array.from(
+          new Set(effect.operations.map((operation) => operation.name)),
+        )
+      : [entry.targetName ?? entry.alias].filter(
+          (name): name is string => typeof name === "string",
+        );
+  const availableNames = new Set(
+    effect.operations.map((operation) => operation.name),
+  );
+  const missingName = selectedNames.find((name) => !availableNames.has(name));
+  if (missingName) {
+    recordImportDiagnostic({
+      params: {
+        kind: "missing-export",
+        moduleId: `${effectModuleId}::${effect.name}`,
+        target: missingName,
+      },
+      span: entry.span,
+      ctx,
+    });
+    return [];
+  }
+
+  if (effectModuleId === ctx.module.id) {
+    return selectedNames.flatMap((name) => {
+      const operations = effect.operations.filter(
+        (operation) => operation.name === name,
+      );
+      const importedName = entry.alias ?? name;
+      const conflict = findEffectOperationSelectionConflict({
+        name: importedName,
+        incomingKind: "effect-op",
+        incomingModuleId: effectModuleId,
+        incomingSymbols: operations.map((operation) => operation.symbol),
+        fallbackSpan: entry.span,
+        ctx,
+      });
+      if (conflict) {
+        recordImportNameConflict({
+          name: importedName,
+          incomingKind: "effect-op",
+          existingKind: conflict.kind,
+          span: entry.span,
+          previousSpan: conflict.span,
+          ctx,
+        });
+        return [];
+      }
+      return operations.map((operation) => {
+          const operationRecord = ctx.symbolTable.getSymbol(operation.symbol);
+          const operationMetadata = (operationRecord.metadata ?? {}) as {
+            unqualifiedEffectOperationNames?: readonly string[];
+          };
+          ctx.symbolTable.setSymbolMetadata(operation.symbol, {
+            unqualifiedEffectOperationNames: Array.from(
+              new Set([
+                ...(operationMetadata.unqualifiedEffectOperationNames ?? []),
+                importedName,
+              ]),
+            ),
+          });
+          return {
+            name: importedName,
+            local: operation.symbol,
+            visibility,
+            span: entry.span,
+          };
+        });
+    });
+  }
+
+  const exports = ctx.moduleExports.get(effectModuleId);
+  if (!exports) {
+    return [];
+  }
+  return selectedNames.flatMap((name) => {
+    const operationSymbols = new Set(
+      effect.operations
+        .filter((operation) => operation.name === name)
+        .map((operation) => operation.symbol),
+    );
+    const exported = exports.get(name);
+    if (!exported || exported.kind !== "effect-op") {
+      return [];
+    }
+    const symbols = (exported.symbols ?? [exported.symbol]).filter((symbol) =>
+      operationSymbols.has(symbol),
+    );
+    if (symbols.length === 0) {
+      return [];
+    }
+    return declareImportedSymbol({
+      exported: { ...exported, symbol: symbols[0]!, symbols },
+      alias: entry.alias ?? name,
+      explicitlyTargetsStdSubmodule,
+      ctx,
+      declaredAt,
+      span: entry.span,
+      visibility,
+    });
+  });
+};
+
+const effectDeclFor = ({
+  effectModuleId,
+  effectSymbol,
+  ctx,
+}: {
+  effectModuleId: string;
+  effectSymbol: SymbolId;
+  ctx: BindingContext;
+}) =>
+  effectModuleId === ctx.module.id
+    ? ctx.decls.getEffect(effectSymbol)
+    : ctx.dependencies.get(effectModuleId)?.decls.getEffect(effectSymbol);
+
+const canonicalExportTarget = ({
+  exported,
+  ctx,
+}: {
+  exported: ModuleExportEntry;
+  ctx: BindingContext;
+}): { moduleId: string; symbol: SymbolId } | undefined => {
+  const dependency = ctx.dependencies.get(exported.moduleId);
+  if (!dependency) {
+    return undefined;
+  }
+  const sourceMetadata = dependency.symbolTable.getSymbol(
+    exported.symbol,
+  ).metadata;
+  return (
+    importedSymbolTargetFromMetadata(
+      sourceMetadata as Record<string, unknown> | undefined,
+    ) ?? { moduleId: exported.moduleId, symbol: exported.symbol }
+  );
+};
+
+const findEffectOperationSelectionConflict = ({
+  name,
+  incomingKind,
+  incomingModuleId,
+  incomingSymbols,
+  fallbackSpan,
+  ctx,
+}: {
+  name: string;
+  incomingKind: SymbolKind;
+  incomingModuleId: string;
+  incomingSymbols: readonly SymbolId[];
+  fallbackSpan: SourceSpan;
+  ctx: BindingContext;
+}): { kind: SymbolKind; span: SourceSpan } | undefined => {
+  const incoming = new Set(incomingSymbols);
+  for (const symbol of ctx.symbolTable.symbolsInScope(
+    ctx.symbolTable.rootScope,
+  )) {
+    if (incoming.has(symbol)) {
+      continue;
+    }
+    const record = ctx.symbolTable.getSymbol(symbol);
+    if (record.kind !== "value" && record.kind !== "effect-op") {
+      continue;
+    }
+    if (incomingKind !== "effect-op" && record.kind !== "effect-op") {
+      continue;
+    }
+    const metadata = (record.metadata ?? {}) as {
+      import?: { moduleId?: unknown; symbol?: unknown };
+      unqualifiedEffectOperationNames?: readonly string[];
+    };
+    const isExposedEffectOperation =
+      record.kind !== "effect-op" ||
+      metadata.import !== undefined ||
+      metadata.unqualifiedEffectOperationNames?.includes(name) === true;
+    if (!isExposedEffectOperation) {
+      continue;
+    }
+    const exposesName =
+      record.name === name ||
+      metadata.unqualifiedEffectOperationNames?.includes(name) === true;
+    if (!exposesName) {
+      continue;
+    }
+    const belongsToIncomingGroup =
+      metadata.import?.moduleId === incomingModuleId &&
+      typeof metadata.import.symbol === "number" &&
+      incoming.has(metadata.import.symbol);
+    if (belongsToIncomingGroup) {
+      continue;
+    }
+    const syntax = ctx.syntaxByNode.get(record.declaredAt);
+    return {
+      kind: record.kind,
+      span: syntax ? toSourceSpan(syntax) : fallbackSpan,
+    };
+  }
+  return undefined;
 };
 
 const resolveLocalTypeNamespaceUseEntry = ({
@@ -643,12 +1028,12 @@ const resolveLocalTypeNamespaceUseEntry = ({
 
   const imports = (() => {
     if (entry.selectionKind === "all") {
-      return Array.from(new Set(namespaceMembers.map(({ name }) => name))).flatMap(
-        (name) => {
-          const imported = localVariant(name);
-          return imported ? [imported] : [];
-        },
-      );
+      return Array.from(
+        new Set(namespaceMembers.map(({ name }) => name)),
+      ).flatMap((name) => {
+        const imported = localVariant(name);
+        return imported ? [imported] : [];
+      });
     }
 
     const targetName = entry.targetName ?? entry.alias;
@@ -788,14 +1173,22 @@ const canonicalBindingSymbol = ({
   while (true) {
     const key = `${currentModuleId}:${currentSymbol}`;
     if (visited.has(key)) {
-      return { moduleId: currentModuleId, symbol: currentSymbol, binding: current };
+      return {
+        moduleId: currentModuleId,
+        symbol: currentSymbol,
+        binding: current,
+      };
     }
     visited.add(key);
     const imported = importedSymbolTargetFromMetadata(
       current.symbolTable.getSymbol(currentSymbol).metadata,
     );
     if (!imported) {
-      return { moduleId: currentModuleId, symbol: currentSymbol, binding: current };
+      return {
+        moduleId: currentModuleId,
+        symbol: currentSymbol,
+        binding: current,
+      };
     }
     const dependency = current.dependencies.get(imported.moduleId);
     if (!dependency) {
@@ -1315,6 +1708,26 @@ const declareImportedSymbol = ({
       ? exported.symbols
       : [exported.symbol];
   const locals: BoundImport[] = [];
+
+  const effectOperationConflict = findEffectOperationSelectionConflict({
+    name: alias,
+    incomingKind: exported.kind,
+    incomingModuleId: exported.moduleId,
+    incomingSymbols: symbols,
+    fallbackSpan: span,
+    ctx,
+  });
+  if (effectOperationConflict) {
+    recordImportNameConflict({
+      name: alias,
+      incomingKind: exported.kind,
+      existingKind: effectOperationConflict.kind,
+      span,
+      previousSpan: effectOperationConflict.span,
+      ctx,
+    });
+    return [];
+  }
 
   symbols.forEach((symbol) => {
     const importNameCollision = findModuleNamespaceNameCollision({

--- a/packages/compiler/src/semantics/binding/binders/module.ts
+++ b/packages/compiler/src/semantics/binding/binders/module.ts
@@ -715,6 +715,23 @@ const bindEffectNamespaceOperations = ({
         (operation) => operation.name === name,
       );
       const importedName = entry.alias ?? name;
+      const moduleConflict = findModuleNamespaceNameCollision({
+        name: importedName,
+        scope: ctx.symbolTable.rootScope,
+        incomingKind: "effect-op",
+        ctx,
+      });
+      if (moduleConflict) {
+        recordImportNameConflict({
+          name: importedName,
+          incomingKind: "effect-op",
+          existingKind: moduleConflict.kind,
+          span: entry.span,
+          previousSpan: moduleConflict.span,
+          ctx,
+        });
+        return [];
+      }
       const conflict = findEffectOperationSelectionConflict({
         name: importedName,
         incomingKind: "effect-op",

--- a/packages/compiler/src/semantics/binding/binders/module.ts
+++ b/packages/compiler/src/semantics/binding/binders/module.ts
@@ -135,6 +135,7 @@ export const bindModule = (
 
   flushPendingStaticMethods(ctx);
   seedTypeAliasNamespaces(ctx);
+  validateEffectOperationSelectionValueConflicts(ctx);
 
   if (tracker.depth() !== 1) {
     throw new Error("binder scope stack imbalance after traversal");
@@ -734,25 +735,31 @@ const bindEffectNamespaceOperations = ({
         return [];
       }
       return operations.map((operation) => {
-          const operationRecord = ctx.symbolTable.getSymbol(operation.symbol);
-          const operationMetadata = (operationRecord.metadata ?? {}) as {
-            unqualifiedEffectOperationNames?: readonly string[];
-          };
-          ctx.symbolTable.setSymbolMetadata(operation.symbol, {
-            unqualifiedEffectOperationNames: Array.from(
-              new Set([
-                ...(operationMetadata.unqualifiedEffectOperationNames ?? []),
-                importedName,
-              ]),
-            ),
-          });
-          return {
-            name: importedName,
-            local: operation.symbol,
-            visibility,
-            span: entry.span,
-          };
+        const operationRecord = ctx.symbolTable.getSymbol(operation.symbol);
+        const operationMetadata = (operationRecord.metadata ?? {}) as {
+          unqualifiedEffectOperationNames?: readonly string[];
+        };
+        ctx.symbolTable.setSymbolMetadata(operation.symbol, {
+          unqualifiedEffectOperationNames: Array.from(
+            new Set([
+              ...(operationMetadata.unqualifiedEffectOperationNames ?? []),
+              importedName,
+            ]),
+          ),
         });
+        if (importedName !== operationRecord.name) {
+          ctx.symbolTable.bindAlias({
+            name: importedName,
+            symbol: operation.symbol,
+          });
+        }
+        return {
+          name: importedName,
+          local: operation.symbol,
+          visibility,
+          span: entry.span,
+        };
+      });
     });
   }
 
@@ -784,6 +791,41 @@ const bindEffectNamespaceOperations = ({
       declaredAt,
       span: entry.span,
       visibility,
+    });
+  });
+};
+
+const validateEffectOperationSelectionValueConflicts = (
+  ctx: BindingContext,
+): void => {
+  ctx.uses.forEach((use) => {
+    use.entries.forEach((entry) => {
+      const effectOperationImports = entry.imports.filter(
+        (imported) =>
+          ctx.symbolTable.getSymbol(imported.local).kind === "effect-op",
+      );
+      const importedNames = new Set(
+        effectOperationImports.map((imported) => imported.name),
+      );
+      importedNames.forEach((name) => {
+        const valueConflict = Array.from(
+          ctx.symbolTable.symbolsInScope(ctx.symbolTable.rootScope),
+        )
+          .map((symbol) => ctx.symbolTable.getSymbol(symbol))
+          .find((record) => record.kind === "value" && record.name === name);
+        if (!valueConflict) {
+          return;
+        }
+        const syntax = ctx.syntaxByNode.get(valueConflict.declaredAt);
+        recordImportNameConflict({
+          name,
+          incomingKind: "effect-op",
+          existingKind: "value",
+          span: entry.span,
+          previousSpan: syntax ? toSourceSpan(syntax) : entry.span,
+          ctx,
+        });
+      });
     });
   });
 };

--- a/packages/compiler/src/semantics/effect-operation-resolution.ts
+++ b/packages/compiler/src/semantics/effect-operation-resolution.ts
@@ -10,24 +10,22 @@ export const resolveUnqualifiedEffectOperation = ({
   scope: ScopeId;
   symbolTable: SymbolTable;
 }): SymbolId | undefined => {
-  const candidates = symbolTable
-    .resolveAllByKinds(name, scope, ["effect-op"])
-    .filter((symbol) => {
-      const metadata = (symbolTable.getSymbol(symbol).metadata ?? {}) as {
-        import?: unknown;
-        unqualifiedEffectOperationNames?: readonly string[];
-      };
-      return (
-        metadata.import !== undefined ||
-        metadata.unqualifiedEffectOperationNames === undefined ||
-        metadata.unqualifiedEffectOperationNames?.includes(name) === true
-      );
-    });
-  const local = candidates.findLast((symbol) => {
+  const candidates = symbolTable.resolveAllByKinds(name, scope, ["effect-op"]);
+  const exposedCandidates = candidates.filter((symbol) => {
+    const metadata = (symbolTable.getSymbol(symbol).metadata ?? {}) as {
+      import?: unknown;
+      unqualifiedEffectOperationNames?: readonly string[];
+    };
+    return (
+      metadata.import !== undefined ||
+      metadata.unqualifiedEffectOperationNames?.includes(name) === true
+    );
+  });
+  const local = exposedCandidates.findLast((symbol) => {
     const metadata = symbolTable.getSymbol(symbol).metadata as
       | { import?: unknown }
       | undefined;
     return metadata?.import === undefined;
   });
-  return local ?? candidates[0];
+  return local ?? exposedCandidates[0] ?? candidates.at(-1);
 };

--- a/packages/compiler/src/semantics/effect-operation-resolution.ts
+++ b/packages/compiler/src/semantics/effect-operation-resolution.ts
@@ -1,0 +1,33 @@
+import type { SymbolTable } from "./binder/index.js";
+import type { ScopeId, SymbolId } from "./ids.js";
+
+export const resolveUnqualifiedEffectOperation = ({
+  name,
+  scope,
+  symbolTable,
+}: {
+  name: string;
+  scope: ScopeId;
+  symbolTable: SymbolTable;
+}): SymbolId | undefined => {
+  const candidates = symbolTable
+    .resolveAllByKinds(name, scope, ["effect-op"])
+    .filter((symbol) => {
+      const metadata = (symbolTable.getSymbol(symbol).metadata ?? {}) as {
+        import?: unknown;
+        unqualifiedEffectOperationNames?: readonly string[];
+      };
+      return (
+        metadata.import !== undefined ||
+        metadata.unqualifiedEffectOperationNames === undefined ||
+        metadata.unqualifiedEffectOperationNames?.includes(name) === true
+      );
+    });
+  const local = candidates.findLast((symbol) => {
+    const metadata = symbolTable.getSymbol(symbol).metadata as
+      | { import?: unknown }
+      | undefined;
+    return metadata?.import === undefined;
+  });
+  return local ?? candidates[0];
+};

--- a/packages/compiler/src/semantics/lowering/expressions/try.ts
+++ b/packages/compiler/src/semantics/lowering/expressions/try.ts
@@ -18,6 +18,7 @@ import { toSourceSpan } from "../../../parser/surface/utils.js";
 import { resolveSymbol } from "../resolution.js";
 import { lowerTypeExpr } from "../type-expressions.js";
 import type { LoweringFormParams } from "./types.js";
+import { resolveUnqualifiedEffectOperation } from "../../effect-operation-resolution.js";
 
 const collectNamespaceSegments = (
   expr: Expr | undefined,
@@ -80,8 +81,11 @@ export const lowerTry = ({
       expr: bodyExpr,
       scope: scopes.current(),
       resolveBareHandlerHead: ({ name, scope }) =>
-        typeof ctx.symbolTable.resolveByKinds(name, scope, ["effect-op"]) ===
-        "number",
+        typeof resolveUnqualifiedEffectOperation({
+          name,
+          scope,
+          symbolTable: ctx.symbolTable,
+        }) === "number",
       getNestedScope: ({ expr, parentScope }) =>
         ctx.scopeByNode.get(expr.syntaxId) ?? parentScope,
     });
@@ -244,5 +248,8 @@ const resolveEffectOperationSymbol = ({
   scope: number;
   ctx: LoweringFormParams["ctx"];
 }): number =>
-  ctx.symbolTable.resolveByKinds(opName, scope, ["effect-op"]) ??
-  resolveSymbol(opName, scope, ctx);
+  resolveUnqualifiedEffectOperation({
+    name: opName,
+    scope,
+    symbolTable: ctx.symbolTable,
+  }) ?? resolveSymbol(opName, scope, ctx);

--- a/packages/compiler/src/semantics/lowering/resolution.ts
+++ b/packages/compiler/src/semantics/lowering/resolution.ts
@@ -25,8 +25,21 @@ const resolveValueSymbol = ({
   while (currentScope !== null) {
     const matches = Array.from(ctx.symbolTable.symbolsInScope(currentScope))
       .map((symbol) => ({ symbol, record: ctx.symbolTable.getSymbol(symbol) }))
-      .filter(({ record }) => {
-        if (record.name !== identifier.name || record.kind === "effect-op") {
+      .filter(({ symbol, record }) => {
+        const metadata = (record.metadata ?? {}) as {
+          unqualifiedEffectOperationNames?: readonly string[];
+        };
+        const explicitlyImportedEffectOperation =
+          record.kind === "effect-op" &&
+          metadata.unqualifiedEffectOperationNames?.includes(identifier.name) ===
+            true;
+        if (
+          (record.name !== identifier.name &&
+            !explicitlyImportedEffectOperation) ||
+          (record.kind === "effect-op" &&
+            !isImportedSymbol(symbol, ctx) &&
+            !explicitlyImportedEffectOperation)
+        ) {
           return false;
         }
         const meta = (record.metadata ?? {}) as { quotedName?: boolean };
@@ -62,7 +75,7 @@ const resolveValueSymbol = ({
 export const resolveIdentifierValue = (
   identifier: { name: string; isQuoted: boolean },
   scope: ScopeId,
-  ctx: LowerContext
+  ctx: LowerContext,
 ): IdentifierResolution => {
   const name = identifier.name;
   const resolved = resolveValueSymbol({ identifier, scope, ctx });
@@ -102,7 +115,7 @@ export const resolveIdentifierValue = (
 export const resolveSymbol = (
   name: string,
   scope: ScopeId,
-  ctx: LowerContext
+  ctx: LowerContext,
 ): SymbolId => {
   const resolved = ctx.symbolTable.resolve(name, scope);
   if (typeof resolved === "number") {
@@ -120,7 +133,7 @@ export const resolveSymbol = (
 export const resolveTypeSymbol = (
   name: string,
   scope: ScopeId,
-  ctx: LowerContext
+  ctx: LowerContext,
 ): SymbolId | undefined => {
   const resolved = ctx.symbolTable.resolve(name, scope);
   if (typeof resolved === "number") {
@@ -138,7 +151,7 @@ export const resolveTypeSymbol = (
 
 const resolveIntrinsicSymbol = (
   name: string,
-  ctx: LowerContext
+  ctx: LowerContext,
 ): SymbolId | undefined => {
   let intrinsic = ctx.intrinsicSymbols.get(name);
   if (typeof intrinsic === "number") {
@@ -165,7 +178,7 @@ const resolveIntrinsicSymbol = (
 
 const resolveIntrinsicTypeSymbol = (
   name: string,
-  ctx: LowerContext
+  ctx: LowerContext,
 ): SymbolId | undefined => {
   const intrinsic = intrinsicTypeMetadataFor(name);
   if (!intrinsic) {
@@ -186,10 +199,7 @@ const resolveIntrinsicTypeSymbol = (
   return symbol;
 };
 
-const declareUnresolvedSymbol = (
-  name: string,
-  ctx: LowerContext
-): SymbolId =>
+const declareUnresolvedSymbol = (name: string, ctx: LowerContext): SymbolId =>
   ctx.symbolTable.declare({
     name,
     kind: "value",
@@ -224,7 +234,7 @@ export const resolveConstructorResolution = ({
   const overloadIds = new Set(
     symbols
       .map((symbol) => ctx.overloadBySymbol.get(symbol))
-      .filter((entry): entry is number => typeof entry === "number")
+      .filter((entry): entry is number => typeof entry === "number"),
   );
 
   if (symbols.length === 1) {
@@ -258,7 +268,9 @@ const unwrapAliasConstructorTargetSymbol = ({
   ctx: LowerContext;
 }): SymbolId => {
   const record = ctx.symbolTable.getSymbol(symbol);
-  const metadata = record.metadata as { aliasConstructorTarget?: unknown } | undefined;
+  const metadata = record.metadata as
+    | { aliasConstructorTarget?: unknown }
+    | undefined;
   return typeof metadata?.aliasConstructorTarget === "number"
     ? metadata.aliasConstructorTarget
     : symbol;

--- a/packages/reference/docs/modules.md
+++ b/packages/reference/docs/modules.md
@@ -62,6 +62,20 @@ For a locally declared enum, its variant names are already in the declaring
 module's scope; importing them again is accepted as an idempotent namespace
 selection and is mainly useful for consistency or re-export declarations.
 
+Effect operations can also be selected through an effect namespace. Selecting
+`all` imports every operation owned by that effect; a grouped selection imports
+only the named operations.
+
+```voyd
+use src::articles::ArticleStorage::all
+use src::audit::{ AuditLog::{ record_change } }
+```
+
+These imports make the selected operations available as unqualified calls.
+They do not import the owning effect name, so import that separately when it is
+also needed in an effect row or qualified call. A module-wide `module::all`
+import continues to exclude effect operations.
+
 ## Re-exports
 
 Use `pub use` to re-export names.

--- a/packages/reference/docs/types/effects.md
+++ b/packages/reference/docs/types/effects.md
@@ -43,6 +43,36 @@ fn load_with(cb: fn() : Async -> i32) -> i32
   cb()
 ```
 
+## Importing operations
+
+An effect alone keeps its operations qualified. Select operations explicitly
+when unqualified calls make the surrounding code clearer.
+
+```voyd
+use src::articles::ArticleStorage
+use ArticleStorage::{ save_article }
+
+fn save(content: String): ArticleStorage -> Result
+  save_article(content)
+```
+
+`EffectName::all` selects every operation owned by that effect, while a grouped
+selection introduces only the named operations. Fully qualified and nested
+module-group spellings are equivalent:
+
+```voyd
+use src::articles::ArticleStorage::all
+use src::articles::{ ArticleStorage::{ save_article } }
+```
+
+Selecting operations does not implicitly import `ArticleStorage`, and importing
+the effect alone does not make `save_article(...)` an unqualified call target.
+Qualified calls such as `ArticleStorage::save_article(...)` remain available.
+
+Effect names should describe the required capability with a noun such as
+`ArticleStorage` or `ArticleAccess`; a universal `Effect` suffix usually adds no
+meaning.
+
 ## Handling effects
 
 ```voyd


### PR DESCRIPTION
## Summary

- support selective and `all` imports through effect namespaces in all five requested spellings
- preserve owning-effect identity, overloads, visibility, aliases, re-exports, duplicate behavior, and deterministic collisions
- keep effect declarations/imports qualified by default and keep `module::all` excluding effect operations
- document effect-operation imports and capability-noun naming guidance

## Root cause

Use-path discovery treated the effect name as a child module for fully qualified selections, the binder only recognized module and enum/union implicit namespaces, and ordinary value lowering excluded effect-operation symbols even when explicitly imported.

## Validation

- `npm test` (18/18 package tasks)
- `npm run typecheck` (17/17 tasks)
- `npm run test:audit`
- focused compiler module graph/import/codegen suite (116 tests)
- consolidated agentic implementation-gap, architecture, and correctness review loop; final pass clean

## Test ownership and cost

Coverage extends existing compiler-owned module import/codegen files. The five syntax spellings share one parameterized compile/run group to batch the same boundary without adding a new compile-heavy test file.