### PR TITLE
Clean up compiler call resolution

### DIFF
--- a/packages/compiler/src/codegen/expressions/call/entrypoints.ts
+++ b/packages/compiler/src/codegen/expressions/call/entrypoints.ts
@@ -23,10 +23,7 @@ import {
   compileIntrinsicCall,
 } from "../../intrinsics.js";
 import { effectsFacade } from "../../effects/facade.js";
-import {
-  getRequiredExprType,
-  substituteTypeForInstance,
-} from "../../types.js";
+import { getRequiredExprType, substituteTypeForInstance } from "../../types.js";
 import { compileCallArgumentsWithMetadata } from "./arguments.js";
 import { compileClosureCall, compileCurriedClosureCall } from "./closure.js";
 import { getFunctionMetadataForCall } from "./metadata.js";
@@ -60,10 +57,24 @@ export const compileCallExpr = (
 
   const callInfo = ctx.program.calls.getCallInfo(ctx.moduleId, expr.id);
   const expectTraitDispatch = callInfo.traitDispatch;
-
-  if (expr.staticTraitTarget && typeof expr.staticTraitSymbol === "number") {
-    return compileStaticTraitCall({
+  const compileResolvedTarget = ({
+    targetFunctionId,
+    traitDispatchEnabled = expectTraitDispatch,
+    missingTraitDispatchMessage,
+    inferImplTypeArgs = true,
+  }: {
+    targetFunctionId: ProgramSymbolId;
+    traitDispatchEnabled?: boolean;
+    missingTraitDispatchMessage: string;
+    inferImplTypeArgs?: boolean;
+  }): CompiledExpression => {
+    const targetRef = ctx.program.symbols.refOf(targetFunctionId);
+    return compileResolvedSymbolCall({
       expr,
+      symbol: targetRef.symbol,
+      moduleId: targetRef.moduleId,
+      traitDispatchEnabled,
+      missingTraitDispatchMessage,
       ctx,
       fnCtx,
       compileExpr,
@@ -72,6 +83,31 @@ export const compileCallExpr = (
       typeInstanceId,
       outResultStorageRef,
       scalarAggregateResultTypeId: options.scalarAggregateResultTypeId,
+      typeArgsOverride: inferImplTypeArgs
+        ? inferTraitImplTypeArgs({
+            expr,
+            implMethod: targetFunctionId,
+            ctx,
+            typeInstanceId,
+          })
+        : undefined,
+    });
+  };
+
+  if (expr.staticTraitTarget && typeof expr.staticTraitSymbol === "number") {
+    const targetFunctionId = resolveTargetFunctionId({
+      targets: callInfo.targets,
+      callInstanceId,
+      typeInstanceId,
+    });
+    if (typeof targetFunctionId !== "number") {
+      throw new Error("codegen missing resolved static trait method target");
+    }
+    return compileResolvedTarget({
+      targetFunctionId: targetFunctionId as ProgramSymbolId,
+      traitDispatchEnabled: false,
+      missingTraitDispatchMessage: "",
+      inferImplTypeArgs: false,
     });
   }
 
@@ -100,31 +136,10 @@ export const compileCallExpr = (
       throw new Error("codegen missing overload resolution for indirect call");
     }
 
-    const targetRef = ctx.program.symbols.refOf(
-      targetFunctionId as ProgramSymbolId,
-    );
-    const traitImplTypeArgs = inferTraitImplTypeArgs({
-      expr,
-      implMethod: targetFunctionId as ProgramSymbolId,
-      ctx,
-      typeInstanceId,
-    });
-    return compileResolvedSymbolCall({
-      expr,
-      symbol: targetRef.symbol,
-      moduleId: targetRef.moduleId,
-      traitDispatchEnabled: expectTraitDispatch,
+    return compileResolvedTarget({
+      targetFunctionId: targetFunctionId as ProgramSymbolId,
       missingTraitDispatchMessage:
         "codegen missing trait dispatch target for indirect call",
-      ctx,
-      fnCtx,
-      compileExpr,
-      tailPosition,
-      expectedResultTypeId,
-      typeInstanceId,
-      outResultStorageRef,
-      scalarAggregateResultTypeId: options.scalarAggregateResultTypeId,
-      typeArgsOverride: traitImplTypeArgs,
     });
   }
 
@@ -150,31 +165,10 @@ export const compileCallExpr = (
     });
 
     if (typeof targetFunctionId === "number") {
-      const targetRef = ctx.program.symbols.refOf(
-        targetFunctionId as ProgramSymbolId,
-      );
-      const traitImplTypeArgs = inferTraitImplTypeArgs({
-        expr,
-        implMethod: targetFunctionId as ProgramSymbolId,
-        ctx,
-        typeInstanceId,
-      });
-      return compileResolvedSymbolCall({
-        expr,
-        symbol: targetRef.symbol,
-        moduleId: targetRef.moduleId,
-        traitDispatchEnabled: expectTraitDispatch,
+      return compileResolvedTarget({
+        targetFunctionId: targetFunctionId as ProgramSymbolId,
         missingTraitDispatchMessage:
           "codegen missing trait dispatch target for call",
-        ctx,
-        fnCtx,
-        compileExpr,
-        tailPosition,
-        expectedResultTypeId,
-        typeInstanceId,
-        outResultStorageRef,
-        scalarAggregateResultTypeId: options.scalarAggregateResultTypeId,
-        typeArgsOverride: traitImplTypeArgs,
       });
     }
 
@@ -394,7 +388,10 @@ const concreteReceiverTypeForTraitCall = ({
   typeInstanceId: ProgramFunctionInstanceId | undefined;
 }): TypeId => {
   const receiverExpr = ctx.module.hir.expressions.get(receiverExprId);
-  if (typeof typeInstanceId === "number" && receiverExpr?.exprKind === "identifier") {
+  if (
+    typeof typeInstanceId === "number" &&
+    receiverExpr?.exprKind === "identifier"
+  ) {
     const instance = ctx.program.functions.getInstance(typeInstanceId);
     const signature = ctx.program.functions.getSignature(
       instance.symbolRef.moduleId,
@@ -600,20 +597,16 @@ const resolveConcreteTraitMethodTarget = ({
       : receiverType;
   const mapping =
     ctx.program.traits.getTraitMethodImpl(selectedMethod) ??
-    ctx.program.traits
-      .getImplTemplates()
-      .flatMap((template) =>
-        template.methods.some(
-          (method) => method.traitMethod === selectedMethod,
-        )
-          ? [
-              {
-                traitSymbol: template.traitSymbol,
-                traitMethodSymbol: selectedMethod,
-              },
-            ]
-          : [],
-      )[0];
+    ctx.program.traits.getImplTemplates().flatMap((template) =>
+      template.methods.some((method) => method.traitMethod === selectedMethod)
+        ? [
+            {
+              traitSymbol: template.traitSymbol,
+              traitMethodSymbol: selectedMethod,
+            },
+          ]
+        : [],
+    )[0];
   if (!mapping) {
     return undefined;
   }
@@ -627,11 +620,15 @@ const resolveConcreteTraitMethodTarget = ({
     if (!method) {
       return [];
     }
-    const match = ctx.program.types.unify(dispatchReceiverType, template.target, {
-      location: expr.ast,
-      reason: "concrete trait method dispatch",
-      variance: "invariant",
-    });
+    const match = ctx.program.types.unify(
+      dispatchReceiverType,
+      template.target,
+      {
+        location: expr.ast,
+        reason: "concrete trait method dispatch",
+        variance: "invariant",
+      },
+    );
     return match.ok ? [method.implMethod] : [];
   });
   const uniqueMatches = Array.from(new Set(matches));
@@ -711,59 +708,6 @@ const receiverSpecializedMetaForCall = ({
       exactParameterTypes,
     }) ?? meta
   );
-};
-
-const compileStaticTraitCall = ({
-  expr,
-  ctx,
-  fnCtx,
-  compileExpr,
-  tailPosition,
-  expectedResultTypeId,
-  typeInstanceId,
-  outResultStorageRef,
-  scalarAggregateResultTypeId,
-}: {
-  expr: HirCallExpr;
-  ctx: CodegenContext;
-  fnCtx: FunctionContext;
-  compileExpr: ExpressionCompiler;
-  tailPosition: boolean;
-  expectedResultTypeId?: TypeId;
-  typeInstanceId?: ProgramFunctionInstanceId;
-  outResultStorageRef?: CompileCallOptions["outResultStorageRef"];
-  scalarAggregateResultTypeId?: TypeId;
-}): CompiledExpression => {
-  if (!expr.staticTraitTarget || typeof expr.staticTraitSymbol !== "number") {
-    throw new Error("codegen expected static trait dispatch metadata");
-  }
-  const callInfo = ctx.program.calls.getCallInfo(ctx.moduleId, expr.id);
-  const targetFunctionId = resolveTargetFunctionId({
-    targets: callInfo.targets,
-    callInstanceId: fnCtx.instanceId ?? typeInstanceId,
-    typeInstanceId,
-  });
-  if (typeof targetFunctionId !== "number") {
-    throw new Error("codegen missing resolved static trait method target");
-  }
-  const targetRef = ctx.program.symbols.refOf(
-    targetFunctionId as ProgramSymbolId,
-  );
-  return compileResolvedSymbolCall({
-    expr,
-    symbol: targetRef.symbol,
-    moduleId: targetRef.moduleId,
-    traitDispatchEnabled: false,
-    missingTraitDispatchMessage: "",
-    ctx,
-    fnCtx,
-    compileExpr,
-    tailPosition,
-    expectedResultTypeId,
-    typeInstanceId,
-    outResultStorageRef,
-    scalarAggregateResultTypeId,
-  });
 };
 
 const compileResolvedSymbolCall = ({

--- a/packages/compiler/src/semantics/codegen-view/index.ts
+++ b/packages/compiler/src/semantics/codegen-view/index.ts
@@ -477,7 +477,10 @@ const defaultValueIsStableCallsiteId = ({
     intrinsic?: unknown;
     intrinsicName?: unknown;
   };
-  return metadata.intrinsic === true && metadata.intrinsicName === "__stable_callsite_id";
+  return (
+    metadata.intrinsic === true &&
+    metadata.intrinsicName === "__stable_callsite_id"
+  );
 };
 
 export const buildProgramCodegenView = (
@@ -1169,7 +1172,8 @@ export const buildProgramCodegenView = (
         name: effect.name,
         effectId: effect.effectId,
         external: Boolean(
-          (effect.form?.attributes as { external?: unknown } | undefined)?.external,
+          (effect.form?.attributes as { external?: unknown } | undefined)
+            ?.external,
         ),
         visibility: effect.visibility,
         symbol: effect.symbol,
@@ -1309,30 +1313,29 @@ export const buildProgramCodegenView = (
     });
   };
 
+  const canonicalizeTraitMethods = (
+    methods: ReadonlyMap<SymbolId, SymbolId>,
+    moduleId: string,
+  ) =>
+    Array.from(methods.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([traitMethod, implMethod]) => ({
+        traitMethod: canonicalProgramSymbolIdOf(moduleId, traitMethod),
+        implMethod: canonicalProgramSymbolIdOf(moduleId, implMethod),
+      }));
+
   const toCodegenTraitImplInstanceForModule = (
     impl: TraitImplInstance,
     moduleId: string,
   ): CodegenTraitImplInstance => {
     const traitSymbol = canonicalProgramSymbolIdOf(moduleId, impl.traitSymbol);
     const implSymbol = canonicalProgramSymbolIdOf(moduleId, impl.implSymbol);
-    const methods = Array.from(impl.methods.entries())
-      .sort(([a], [b]) => a - b)
-      .map(([traitMethod, implMethod]) => ({
-        traitMethod: canonicalProgramSymbolIdOf(moduleId, traitMethod),
-        implMethod: canonicalProgramSymbolIdOf(moduleId, implMethod),
-      }));
-    const staticMethods = Array.from(impl.staticMethods.entries())
-      .sort(([a], [b]) => a - b)
-      .map(([traitMethod, implMethod]) => ({
-        traitMethod: canonicalProgramSymbolIdOf(moduleId, traitMethod),
-        implMethod: canonicalProgramSymbolIdOf(moduleId, implMethod),
-      }));
     return toCodegenTraitImplInstance({
       impl,
       traitSymbol,
       implSymbol,
-      methods,
-      staticMethods,
+      methods: canonicalizeTraitMethods(impl.methods, moduleId),
+      staticMethods: canonicalizeTraitMethods(impl.staticMethods, moduleId),
     });
   };
 
@@ -1355,18 +1358,8 @@ export const buildProgramCodegenView = (
     traitSymbol: canonicalProgramSymbolIdOf(moduleId, template.traitSymbol),
     target: template.target,
     typeParams: template.typeParams.map((parameter) => parameter.typeParam),
-    methods: Array.from(template.methods.entries())
-      .sort(([a], [b]) => a - b)
-      .map(([traitMethod, implMethod]) => ({
-        traitMethod: canonicalProgramSymbolIdOf(moduleId, traitMethod),
-        implMethod: canonicalProgramSymbolIdOf(moduleId, implMethod),
-      })),
-    staticMethods: Array.from(template.staticMethods.entries())
-      .sort(([a], [b]) => a - b)
-      .map(([traitMethod, implMethod]) => ({
-        traitMethod: canonicalProgramSymbolIdOf(moduleId, traitMethod),
-        implMethod: canonicalProgramSymbolIdOf(moduleId, implMethod),
-      })),
+    methods: canonicalizeTraitMethods(template.methods, moduleId),
+    staticMethods: canonicalizeTraitMethods(template.staticMethods, moduleId),
     implSymbol: canonicalProgramSymbolIdOf(moduleId, template.implSymbol),
   });
 
@@ -1916,13 +1909,14 @@ export const buildProgramCodegenView = (
     );
   };
   uniqueTraitImplTemplates.forEach((template) => {
-    [...template.methods, ...template.staticMethods].forEach(({ traitMethod, implMethod }) =>
-      registerTraitMethodImplMapping({
-        implMethod,
-        traitSymbol: template.traitSymbol,
-        traitMethodSymbol: traitMethod,
-        source: `template ${describeProgramSymbol(template.implSymbol)}`,
-      }),
+    [...template.methods, ...template.staticMethods].forEach(
+      ({ traitMethod, implMethod }) =>
+        registerTraitMethodImplMapping({
+          implMethod,
+          traitSymbol: template.traitSymbol,
+          traitMethodSymbol: traitMethod,
+          source: `template ${describeProgramSymbol(template.implSymbol)}`,
+        }),
     );
   });
   const assertTraitDispatchConsistency = (): void => {
@@ -1951,25 +1945,27 @@ export const buildProgramCodegenView = (
     };
 
     uniqueTraitImplTemplates.forEach((template) => {
-      [...template.methods, ...template.staticMethods].forEach(({ traitMethod, implMethod }) =>
-        registerRegistration({
-          implMethod,
-          traitSymbol: template.traitSymbol,
-          traitMethodSymbol: traitMethod,
-          source: `template ${describeProgramSymbol(template.implSymbol)}`,
-        }),
+      [...template.methods, ...template.staticMethods].forEach(
+        ({ traitMethod, implMethod }) =>
+          registerRegistration({
+            implMethod,
+            traitSymbol: template.traitSymbol,
+            traitMethodSymbol: traitMethod,
+            source: `template ${describeProgramSymbol(template.implSymbol)}`,
+          }),
       );
     });
 
     traitImplsByNominal.forEach((impls, nominal) => {
       impls.forEach((impl) => {
-        [...impl.methods, ...impl.staticMethods].forEach(({ traitMethod, implMethod }) =>
-          registerRegistration({
-            implMethod,
-            traitSymbol: impl.traitSymbol,
-            traitMethodSymbol: traitMethod,
-            source: `nominal ${nominal} impl ${describeProgramSymbol(impl.implSymbol)}`,
-          }),
+        [...impl.methods, ...impl.staticMethods].forEach(
+          ({ traitMethod, implMethod }) =>
+            registerRegistration({
+              implMethod,
+              traitSymbol: impl.traitSymbol,
+              traitMethodSymbol: traitMethod,
+              source: `nominal ${nominal} impl ${describeProgramSymbol(impl.implSymbol)}`,
+            }),
         );
       });
     });

--- a/packages/compiler/src/semantics/typing/expressions/call.ts
+++ b/packages/compiler/src/semantics/typing/expressions/call.ts
@@ -67,12 +67,14 @@ import {
   type ExpectedCallContext,
 } from "./overload-candidates.js";
 import {
-  applyExplicitTypeArguments,
+  applyExplicitTypeArgumentSubstitution,
+  applyTargetTypeArguments,
   enforceOverloadCandidateBudget,
   findOverloadMatches,
   type OverloadMatchScoreOverrides,
   selectHintedOverloadCandidates,
   signatureCallShapeCouldMatch,
+  specializeOverloadParameters,
 } from "./overload-resolution.js";
 import { typeExpression, withSpeculativeExprTyping } from "../expressions.js";
 import { applyCurrentSubstitution } from "./shared.js";
@@ -103,8 +105,10 @@ import {
 } from "../import-type-translation.js";
 import { typingContextsShareInterners } from "../shared-interners.js";
 import { mapDependencySymbolToLocal } from "../import-symbol-mapping.js";
-import { hydrateImportedTraitMetadataForOwnerRef } from "../import-trait-impl-hydration.js";
-import { hydrateExternalTraitImplsForOwnerRef } from "../import-trait-impl-hydration.js";
+import {
+  hydrateExternalTraitImplsForOwnerRef,
+  hydrateImportedTraitMetadataForOwnerRef,
+} from "../import-trait-impl-hydration.js";
 import { collectTraitOwnersFromTypeParams } from "../constraint-trait-owners.js";
 import { typeDefaultParameterValues } from "../default-parameters.js";
 import { stableCallsiteIdFor } from "../../../stable-callsite-id.js";
@@ -138,24 +142,6 @@ const dependencyMethodSignatureCache = new WeakMap<
   TypingContext,
   Map<string, FunctionSignature>
 >();
-
-const valueTraitObjectWideningFor = ({
-  actual,
-  expected,
-  ctx,
-  state,
-}: {
-  actual: TypeId;
-  expected: TypeId;
-  ctx: TypingContext;
-  state: TypingState;
-}) =>
-  disallowedValueTraitObjectWidening({
-    actual,
-    expected,
-    ctx,
-    state,
-  });
 
 const ensureImportedConstraintTraitsForSignature = ({
   signature,
@@ -244,6 +230,78 @@ const getDependencyMethodSignature = ({
   }).signature;
   cache.set(key, translated);
   return translated;
+};
+
+const getMethodSignature = ({
+  symbolRef,
+  ctx,
+}: {
+  symbolRef: SymbolRef;
+  ctx: TypingContext;
+}): FunctionSignature | undefined => {
+  if (symbolRef.moduleId === ctx.moduleId) {
+    return ctx.functions.getSignature(symbolRef.symbol);
+  }
+  const dependency = ctx.dependencies.get(symbolRef.moduleId);
+  return dependency
+    ? getDependencyMethodSignature({
+        dependency,
+        symbol: symbolRef.symbol,
+        ctx,
+      })
+    : undefined;
+};
+
+const specializeImplMethodSignature = ({
+  signature,
+  implTypeArguments,
+  ctx,
+}: {
+  signature: FunctionSignature;
+  implTypeArguments: readonly TypeId[];
+  ctx: TypingContext;
+}): FunctionSignature => {
+  const methodTypeParamCount = Math.max(
+    0,
+    (signature.typeParams?.length ?? 0) - implTypeArguments.length,
+  );
+  const substitution = new Map<TypeParamId, TypeId>();
+  signature.typeParams
+    ?.slice(methodTypeParamCount)
+    .forEach((parameter, index) =>
+      substitution.set(parameter.typeParam, implTypeArguments[index]!),
+    );
+  return {
+    ...signature,
+    parameters: signature.parameters.map((parameter) => ({
+      ...parameter,
+      type: ctx.arena.substitute(parameter.type, substitution),
+    })),
+    returnType: ctx.arena.substitute(signature.returnType, substitution),
+    typeParams: signature.typeParams?.slice(0, methodTypeParamCount),
+  };
+};
+
+const recordCallTarget = ({
+  callId,
+  target,
+  context,
+  ctx,
+  state,
+}: {
+  callId: HirExprId;
+  target: SymbolRef;
+  context: string;
+  ctx: TypingContext;
+  state: TypingState;
+}): void => {
+  const instanceKey = state.currentFunction?.instanceKey;
+  if (!instanceKey) {
+    throw new Error(`missing function instance key for ${context} ${callId}`);
+  }
+  const targets = ctx.callResolution.targets.get(callId) ?? new Map();
+  targets.set(instanceKey, target);
+  ctx.callResolution.targets.set(callId, targets);
 };
 
 export const typeCallExpr = (
@@ -823,19 +881,7 @@ const typeStaticTraitCall = ({
           seenGenericTraitMethods.add(traitMethodKey);
         }
         const symbolRef = canonicalSymbolRefForTypingContext(implMethod, ctx);
-        const signature =
-          symbolRef.moduleId === ctx.moduleId
-            ? ctx.functions.getSignature(symbolRef.symbol)
-            : (() => {
-                const dependency = ctx.dependencies.get(symbolRef.moduleId);
-                return dependency
-                  ? getDependencyMethodSignature({
-                      dependency,
-                      symbol: symbolRef.symbol,
-                      ctx,
-                    })
-                  : undefined;
-              })();
+        const signature = getMethodSignature({ symbolRef, ctx });
         if (!signature) {
           return [];
         }
@@ -843,31 +889,6 @@ const typeStaticTraitCall = ({
           ({ typeParam }) =>
             inferredSubstitution.get(typeParam) ?? ctx.primitives.unknown,
         );
-        const methodTypeParamCount = Math.max(
-          0,
-          (signature.typeParams?.length ?? 0) - inferredTypeArguments.length,
-        );
-        const signatureSubstitution = new Map<TypeParamId, TypeId>();
-        signature.typeParams
-          ?.slice(methodTypeParamCount)
-          .forEach((parameter, index) =>
-            signatureSubstitution.set(
-              parameter.typeParam,
-              inferredTypeArguments[index]!,
-            ),
-          );
-        const specializedSignature: FunctionSignature = {
-          ...signature,
-          parameters: signature.parameters.map((parameter) => ({
-            ...parameter,
-            type: ctx.arena.substitute(parameter.type, signatureSubstitution),
-          })),
-          returnType: ctx.arena.substitute(
-            signature.returnType,
-            signatureSubstitution,
-          ),
-          typeParams: signature.typeParams?.slice(0, methodTypeParamCount),
-        };
         return [
           {
             template,
@@ -876,7 +897,11 @@ const typeStaticTraitCall = ({
             substitution: inferredSubstitution,
             symbol: symbolRef.symbol,
             symbolRef,
-            signature: specializedSignature,
+            signature: specializeImplMethodSignature({
+              signature,
+              implTypeArguments: inferredTypeArguments,
+              ctx,
+            }),
             originalSignature: signature,
             inferredTypeArguments,
           },
@@ -928,13 +953,13 @@ const typeStaticTraitCall = ({
       ctx,
       state,
     });
-    const callerInstanceKey = state.currentFunction?.instanceKey;
-    if (!callerInstanceKey) {
-      throw new Error(`missing function instance key for call ${expr.id}`);
-    }
-    const targets = ctx.callResolution.targets.get(expr.id) ?? new Map();
-    targets.set(callerInstanceKey, selected.symbolRef);
-    ctx.callResolution.targets.set(expr.id, targets);
+    recordCallTarget({
+      callId: expr.id,
+      target: selected.symbolRef,
+      context: "call",
+      ctx,
+      state,
+    });
     return result;
   }
   const traitDecl = ctx.traits.getDecl(expr.staticTraitSymbol);
@@ -1022,13 +1047,13 @@ const typeStaticTraitCall = ({
     calleeExpr.symbol,
     ctx,
   );
-  const callerInstanceKey = state.currentFunction?.instanceKey;
-  if (!callerInstanceKey) {
-    throw new Error(`missing function instance key for call ${expr.id}`);
-  }
-  const targets = ctx.callResolution.targets.get(expr.id) ?? new Map();
-  targets.set(callerInstanceKey, selectedRef);
-  ctx.callResolution.targets.set(expr.id, targets);
+  recordCallTarget({
+    callId: expr.id,
+    target: selectedRef,
+    context: "call",
+    ctx,
+    state,
+  });
   ctx.callResolution.traitDispatches.add(expr.id);
   return { returnType, effectRow };
 };
@@ -1194,11 +1219,6 @@ export const typeMethodCallExpr = (
     return finalizeCall({ returnType: ctx.primitives.unknown });
   }
 
-  const instanceKey = state.currentFunction?.instanceKey;
-  if (!instanceKey) {
-    throw new Error(`missing function instance key for method call ${expr.id}`);
-  }
-
   if (selection.usedTraitDispatch) {
     ctx.callResolution.traitDispatches.add(expr.id);
   } else {
@@ -1230,10 +1250,13 @@ export const typeMethodCallExpr = (
       ? canonicalSymbolRefInTypingContext(selected.symbolRef, ctx)
       : selected.symbolRef
     : canonicalSymbolRefForTypingContext(selected.symbol, ctx);
-  const targets =
-    ctx.callResolution.targets.get(expr.id) ?? new Map<string, SymbolRef>();
-  targets.set(instanceKey, selectedRef);
-  ctx.callResolution.targets.set(expr.id, targets);
+  recordCallTarget({
+    callId: expr.id,
+    target: selectedRef,
+    context: "method call",
+    ctx,
+    state,
+  });
 
   const receiverType = selected.receiverTypeOverride ?? targetType;
   if (selected.receiverTypeOverride) {
@@ -1406,25 +1429,13 @@ const getExpectedCallParameters = ({
       return { expectedReturnCandidates };
     }
     const selected = matchingReturn[0]!;
-    const substitution =
-      selected.signature.typeParams && selected.signature.typeParams.length > 0
-        ? applyExplicitTypeArguments({
-            signature: selected.signature,
-            typeArguments,
-            calleeSymbol: selected.symbol,
-            ctx,
-          })
-        : undefined;
-    const combinedSubstitution = mergeInitialCallSubstitutions(
-      substitution,
-      buildTargetTypeArgumentSubstitution({
-        signature: selected.signature,
-        typeArguments,
-        targetTypeArguments,
-        calleeSymbol: selected.symbol,
-        ctx,
-      }),
-    );
+    const combinedSubstitution = applyExplicitTypeArgumentSubstitution({
+      symbol: selected.symbol,
+      signature: selected.signature,
+      typeArguments,
+      targetTypeArguments,
+      ctx,
+    });
     return {
       params: publicCallParametersFor({ signature: selected.signature }).map(
         (param) =>
@@ -1446,25 +1457,13 @@ const getExpectedCallParameters = ({
   if (!signature) {
     return {};
   }
-  const substitution =
-    signature.typeParams && signature.typeParams.length > 0
-      ? applyExplicitTypeArguments({
-          signature,
-          typeArguments,
-          calleeSymbol: callee.symbol,
-          ctx,
-        })
-      : undefined;
-  const combinedSubstitution = mergeInitialCallSubstitutions(
-    substitution,
-    buildTargetTypeArgumentSubstitution({
-      signature,
-      typeArguments,
-      targetTypeArguments,
-      calleeSymbol: callee.symbol,
-      ctx,
-    }),
-  );
+  const combinedSubstitution = applyExplicitTypeArgumentSubstitution({
+    symbol: callee.symbol,
+    signature,
+    typeArguments,
+    targetTypeArguments,
+    ctx,
+  });
   return {
     params: publicCallParametersFor({ signature }).map((param) =>
       combinedSubstitution
@@ -1492,26 +1491,13 @@ const mergeExplicitTypeArgumentSubstitution = ({
   seedSubstitution?: ReadonlyMap<TypeParamId, TypeId>;
   ctx: TypingContext;
 }): ReadonlyMap<TypeParamId, TypeId> | undefined => {
-  const explicitSubstitution =
-    signature.typeParams && signature.typeParams.length > 0
-      ? applyExplicitTypeArguments({
-          signature,
-          typeArguments,
-          calleeSymbol,
-          ctx,
-        })
-      : undefined;
-  const targetSubstitution = buildTargetTypeArgumentSubstitution({
+  const typeArgumentSubstitution = applyExplicitTypeArgumentSubstitution({
     signature,
+    symbol: calleeSymbol,
     typeArguments,
     targetTypeArguments,
-    calleeSymbol,
     ctx,
   });
-  const typeArgumentSubstitution = mergeInitialCallSubstitutions(
-    explicitSubstitution,
-    targetSubstitution,
-  );
 
   if (!seedSubstitution || seedSubstitution.size === 0) {
     return typeArgumentSubstitution;
@@ -1523,76 +1509,6 @@ const mergeExplicitTypeArgumentSubstitution = ({
   const merged = new Map<TypeParamId, TypeId>(seedSubstitution);
   typeArgumentSubstitution.forEach((value, key) => merged.set(key, value));
   return merged;
-};
-
-const buildTargetTypeArgumentSubstitution = ({
-  signature,
-  typeArguments,
-  targetTypeArguments,
-  calleeSymbol,
-  ctx,
-}: {
-  signature: FunctionSignature;
-  typeArguments: readonly TypeId[] | undefined;
-  targetTypeArguments: readonly TypeId[] | undefined;
-  calleeSymbol: SymbolId;
-  ctx: TypingContext;
-}): ReadonlyMap<TypeParamId, TypeId> | undefined => {
-  if (!targetTypeArguments || targetTypeArguments.length === 0) {
-    return undefined;
-  }
-
-  const params = signature.typeParams ?? [];
-  const explicitCount = typeArguments?.length ?? 0;
-  const totalCount = explicitCount + targetTypeArguments.length;
-  if (totalCount > params.length) {
-    throw new Error(
-      `function ${getSymbolName(
-        calleeSymbol,
-        ctx,
-      )} received too many type arguments`,
-    );
-  }
-
-  const start = params.length - targetTypeArguments.length;
-  const substitution = new Map<TypeParamId, TypeId>();
-  targetTypeArguments.forEach((arg, index) => {
-    const param = params[start + index];
-    if (param) {
-      substitution.set(param.typeParam, arg);
-    }
-  });
-  return substitution.size > 0 ? substitution : undefined;
-};
-
-const specializeOverloadParametersWithTargetTypeArguments = ({
-  symbol,
-  signature,
-  typeArguments,
-  targetTypeArguments,
-  ctx,
-}: {
-  symbol: SymbolId;
-  signature: FunctionSignature;
-  typeArguments?: readonly TypeId[];
-  targetTypeArguments?: readonly TypeId[];
-  ctx: TypingContext;
-}): readonly ParamSignature[] => {
-  const substitution = mergeExplicitTypeArgumentSubstitution({
-    signature,
-    typeArguments,
-    targetTypeArguments,
-    calleeSymbol: symbol,
-    ctx,
-  });
-  if (!substitution || substitution.size === 0) {
-    return signature.parameters;
-  }
-
-  return signature.parameters.map((param) => ({
-    ...param,
-    type: ctx.arena.substitute(param.type, substitution),
-  }));
 };
 
 const findMatchingOverloadCandidates = <
@@ -2521,7 +2437,7 @@ const callArgumentsSatisfyParams = ({
     onMatch: (match) =>
       match.matchedType === ctx.primitives.unknown
         ? true
-        : !valueTraitObjectWideningFor({
+        : !disallowedValueTraitObjectWidening({
             actual: match.matchedType,
             expected: providedArgumentTypeForParam(match.param, ctx),
             ctx,
@@ -2645,7 +2561,7 @@ const typeSatisfiesForDiagnostic = ({
   state: TypingState;
 }): boolean => {
   if (
-    valueTraitObjectWideningFor({
+    disallowedValueTraitObjectWidening({
       actual,
       expected,
       ctx,
@@ -4321,19 +4237,7 @@ const resolveStructuralTraitMethodCandidates = ({
       return [];
     }
     const symbolRef = canonicalSymbolRefForTypingContext(implMethod, ctx);
-    const signature =
-      symbolRef.moduleId === ctx.moduleId
-        ? ctx.functions.getSignature(symbolRef.symbol)
-        : (() => {
-            const dependency = ctx.dependencies.get(symbolRef.moduleId);
-            return dependency
-              ? getDependencyMethodSignature({
-                  dependency,
-                  symbol: symbolRef.symbol,
-                  ctx,
-                })
-              : undefined;
-          })();
+    const signature = getMethodSignature({ symbolRef, ctx });
     if (!signature) {
       return [];
     }
@@ -4360,30 +4264,15 @@ const resolveStructuralTraitMethodCandidates = ({
       ({ typeParam }) =>
         inferredSubstitution.get(typeParam) ?? ctx.primitives.unknown,
     );
-    const substitution = new Map<TypeParamId, TypeId>();
-    const methodTypeParamCount = Math.max(
-      0,
-      (signature.typeParams?.length ?? 0) - inferredTypeArguments.length,
-    );
-    signature.typeParams
-      ?.slice(methodTypeParamCount)
-      .forEach((parameter, index) =>
-        substitution.set(parameter.typeParam, inferredTypeArguments[index]!),
-      );
-    const specializedSignature: FunctionSignature = {
-      ...signature,
-      parameters: signature.parameters.map((parameter) => ({
-        ...parameter,
-        type: ctx.arena.substitute(parameter.type, substitution),
-      })),
-      returnType: ctx.arena.substitute(signature.returnType, substitution),
-      typeParams: signature.typeParams?.slice(0, methodTypeParamCount),
-    };
     return [
       {
         symbol: symbolRef.symbol,
         symbolRef,
-        signature: specializedSignature,
+        signature: specializeImplMethodSignature({
+          signature,
+          implTypeArguments: inferredTypeArguments,
+          ctx,
+        }),
         originalSignature: signature,
         inferredTypeArguments,
         trustedTypeArguments: true,
@@ -4780,13 +4669,6 @@ const typeOperatorOverloadCall = ({
     };
   }
 
-  const instanceKey = state.currentFunction?.instanceKey;
-  if (!instanceKey) {
-    throw new Error(
-      `missing function instance key for operator resolution at call ${call.id}`,
-    );
-  }
-
   if (traitDispatch) {
     ctx.callResolution.traitDispatches.add(call.id);
   } else {
@@ -4813,10 +4695,13 @@ const typeOperatorOverloadCall = ({
     }
   }
 
-  const targets =
-    ctx.callResolution.targets.get(call.id) ?? new Map<string, SymbolRef>();
-  targets.set(instanceKey, selected.symbolRef);
-  ctx.callResolution.targets.set(call.id, targets);
+  recordCallTarget({
+    callId: call.id,
+    target: selected.symbolRef,
+    context: "operator call",
+    ctx,
+    state,
+  });
 
   return typeFunctionCall({
     args,
@@ -5651,7 +5536,7 @@ const typeFunctionCall = ({
           state,
         })
       : undefined;
-  const typeArgumentSubstitution = buildTargetTypeArgumentSubstitution({
+  const typeArgumentSubstitution = applyTargetTypeArguments({
     signature,
     typeArguments,
     targetTypeArguments,
@@ -6378,19 +6263,13 @@ const typeIntrinsicFallbackCall = ({
   if (typeof fallbackSymbol !== "number") {
     return undefined;
   }
-  const instanceKey = state.currentFunction?.instanceKey;
-  if (!instanceKey) {
-    throw new Error(
-      `missing function instance key for intrinsic fallback at call ${callId}`,
-    );
-  }
-  const targets =
-    ctx.callResolution.targets.get(callId) ?? new Map<string, SymbolRef>();
-  targets.set(
-    instanceKey,
-    canonicalSymbolRefForTypingContext(fallbackSymbol, ctx),
-  );
-  ctx.callResolution.targets.set(callId, targets);
+  recordCallTarget({
+    callId,
+    target: canonicalSymbolRefForTypingContext(fallbackSymbol, ctx),
+    context: "intrinsic fallback call",
+    ctx,
+    state,
+  });
   ctx.callResolution.traitDispatches.delete(callId);
 
   const returnType = typeIntrinsicCall(
@@ -6655,12 +6534,6 @@ const typeOverloadedCall = (
       effectRow: ctx.effects.emptyRow,
     };
   }
-  const instanceKey = state.currentFunction?.instanceKey;
-  if (!instanceKey) {
-    throw new Error(
-      `missing function instance key for overload resolution at call ${call.id}`,
-    );
-  }
   if (traitDispatch) {
     ctx.callResolution.traitDispatches.add(call.id);
   } else {
@@ -6674,10 +6547,13 @@ const typeOverloadedCall = (
     context: "calling member",
   });
   const selectedRef = canonicalSymbolRefForTypingContext(selected.symbol, ctx);
-  const targets =
-    ctx.callResolution.targets.get(call.id) ?? new Map<string, SymbolRef>();
-  targets.set(instanceKey, selectedRef);
-  ctx.callResolution.targets.set(call.id, targets);
+  recordCallTarget({
+    callId: call.id,
+    target: selectedRef,
+    context: "overload call",
+    ctx,
+    state,
+  });
   const lambdaReturnSubstitution =
     inferLambdaReturnSubstitutionForCandidateCached({
       candidate: selected,
@@ -6980,20 +6856,14 @@ const inferLambdaReturnSubstitutionForCandidate = <
   state: TypingState;
 }): LambdaReturnInferenceResult => {
   const substitution = new Map<TypeParamId, TypeId>(
-    applyExplicitTypeArguments({
+    applyExplicitTypeArgumentSubstitution({
+      symbol: candidate.symbol,
       signature: candidate.signature,
       typeArguments,
-      calleeSymbol: candidate.symbol,
+      targetTypeArguments,
       ctx,
     }),
   );
-  buildTargetTypeArgumentSubstitution({
-    signature: candidate.signature,
-    typeArguments,
-    targetTypeArguments,
-    calleeSymbol: candidate.symbol,
-    ctx,
-  })?.forEach((value, key) => substitution.set(key, value));
   const lambdaArgIndexes = callArgs
     .map((arg, index) => ({ arg, index }))
     .filter(
@@ -7235,7 +7105,7 @@ const inlineLambdaArityScoreForCandidate = <
   targetTypeArguments?: readonly TypeId[] | undefined;
   ctx: TypingContext;
 }): { exactMatches: number; omittedParameters: number } | undefined => {
-  const params = specializeOverloadParametersWithTargetTypeArguments({
+  const params = specializeOverloadParameters({
     symbol: candidate.symbol,
     signature: candidate.signature,
     typeArguments,
@@ -7305,7 +7175,7 @@ const inlineLambdaCompatibility = <
   ctx: TypingContext;
   state: TypingState;
 }): InlineLambdaCompatibility => {
-  const params = specializeOverloadParametersWithTargetTypeArguments({
+  const params = specializeOverloadParameters({
     symbol: candidate.symbol,
     signature: candidate.signature,
     typeArguments,
@@ -7398,7 +7268,7 @@ const inlineLambdaExpectedTypeParamPenalty = <
   ctx: TypingContext;
   state: TypingState;
 }): number => {
-  const params = specializeOverloadParametersWithTargetTypeArguments({
+  const params = specializeOverloadParameters({
     symbol: candidate.symbol,
     signature: candidate.signature,
     typeArguments,

--- a/packages/compiler/src/semantics/typing/expressions/overload-resolution.ts
+++ b/packages/compiler/src/semantics/typing/expressions/overload-resolution.ts
@@ -252,12 +252,14 @@ export const signatureCallShapeCouldMatch = ({
   }
 
   const params = publicCallParametersForShape(signature);
-  return callShapeCouldMatch({
-    args,
-    params,
-    ctx,
-    state,
-  }) && positionalArgumentTypesCouldMatch({ args, params, ctx, state });
+  return (
+    callShapeCouldMatch({
+      args,
+      params,
+      ctx,
+      state,
+    }) && positionalArgumentTypesCouldMatch({ args, params, ctx, state })
+  );
 };
 
 // Reject only direct argument/parameter pairs whose fully concrete types are
@@ -531,15 +533,47 @@ export const applyExplicitTypeArgumentSubstitution = ({
   targetTypeArguments?: readonly TypeId[];
   ctx: TypingContext;
 }) =>
-  signature.typeParams && signature.typeParams.length > 0
-    ? mergeTypeArgumentSubstitutions({
-        signature,
-        typeArguments,
-        targetTypeArguments,
-        calleeSymbol: symbol,
-        ctx,
-      })
-    : undefined;
+  mergeTypeArgumentSubstitutions({
+    signature,
+    typeArguments,
+    targetTypeArguments,
+    calleeSymbol: symbol,
+    ctx,
+  });
+
+export const applyTargetTypeArguments = ({
+  signature,
+  typeArguments,
+  targetTypeArguments,
+  calleeSymbol,
+  ctx,
+}: {
+  signature: FunctionSignature;
+  typeArguments: readonly TypeId[] | undefined;
+  targetTypeArguments: readonly TypeId[] | undefined;
+  calleeSymbol: SymbolId;
+  ctx: TypingContext;
+}): ReadonlyMap<TypeParamId, TypeId> | undefined => {
+  if (!targetTypeArguments || targetTypeArguments.length === 0) {
+    return undefined;
+  }
+  const params = signature.typeParams ?? [];
+  if (
+    (typeArguments?.length ?? 0) + targetTypeArguments.length >
+    params.length
+  ) {
+    throw new Error(
+      `function ${getSymbolName(calleeSymbol, ctx)} received too many type arguments`,
+    );
+  }
+  const start = params.length - targetTypeArguments.length;
+  return new Map(
+    targetTypeArguments.map((argument, index) => [
+      params[start + index]!.typeParam,
+      argument,
+    ]),
+  );
+};
 
 const mergeTypeArgumentSubstitutions = ({
   signature,
@@ -554,35 +588,27 @@ const mergeTypeArgumentSubstitutions = ({
   calleeSymbol: SymbolId;
   ctx: TypingContext;
 }): ReadonlyMap<TypeParamId, TypeId> | undefined => {
-  const explicit = applyExplicitTypeArguments({
+  const explicit =
+    signature.typeParams && signature.typeParams.length > 0
+      ? applyExplicitTypeArguments({
+          signature,
+          typeArguments,
+          calleeSymbol,
+          ctx,
+        })
+      : undefined;
+  const target = applyTargetTypeArguments({
     signature,
     typeArguments,
+    targetTypeArguments,
     calleeSymbol,
     ctx,
   });
-  if (!targetTypeArguments || targetTypeArguments.length === 0) {
+  if (!target) {
     return explicit;
   }
-
-  const params = signature.typeParams ?? [];
-  const explicitCount = typeArguments?.length ?? 0;
-  const totalCount = explicitCount + targetTypeArguments.length;
-  if (totalCount > params.length) {
-    throw new Error(
-      `function ${getSymbolName(calleeSymbol, ctx)} received too many type arguments`,
-    );
-  }
-
-  const start = params.length - targetTypeArguments.length;
-  const target = new Map<TypeParamId, TypeId>();
-  targetTypeArguments.forEach((arg, index) => {
-    const param = params[start + index];
-    if (param) {
-      target.set(param.typeParam, arg);
-    }
-  });
   if (!explicit || explicit.size === 0) {
-    return target.size > 0 ? target : undefined;
+    return target;
   }
   const merged = new Map<TypeParamId, TypeId>(explicit);
   target.forEach((value, key) => merged.set(key, value));

--- a/packages/compiler/src/semantics/typing/import-trait-impl-hydration.ts
+++ b/packages/compiler/src/semantics/typing/import-trait-impl-hydration.ts
@@ -48,7 +48,10 @@ const resolveDependencySymbolChain = ({
     }
     const importModuleId = metadata?.import?.moduleId;
     const importSymbol = metadata?.import?.symbol;
-    if (typeof importModuleId !== "string" || typeof importSymbol !== "number") {
+    if (
+      typeof importModuleId !== "string" ||
+      typeof importSymbol !== "number"
+    ) {
       return { dependency: currentDependency, dependencySymbol: currentSymbol };
     }
     const importedDependency = ctx.dependencies.get(importModuleId);
@@ -162,9 +165,7 @@ export const hydrateExternalTraitImplsForOwnerRef = ({
   ctx: TypingContext;
 }): void => {
   const hydrated = externallyHydratedTraitOwners.get(ctx) ?? new Set<string>();
-  if (!externallyHydratedTraitOwners.has(ctx)) {
-    externallyHydratedTraitOwners.set(ctx, hydrated);
-  }
+  externallyHydratedTraitOwners.set(ctx, hydrated);
   const ownerKey = `${ownerModuleId}::${ownerSymbol}`;
   if (hydrated.has(ownerKey)) {
     return;


### PR DESCRIPTION
## Summary

- consolidate compiler call-target recording and trait method signature specialization
- reuse the overload-resolution type-argument helpers instead of maintaining duplicate implementations in call typing
- share resolved-target codegen and trait method canonicalization paths
- remove pass-through helpers and redundant cache initialization branches

## Impact

This is a behavior-preserving cleanup focused on the recently expanded trait and overload call paths. It removes 163 net lines and leaves the compiler boundaries easier to audit without changing public APIs.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run test:audit`
- focused compiler tests: 61 passing across overload resolution, static access, and module codegen
