### PR TITLE
Optimize memory safety analysis compile time

### DIFF
--- a/packages/compiler/src/modules/semantic-analysis.ts
+++ b/packages/compiler/src/modules/semantic-analysis.ts
@@ -516,6 +516,7 @@ const analyzeCyclicScc = ({
       effectInterner,
       isCancelled,
       reusableBorrowing,
+      retainBorrowingIncrementalData: false,
     });
     if (!result) {
       return;

--- a/packages/compiler/src/semantics/borrowing/call-resolution.ts
+++ b/packages/compiler/src/semantics/borrowing/call-resolution.ts
@@ -937,11 +937,115 @@ const expressionCanCarryReference = (
   return typeof type !== "number" || typeCanCarryReference(type, ctx.typing);
 };
 
+const projectedTypesCache = new WeakMap<
+  TypingResult,
+  Map<TypeId, Map<string, readonly TypeId[]>>
+>();
+const projectedTypeFieldsCache = new WeakMap<
+  TypingResult,
+  Map<
+    TypeId,
+    {
+      byName: ReadonlyMap<string, TypeId>;
+      byIndex: readonly TypeId[];
+    }
+  >
+>();
+
+const projectionPathKey = (projections: readonly PlaceProjection[]): string =>
+  projections
+    .map((projection) => {
+      switch (projection.kind) {
+        case "field":
+          return `f${projection.name.length}:${projection.name}`;
+        case "tuple":
+          return `t${projection.index}`;
+        case "index":
+          return `i${projection.stable ? 1 : 0}:${projection.constant ?? ""}`;
+        case "region":
+          return `r${projection.scope.length}:${projection.scope}:${projection.name.length}:${projection.name}:${projection.disjoint.join(",")}`;
+        case "discriminant":
+          return "c";
+        case "dereference":
+          return "d";
+        case "identity":
+          return "y";
+      }
+    })
+    .join("/");
+
+const projectedTypeFields = (
+  type: TypeId,
+  typing: TypingResult,
+):
+  | {
+      byName: ReadonlyMap<string, TypeId>;
+      byIndex: readonly TypeId[];
+    }
+  | undefined => {
+  let fieldsByType = projectedTypeFieldsCache.get(typing);
+  if (!fieldsByType) {
+    fieldsByType = new Map();
+    projectedTypeFieldsCache.set(typing, fieldsByType);
+  }
+  const cached = fieldsByType.get(type);
+  if (cached) {
+    return cached;
+  }
+  const descriptor = typing.arena.get(type);
+  const fields =
+    descriptor.kind === "structural-object"
+      ? descriptor.fields
+      : descriptor.kind === "nominal-object" ||
+          descriptor.kind === "value-object"
+        ? typing.objectsByNominal.get(type)?.fields
+        : undefined;
+  if (!fields) {
+    return undefined;
+  }
+  const indexed = {
+    byName: new Map(fields.map((field) => [field.name, field.type])),
+    byIndex: fields.map((field) => field.type),
+  };
+  fieldsByType.set(type, indexed);
+  return indexed;
+};
+
 export const projectedTypes = (
   type: TypeId,
   projections: readonly PlaceProjection[],
   typing: TypingResult,
-  active = new Set<TypeId>(),
+): readonly TypeId[] => {
+  let cacheByType = projectedTypesCache.get(typing);
+  if (!cacheByType) {
+    cacheByType = new Map();
+    projectedTypesCache.set(typing, cacheByType);
+  }
+  let cacheByPath = cacheByType.get(type);
+  if (!cacheByPath) {
+    cacheByPath = new Map();
+    cacheByType.set(type, cacheByPath);
+  }
+  const pathKey = projectionPathKey(projections);
+  const cached = cacheByPath.get(pathKey);
+  if (cached) {
+    return cached;
+  }
+  const result = resolveProjectedTypes(
+    type,
+    projections,
+    typing,
+    new Set<TypeId>(),
+  );
+  cacheByPath.set(pathKey, result);
+  return result;
+};
+
+const resolveProjectedTypes = (
+  type: TypeId,
+  projections: readonly PlaceProjection[],
+  typing: TypingResult,
+  active: Set<TypeId>,
 ): readonly TypeId[] => {
   if (projections.length === 0 || active.has(type)) {
     return projections.length === 0 ? [type] : [];
@@ -950,44 +1054,55 @@ export const projectedTypes = (
   const descriptor = typing.arena.get(type);
   const [projection, ...remaining] = projections;
   if (projection?.kind === "dereference") {
-    return projectedTypes(type, remaining, typing);
+    return resolveProjectedTypes(type, remaining, typing, new Set<TypeId>());
   }
   const candidates = (() => {
     if (descriptor.kind === "borrowed") {
-      return projectedTypes(descriptor.inner, projections, typing, active);
+      return resolveProjectedTypes(
+        descriptor.inner,
+        projections,
+        typing,
+        active,
+      );
     }
     if (descriptor.kind === "recursive") {
-      return projectedTypes(descriptor.body, projections, typing, active);
+      return resolveProjectedTypes(
+        descriptor.body,
+        projections,
+        typing,
+        active,
+      );
     }
     if (descriptor.kind === "union") {
       return descriptor.members.flatMap((member) =>
-        projectedTypes(member, projections, typing, new Set(active)),
+        resolveProjectedTypes(member, projections, typing, new Set(active)),
       );
     }
     if (descriptor.kind === "intersection") {
       return [descriptor.nominal, descriptor.structural].flatMap((member) =>
         typeof member === "number"
-          ? projectedTypes(member, projections, typing, new Set(active))
+          ? resolveProjectedTypes(member, projections, typing, new Set(active))
           : [],
       );
     }
     if (projection?.kind === "index" && descriptor.kind === "fixed-array") {
-      return projectedTypes(descriptor.element, remaining, typing, active);
+      return resolveProjectedTypes(
+        descriptor.element,
+        remaining,
+        typing,
+        active,
+      );
     }
-    const fields =
-      descriptor.kind === "structural-object"
-        ? descriptor.fields
-        : descriptor.kind === "nominal-object" ||
-            descriptor.kind === "value-object"
-          ? typing.objectsByNominal.get(type)?.fields
-          : undefined;
-    const field =
+    const fields = projectedTypeFields(type, typing);
+    const fieldType =
       projection?.kind === "field"
-        ? fields?.find((candidate) => candidate.name === projection.name)
+        ? fields?.byName.get(projection.name)
         : projection?.kind === "tuple"
-          ? fields?.[projection.index]
+          ? fields?.byIndex[projection.index]
           : undefined;
-    return field ? projectedTypes(field.type, remaining, typing, active) : [];
+    return typeof fieldType === "number"
+      ? resolveProjectedTypes(fieldType, remaining, typing, active)
+      : [];
   })();
   active.delete(type);
   return candidates;

--- a/packages/compiler/src/semantics/borrowing/result-provenance.ts
+++ b/packages/compiler/src/semantics/borrowing/result-provenance.ts
@@ -71,6 +71,8 @@ type PreparedResultCallable = {
   resultValues: readonly HirExprId[];
 };
 
+type ResultProjectionIndex = ReadonlyMap<string, ResultProjectionProvenance>;
+
 type BindingSource =
   | {
       kind: "parameter";
@@ -500,6 +502,7 @@ const classifyCallable = ({
   resolvedCalls,
   dependents,
   contractOrigins,
+  projectionIndexes,
 }: {
   prepared: PreparedResultCallable;
   context: ResolveContext;
@@ -512,6 +515,7 @@ const classifyCallable = ({
   dependents: Map<SymbolId, Set<SymbolId>>;
   /** Stable, pass-scoped substitutions keyed by call expression and result path. */
   contractOrigins: Map<string, readonly ResultProvenanceOrigin[]>;
+  projectionIndexes: WeakMap<CallableResultProvenance, ResultProjectionIndex>;
 }): CallableResultProvenance => {
   const { bindings, resultValues, signature } = prepared;
   const active = new Set<string>();
@@ -537,9 +541,15 @@ const classifyCallable = ({
     path: readonly PlaceProjection[],
   ): readonly ResultProvenanceOrigin[] => {
     if (path.length > MAX_RESULT_PROVENANCE_DEPTH) {
-      return unknown("depth-limit");
+      const depthLimitKey = `${expressionId}:depth-limit`;
+      const cached = classified.get(depthLimitKey);
+      if (cached) return cached;
+      const result = unknown("depth-limit");
+      classified.set(depthLimitKey, result);
+      return result;
     }
-    const activeKey = `${expressionId}:${pathKey(path)}`;
+    const currentPathKey = pathKey(path);
+    const activeKey = `${expressionId}:${currentPathKey}`;
     const cached = classified.get(activeKey);
     if (cached) return cached;
     if (active.has(activeKey)) return [];
@@ -693,9 +703,19 @@ const classifyCallable = ({
               callers.add(prepared.callable.symbol);
               dependents.set(target.symbol, callers);
               const summary = summaries.get(target.symbol);
-              const projection = summary?.projections.find(
-                (candidate) => pathKey(candidate.path) === pathKey(path),
-              );
+              let projectionIndex = summary
+                ? projectionIndexes.get(summary)
+                : undefined;
+              if (summary && !projectionIndex) {
+                const indexed = new Map<string, ResultProjectionProvenance>();
+                summary.projections.forEach((projection) => {
+                  const key = pathKey(projection.path);
+                  if (!indexed.has(key)) indexed.set(key, projection);
+                });
+                projectionIndex = indexed;
+                projectionIndexes.set(summary, projectionIndex);
+              }
+              const projection = projectionIndex?.get(currentPathKey);
               if (!projection) return [];
               return projection.origins.flatMap((origin) => {
                 if (origin.kind !== "parameter") return [origin];
@@ -720,7 +740,7 @@ const classifyCallable = ({
       }
       const contract = resolved.contract;
       if (!contract) return finish([]);
-      const contractOriginKey = `${expression.id}:${pathKey(path)}`;
+      const contractOriginKey = `${expression.id}:${currentPathKey}`;
       let abstractOrigins = contractOrigins.get(contractOriginKey);
       if (!abstractOrigins) {
         const computed: ResultProvenanceOrigin[] = [];
@@ -867,6 +887,10 @@ export const inferCallableResultProvenance = ({
   >();
   const dependents = new Map<SymbolId, Set<SymbolId>>();
   const contractOrigins = new Map<string, readonly ResultProvenanceOrigin[]>();
+  const projectionIndexes = new WeakMap<
+    CallableResultProvenance,
+    ResultProjectionIndex
+  >();
   const worklist = Array.from(prepared.keys()).filter(
     (symbol) => !baseContracts.has(symbol),
   );
@@ -893,6 +917,7 @@ export const inferCallableResultProvenance = ({
             resolvedCalls,
             dependents,
             contractOrigins,
+            projectionIndexes,
           });
     if (evaluationCount > MAX_RESULT_PROVENANCE_EVALUATIONS) {
       widened.add(symbol);

--- a/packages/compiler/src/semantics/pipeline.ts
+++ b/packages/compiler/src/semantics/pipeline.ts
@@ -410,9 +410,36 @@ const collectModuleExports = ({
     }
     return `${(first >>> 0).toString(36)}${(second >>> 0).toString(36)}`;
   };
-  const typeContainsPrivateField = (
+  const summaryProjectionPathKey = (path: readonly PlaceProjection[]): string =>
+    path
+      .map((projection) => {
+        switch (projection.kind) {
+          case "field":
+            return `f:${projection.name.length}:${projection.name}`;
+          case "tuple":
+            return `t:${projection.index}`;
+          case "index":
+            return `i:${projection.stable ? 1 : 0}:${projection.constant ?? ""}`;
+          case "region":
+            return `g:${JSON.stringify([
+              projection.scope,
+              projection.name,
+              [...projection.disjoint].sort(),
+            ])}`;
+          case "discriminant":
+            return "c";
+          case "dereference":
+            return "d";
+          case "identity":
+            return "r";
+        }
+      })
+      .map((projection) => `${projection.length}:${projection}`)
+      .join("");
+  const typeContainsPrivateFieldCache = new Map<number, boolean>();
+  const typeContainsPrivateFieldUncached = (
     type: number,
-    active = new Set<number>(),
+    active: ReadonlySet<number>,
   ): boolean => {
     if (active.has(type)) {
       return false;
@@ -420,23 +447,23 @@ const collectModuleExports = ({
     const nextActive = new Set(active).add(type);
     const descriptor = typing.arena.get(type);
     if (descriptor.kind === "borrowed") {
-      return typeContainsPrivateField(descriptor.inner, nextActive);
+      return typeContainsPrivateFieldUncached(descriptor.inner, nextActive);
     }
     if (descriptor.kind === "recursive") {
-      return typeContainsPrivateField(descriptor.body, nextActive);
+      return typeContainsPrivateFieldUncached(descriptor.body, nextActive);
     }
     if (descriptor.kind === "union") {
       return descriptor.members.some((member) =>
-        typeContainsPrivateField(member, nextActive),
+        typeContainsPrivateFieldUncached(member, nextActive),
       );
     }
     if (descriptor.kind === "intersection") {
       return [descriptor.nominal, descriptor.structural]
         .filter((member): member is number => typeof member === "number")
-        .some((member) => typeContainsPrivateField(member, nextActive));
+        .some((member) => typeContainsPrivateFieldUncached(member, nextActive));
     }
     if (descriptor.kind === "fixed-array") {
-      return typeContainsPrivateField(descriptor.element, nextActive);
+      return typeContainsPrivateFieldUncached(descriptor.element, nextActive);
     }
     const fields =
       descriptor.kind === "structural-object"
@@ -449,16 +476,27 @@ const collectModuleExports = ({
       fields?.some(
         (field) =>
           (field.visibility !== undefined && field.visibility.api !== true) ||
-          typeContainsPrivateField(field.type, nextActive),
+          typeContainsPrivateFieldUncached(field.type, nextActive),
       ) ?? false
     );
   };
-  const privateFieldProjection = (
+  const typeContainsPrivateField = (type: number): boolean => {
+    const cached = typeContainsPrivateFieldCache.get(type);
+    if (cached !== undefined) return cached;
+    const result = typeContainsPrivateFieldUncached(type, new Set());
+    typeContainsPrivateFieldCache.set(type, result);
+    return result;
+  };
+  const privateFieldProjectionCache = new Map<
+    string,
+    PrivateSummaryPathRedaction | undefined
+  >();
+  const privateFieldProjectionUncached = (
     type: number,
     path: readonly PlaceProjection[],
-    active = new Set<string>(),
+    active: ReadonlySet<string>,
   ): PrivateSummaryPathRedaction | undefined => {
-    const key = `${type}:${JSON.stringify(path)}`;
+    const key = `${type}:${summaryProjectionPathKey(path)}`;
     if (active.has(key)) {
       return undefined;
     }
@@ -473,14 +511,18 @@ const collectModuleExports = ({
     const nextActive = new Set(active).add(key);
     const descriptor = typing.arena.get(type);
     if (descriptor.kind === "borrowed") {
-      return privateFieldProjection(descriptor.inner, path, nextActive);
+      return privateFieldProjectionUncached(descriptor.inner, path, nextActive);
     }
     if (descriptor.kind === "recursive") {
-      return privateFieldProjection(descriptor.body, path, nextActive);
+      return privateFieldProjectionUncached(descriptor.body, path, nextActive);
     }
     if (descriptor.kind === "union") {
       const candidates = descriptor.members.flatMap((member) => {
-        const candidate = privateFieldProjection(member, path, nextActive);
+        const candidate = privateFieldProjectionUncached(
+          member,
+          path,
+          nextActive,
+        );
         return candidate === undefined ? [] : [candidate];
       });
       return candidates.toSorted(
@@ -494,7 +536,11 @@ const collectModuleExports = ({
           if (typeof member !== "number") {
             return [];
           }
-          const candidate = privateFieldProjection(member, path, nextActive);
+          const candidate = privateFieldProjectionUncached(
+            member,
+            path,
+            nextActive,
+          );
           return candidate === undefined ? [] : [candidate];
         },
       );
@@ -509,11 +555,11 @@ const collectModuleExports = ({
       projection?.kind === "identity" ||
       projection?.kind === "discriminant"
     ) {
-      const nested = privateFieldProjection(type, remaining, active);
+      const nested = privateFieldProjectionUncached(type, remaining, active);
       return nested ? { ...nested, index: nested.index + 1 } : undefined;
     }
     if (projection?.kind === "index" && descriptor.kind === "fixed-array") {
-      const nested = privateFieldProjection(
+      const nested = privateFieldProjectionUncached(
         descriptor.element,
         remaining,
         nextActive,
@@ -551,8 +597,24 @@ const collectModuleExports = ({
         token: opaquePrivateProjectionToken(`${owner}:${fieldIndex}`),
       };
     }
-    const nested = privateFieldProjection(field.type, remaining, nextActive);
+    const nested = privateFieldProjectionUncached(
+      field.type,
+      remaining,
+      nextActive,
+    );
     return nested ? { ...nested, index: nested.index + 1 } : undefined;
+  };
+  const privateFieldProjection = (
+    type: number,
+    path: readonly PlaceProjection[],
+  ): PrivateSummaryPathRedaction | undefined => {
+    const key = `${type}:${summaryProjectionPathKey(path)}`;
+    if (privateFieldProjectionCache.has(key)) {
+      return privateFieldProjectionCache.get(key);
+    }
+    const result = privateFieldProjectionUncached(type, path, new Set());
+    privateFieldProjectionCache.set(key, result);
+    return result;
   };
   const borrowSummaryPrivacyFor = (
     callableSymbol: SymbolId,
@@ -2560,6 +2622,12 @@ const collectModuleExports = ({
     localCalls: Map<string, LocalResultCall>;
     widenResultPaths: boolean;
   };
+  const cloneResultExposure = (exposure: ResultExposure): ResultExposure => ({
+    coercions: new Map(exposure.coercions),
+    localCalls: new Map(exposure.localCalls),
+    widenResultPaths: exposure.widenResultPaths,
+  });
+  const resultExposureCache = new Map<string, ResultExposure>();
   const resultExposureForExpression = (
     exprId: number,
     targetType: TypeId | undefined,
@@ -2569,6 +2637,52 @@ const collectModuleExports = ({
     requestedPath: readonly PlaceProjection[] = [],
     resultType?: { moduleId: string; symbol: SymbolId },
     requestedTypes: readonly { moduleId: string; symbol: SymbolId }[] = [],
+  ): ResultExposure => {
+    if (active.size > 0) {
+      return computeResultExposureForExpression(
+        exprId,
+        targetType,
+        active,
+        useAtExpression,
+        resultPath,
+        requestedPath,
+        resultType,
+        requestedTypes,
+      );
+    }
+    const key = JSON.stringify([
+      exprId,
+      targetType,
+      useAtExpression,
+      resultPath,
+      requestedPath,
+      resultType,
+      requestedTypes,
+    ]);
+    const cached = resultExposureCache.get(key);
+    if (cached) return cloneResultExposure(cached);
+    const result = computeResultExposureForExpression(
+      exprId,
+      targetType,
+      active,
+      useAtExpression,
+      resultPath,
+      requestedPath,
+      resultType,
+      requestedTypes,
+    );
+    resultExposureCache.set(key, cloneResultExposure(result));
+    return result;
+  };
+  const computeResultExposureForExpression = (
+    exprId: number,
+    targetType: TypeId | undefined,
+    active: Set<string>,
+    useAtExpression: number | undefined,
+    resultPath: readonly PlaceProjection[],
+    requestedPath: readonly PlaceProjection[],
+    resultType: { moduleId: string; symbol: SymbolId } | undefined,
+    requestedTypes: readonly { moduleId: string; symbol: SymbolId }[],
   ): ResultExposure => {
     const exposure: ResultExposure = {
       coercions: new Map(),
@@ -3249,30 +3363,46 @@ const collectModuleExports = ({
     });
     resultExposures.set(item.symbol, exposure);
   });
-  let resultExposureChanged = true;
-  while (resultExposureChanged) {
-    resultExposureChanged = false;
-    resultExposures.forEach((exposure) => {
-      exposure.localCalls.forEach((call) => {
-        resultExposures.get(call.symbol)?.coercions.forEach((coercion) => {
-          const translated = translatedCoercionReachability({
-            coercion,
-            requested: call.requested,
-            result: call.result,
-            requestedTypes: call.requestedTypes,
-            resultType: call.resultType,
-          });
-          if (!translated) {
-            return;
-          }
-          const key = coercionKey(translated);
-          if (exposure.coercions.has(key)) {
-            return;
-          }
-          exposure.coercions.set(key, translated);
-          resultExposureChanged = true;
+  const resultExposureDependents = new Map<SymbolId, Set<SymbolId>>();
+  resultExposures.forEach((exposure, caller) => {
+    exposure.localCalls.forEach((call) => {
+      const callers = resultExposureDependents.get(call.symbol) ?? new Set();
+      callers.add(caller);
+      resultExposureDependents.set(call.symbol, callers);
+    });
+  });
+  const resultExposureWorklist = Array.from(resultExposures.keys());
+  const queuedResultExposures = new Set(resultExposureWorklist);
+  for (let cursor = 0; cursor < resultExposureWorklist.length; cursor += 1) {
+    const symbol = resultExposureWorklist[cursor]!;
+    queuedResultExposures.delete(symbol);
+    const exposure = resultExposures.get(symbol)!;
+    let changed = false;
+    exposure.localCalls.forEach((call) => {
+      resultExposures.get(call.symbol)?.coercions.forEach((coercion) => {
+        const translated = translatedCoercionReachability({
+          coercion,
+          requested: call.requested,
+          result: call.result,
+          requestedTypes: call.requestedTypes,
+          resultType: call.resultType,
         });
+        if (!translated) {
+          return;
+        }
+        const key = coercionKey(translated);
+        if (exposure.coercions.has(key)) {
+          return;
+        }
+        exposure.coercions.set(key, translated);
+        changed = true;
       });
+    });
+    if (!changed) continue;
+    resultExposureDependents.get(symbol)?.forEach((caller) => {
+      if (queuedResultExposures.has(caller)) return;
+      queuedResultExposures.add(caller);
+      resultExposureWorklist.push(caller);
     });
   }
   const coercionsFor = (


### PR DESCRIPTION
## Summary

- skip durable borrowing-query hashes for discarded cyclic-SCC stabilization results
- memoize projected-type queries and index object fields
- index result-provenance projections and cache conservative depth-limit classifications
- cache export privacy/result-exposure traversals and propagate exposure changes through a reverse-dependency worklist

## Why

PR #752 completed the memory and mutation safety specification, but made memory-safety analysis the dominant compile-time cost. Profiling found repeated canonicalization and graph traversal, plus an unintended durable-cache hashing pass during cyclic-module stabilization.

## Performance

Cold whole-Web compile using the same command and environment:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Total compile | 57.76s | 37.63s | -34.9% |
| Borrowing analysis | 35.62s | 16.63s | -53.3% |
| Result provenance | 13.31s | 2.58s | -80.6% |
| Full-fact materialization | 3.66s | 0.79s | -78.5% |
| Ordinary call resolution | 2.59s | 0.13s | -95.0% |
| Maximum RSS | 2.34 GB | 2.08 GB | -11.0% |
| Depth-limit events | 251,490 | 181 | -99.9% |

A matching seven-sample representative benchmark improved from 1,433.15ms to 1,351.71ms unoptimized (-5.7%) and from 1,656.69ms to 1,569.20ms in release mode (-5.3%).

Generated Wasm sizes and retained borrowing-contract counters were unchanged.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run test:audit`
- `npx turbo run build --filter=@voyd-lang/sdk`
- focused borrowing and result-provenance suites
- two independent standard review loops covering completeness, design, and correctness
