### PR TITLE
[V-439] Exploit checked access facts in the optimizer

### DIFF
--- a/.github/workflows/language-server-perf.yml
+++ b/.github/workflows/language-server-perf.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           cache: npm

--- a/.github/workflows/optimizer-scorecard.yml
+++ b/.github/workflows/optimizer-scorecard.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           cache: npm
@@ -23,7 +23,7 @@ jobs:
       - name: Run full optimizer scorecard
         run: npm run bench:optimizer -- --preset full --output optimizer-scorecard.json > /dev/null
       - name: Upload optimizer scorecard
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: optimizer-scorecard-${{ github.sha }}
           path: optimizer-scorecard.json

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,16 +26,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
         id: pages
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: "24.x"
           cache: npm
 
       - name: Set Turbo SCM range
@@ -62,7 +62,7 @@ jobs:
           GITHUB_PAGES_BASE_PATH: ${{ steps.pages.outputs.base_path }}
         run: npm run build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: apps/site/build/client${{ steps.pages.outputs.base_path }}
 
@@ -73,5 +73,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
         id: deployment

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,11 +14,11 @@ jobs:
       TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
       TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Restore Turbo cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-pr-${{ hashFiles('package-lock.json') }}-${{ github.job }}-${{ github.event.pull_request.head.sha }}
@@ -26,7 +26,7 @@ jobs:
             ${{ runner.os }}-turbo-pr-${{ hashFiles('package-lock.json') }}-${{ github.job }}-
             ${{ runner.os }}-turbo-pr-${{ hashFiles('package-lock.json') }}-
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           cache: npm
@@ -41,11 +41,11 @@ jobs:
       TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
       TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Restore Turbo cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-pr-${{ hashFiles('package-lock.json') }}-${{ github.job }}-${{ github.event.pull_request.head.sha }}
@@ -54,7 +54,7 @@ jobs:
             ${{ runner.os }}-turbo-pr-${{ hashFiles('package-lock.json') }}-
       - name: Detect changed areas
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             compiler_semantics:
@@ -67,7 +67,7 @@ jobs:
               - "turbo.json"
               - "tsconfig*.json"
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           cache: npm
@@ -89,7 +89,7 @@ jobs:
         run: node scripts/testing/summarize-test-timings.mjs --dir test-timings --lane unit --output test-timings/unit-core-summary.json
       - name: Upload core unit timings
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: core-unit-test-timings
           path: test-timings
@@ -110,12 +110,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Detect web-test-sensitive changes
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             web:
@@ -137,7 +137,7 @@ jobs:
               - "tsconfig*.json"
       - name: Use Node.js
         if: steps.changes.outputs.web == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           cache: npm
@@ -158,7 +158,7 @@ jobs:
         run: node scripts/testing/summarize-test-timings.mjs --dir test-timings --lane web-unit --output test-timings/web-unit-summary.json
       - name: Upload web package timings
         if: always() && steps.changes.outputs.web == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: web-unit-test-timings
           path: test-timings
@@ -171,11 +171,11 @@ jobs:
       TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
       TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Restore Turbo cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-pr-${{ hashFiles('package-lock.json') }}-${{ github.job }}-${{ github.event.pull_request.head.sha }}
@@ -183,7 +183,7 @@ jobs:
             ${{ runner.os }}-turbo-pr-${{ hashFiles('package-lock.json') }}-${{ github.job }}-
             ${{ runner.os }}-turbo-pr-${{ hashFiles('package-lock.json') }}-
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           cache: npm
@@ -202,7 +202,7 @@ jobs:
         run: node scripts/testing/summarize-test-timings.mjs --dir test-timings --lane unit --output test-timings/unit-tooling-summary.json
       - name: Upload tooling unit timings
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tooling-unit-test-timings
           path: test-timings
@@ -212,12 +212,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Detect conformance-sensitive changes
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             conformance:
@@ -235,7 +235,7 @@ jobs:
               - "tsconfig*.json"
       - name: Use Node.js
         if: steps.changes.outputs.conformance == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           cache: npm
@@ -258,7 +258,7 @@ jobs:
         run: node scripts/testing/summarize-test-timings.mjs --dir test-timings --lane conformance --output test-timings/conformance-summary.json
       - name: Upload conformance timings
         if: always() && steps.changes.outputs.conformance == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: conformance-test-timings
           path: test-timings
@@ -268,12 +268,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Detect integration-sensitive changes
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             integration:
@@ -294,7 +294,7 @@ jobs:
               - "tsconfig*.json"
       - name: Use Node.js
         if: steps.changes.outputs.integration == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           cache: npm
@@ -317,7 +317,7 @@ jobs:
         run: node scripts/testing/summarize-test-timings.mjs --dir test-timings --lane integration --output test-timings/integration-summary.json
       - name: Upload integration timings
         if: always() && steps.changes.outputs.integration == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: integration-test-timings
           path: test-timings
@@ -325,21 +325,17 @@ jobs:
 
   compiler-codegen:
     runs-on: ubuntu-latest
-    timeout-minutes: 12
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3, 4]
+    timeout-minutes: 20
     env:
       TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
       TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Detect changed areas
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             compiler_codegen:
@@ -354,7 +350,7 @@ jobs:
               - "tsconfig*.json"
       - name: Use Node.js
         if: steps.changes.outputs.compiler_codegen == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           cache: npm
@@ -362,9 +358,9 @@ jobs:
       - name: Install dependencies
         if: steps.changes.outputs.compiler_codegen == 'true'
         run: npm ci --include=optional
-      - name: Run compiler codegen shard
+      - name: Run compiler codegen tests
         if: steps.changes.outputs.compiler_codegen == 'true'
-        run: npm run --workspace @voyd-lang/compiler test:codegen -- --shard=${{ matrix.shard }}/4
+        run: npm run --workspace @voyd-lang/compiler test:codegen
 
   cli-dist-e2e:
     runs-on: ubuntu-latest
@@ -373,11 +369,11 @@ jobs:
       TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
       TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Restore Turbo cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-pr-${{ hashFiles('package-lock.json') }}-${{ github.job }}-${{ github.event.pull_request.head.sha }}
@@ -386,7 +382,7 @@ jobs:
             ${{ runner.os }}-turbo-pr-${{ hashFiles('package-lock.json') }}-
       - name: Detect changed areas
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             cli_direct:
@@ -407,7 +403,7 @@ jobs:
               - "tsconfig*.json"
       - name: Use Node.js
         if: steps.changes.outputs.cli_runtime == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           cache: npm
@@ -430,12 +426,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Detect optimizer-sensitive changes
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             web:
@@ -476,7 +472,7 @@ jobs:
               - "package-lock.json"
       - name: Use Node.js
         if: steps.changes.outputs.optimizer == 'true' || steps.changes.outputs.web == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           cache: npm

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -325,6 +325,7 @@ jobs:
 
   compiler-codegen:
     runs-on: ubuntu-latest
+    # Keep the complete suite in one job so CI reports its true end-to-end cost.
     timeout-minutes: 20
     env:
       TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,12 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           cache: npm

--- a/docs/notes/v439-checked-access-optimization-results.md
+++ b/docs/notes/v439-checked-access-optimization-results.md
@@ -18,10 +18,11 @@ npm run bench:v439 -- --label <label> --samples 7 --runtime-samples 31
 ```
 
 Each reported compile time is the median of seven fresh SDK compiles. Runtime
-results are medians of 31 samples after three warmups. Scenarios run in isolated
-child processes so differently shaped Binaryen programs cannot share runtime
-type state. Code-shape counts are static instruction-site counts over each
-complete emitted module.
+results are medians of 31 samples after three warmups. Each entrypoint gets a
+fresh host instance so one stage cannot inherit another stage's GC heap.
+Scenarios run in isolated child processes so differently shaped Binaryen
+programs cannot share runtime type state. Code-shape counts are static
+instruction-site counts over each complete emitted module.
 
 These measurements used Node 24.18.0 on an Apple M4 Pro with 14 logical CPUs.
 The before run used the benchmark commit before either optimization; the after
@@ -69,7 +70,55 @@ time was 1448.440 -> 1449.742 ms (+0.09%), Wasm was 54,536 -> 54,555 bytes
 `Array.get` workload improved from 0.856292 to 0.305583 ms (-64.3%); the other
 focused runtimes moved by at most 5.2%.
 
-## Representative controls
+## Representative web-app request pipeline
+
+`web-app-request-pipeline.voyd` models the CPU-bound part of a server-rendered
+product page after network and database I/O completes. Each 10,000-request
+batch performs:
+
+- indexed route selection over a stable route table;
+- product-card view-model construction over a stable catalog;
+- `Array.get` handling as an application would use before V-476; and
+- serialization of a 128-node response using stable template, locale,
+  escaping, and hydration configuration while a writer updates response byte
+  and node counters.
+
+The route/view-model and serialization stages are exported separately to
+attribute their cost, while `main` measures the integrated handler. The
+V-475-only revision is included between the original baseline and the final
+branch.
+
+| Release runtime | Baseline | V-475 only | Final | Final vs baseline |
+| --- | ---: | ---: | ---: | ---: |
+| Integrated request pipeline | 8.020 ms | 7.770 ms | 5.067 ms | **-36.8%** |
+| Route and view-model lookup | 1.789 ms | 1.817 ms | 0.682 ms | **-61.9%** |
+| Response serialization | 7.229 ms | 7.058 ms | 7.072 ms | **-2.2%** |
+
+V-475 alone improved the integrated pipeline by 3.1% and the serialization
+stage by 2.4%. The lookup movement on that revision was noise: its emitted
+lookup path did not change. Adding V-476 improved the lookup stage by 62.5%
+relative to V-475 and the integrated pipeline by another 34.8%. Compiler
+telemetry reports four forwarded stable loads in the serialization loop.
+
+| Release module metric | Baseline | V-475 only | Final | Final vs baseline |
+| --- | ---: | ---: | ---: | ---: |
+| Compile median | 1705.131 ms | 1719.093 ms | 1664.837 ms | -2.4% |
+| Wasm | 4,945 B | 4,937 B | 4,550 B | -8.0% |
+| Gzip | 2,320 B | 2,334 B | 2,154 B | -7.2% |
+| Allocation sites | 38 | 38 | 38 | 0 |
+| `struct.get` sites | 60 | 56 | 52 | -8 |
+| `struct.set` sites | 16 | 16 | 16 | 0 |
+| Direct calls | 67 | 67 | 53 | -14 |
+| Indirect calls | 32 | 32 | 26 | -6 |
+| Linear-memory growth | 0 B | 0 B | 0 B | 0 B |
+
+Without release optimization, the final compiler improved the integrated
+pipeline from 36.085 to 31.004 ms (-14.1%) and the lookup stage from 6.388 to
+1.053 ms (-83.5%). Serialization was unchanged. This is expected: V-476 is a
+proven codegen fast path, while V-475 consumes release optimizer facts. The
+non-release module grew by 0.27% before gzip and 0.68% after gzip.
+
+## Unmatched representative controls
 
 The final Wasm hash and every recorded instruction-site count are identical
 before and after for both representative programs, in both compiler modes.
@@ -105,8 +154,8 @@ retains its Option behavior outside the proven region.
 
 | Opportunity | Decision | Reason |
 | --- | --- | --- |
-| Stable field loads across calls | Accepted as V-475 | Repeatable 19.8% focused win; focused Wasm shrank; representatives were byte-identical. |
-| `Array.get` Option traffic in proven loops | Accepted as V-476 | Repeatable 72.3% focused win; focused Wasm shrank; representatives were byte-identical. |
+| Stable field loads across calls | Accepted as V-475 | Repeatable 19.8% focused win and a 2.4% representative response-serialization win. |
+| `Array.get` Option traffic in proven loops | Accepted as V-476 | Repeatable 72.3% focused win and a 61.9% representative route/view-model lookup win. |
 | `SharedCell` runtime-check traffic | Deferred | The focused gap was large, but the representative programs had no meaningful use and explicit shared-cell runtime semantics need a separate design decision. |
 | Remaining access guards | Stopped | The existing focused guard benchmark measured about 1.34 ns per call, below the threshold for another optimization ticket. |
 | Aggregate materialization | Stopped | Existing scalar-replacement work already removes the representative traffic; measurement found no new checked-access-specific gap. |

--- a/docs/notes/v439-checked-access-optimization-results.md
+++ b/docs/notes/v439-checked-access-optimization-results.md
@@ -111,6 +111,117 @@ mutation control's cost. The full focused release module changes as follows:
 Without release optimization, the focused module's Wasm hash, byte size, and
 every instruction-site count are identical before and after V-479.
 
+## How V-479 transforms Voyd
+
+V-479 keeps a fresh mutable object in scalar Wasm values even when the object
+crosses an eligible function call. It does this by specializing the callee's
+internal Wasm ABI. It does not inline the function or change the source-level
+Voyd API.
+
+Consider a reduced version of the response-writer pattern exercised by the
+representative web application:
+
+```voyd
+obj Writer {
+  bytes: i32,
+  nodes: i32,
+  escape_cost: i32
+}
+
+fn append_node(~writer: Writer, width: i32) -> void
+  writer.bytes = writer.bytes + width + writer.escape_cost
+  writer.nodes = writer.nodes + 1
+
+pub fn render(count: i32) -> i32
+  let ~writer = Writer {
+    bytes: 0,
+    nodes: 0,
+    escape_cost: 3
+  }
+
+  for i in 0..count:
+    append_node(~writer, i)
+
+  writer.bytes + writer.nodes
+```
+
+Without V-479, the compiler must preserve `writer` as a Wasm GC object across
+the call. Conceptually, it allocates the object, passes its reference to
+`append_node`, and performs `struct.get` and `struct.set` operations in the
+callee:
+
+```text
+writer_ref = allocate Writer(0, 0, 3)
+
+for i in 0..count:
+  append_node(writer_ref, i)
+
+load(writer_ref.bytes) + load(writer_ref.nodes)
+```
+
+When V-479's proof succeeds, the compiler instead keeps each field in a local
+scalar lane. The following is explanatory pseudocode rather than valid Voyd:
+
+```text
+writer_bytes = 0
+writer_nodes = 0
+writer_escape_cost = 3
+
+for i in 0..count:
+  (writer_bytes, writer_nodes, writer_escape_cost) =
+    append_node$scalar(
+      writer_bytes,
+      writer_nodes,
+      writer_escape_cost,
+      i
+    )
+
+writer_bytes + writer_nodes
+```
+
+The specialized callee receives the fields as individual Wasm parameters,
+operates on locals, and returns their updated state as a Wasm multivalue:
+
+```text
+append_node$scalar(bytes, nodes, escape_cost, width):
+  updated_bytes = bytes + width + escape_cost
+  updated_nodes = nodes + 1
+  return (updated_bytes, updated_nodes, escape_cost)
+```
+
+The caller captures those returned values back into the same scalar lanes. For
+the matching case, no `struct.new`, `struct.get`, or `struct.set` is needed for
+the source object.
+
+Immutable aliases continue to observe the same logical state:
+
+```voyd
+let ~writer = Writer { bytes: 0, nodes: 0, escape_cost: 3 }
+let writer_alias = writer
+
+append_node(~writer, 20)
+writer_alias.bytes
+```
+
+Both names are represented by the same lane group. If a later operation needs
+observable object identity or crosses a boundary that does not support the
+lane ABI, the compiler materializes one ordinary object and reconnects all of
+its aliases to it.
+
+The optimization requires a fresh object proven not to escape, one exact and
+pure callee, a `void` return, and a first mutable-borrow parameter used only
+through known direct fields. It rejects calls that may retain or return the
+object, suspend, perform external access, observe runtime identity, introduce
+unsupported aliases, or exceed the specialization budget. Rejected calls keep
+the normal reference ABI.
+
+This transformation depends directly on Voyd's memory-safety analysis. Escape
+facts prove where the object's identity can be observed. Callable access
+summaries prove that the exact callee cannot hide the reference or read and
+write storage outside its declared field footprint. Together, those facts make
+it sound to replace one heap identity with independent scalar values across a
+mutable call.
+
 ## Representative web-app request pipeline
 
 `web-app-request-pipeline.voyd` models the CPU-bound part of a server-rendered

--- a/docs/notes/v439-checked-access-optimization-results.md
+++ b/docs/notes/v439-checked-access-optimization-results.md
@@ -83,6 +83,11 @@ batch performs:
   escaping, and hydration configuration while a writer updates response byte
   and node counters.
 
+Setup, array traversal, and the 10,000-request driver use idiomatic range-based
+`for` loops. The 128-node serialization inner loop remains an explicit `while`
+loop; the loop-syntax control below shows why that distinction matters with the
+current compiler.
+
 The route/view-model and serialization stages are exported separately to
 attribute their cost, while `main` measures the integrated handler. The
 V-475-only revision is included between the original baseline and the final
@@ -90,33 +95,60 @@ branch.
 
 | Release runtime | Baseline | V-475 only | Final | Final vs baseline |
 | --- | ---: | ---: | ---: | ---: |
-| Integrated request pipeline | 8.020 ms | 7.770 ms | 5.067 ms | **-36.8%** |
-| Route and view-model lookup | 1.789 ms | 1.817 ms | 0.682 ms | **-61.9%** |
-| Response serialization | 7.229 ms | 7.058 ms | 7.072 ms | **-2.2%** |
+| Integrated request pipeline | 7.945 ms | 7.680 ms | 5.132 ms | **-35.4%** |
+| Route and view-model lookup | 3.203 ms | 3.211 ms | 0.691 ms | **-78.4%** |
+| Response serialization | 6.225 ms | 6.219 ms | 6.232 ms | +0.1% |
 
-V-475 alone improved the integrated pipeline by 3.1% and the serialization
-stage by 2.4%. The lookup movement on that revision was noise: its emitted
-lookup path did not change. Adding V-476 improved the lookup stage by 62.5%
-relative to V-475 and the integrated pipeline by another 34.8%. Compiler
+V-475 removes four repeated field-load sites and improved the integrated
+pipeline by 3.3%; the isolated serialization timing was unchanged at this
+workload size. The lookup movement on that revision was noise: its emitted
+lookup path did not change. Adding V-476 improved the lookup stage by 78.5%
+relative to V-475 and the integrated pipeline by another 33.2%. Compiler
 telemetry reports four forwarded stable loads in the serialization loop.
 
 | Release module metric | Baseline | V-475 only | Final | Final vs baseline |
 | --- | ---: | ---: | ---: | ---: |
-| Compile median | 1705.131 ms | 1719.093 ms | 1664.837 ms | -2.4% |
-| Wasm | 4,945 B | 4,937 B | 4,550 B | -8.0% |
-| Gzip | 2,320 B | 2,334 B | 2,154 B | -7.2% |
-| Allocation sites | 38 | 38 | 38 | 0 |
-| `struct.get` sites | 60 | 56 | 52 | -8 |
-| `struct.set` sites | 16 | 16 | 16 | 0 |
-| Direct calls | 67 | 67 | 53 | -14 |
-| Indirect calls | 32 | 32 | 26 | -6 |
+| Compile median | 1700.449 ms | 1741.339 ms | 1710.165 ms | +0.6% |
+| Wasm | 6,195 B | 6,187 B | 5,418 B | -12.5% |
+| Gzip | 2,857 B | 2,870 B | 2,558 B | -10.5% |
+| Allocation sites | 82 | 82 | 65 | -17 |
+| `struct.get` sites | 92 | 88 | 71 | -21 |
+| `struct.set` sites | 20 | 20 | 20 | 0 |
+| Direct calls | 99 | 99 | 77 | -22 |
+| Indirect calls | 41 | 41 | 33 | -8 |
 | Linear-memory growth | 0 B | 0 B | 0 B | 0 B |
 
 Without release optimization, the final compiler improved the integrated
-pipeline from 36.085 to 31.004 ms (-14.1%) and the lookup stage from 6.388 to
-1.053 ms (-83.5%). Serialization was unchanged. This is expected: V-476 is a
-proven codegen fast path, while V-475 consumes release optimizer facts. The
-non-release module grew by 0.27% before gzip and 0.68% after gzip.
+pipeline from 45.098 to 30.434 ms (-32.5%) and the lookup stage from 15.107 to
+1.175 ms (-92.2%). Serialization moved from 31.661 to 29.342 ms (-7.3%). V-476
+is a proven codegen fast path, while V-475 consumes release optimizer facts.
+The non-release module shrank by 1.0% before gzip and 1.7% after gzip.
+
+### Counted-loop syntax control
+
+The final compiler was also measured with the fixture's counted loops written
+three ways. The hybrid retained below uses `for` for setup, array traversal,
+and each 10,000-request driver, while keeping the 128-iteration serialization
+inner loop as `while`.
+
+| Final-compiler release metric | All `while` | Idiomatic hybrid | All `for` |
+| --- | ---: | ---: | ---: |
+| Integrated request pipeline | 5.067 ms | 5.132 ms (+1.3%) | 9.083 ms (+79.3%) |
+| Route and view-model lookup | 0.682 ms | 0.691 ms (+1.4%) | 0.679 ms (-0.4%) |
+| Response serialization | 7.072 ms | 6.232 ms (-11.9%) | 11.648 ms (+64.7%) |
+| Wasm | 4,550 B | 5,418 B (+19.1%) | 5,489 B (+20.6%) |
+| Gzip | 2,154 B | 2,558 B (+18.8%) | 2,576 B (+19.6%) |
+
+The array lookup timing confirms that V-476 works with
+`for index in 0..array.len()`: that form has a dedicated direct counted-loop
+path. A general `for index in 0..N` currently expands through `Range.iter()` and
+`next()`. Using that form for the 1.28 million serialization-node iterations
+per sample adds iterator allocation and dispatch, and the macro-generated loop
+does not expose V-475's stable-load opportunity. The hybrid keeps the requested
+idiomatic 10,000-request loops with a 1.3% integrated runtime cost, while
+avoiding the large hot-inner-loop regression. Its 18.8% gzip-size cost is the
+current price of including general range-iterator machinery in this small
+standalone module.
 
 ## Unmatched representative controls
 
@@ -154,8 +186,8 @@ retains its Option behavior outside the proven region.
 
 | Opportunity | Decision | Reason |
 | --- | --- | --- |
-| Stable field loads across calls | Accepted as V-475 | Repeatable 19.8% focused win and a 2.4% representative response-serialization win. |
-| `Array.get` Option traffic in proven loops | Accepted as V-476 | Repeatable 72.3% focused win and a 61.9% representative route/view-model lookup win. |
+| Stable field loads across calls | Accepted as V-475 | Repeatable 19.8% focused win; the representative loop removes four repeated field-load sites. |
+| `Array.get` Option traffic in proven loops | Accepted as V-476 | Repeatable 72.3% focused win and a 78.4% representative route/view-model lookup win. |
 | `SharedCell` runtime-check traffic | Deferred | The focused gap was large, but the representative programs had no meaningful use and explicit shared-cell runtime semantics need a separate design decision. |
 | Remaining access guards | Stopped | The existing focused guard benchmark measured about 1.34 ns per call, below the threshold for another optimization ticket. |
 | Aggregate materialization | Stopped | Existing scalar-replacement work already removes the representative traffic; measurement found no new checked-access-specific gap. |

--- a/docs/notes/v439-checked-access-optimization-results.md
+++ b/docs/notes/v439-checked-access-optimization-results.md
@@ -1,0 +1,116 @@
+# V-439 checked-access optimization results
+
+V-439 measured where Voyd's checked memory-access facts leave avoidable work in
+optimized Wasm, then implemented only the opportunities with a repeatable win.
+The final branch contains two accepted optimizations:
+
+- V-475 forwards fixed-field loads out of loops when every resolved call is
+  proven unable to write the loaded place.
+- V-476 lowers `Array.get` to a proven `Some` inside the existing safe counted
+  array-loop proof.
+
+## Method
+
+Run the benchmark with:
+
+```sh
+npm run bench:v439 -- --label <label> --samples 7 --runtime-samples 31
+```
+
+Each reported compile time is the median of seven fresh SDK compiles. Runtime
+results are medians of 31 samples after three warmups. Scenarios run in isolated
+child processes so differently shaped Binaryen programs cannot share runtime
+type state. Code-shape counts are static instruction-site counts over each
+complete emitted module.
+
+These measurements used Node 24.18.0 on an Apple M4 Pro with 14 logical CPUs.
+The before run used the benchmark commit before either optimization; the after
+run used the final integrated V-475 and V-476 commits. Both runs used the same
+harness, fixture, sample counts, and machine.
+
+## Focused release results
+
+All runtime entries are milliseconds for the workload defined in
+`tests/performance/fixtures/checked-access-optimizer.voyd`.
+
+| Workload | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| Checked-access projected fields | 0.373625 | 0.375208 | +0.4% |
+| Direct stable fields across calls | 0.303459 | 0.243250 | **-19.8%** |
+| Manually hoisted stable-field control | 0.245292 | 0.245208 | -0.0% |
+| Ordinary mutation control | 0.026208 | 0.026208 | 0.0% |
+| `SharedCell` runtime checks | 0.230875 | 0.230167 | -0.3% |
+| Proven `Array.at` loop | 0.074792 | 0.070958 | -5.1% |
+| Matched `Array.get` loop | 0.255250 | 0.070792 | **-72.3%** |
+
+The stable-field case now matches its manually hoisted control. The matched
+`Array.get` case now matches the existing `Array.at` fast path.
+
+| Focused release metric | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| Compile median | 1758.852 ms | 1765.538 ms | +0.38% |
+| Wasm | 7,528 B | 7,010 B | -6.9% |
+| Gzip | 2,898 B | 2,685 B | -7.3% |
+| Allocation sites | 56 | 51 | -5 |
+| `struct.get` sites | 131 | 114 | -17 |
+| `struct.set` sites | 15 | 15 | 0 |
+| `array.get` sites | 12 | 11 | -1 |
+| `array.set` sites | 6 | 6 | 0 |
+| `array.len` sites | 4 | 4 | 0 |
+| Direct calls | 65 | 55 | -10 |
+| Indirect calls | 29 | 26 | -3 |
+| Linear-memory growth | 0 B | 0 B | 0 B |
+
+## Non-release control
+
+The same focused module was also measured without release optimization. Compile
+time was 1448.440 -> 1449.742 ms (+0.09%), Wasm was 54,536 -> 54,555 bytes
+(+0.03%), and gzip was 13,332 -> 13,296 bytes (-0.27%). The matched
+`Array.get` workload improved from 0.856292 to 0.305583 ms (-64.3%); the other
+focused runtimes moved by at most 5.2%.
+
+## Representative controls
+
+The final Wasm hash and every recorded instruction-site count are identical
+before and after for both representative programs, in both compiler modes.
+Their small timing movements therefore reflect run-to-run measurement variance
+rather than added runtime instructions.
+
+| Scenario | Mode | Compile before -> after | Runtime before -> after | Wasm / gzip |
+| --- | --- | ---: | ---: | ---: |
+| vtrace | none | 1994.066 -> 1888.228 ms | 419.874 -> 414.341 ms | 166,859 / 42,559 B, identical |
+| vtrace | release | 3148.938 -> 3168.819 ms | 83.860 -> 84.448 ms | 34,669 / 12,826 B, identical |
+| Scalar aggregate | none | 1406.918 -> 1416.401 ms | 0.173792 -> 0.176958 ms | 37,854 / 9,387 B, identical |
+| Scalar aggregate | release | 1624.346 -> 1658.518 ms | 0.040708 -> 0.041875 ms | 1,112 / 677 B, identical |
+
+All representative runs reported zero linear-memory growth.
+
+## Safety boundaries
+
+Stable-field forwarding is limited to fresh nominal objects, fixed field
+projections, and resolved callees whose immutable codegen-view footprints prove
+that every possible write is disjoint. It bails out for dynamic or method
+dispatch, root or same-field writes, external access, suspension, retention or
+returned provenance, indexed uncertainty, aliases, capture/escape, and mutable
+root replacement.
+
+The `Array.get` fast path reuses the existing zero-start, unit-increment,
+length-bounded loop proof. It requires stable array identity, length, and
+storage, and bails out for resizing or replacement, array aliases passed to
+calls, unknown/effectful calls, stale lengths, non-unit or non-monotonic indices,
+nested control flow, and unsupported access shapes. Ordinary `Array.get`
+retains its Option behavior outside the proven region.
+
+## Opportunity decisions
+
+| Opportunity | Decision | Reason |
+| --- | --- | --- |
+| Stable field loads across calls | Accepted as V-475 | Repeatable 19.8% focused win; focused Wasm shrank; representatives were byte-identical. |
+| `Array.get` Option traffic in proven loops | Accepted as V-476 | Repeatable 72.3% focused win; focused Wasm shrank; representatives were byte-identical. |
+| `SharedCell` runtime-check traffic | Deferred | The focused gap was large, but the representative programs had no meaningful use and explicit shared-cell runtime semantics need a separate design decision. |
+| Remaining access guards | Stopped | The existing focused guard benchmark measured about 1.34 ns per call, below the threshold for another optimization ticket. |
+| Aggregate materialization | Stopped | Existing scalar-replacement work already removes the representative traffic; measurement found no new checked-access-specific gap. |
+
+Each accepted optimization passed focused runtime and emitted-shape tests,
+repository typechecking, the test inventory audit, and an independent Standard
+review followed by a fresh verification review.

--- a/docs/notes/v439-checked-access-optimization-results.md
+++ b/docs/notes/v439-checked-access-optimization-results.md
@@ -2,12 +2,15 @@
 
 V-439 measured where Voyd's checked memory-access facts leave avoidable work in
 optimized Wasm, then implemented only the opportunities with a repeatable win.
-The final branch contains two accepted optimizations:
+The final branch contains three accepted optimizations:
 
 - V-475 forwards fixed-field loads out of loops when every resolved call is
   proven unable to write the loaded place.
 - V-476 lowers `Array.get` to a proven `Some` inside the existing safe counted
   array-loop proof.
+- V-477 recognizes the compiler-owned `Range<i32>` plus the standard `for`
+  expansion and emits a direct counted loop instead of allocating an iterator
+  and matching `Option` on every iteration.
 
 ## Method
 
@@ -25,9 +28,11 @@ programs cannot share runtime type state. Code-shape counts are static
 instruction-site counts over each complete emitted module.
 
 These measurements used Node 24.18.0 on an Apple M4 Pro with 14 logical CPUs.
-The before run used the benchmark commit before either optimization; the after
-run used the final integrated V-475 and V-476 commits. Both runs used the same
-harness, fixture, sample counts, and machine.
+The focused table measures the original compiler against V-475 and V-476. The
+representative web-app table measures four compiler revisions against the same
+final all-`for` fixture: original baseline, V-475 only, V-475 plus V-476, and
+the final branch with V-477. Every comparison used the same harness, fixture,
+sample counts, and machine.
 
 ## Focused release results
 
@@ -83,72 +88,64 @@ batch performs:
   escaping, and hydration configuration while a writer updates response byte
   and node counters.
 
-Setup, array traversal, and the 10,000-request driver use idiomatic range-based
-`for` loops. The 128-node serialization inner loop remains an explicit `while`
-loop; the loop-syntax control below shows why that distinction matters with the
-current compiler.
+Every counted loop uses idiomatic range-based `for` syntax, including the
+10,000-request drivers and the 128-node serialization inner loop.
 
 The route/view-model and serialization stages are exported separately to
-attribute their cost, while `main` measures the integrated handler. The
-V-475-only revision is included between the original baseline and the final
-branch.
+attribute their cost, while `main` measures the integrated handler.
 
-| Release runtime | Baseline | V-475 only | Final | Final vs baseline |
-| --- | ---: | ---: | ---: | ---: |
-| Integrated request pipeline | 7.945 ms | 7.680 ms | 5.132 ms | **-35.4%** |
-| Route and view-model lookup | 3.203 ms | 3.211 ms | 0.691 ms | **-78.4%** |
-| Response serialization | 6.225 ms | 6.219 ms | 6.232 ms | +0.1% |
+| Release runtime | Baseline | V-475 | + V-476 | + V-477 final | Final vs baseline |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Integrated request pipeline | 14.170 ms | 14.192 ms | 9.171 ms | 5.103 ms | **-64.0%** |
+| Route and view-model lookup | 3.275 ms | 3.261 ms | 0.691 ms | 0.644 ms | **-80.3%** |
+| Response serialization | 11.810 ms | 11.714 ms | 11.789 ms | 7.059 ms | **-40.2%** |
 
-V-475 removes four repeated field-load sites and improved the integrated
-pipeline by 3.3%; the isolated serialization timing was unchanged at this
-workload size. The lookup movement on that revision was noise: its emitted
-lookup path did not change. Adding V-476 improved the lookup stage by 78.5%
-relative to V-475 and the integrated pipeline by another 33.2%. Compiler
-telemetry reports four forwarded stable loads in the serialization loop.
+V-475 alone cannot see through the macro-generated iterator's `.next()` call,
+so this all-`for` fixture does not benefit until V-477 removes that plumbing
+and uses callable access footprints to prove the synthetic method call
+disjoint. V-476 then cuts the array-heavy lookup stage by 78.8%. V-477 cuts the
+remaining integrated runtime by 44.3% and serialization by 40.1%. Compiler
+telemetry reports four forwarded V-475 loads in the final serialization loop.
 
-| Release module metric | Baseline | V-475 only | Final | Final vs baseline |
-| --- | ---: | ---: | ---: | ---: |
-| Compile median | 1700.449 ms | 1741.339 ms | 1710.165 ms | +0.6% |
-| Wasm | 6,195 B | 6,187 B | 5,418 B | -12.5% |
-| Gzip | 2,857 B | 2,870 B | 2,558 B | -10.5% |
-| Allocation sites | 82 | 82 | 65 | -17 |
-| `struct.get` sites | 92 | 88 | 71 | -21 |
-| `struct.set` sites | 20 | 20 | 20 | 0 |
-| Direct calls | 99 | 99 | 77 | -22 |
-| Indirect calls | 41 | 41 | 33 | -8 |
-| Linear-memory growth | 0 B | 0 B | 0 B | 0 B |
+| Release module metric | Baseline | V-475 | + V-476 | + V-477 final | Final vs baseline |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Compile median | 1768.823 ms | 1758.027 ms | 1770.576 ms | 1739.948 ms | -1.6% |
+| Wasm | 6,262 B | 6,262 B | 5,489 B | 4,579 B | -26.9% |
+| Gzip | 2,884 B | 2,884 B | 2,576 B | 2,147 B | -25.6% |
+| Allocation sites | 86 | 86 | 69 | 38 | -48 |
+| `struct.get` sites | 92 | 92 | 75 | 52 | -40 |
+| `struct.set` sites | 20 | 20 | 20 | 16 | -4 |
+| Direct calls | 103 | 103 | 81 | 53 | -50 |
+| Indirect calls | 42 | 42 | 34 | 26 | -16 |
+| Linear-memory growth | 0 B | 0 B | 0 B | 0 B | 0 B |
 
-Without release optimization, the final compiler improved the integrated
-pipeline from 45.098 to 30.434 ms (-32.5%) and the lookup stage from 15.107 to
-1.175 ms (-92.2%). Serialization moved from 31.661 to 29.342 ms (-7.3%). V-476
-is a proven codegen fast path, while V-475 consumes release optimizer facts.
-The non-release module shrank by 1.0% before gzip and 1.7% after gzip.
+Without release optimization, the final compiler improves the integrated
+pipeline from 62.539 to 30.883 ms (-50.6%), lookup from 15.475 to 1.221 ms
+(-92.1%), and serialization from 47.200 to 29.630 ms (-37.2%). The non-release
+module shrinks from 56,626 to 53,925 bytes (-4.8%) and from 13,950 to 13,074
+bytes after gzip (-6.3%). V-476 and V-477 are proven codegen fast paths;
+V-475 additionally consumes release optimizer facts.
 
 ### Counted-loop syntax control
 
-The final compiler was also measured with the fixture's counted loops written
-three ways. The hybrid retained below uses `for` for setup, array traversal,
-and each 10,000-request driver, while keeping the 128-iteration serialization
-inner loop as `while`.
+Before V-477, using `for` for every counted loop made the integrated pipeline
+79.3% slower than the original all-`while` control. With V-477, the idiomatic
+source is effectively at parity with that control:
 
-| Final-compiler release metric | All `while` | Idiomatic hybrid | All `for` |
+| Final release metric | All-`while` control | All-`for` with V-477 | Change |
 | --- | ---: | ---: | ---: |
-| Integrated request pipeline | 5.067 ms | 5.132 ms (+1.3%) | 9.083 ms (+79.3%) |
-| Route and view-model lookup | 0.682 ms | 0.691 ms (+1.4%) | 0.679 ms (-0.4%) |
-| Response serialization | 7.072 ms | 6.232 ms (-11.9%) | 11.648 ms (+64.7%) |
-| Wasm | 4,550 B | 5,418 B (+19.1%) | 5,489 B (+20.6%) |
-| Gzip | 2,154 B | 2,558 B (+18.8%) | 2,576 B (+19.6%) |
+| Integrated request pipeline | 5.067 ms | 5.103 ms | +0.7% |
+| Route and view-model lookup | 0.682 ms | 0.644 ms | -5.6% |
+| Response serialization | 7.072 ms | 7.059 ms | -0.2% |
+| Wasm | 4,550 B | 4,579 B | +0.6% |
+| Gzip | 2,154 B | 2,147 B | -0.3% |
 
-The array lookup timing confirms that V-476 works with
-`for index in 0..array.len()`: that form has a dedicated direct counted-loop
-path. A general `for index in 0..N` currently expands through `Range.iter()` and
-`next()`. Using that form for the 1.28 million serialization-node iterations
-per sample adds iterator allocation and dispatch, and the macro-generated loop
-does not expose V-475's stable-load opportunity. The hybrid keeps the requested
-idiomatic 10,000-request loops with a 1.3% integrated runtime cost, while
-avoiding the large hot-inner-loop regression. Its 18.8% gzip-size cost is the
-current price of including general range-iterator machinery in this small
-standalone module.
+The direct path recognizes only the validated standard intrinsic
+`Range<i32>` and the exact standard `for` expansion. It evaluates bounded range
+endpoints once in source order, advances iterator state before the user body so
+`continue` remains correct, handles inclusive `i32::MAX` without overflow, and
+reuses V-476's array-stability scope for `0..array.len()`. Effectful functions
+conservatively keep the normal continuation-aware iterator path.
 
 ## Unmatched representative controls
 
@@ -159,10 +156,10 @@ rather than added runtime instructions.
 
 | Scenario | Mode | Compile before -> after | Runtime before -> after | Wasm / gzip |
 | --- | --- | ---: | ---: | ---: |
-| vtrace | none | 1994.066 -> 1888.228 ms | 419.874 -> 414.341 ms | 166,859 / 42,559 B, identical |
-| vtrace | release | 3148.938 -> 3168.819 ms | 83.860 -> 84.448 ms | 34,669 / 12,826 B, identical |
-| Scalar aggregate | none | 1406.918 -> 1416.401 ms | 0.173792 -> 0.176958 ms | 37,854 / 9,387 B, identical |
-| Scalar aggregate | release | 1624.346 -> 1658.518 ms | 0.040708 -> 0.041875 ms | 1,112 / 677 B, identical |
+| vtrace | none | 1868.779 -> 1803.813 ms | 413.442 -> 416.026 ms | 166,859 / 42,559 B, identical |
+| vtrace | release | 3181.175 -> 3126.605 ms | 81.993 -> 82.598 ms | 34,669 / 12,826 B, identical |
+| Scalar aggregate | none | 1362.637 -> 1368.629 ms | 0.181083 -> 0.169583 ms | 37,854 / 9,387 B, identical |
+| Scalar aggregate | release | 1587.866 -> 1606.815 ms | 0.041125 -> 0.040834 ms | 1,112 / 677 B, identical |
 
 All representative runs reported zero linear-memory growth.
 
@@ -170,10 +167,11 @@ All representative runs reported zero linear-memory growth.
 
 Stable-field forwarding is limited to fresh nominal objects, fixed field
 projections, and resolved callees whose immutable codegen-view footprints prove
-that every possible write is disjoint. It bails out for dynamic or method
-dispatch, root or same-field writes, external access, suspension, retention or
-returned provenance, indexed uncertainty, aliases, capture/escape, and mutable
-root replacement.
+that every possible write is disjoint. It bails out for dynamic method
+dispatch that receives the candidate, unresolved calls, root or same-field
+writes, external access, suspension, retention or returned provenance, indexed
+uncertainty, aliases, capture/escape, and mutable root replacement. Resolved
+method calls use the same callable-access proof as ordinary calls.
 
 The `Array.get` fast path reuses the existing zero-start, unit-increment,
 length-bounded loop proof. It requires stable array identity, length, and
@@ -182,12 +180,19 @@ calls, unknown/effectful calls, stale lengths, non-unit or non-monotonic indices
 nested control flow, and unsupported access shapes. Ordinary `Array.get`
 retains its Option behavior outside the proven region.
 
+The `Range<i32>` fast path requires the validated std intrinsic type, its exact
+`i32` argument, both bounded endpoints, literal inclusive/exclusive mode, and
+the exact std `for` macro shape. Other range instantiations, open-ended ranges,
+arbitrary iterators, malformed expansions, and effectful functions use normal
+iteration. Bounds are evaluated once before any forwarded field loads.
+
 ## Opportunity decisions
 
 | Opportunity | Decision | Reason |
 | --- | --- | --- |
 | Stable field loads across calls | Accepted as V-475 | Repeatable 19.8% focused win; the representative loop removes four repeated field-load sites. |
-| `Array.get` Option traffic in proven loops | Accepted as V-476 | Repeatable 72.3% focused win and a 78.4% representative route/view-model lookup win. |
+| `Array.get` Option traffic in proven loops | Accepted as V-476 | Repeatable 72.3% focused win and a 78.8% representative route/view-model lookup win. |
+| Intrinsic `Range<i32>` iterator traffic | Accepted as V-477 | Restores all-`for` source to all-`while` parity; cuts the incremental integrated pipeline by 44.3%, serialization by 40.1%, and gzip size by 16.7%. |
 | `SharedCell` runtime-check traffic | Deferred | The focused gap was large, but the representative programs had no meaningful use and explicit shared-cell runtime semantics need a separate design decision. |
 | Remaining access guards | Stopped | The existing focused guard benchmark measured about 1.34 ns per call, below the threshold for another optimization ticket. |
 | Aggregate materialization | Stopped | Existing scalar-replacement work already removes the representative traffic; measurement found no new checked-access-specific gap. |

--- a/docs/notes/v439-checked-access-optimization-results.md
+++ b/docs/notes/v439-checked-access-optimization-results.md
@@ -12,8 +12,9 @@ The final branch contains six accepted optimizations:
   expansion and emits a direct counted loop instead of allocating an iterator
   and matching `Option` on every iteration.
 - V-479 keeps eligible fresh mutable objects in scalar lanes across exact,
-  pure mutable-borrow calls and returns the updated lanes directly instead of
-  allocating and repeatedly loading and storing a heap object.
+  pure mutable-borrow calls. Its original `void` form returns the updated lanes
+  directly; the generalized form returns the callee's logical value followed
+  by those updated lanes.
 - Intrinsic `Array<T>` iteration recognizes the exact standard `for` expansion
   and emits direct array traversal without allocating `ArrayIterator` or
   constructing and matching `Option` for every element.
@@ -44,13 +45,27 @@ npm run bench:iterator-for -- \
   --runtime-samples 31
 ```
 
+Run the generalized V-479 value-result benchmark with:
+
+```sh
+npm run bench:mutable-result -- \
+  --label <label> \
+  --compile-samples 7 \
+  --runtime-samples 31
+```
+
+Add `--sdk-root /path/to/voyd-checkout` to compile the current fixture with a
+different compiler revision.
+
 The V-439 and general-iterator compile times are medians of seven fresh SDK
 compiles, and their runtimes are medians of 31 samples after three warmups. The
-Array follow-up uses five compile and 21 runtime samples. Each V-439 entrypoint
-gets a fresh host instance so one stage cannot inherit another stage's GC heap.
-Scenarios run in isolated child processes so differently shaped Binaryen
-programs cannot share runtime type state. Code-shape counts are static
-instruction-site counts over each complete emitted module.
+Array follow-up uses five compile and 21 runtime samples. The generalized
+V-479 benchmark uses seven uncached compiles and 31 timed runs after one
+untimed warmup for each entrypoint. Each V-439 entrypoint gets a fresh host
+instance so one stage cannot inherit another stage's GC heap. Scenarios run in
+isolated child processes so differently shaped Binaryen programs cannot share
+runtime type state. Code-shape counts are static instruction-site counts over
+each complete emitted module.
 
 These measurements used Node 24.18.0 on an Apple M4 Pro with 14 logical CPUs.
 The focused table measures the original compiler against V-475 and V-476. The
@@ -137,12 +152,13 @@ every instruction-site count are identical before and after V-479.
 ## How V-479 transforms Voyd
 
 V-479 keeps a fresh mutable object in scalar Wasm values even when the object
-crosses an eligible function call. It does this by specializing the callee's
-internal Wasm ABI. It does not inline the function or change the source-level
-Voyd API.
+crosses an eligible function call. It does this by specializing an internal
+Wasm ABI between the caller and the exact callee. The source-level Voyd API is
+unchanged, and the optimization does not depend on inlining.
 
-Consider a reduced version of the response-writer pattern exercised by the
-representative web application:
+### Original `void` writeback
+
+The original V-479 case was a procedure that only updated the borrowed object:
 
 ```voyd
 obj Writer {
@@ -168,53 +184,94 @@ pub fn render(count: i32) -> i32
   writer.bytes + writer.nodes
 ```
 
-Without V-479, the compiler must preserve `writer` as a Wasm GC object across
-the call. Conceptually, it allocates the object, passes its reference to
-`append_node`, and performs `struct.get` and `struct.set` operations in the
-callee:
+Without specialization, the compiler preserves `writer` as a Wasm GC object,
+passes its reference to `append_node`, and loads and stores fields through that
+reference. V-479 instead keeps the fields in local scalar lanes. Its internal
+specialized call is conceptually:
 
 ```text
-writer_ref = allocate Writer(0, 0, 3)
-
-for i in 0..count:
-  append_node(writer_ref, i)
-
-load(writer_ref.bytes) + load(writer_ref.nodes)
+append_node$scalar(bytes, nodes, escape_cost, width)
+  -> (updated_bytes, updated_nodes, updated_escape_cost)
 ```
 
-When V-479's proof succeeds, the compiler instead keeps each field in a local
-scalar lane. The following is explanatory pseudocode rather than valid Voyd:
+The caller passes each field as a normal Wasm value, captures the returned
+lanes, and uses them as the object's new state. For a fully matched object,
+there is no source-object `struct.new`, `struct.get`, or `struct.set` in the
+hot path.
+
+### Returning a value and mutable state together
+
+Real helpers often update state and return a useful result. A response encoder,
+for example, needs both the updated writer and the byte count for its response
+budget:
+
+```voyd
+obj ResponseWriter {
+  template_seed: i32,
+  response_bytes: i32,
+  emitted_nodes: i32,
+  checksum: i32
+}
+
+fn write_dynamic_text(~writer: ResponseWriter, value: i32) -> i32
+  if value < 0:
+    writer.response_bytes = writer.response_bytes + 12
+    writer.emitted_nodes = writer.emitted_nodes + 1
+    return 12
+
+  let bytes = 8 + ((value + writer.template_seed) % 23)
+  writer.response_bytes = writer.response_bytes + bytes
+  writer.emitted_nodes = writer.emitted_nodes + 1
+  writer.checksum = (writer.checksum + value * 7) % 1000003
+  bytes
+
+pub fn render_response() -> i32
+  let ~writer = ResponseWriter {
+    template_seed: 19,
+    response_bytes: 0,
+    emitted_nodes: 0,
+    checksum: 0
+  }
+  var budget = 0
+
+  for value in 0..10000:
+    budget = budget + write_dynamic_text(~writer, value)
+
+  budget + writer.response_bytes + writer.checksum
+```
+
+The generalized ABI places the normal function result first and the mutable
+writeback lanes after it:
 
 ```text
-writer_bytes = 0
-writer_nodes = 0
-writer_escape_cost = 3
-
-for i in 0..count:
-  (writer_bytes, writer_nodes, writer_escape_cost) =
-    append_node$scalar(
-      writer_bytes,
-      writer_nodes,
-      writer_escape_cost,
-      i
-    )
-
-writer_bytes + writer_nodes
+write_dynamic_text$scalar(template_seed, response_bytes, emitted_nodes,
+                          checksum, value)
+  -> (bytes_written,
+      updated_template_seed,
+      updated_response_bytes,
+      updated_emitted_nodes,
+      updated_checksum)
 ```
 
-The specialized callee receives the fields as individual Wasm parameters,
-operates on locals, and returns their updated state as a Wasm multivalue:
+The caller evaluates that call exactly once, writes the trailing state lanes
+back to the scalarized `writer`, and then exposes `bytes_written` as the value
+of the original Voyd call. This ordering also handles a discarded logical
+result: the compiler can drop `bytes_written` while still applying every state
+update. Logical results that already use several direct ABI lanes keep their
+lane order ahead of the writeback lanes.
 
-```text
-append_node$scalar(bytes, nodes, escape_cost, width):
-  updated_bytes = bytes + width + escape_cost
-  updated_nodes = nodes + 1
-  return (updated_bytes, updated_nodes, escape_cost)
-```
+Every explicit early return in the specialized callee packages its logical
+value with the current mutable state. The ordinary fallthrough result does the
+same.
 
-The caller captures those returned values back into the same scalar lanes. For
-the matching case, no `struct.new`, `struct.get`, or `struct.set` is needed for
-the source object.
+Specialization stops when a callee passes its mutable receiver to another
+helper. For example, a `write_pair(~writer, ...)` wrapper that calls
+`write_dynamic_text(~writer, ...)` stays on the ordinary reference ABI even
+when `write_dynamic_text` is independently eligible at direct call sites. This
+conservative boundary avoids reconstructing scalar state after conditional or
+zero-iteration nested calls. Supporting that composition would require a
+path-aware state merge or transitive specialization reservation; neither is
+part of this optimization.
 
 Immutable aliases continue to observe the same logical state:
 
@@ -232,11 +289,13 @@ lane ABI, the compiler materializes one ordinary object and reconnects all of
 its aliases to it.
 
 The optimization requires a fresh object proven not to escape, one exact and
-pure callee, a `void` return, and a first mutable-borrow parameter used only
-through known direct fields. It rejects calls that may retain or return the
-object, suspend, perform external access, observe runtime identity, introduce
-unsupported aliases, or exceed the specialization budget. Rejected calls keep
-the normal reference ABI.
+pure callee, and a first source argument that maps to a mutable-borrow parameter
+used only through known direct fields. A non-`void` logical result must use the
+direct ABI. Wide results that require an out pointer retain the normal ABI.
+Calls also fall back when they pass the receiver to another helper, may retain
+or return the borrowed object or its provenance, suspend, perform external
+access, require runtime identity guards, introduce unsupported aliases, or
+exceed the specialization budget.
 
 This transformation depends directly on Voyd's memory-safety analysis. Escape
 facts prove where the object's identity can be observed. Callable access
@@ -244,6 +303,53 @@ summaries prove that the exact callee cannot hide the reference or read and
 write storage outside its declared field footprint. Together, those facts make
 it sound to replace one heap identity with independent scalar values across a
 mutable call.
+
+### Generalized value-result benchmark
+
+The opt-in benchmark expands the response-writer example into 640,000 dynamic
+text writes per sample. It measures a caller that uses the byte result, one
+that discards it, and a manually expanded checksum control. Nested-call
+fallback is covered by focused conditional and zero-iteration-loop regressions
+instead of sharing the helper in this module and distorting the direct-path
+artifact measurement. Both revisions compiled the same final fixture.
+Checksums matched for every entrypoint.
+
+Runtime was measured in three isolated, counterbalanced A/B pairs with 31 timed
+samples per process. The table reports the range of each process median rather
+than selecting the most favorable run.
+
+| Release runtime | Before range | Generalized range | Paired change range | Conclusion |
+| --- | ---: | ---: | ---: | --- |
+| Used logical result | 3.0264–3.0606 ms | 2.8347–3.0332 ms | +0.1% to -7.4% | Inconclusive |
+| Discarded logical result | 3.0055–3.0274 ms | 2.7936–2.8037 ms | **-7.0% to -7.6%** | Repeatable improvement |
+| Manual checksum control | 4.6820–4.7293 ms | 4.5313–4.5968 ms | -2.4% to -4.2% | Whole-run timing drift |
+
+| Release module metric | Before generalized ABI | Generalized ABI | Change |
+| --- | ---: | ---: | ---: |
+| Wasm | 3,861 B | 3,334 B | **-13.6%** |
+| Gzip | 1,541 B | 1,559 B | +1.2% |
+| Allocation sites | 33 | 27 | -6 |
+| `struct.get` sites | 121 | 41 | -80 |
+| `struct.set` sites | 26 | 10 | -16 |
+
+The seven-sample compile median moved from 1,579.2 to 1,609.5 ms (+1.9%), which
+is within normal run-to-run variation. A separate 51-sample pair measured a
+7.8% discarded-result improvement. The manual control exposes meaningful
+whole-run timing drift; the discarded-result path nevertheless improves in a
+tight range and by another 2.8 to 5.2 percentage points beyond its paired
+control. The emitted-shape reduction and repeatable discarded-result change are
+the useful signals. There is no supported used-result runtime claim.
+
+This generalization complements the two `for in` optimizations rather than
+replacing them. Intrinsic `Array<T>` lowering bypasses iterator objects and
+`Option` traffic directly, so its release module remained byte- and
+instruction-identical with the generalized V-479 change. General exact
+iterator specialization keeps the ordinary `next() -> Option<T>` source ABI
+and exposes the exact state machine to Binaryen; its optimized module likewise
+remained identical, with no allocation, field-access, or indirect-call sites.
+Runtime movements in both controls were measurement noise. Those loop paths
+are already doing their intended jobs, while generalized V-479 covers ordinary
+non-void mutable helpers elsewhere in application code.
 
 ## Representative web-app request pipeline
 
@@ -523,18 +629,23 @@ instance. The scoped direct-call and receiver facts preserve the normal ABI;
 dynamic, ambiguous, noncanonical, or non-fresh paths retain trait dispatch.
 
 Mutable aggregate promotion requires a fresh heap object covered by escape
-analysis, a single exact canonical call target, a pure `void` callee, and a
+analysis, a single exact canonical call target, a pure callee, and a
 mutable-borrow parameter whose callable-access footprint reads and writes only
-known direct fields. The callee cannot retain or return the object, suspend,
-perform external access, use runtime identity guards, alias the parameter, or
-contain an explicit return. The mutable object must be the first source
-argument, and later arguments cannot reference any of its aliases. Eligible
-specialization identities are reserved before scalar lanes are installed, so a
-budget rejection materializes normally before control flow. Imported targets
-and receiver specializations are resolved through the shared eligibility
-contract, call-shape variants preserve the lane result, and fallback
-materializes every shared alias together. Balanced and non-release builds set
-the mutable-lane allowance to zero.
+known direct fields. A logical result must have a direct ABI; out-pointer
+results fall back. The callee cannot retain or return the borrowed object or
+its provenance, suspend, perform external access, use runtime identity guards,
+or introduce an unsupported alias. Explicit non-`void` returns are supported
+because each return packages the logical result and current writeback lanes.
+
+The mutable object must be the first source argument, and later arguments
+cannot reference any of its aliases. Passing the mutable receiver to a nested
+call rejects specialization for the outer callee, including conditional and
+loop-shaped calls. Eligible specialization identities are reserved before
+scalar lanes are installed, so a budget rejection materializes normally before
+control flow. Imported targets and receiver specializations are resolved
+through the shared eligibility contract, call-shape variants preserve the
+combined result, and fallback materializes every shared alias together.
+Balanced and non-release builds set the mutable-lane allowance to zero.
 
 Mutable aggregate promotion directly depends on Voyd's memory-safety work.
 Fresh-origin escape facts prove where identity can be observed, while immutable callable
@@ -549,7 +660,7 @@ with independent scalar values across a mutable call would be unsound.
 | Stable field loads across calls | Accepted as V-475 | Repeatable 19.8% focused win; the representative loop removes four repeated field-load sites. |
 | `Array.get` Option traffic in proven loops | Accepted as V-476 | Repeatable 72.3% focused win and a 78.8% representative route/view-model lookup win. |
 | Intrinsic `Range<i32>` iterator traffic | Accepted as V-477 | Restores all-`for` source to all-`while` parity; cuts the incremental integrated pipeline by 44.3%, serialization by 40.1%, and gzip size by 16.7%. |
-| Fresh mutable aggregate traffic across exact calls | Accepted as V-479 | Cuts incremental integrated runtime by 44.1%, serialization by 69.4%, and the direct-object focused workload by 90.0%; shrinks representative gzip by 6.5%. |
+| Fresh mutable aggregate traffic across exact calls | Accepted as V-479 | The original `void` path cuts incremental integrated runtime by 44.1%, serialization by 69.4%, and the direct-object focused workload by 90.0%. Generalized direct value-returning calls remove 80 field-load and 16 field-store sites from the realistic writer module and improve its discarded-result path by 7.0–7.6%; used-result timing is inconclusive and nested receiver helpers conservatively retain the ordinary ABI. |
 | Intrinsic `Array<T>` `for` traffic | Accepted | Reaches indexed-loop parity: 95.6% faster in the focused element loop and 91.2% faster in representative view-model serialization. |
 | Exact user-iterator and receiver traffic | Accepted | Non-intrinsic iterators improve by 84.4% in the light case and 55.7% for filtered/strided traversal; emitted iterator traffic falls to zero, and the shared exact-store proof improves the projected-field workload by 70.7%. |
 | `SharedCell` runtime-check traffic | Deferred | The focused gap was large, but the representative programs had no meaningful use and explicit shared-cell runtime semantics need a separate design decision. |

--- a/docs/notes/v439-checked-access-optimization-results.md
+++ b/docs/notes/v439-checked-access-optimization-results.md
@@ -556,32 +556,56 @@ The complete representative suite was rerun after both iterator optimizations.
 These rows compare the original PR base with the combined final branch using
 the same final fixtures and harness.
 
+The Vtrace fixture now preserves the source shape an application author would
+naturally write. `ScatterResult` is an ordinary `obj`, the world uses
+`for object in self.objects`, and the color accumulator calls a named mutable
+helper. The old fixture used a `val` result plus a manually indexed `while`
+loop, which hid the cost of standard Array iteration from this representative
+program.
+
 | Representative release program | Before PR | Final | Change |
 | --- | ---: | ---: | ---: |
-| Vtrace renderer | 79.094 ms | 79.835 ms | +0.9% |
+| Idiomatic Vtrace renderer | 167.419 ms | 78.101 ms | **-53.4%** |
 | Scalar aggregate | 0.0407 ms | 0.0408 ms | +0.3% |
 | Web request pipeline | 14.199 ms | 2.850 ms | **-79.9%** |
 
 | Representative release artifact | Before PR | Final | Change |
 | --- | ---: | ---: | ---: |
-| Vtrace Wasm / gzip | 34,669 / 12,826 B | 34,037 / 12,702 B | -1.8% / -1.0% |
+| Idiomatic Vtrace Wasm / gzip | 36,058 / 13,108 B | 34,105 / 12,666 B | -5.4% / -3.4% |
 | Scalar aggregate Wasm / gzip | 1,112 / 677 B | 1,112 / 677 B | 0.0% / 0.0% |
 | Web pipeline Wasm / gzip | 6,262 / 2,884 B | 3,878 / 1,883 B | **-38.1% / -34.7%** |
 
+Vtrace's non-release runtime also improves from 521.656 to 367.473 ms
+(-29.6%). The release compile median moves from 2,881.7 to 2,908.1 ms (+0.9%),
+which is within the observed noise for this module. The release artifact drops
+23 allocation sites, 46 `struct.get` sites, four `struct.set` sites, and 24
+indirect-call sites.
+
+An intermediate attribution run compiled the same idiomatic source immediately
+before and after the intrinsic Array path. Using three compile samples and 11
+warmed runtime samples, release runtime fell from 165.317 to 77.689 ms (-53.0%).
+The later exact-iterator and generalized V-479 work reduced the emitted module
+further, but did not produce a measurable additional Vtrace runtime change.
+The former hand-shaped fixture ran in 78.448 ms on the final compiler, so the
+idiomatic 78.101 ms result is parity within noise. The practical gain is that
+ordinary `for object in objects` source no longer needs to be rewritten as a
+manual indexed loop to reach that performance.
+
 The final web lookup stage is 0.644 ms versus 3.245 ms at the PR base (-80.2%),
 and serialization is 2.152 versus 11.715 ms (-81.6%). Vtrace now benefits in
-release artifact shape from exact iterator/receiver specialization while its
-runtime remains effectively flat. Scalar aggregate remains byte-identical.
-Without release optimization, Vtrace and scalar aggregate remain byte-identical
-to the PR base; the existing proven Array/range codegen paths account for the
-non-release web improvement already described above.
+release runtime and artifact shape from intrinsic Array iteration. Scalar
+aggregate remains byte-identical. Without release optimization, the proven
+Array/range codegen paths account for the Vtrace and web improvements; scalar
+aggregate remains byte-identical to the PR base.
 
-## V-479 unmatched controls
+## V-479 unmatched controls on the former Vtrace source
 
-The Wasm hash and every recorded instruction-site count are identical before
-and after V-479 for both unmatched representative programs, in both modes.
-Their small timing movements therefore reflect run-to-run measurement variance
-rather than added runtime instructions.
+The incremental V-479 measurements used the Vtrace source that existed at that
+stage of the work: a `val` result and manually indexed scene loop. The Wasm hash
+and every recorded instruction-site count were identical before and after
+V-479 for both unmatched representative programs, in both modes. Their small
+timing movements therefore reflect run-to-run measurement variance rather than
+added runtime instructions.
 
 | Scenario | Mode | Compile before -> after | Runtime before -> after | Wasm / gzip |
 | --- | --- | ---: | ---: | ---: |
@@ -661,7 +685,7 @@ with independent scalar values across a mutable call would be unsound.
 | `Array.get` Option traffic in proven loops | Accepted as V-476 | Repeatable 72.3% focused win and a 78.8% representative route/view-model lookup win. |
 | Intrinsic `Range<i32>` iterator traffic | Accepted as V-477 | Restores all-`for` source to all-`while` parity; cuts the incremental integrated pipeline by 44.3%, serialization by 40.1%, and gzip size by 16.7%. |
 | Fresh mutable aggregate traffic across exact calls | Accepted as V-479 | The original `void` path cuts incremental integrated runtime by 44.1%, serialization by 69.4%, and the direct-object focused workload by 90.0%. Generalized direct value-returning calls remove 80 field-load and 16 field-store sites from the realistic writer module and improve its discarded-result path by 7.0–7.6%; used-result timing is inconclusive and nested receiver helpers conservatively retain the ordinary ABI. |
-| Intrinsic `Array<T>` `for` traffic | Accepted | Reaches indexed-loop parity: 95.6% faster in the focused element loop and 91.2% faster in representative view-model serialization. |
+| Intrinsic `Array<T>` `for` traffic | Accepted | Reaches indexed-loop parity: 95.6% faster in the focused element loop, 91.2% faster in representative view-model serialization, and 53.0% faster in the idiomatic Vtrace renderer. |
 | Exact user-iterator and receiver traffic | Accepted | Non-intrinsic iterators improve by 84.4% in the light case and 55.7% for filtered/strided traversal; emitted iterator traffic falls to zero, and the shared exact-store proof improves the projected-field workload by 70.7%. |
 | `SharedCell` runtime-check traffic | Deferred | The focused gap was large, but the representative programs had no meaningful use and explicit shared-cell runtime semantics need a separate design decision. |
 | Remaining access guards | Stopped | The existing focused guard benchmark measured about 1.34 ns per call, below the threshold for another optimization ticket. |

--- a/docs/notes/v439-checked-access-optimization-results.md
+++ b/docs/notes/v439-checked-access-optimization-results.md
@@ -430,6 +430,15 @@ moved from 1,554.7 to 1,588.3 ms (+2.2%), which is inconclusive at this sample
 count. A parent rerun reproduced the final emitted shape and measured 0.354 ms
 for the light loop and 0.423 ms for the filtered traversal.
 
+The exact nominal receiver fact used to specialize mutable `next()` calls now
+also permits direct field stores under the same proof that already permitted
+direct field loads. That is a general receiver-specialization improvement, so
+it benefits exact receivers outside iteration as well. In the final focused
+suite, the projected-field workload that remained outside V-479 improves from
+0.3635 to 0.1064 ms (-70.7%). The final focused module is 6,688 bytes (2,626
+gzip), with 99 `struct.get` and eight `struct.set` sites, compared with 6,968
+bytes, 2,694 gzip, 108 gets, and 15 sets immediately before this follow-up.
+
 Dynamic or ambiguous dispatch, noncanonical traits, non-fresh iterator
 results, unsupported result control flow, and builds without release optimizer
 facts keep the ordinary trait call. The intrinsic Array path retains its
@@ -542,7 +551,7 @@ with independent scalar values across a mutable call would be unsound.
 | Intrinsic `Range<i32>` iterator traffic | Accepted as V-477 | Restores all-`for` source to all-`while` parity; cuts the incremental integrated pipeline by 44.3%, serialization by 40.1%, and gzip size by 16.7%. |
 | Fresh mutable aggregate traffic across exact calls | Accepted as V-479 | Cuts incremental integrated runtime by 44.1%, serialization by 69.4%, and the direct-object focused workload by 90.0%; shrinks representative gzip by 6.5%. |
 | Intrinsic `Array<T>` `for` traffic | Accepted | Reaches indexed-loop parity: 95.6% faster in the focused element loop and 91.2% faster in representative view-model serialization. |
-| Exact user-iterator dispatch and state traffic | Accepted | Non-intrinsic iterators improve by 84.4% in the light case and 55.7% for filtered/strided traversal; emitted allocation, indirect-call, and iterator field traffic falls to zero. |
+| Exact user-iterator and receiver traffic | Accepted | Non-intrinsic iterators improve by 84.4% in the light case and 55.7% for filtered/strided traversal; emitted iterator traffic falls to zero, and the shared exact-store proof improves the projected-field workload by 70.7%. |
 | `SharedCell` runtime-check traffic | Deferred | The focused gap was large, but the representative programs had no meaningful use and explicit shared-cell runtime semantics need a separate design decision. |
 | Remaining access guards | Stopped | The existing focused guard benchmark measured about 1.34 ns per call, below the threshold for another optimization ticket. |
 

--- a/docs/notes/v439-checked-access-optimization-results.md
+++ b/docs/notes/v439-checked-access-optimization-results.md
@@ -2,7 +2,7 @@
 
 V-439 measured where Voyd's checked memory-access facts leave avoidable work in
 optimized Wasm, then implemented only the opportunities with a repeatable win.
-The final branch contains four accepted optimizations:
+The final branch contains six accepted optimizations:
 
 - V-475 forwards fixed-field loads out of loops when every resolved call is
   proven unable to write the loaded place.
@@ -14,6 +14,13 @@ The final branch contains four accepted optimizations:
 - V-479 keeps eligible fresh mutable objects in scalar lanes across exact,
   pure mutable-borrow calls and returns the updated lanes directly instead of
   allocating and repeatedly loading and storing a heap object.
+- Intrinsic `Array<T>` iteration recognizes the exact standard `for` expansion
+  and emits direct array traversal without allocating `ArrayIterator` or
+  constructing and matching `Option` for every element.
+- General exact-iterator specialization proves fresh concrete iterator results
+  from canonical standard `Sequence.iter` implementations, directly targets
+  their standard `Iterator.next` implementation, and exposes the unchanged
+  iterator state machine to Binaryen scalar replacement.
 
 ## Method
 
@@ -23,9 +30,24 @@ Run the benchmark with:
 npm run bench:v439 -- --label <label> --samples 7 --runtime-samples 31
 ```
 
-Each reported compile time is the median of seven fresh SDK compiles. Runtime
-results are medians of 31 samples after three warmups. Each entrypoint gets a
-fresh host instance so one stage cannot inherit another stage's GC heap.
+Run the two iterator follow-up benchmarks with:
+
+```sh
+npm run bench:array-for -- \
+  --label <label> \
+  --compile-samples 5 \
+  --runtime-samples 21
+
+npm run bench:iterator-for -- \
+  --label <label> \
+  --compile-samples 7 \
+  --runtime-samples 31
+```
+
+The V-439 and general-iterator compile times are medians of seven fresh SDK
+compiles, and their runtimes are medians of 31 samples after three warmups. The
+Array follow-up uses five compile and 21 runtime samples. Each V-439 entrypoint
+gets a fresh host instance so one stage cannot inherit another stage's GC heap.
 Scenarios run in isolated child processes so differently shaped Binaryen
 programs cannot share runtime type state. Code-shape counts are static
 instruction-site counts over each complete emitted module.
@@ -36,7 +58,8 @@ representative web-app table measures four compiler revisions against the same
 final all-`for` fixture: original baseline, V-475 only, V-475 plus V-476, and
 V-477. V-479 was then measured against the merged V-477 branch with the same
 harness, fixtures, sample counts, and machine. The final overall comparison
-uses the original baseline and the accepted V-479 end state.
+uses the original baseline and the combined accepted end state after both
+iterator follow-ups.
 
 ## Focused release results
 
@@ -329,6 +352,115 @@ endpoints once in source order, advances iterator state before the user body so
 reuses V-476's array-stability scope for `0..array.len()`. Effectful functions
 conservatively keep the normal continuation-aware iterator path.
 
+## Intrinsic Array `for` follow-up
+
+`Array<T>` is a compiler-owned intrinsic type. The follow-up recognizes the
+exact standard expansion of `for element in array`, evaluates the array once,
+and directly reads its count, current backing storage, and element. It advances
+the synthetic cursor before the user body so `continue` retains its original
+meaning.
+
+The lowering re-reads count and storage every iteration. That preserves the
+existing `ArrayIterator` behavior when the body grows the array, triggers
+backing-storage replacement, or mutates it through an alias. Reassigning the
+source variable does not retarget iteration because the original array value is
+captured once. Custom and non-intrinsic `Sequence` implementations remain on
+the general iterator path.
+
+The benchmark traverses 48 view-model records. Its light-body case isolates
+iterator overhead, while the rendering case performs record-based response
+size calculation representative of serialization work.
+
+| Release runtime | General Array iterator | Intrinsic direct path | Indexed control | Change |
+| --- | ---: | ---: | ---: | ---: |
+| Light element loop | 3.264 ms | 0.143 ms | 0.145 ms | **-95.6%** |
+| View-model serialization | 1.708 ms | 0.150 ms | 0.154 ms | **-91.2%** |
+
+| Release module metric | Before | Array path | Change |
+| --- | ---: | ---: | ---: |
+| Wasm | 4,078 B | 3,018 B | -26.0% |
+| Gzip | 1,956 B | 1,482 B | -24.2% |
+| Indirect calls | 23 | 12 | -11 |
+| Allocation sites | 31 | 18 | -13 |
+
+Five uncached compiles and 21 warmed runtime samples were used. The adjacent
+compile medians were 1,606.9 and 1,602.7 ms (-0.3%); later reruns were noisy,
+so this is evidence of no material compile regression rather than a compile
+speedup. On the combined final branch, the same benchmark is 2,880 bytes
+(1,413 gzip) and retains indexed-loop runtime parity.
+
+## General exact-iterator follow-up
+
+The general path applies to non-intrinsic user types implementing the standard
+`Sequence` and `Iterator` traits. It requires an exact nominal iterable, an
+exact selected `iter` implementation, and a fresh concrete nominal iterator
+returned directly by that implementation. It uses the selected generic
+function instance when the iterator is generic, resolves exactly one canonical
+standard `Iterator.next` implementation for that returned type, and scopes the
+direct target to the macro-generated call.
+
+The iterator still has its ordinary source-level object representation and
+`next() -> Option<T>` ABI. Exact receiver specialization removes dynamic
+dispatch and permits direct field stores under the same exact nominal-type fact
+already used for direct field loads. Binaryen then inlines the state machine
+and removes the iterator and `Option` objects when its own escape analysis
+proves them unobservable. This avoids a new combined value-plus-mutable-state
+ABI and naturally preserves early returns, variable strides, skipped values,
+aliases, wide and object results, and existing fallback behavior.
+
+The representative case uses a filtered, strided iterator whose `next` method
+performs variable internal work and returns early when it finds a usable value.
+
+| Release runtime | General dispatch | Exact specialization | Manual state machine | Change |
+| --- | ---: | ---: | ---: | ---: |
+| Light user iterator | 2.472 ms | 0.385 ms | 0.309 ms | **-84.4%** |
+| Filtered/strided traversal | 0.992 ms | 0.440 ms | 0.398 ms | **-55.7%** |
+
+| Release module metric | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| Wasm | 2,221 B | 1,654 B | -25.5% |
+| Gzip | 1,088 B | 781 B | -28.2% |
+| Indirect calls | 4 | 0 | -4 |
+| Allocation sites | 15 | 0 | -15 |
+| `struct.get` sites | 13 | 0 | -13 |
+| `struct.set` sites | 7 | 0 | -7 |
+
+Seven uncached compiles and 31 warmed runtime samples were used. Compile median
+moved from 1,554.7 to 1,588.3 ms (+2.2%), which is inconclusive at this sample
+count. A parent rerun reproduced the final emitted shape and measured 0.354 ms
+for the light loop and 0.423 ms for the filtered traversal.
+
+Dynamic or ambiguous dispatch, noncanonical traits, non-fresh iterator
+results, unsupported result control flow, and builds without release optimizer
+facts keep the ordinary trait call. The intrinsic Array path retains its
+stricter requirement that both implementations belong to std.
+
+## Final representative results with iterator follow-ups
+
+The complete representative suite was rerun after both iterator optimizations.
+These rows compare the original PR base with the combined final branch using
+the same final fixtures and harness.
+
+| Representative release program | Before PR | Final | Change |
+| --- | ---: | ---: | ---: |
+| Vtrace renderer | 79.094 ms | 79.835 ms | +0.9% |
+| Scalar aggregate | 0.0407 ms | 0.0408 ms | +0.3% |
+| Web request pipeline | 14.199 ms | 2.850 ms | **-79.9%** |
+
+| Representative release artifact | Before PR | Final | Change |
+| --- | ---: | ---: | ---: |
+| Vtrace Wasm / gzip | 34,669 / 12,826 B | 34,037 / 12,702 B | -1.8% / -1.0% |
+| Scalar aggregate Wasm / gzip | 1,112 / 677 B | 1,112 / 677 B | 0.0% / 0.0% |
+| Web pipeline Wasm / gzip | 6,262 / 2,884 B | 3,878 / 1,883 B | **-38.1% / -34.7%** |
+
+The final web lookup stage is 0.644 ms versus 3.245 ms at the PR base (-80.2%),
+and serialization is 2.152 versus 11.715 ms (-81.6%). Vtrace now benefits in
+release artifact shape from exact iterator/receiver specialization while its
+runtime remains effectively flat. Scalar aggregate remains byte-identical.
+Without release optimization, Vtrace and scalar aggregate remain byte-identical
+to the PR base; the existing proven Array/range codegen paths account for the
+non-release web improvement already described above.
+
 ## V-479 unmatched controls
 
 The Wasm hash and every recorded instruction-site count are identical before
@@ -369,6 +501,18 @@ the exact std `for` macro shape. Other range instantiations, open-ended ranges,
 arbitrary iterators, malformed expansions, and effectful functions use normal
 iteration. Bounds are evaluated once before any forwarded field loads.
 
+The intrinsic Array `for` path requires the validated std intrinsic Array
+type, the exact standard `for` expansion, and canonical std-owned `iter` and
+`next` implementations. It captures the iterable once and reloads count and
+storage on every iteration to preserve mutation and reallocation semantics.
+
+General iterator specialization requires the exact standard `for` expansion,
+an exact nominal source, a single canonical standard `Sequence.iter` target,
+and a fresh concrete nominal object result that resolves to one standard
+`Iterator.next` implementation. Generic results use the selected function
+instance. The scoped direct-call and receiver facts preserve the normal ABI;
+dynamic, ambiguous, noncanonical, or non-fresh paths retain trait dispatch.
+
 Mutable aggregate promotion requires a fresh heap object covered by escape
 analysis, a single exact canonical call target, a pure `void` callee, and a
 mutable-borrow parameter whose callable-access footprint reads and writes only
@@ -383,8 +527,8 @@ contract, call-shape variants preserve the lane result, and fallback
 materializes every shared alias together. Balanced and non-release builds set
 the mutable-lane allowance to zero.
 
-This optimization directly depends on Voyd's memory-safety work. Fresh-origin
-escape facts prove where identity can be observed, while immutable callable
+Mutable aggregate promotion directly depends on Voyd's memory-safety work.
+Fresh-origin escape facts prove where identity can be observed, while immutable callable
 access summaries prove the exact callee cannot hide, retain, or mutate storage
 outside the listed fields. Without those contracts, replacing a heap identity
 with independent scalar values across a mutable call would be unsound.
@@ -397,6 +541,8 @@ with independent scalar values across a mutable call would be unsound.
 | `Array.get` Option traffic in proven loops | Accepted as V-476 | Repeatable 72.3% focused win and a 78.8% representative route/view-model lookup win. |
 | Intrinsic `Range<i32>` iterator traffic | Accepted as V-477 | Restores all-`for` source to all-`while` parity; cuts the incremental integrated pipeline by 44.3%, serialization by 40.1%, and gzip size by 16.7%. |
 | Fresh mutable aggregate traffic across exact calls | Accepted as V-479 | Cuts incremental integrated runtime by 44.1%, serialization by 69.4%, and the direct-object focused workload by 90.0%; shrinks representative gzip by 6.5%. |
+| Intrinsic `Array<T>` `for` traffic | Accepted | Reaches indexed-loop parity: 95.6% faster in the focused element loop and 91.2% faster in representative view-model serialization. |
+| Exact user-iterator dispatch and state traffic | Accepted | Non-intrinsic iterators improve by 84.4% in the light case and 55.7% for filtered/strided traversal; emitted allocation, indirect-call, and iterator field traffic falls to zero. |
 | `SharedCell` runtime-check traffic | Deferred | The focused gap was large, but the representative programs had no meaningful use and explicit shared-cell runtime semantics need a separate design decision. |
 | Remaining access guards | Stopped | The existing focused guard benchmark measured about 1.34 ns per call, below the threshold for another optimization ticket. |
 
@@ -404,4 +550,7 @@ Each accepted optimization passed focused runtime and emitted-shape tests,
 repository tests and typechecking, the test inventory audit, and an independent
 review followed by a fresh verification review. V-479 additionally passed
 separate completeness, design, and correctness review lenses because it crosses
-the scalar-replacement and call-ABI boundaries.
+the scalar-replacement and call-ABI boundaries. The intrinsic Array review
+caught and repaired an overbroad macro-lookalike matcher. The general iterator
+review caught and repaired missing generic contextual instantiation and missing
+post-Binaryen shape coverage before a clean extra-high verification.

--- a/docs/notes/v439-checked-access-optimization-results.md
+++ b/docs/notes/v439-checked-access-optimization-results.md
@@ -2,7 +2,7 @@
 
 V-439 measured where Voyd's checked memory-access facts leave avoidable work in
 optimized Wasm, then implemented only the opportunities with a repeatable win.
-The final branch contains three accepted optimizations:
+The final branch contains four accepted optimizations:
 
 - V-475 forwards fixed-field loads out of loops when every resolved call is
   proven unable to write the loaded place.
@@ -11,6 +11,9 @@ The final branch contains three accepted optimizations:
 - V-477 recognizes the compiler-owned `Range<i32>` plus the standard `for`
   expansion and emits a direct counted loop instead of allocating an iterator
   and matching `Option` on every iteration.
+- V-479 keeps eligible fresh mutable objects in scalar lanes across exact,
+  pure mutable-borrow calls and returns the updated lanes directly instead of
+  allocating and repeatedly loading and storing a heap object.
 
 ## Method
 
@@ -31,8 +34,9 @@ These measurements used Node 24.18.0 on an Apple M4 Pro with 14 logical CPUs.
 The focused table measures the original compiler against V-475 and V-476. The
 representative web-app table measures four compiler revisions against the same
 final all-`for` fixture: original baseline, V-475 only, V-475 plus V-476, and
-the final branch with V-477. Every comparison used the same harness, fixture,
-sample counts, and machine.
+V-477. V-479 was then measured against the merged V-477 branch with the same
+harness, fixtures, sample counts, and machine. The final overall comparison
+uses the original baseline and the accepted V-479 end state.
 
 ## Focused release results
 
@@ -75,6 +79,38 @@ time was 1448.440 -> 1449.742 ms (+0.09%), Wasm was 54,536 -> 54,555 bytes
 `Array.get` workload improved from 0.856292 to 0.305583 ms (-64.3%); the other
 focused runtimes moved by at most 5.2%.
 
+### V-479 focused increment
+
+V-479 directly exercises the two focused functions that create mutable records,
+retain immutable aliases, and repeatedly call an exact field mutator. The
+projected-array case remains outside the proof because the mutable records come
+from array element views.
+
+| Focused release workload | V-477 | + V-479 | Change |
+| --- | ---: | ---: | ---: |
+| Checked-access projected fields | 0.358875 | 0.372208 | +3.7% |
+| Direct stable fields across calls | 0.268875 | 0.026916 | **-90.0%** |
+| Manually hoisted stable-field control | 0.241375 | 0.026958 | **-88.8%** |
+| Ordinary mutation control | 0.023542 | 0.023542 | 0.0% |
+| `SharedCell` runtime checks | 0.223709 | 0.229375 | +2.5% |
+| Proven `Array.at` loop | 0.070625 | 0.071000 | +0.5% |
+| Matched `Array.get` loop | 0.070458 | 0.070667 | +0.3% |
+
+The direct and manually hoisted workloads now run at roughly the ordinary
+mutation control's cost. The full focused release module changes as follows:
+
+| Focused release metric | V-477 | + V-479 | Change |
+| --- | ---: | ---: | ---: |
+| Compile median | 1608.537 ms | 1640.757 ms | +2.0% |
+| Wasm | 7,010 B | 6,968 B | -0.6% |
+| Gzip | 2,685 B | 2,694 B | +0.3% |
+| Allocation sites | 51 | 47 | -4 |
+| `struct.get` sites | 114 | 108 | -6 |
+| `struct.set` sites | 15 | 15 | 0 |
+
+Without release optimization, the focused module's Wasm hash, byte size, and
+every instruction-site count are identical before and after V-479.
+
 ## Representative web-app request pipeline
 
 `web-app-request-pipeline.voyd` models the CPU-bound part of a server-rendered
@@ -94,7 +130,7 @@ Every counted loop uses idiomatic range-based `for` syntax, including the
 The route/view-model and serialization stages are exported separately to
 attribute their cost, while `main` measures the integrated handler.
 
-| Release runtime | Baseline | V-475 | + V-476 | + V-477 final | Final vs baseline |
+| Release runtime | Baseline | V-475 | + V-476 | + V-477 stage | V-477 vs baseline |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | Integrated request pipeline | 14.170 ms | 14.192 ms | 9.171 ms | 5.103 ms | **-64.0%** |
 | Route and view-model lookup | 3.275 ms | 3.261 ms | 0.691 ms | 0.644 ms | **-80.3%** |
@@ -105,9 +141,9 @@ so this all-`for` fixture does not benefit until V-477 removes that plumbing
 and uses callable access footprints to prove the synthetic method call
 disjoint. V-476 then cuts the array-heavy lookup stage by 78.8%. V-477 cuts the
 remaining integrated runtime by 44.3% and serialization by 40.1%. Compiler
-telemetry reports four forwarded V-475 loads in the final serialization loop.
+telemetry reports four forwarded V-475 loads in the V-477 serialization loop.
 
-| Release module metric | Baseline | V-475 | + V-476 | + V-477 final | Final vs baseline |
+| Release module metric | Baseline | V-475 | + V-476 | + V-477 stage | V-477 vs baseline |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | Compile median | 1768.823 ms | 1758.027 ms | 1770.576 ms | 1739.948 ms | -1.6% |
 | Wasm | 6,262 B | 6,262 B | 5,489 B | 4,579 B | -26.9% |
@@ -119,12 +155,47 @@ telemetry reports four forwarded V-475 loads in the final serialization loop.
 | Indirect calls | 42 | 42 | 34 | 26 | -16 |
 | Linear-memory growth | 0 B | 0 B | 0 B | 0 B | 0 B |
 
-Without release optimization, the final compiler improves the integrated
+Without release optimization, the V-477 compiler improves the integrated
 pipeline from 62.539 to 30.883 ms (-50.6%), lookup from 15.475 to 1.221 ms
 (-92.1%), and serialization from 47.200 to 29.630 ms (-37.2%). The non-release
 module shrinks from 56,626 to 53,925 bytes (-4.8%) and from 13,950 to 13,074
 bytes after gzip (-6.3%). V-476 and V-477 are proven codegen fast paths;
 V-475 additionally consumes release optimizer facts.
+
+### V-479 mutable-object increment
+
+The writer state in the serialization stage is a fresh mutable object with
+immutable aliases. Its exact callees are pure, return `void`, and access only
+known direct fields. V-479 proves that boundary once, passes the object's fields
+as scalar Wasm values, and returns the updated fields as a multivalue result.
+
+| Release runtime | V-477 | + V-479 final | Change |
+| --- | ---: | ---: | ---: |
+| Integrated request pipeline | 5.094708 ms | 2.847125 ms | **-44.1%** |
+| Route and view-model lookup | 0.643083 ms | 0.643375 ms | 0.0% |
+| Response serialization | 7.046667 ms | 2.154000 ms | **-69.4%** |
+
+| Release module metric | V-477 | + V-479 final | Change |
+| --- | ---: | ---: | ---: |
+| Compile median | 1640.083 ms | 1653.090 ms | +0.8% |
+| Wasm | 4,579 B | 4,219 B | -7.9% |
+| Gzip | 2,147 B | 2,008 B | -6.5% |
+| Allocation sites | 38 | 30 | -8 |
+| `struct.get` sites | 52 | 38 | -14 |
+| `struct.set` sites | 16 | 10 | -6 |
+| Direct calls | 53 | 51 | -2 |
+| Indirect calls | 26 | 24 | -2 |
+| Linear-memory growth | 0 B | 0 B | 0 B |
+
+The serialization result reaches the manual scalar-control ceiling. In
+non-release mode, the module hash, byte size, and every instruction-site count
+remain identical; integrated, lookup, and serialization medians moved by
+-0.2%, +2.5%, and +0.1%, respectively.
+
+Across the complete V-439 branch, the original release pipeline moves from
+14.170 to 2.847 ms (-79.9%), lookup from 3.275 to 0.643 ms (-80.4%), and
+serialization from 11.810 to 2.154 ms (-81.8%). The release module shrinks from
+6,262 to 4,219 bytes (-32.6%) and from 2,884 to 2,008 bytes after gzip (-30.4%).
 
 ### Counted-loop syntax control
 
@@ -132,7 +203,7 @@ Before V-477, using `for` for every counted loop made the integrated pipeline
 79.3% slower than the original all-`while` control. With V-477, the idiomatic
 source is effectively at parity with that control:
 
-| Final release metric | All-`while` control | All-`for` with V-477 | Change |
+| V-477 release metric | All-`while` control | All-`for` with V-477 | Change |
 | --- | ---: | ---: | ---: |
 | Integrated request pipeline | 5.067 ms | 5.103 ms | +0.7% |
 | Route and view-model lookup | 0.682 ms | 0.644 ms | -5.6% |
@@ -147,21 +218,22 @@ endpoints once in source order, advances iterator state before the user body so
 reuses V-476's array-stability scope for `0..array.len()`. Effectful functions
 conservatively keep the normal continuation-aware iterator path.
 
-## Unmatched representative controls
+## V-479 unmatched controls
 
-The final Wasm hash and every recorded instruction-site count are identical
-before and after for both representative programs, in both compiler modes.
+The Wasm hash and every recorded instruction-site count are identical before
+and after V-479 for both unmatched representative programs, in both modes.
 Their small timing movements therefore reflect run-to-run measurement variance
 rather than added runtime instructions.
 
 | Scenario | Mode | Compile before -> after | Runtime before -> after | Wasm / gzip |
 | --- | --- | ---: | ---: | ---: |
-| vtrace | none | 1868.779 -> 1803.813 ms | 413.442 -> 416.026 ms | 166,859 / 42,559 B, identical |
-| vtrace | release | 3181.175 -> 3126.605 ms | 81.993 -> 82.598 ms | 34,669 / 12,826 B, identical |
-| Scalar aggregate | none | 1362.637 -> 1368.629 ms | 0.181083 -> 0.169583 ms | 37,854 / 9,387 B, identical |
-| Scalar aggregate | release | 1587.866 -> 1606.815 ms | 0.041125 -> 0.040834 ms | 1,112 / 677 B, identical |
+| vtrace | none | 1585.825 -> 1689.906 ms | 401.008 -> 413.823 ms | 166,859 / 42,559 B, identical |
+| vtrace | release | 2848.184 -> 2952.175 ms | 81.410 -> 83.195 ms | 34,669 / 12,826 B, identical |
+| Scalar aggregate | none | 1236.224 -> 1260.534 ms | 0.169500 -> 0.169750 ms | 37,854 / 9,387 B, identical |
+| Scalar aggregate | release | 1438.153 -> 1550.875 ms | 0.037208 -> 0.036959 ms | 1,112 / 677 B, identical |
 
-All representative runs reported zero linear-memory growth.
+The focused and web-app modules are also byte- and instruction-identical in
+non-release mode. All benchmark runs reported zero linear-memory growth.
 
 ## Safety boundaries
 
@@ -186,6 +258,26 @@ the exact std `for` macro shape. Other range instantiations, open-ended ranges,
 arbitrary iterators, malformed expansions, and effectful functions use normal
 iteration. Bounds are evaluated once before any forwarded field loads.
 
+Mutable aggregate promotion requires a fresh heap object covered by escape
+analysis, a single exact canonical call target, a pure `void` callee, and a
+mutable-borrow parameter whose callable-access footprint reads and writes only
+known direct fields. The callee cannot retain or return the object, suspend,
+perform external access, use runtime identity guards, alias the parameter, or
+contain an explicit return. The mutable object must be the first source
+argument, and later arguments cannot reference any of its aliases. Eligible
+specialization identities are reserved before scalar lanes are installed, so a
+budget rejection materializes normally before control flow. Imported targets
+and receiver specializations are resolved through the shared eligibility
+contract, call-shape variants preserve the lane result, and fallback
+materializes every shared alias together. Balanced and non-release builds set
+the mutable-lane allowance to zero.
+
+This optimization directly depends on Voyd's memory-safety work. Fresh-origin
+escape facts prove where identity can be observed, while immutable callable
+access summaries prove the exact callee cannot hide, retain, or mutate storage
+outside the listed fields. Without those contracts, replacing a heap identity
+with independent scalar values across a mutable call would be unsound.
+
 ## Opportunity decisions
 
 | Opportunity | Decision | Reason |
@@ -193,10 +285,12 @@ iteration. Bounds are evaluated once before any forwarded field loads.
 | Stable field loads across calls | Accepted as V-475 | Repeatable 19.8% focused win; the representative loop removes four repeated field-load sites. |
 | `Array.get` Option traffic in proven loops | Accepted as V-476 | Repeatable 72.3% focused win and a 78.8% representative route/view-model lookup win. |
 | Intrinsic `Range<i32>` iterator traffic | Accepted as V-477 | Restores all-`for` source to all-`while` parity; cuts the incremental integrated pipeline by 44.3%, serialization by 40.1%, and gzip size by 16.7%. |
+| Fresh mutable aggregate traffic across exact calls | Accepted as V-479 | Cuts incremental integrated runtime by 44.1%, serialization by 69.4%, and the direct-object focused workload by 90.0%; shrinks representative gzip by 6.5%. |
 | `SharedCell` runtime-check traffic | Deferred | The focused gap was large, but the representative programs had no meaningful use and explicit shared-cell runtime semantics need a separate design decision. |
 | Remaining access guards | Stopped | The existing focused guard benchmark measured about 1.34 ns per call, below the threshold for another optimization ticket. |
-| Aggregate materialization | Stopped | Existing scalar-replacement work already removes the representative traffic; measurement found no new checked-access-specific gap. |
 
 Each accepted optimization passed focused runtime and emitted-shape tests,
-repository typechecking, the test inventory audit, and an independent Standard
-review followed by a fresh verification review.
+repository tests and typechecking, the test inventory audit, and an independent
+review followed by a fresh verification review. V-479 additionally passed
+separate completeness, design, and correctness review lenses because it crosses
+the scalar-replacement and call-ABI boundaries.

--- a/docs/testing/test-inventory.json
+++ b/docs/testing/test-inventory.json
@@ -651,6 +651,13 @@
     ]
   },
   {
+    "file": "packages/compiler/src/codegen/__tests__/iterator-for-specialization.test.ts",
+    "owner": "compiler-implementation",
+    "reviewed": "2026-08-06",
+    "disposition": "compiler-local",
+    "rationale": "Exact standard-for recognition, concrete trait-target selection, specialized direct-call shape, and conservative dynamic/noncanonical fallback are compiler-internal optimization contracts. Runtime assertions guard equivalence while exercising those codegen paths rather than introducing new language behavior."
+  },
+  {
     "file": "packages/compiler/src/codegen/__tests__/memory-exports.test.ts",
     "owner": "compiler-implementation",
     "reviewed": "2026-07-10",

--- a/docs/testing/test-inventory.json
+++ b/docs/testing/test-inventory.json
@@ -660,6 +660,17 @@
     "rationale": "Asserts one-time/deduplicated dispatcher and runtime helper emission across module contexts and test builds, an implementation registry property."
   },
   {
+    "file": "packages/compiler/src/codegen/__tests__/range-for-fast-path.test.ts",
+    "owner": "compiler-implementation",
+    "reviewed": "2026-08-06",
+    "disposition": "compiler-local-with-portable-signal",
+    "rationale": "Emitted direct-loop shape and optimizer-fact integration are compiler-local; portable Range iteration semantics remain in runtime.range-for.",
+    "portableCaseIds": [
+      "runtime.range-for.half-open",
+      "runtime.range-for.inclusive"
+    ]
+  },
+  {
     "file": "packages/compiler/src/codegen/__tests__/scalar-aggregate-replacement.test.ts",
     "owner": "compiler-implementation",
     "reviewed": "2026-07-10",

--- a/docs/testing/test-inventory.json
+++ b/docs/testing/test-inventory.json
@@ -686,6 +686,13 @@
     "rationale": "Tests internal specialization identities, reservation ordering, per-kind/program/body-node budgets, and context caps; another compiler may use no such policy."
   },
   {
+    "file": "packages/compiler/src/codegen/__tests__/stable-field-load-forwarding.test.ts",
+    "owner": "compiler-implementation",
+    "reviewed": "2026-08-05",
+    "disposition": "compiler-local",
+    "rationale": "Tests the optimizer's checked-access planning facts, conservative bailout rules, runtime behavior, and emitted struct.get shape; these are compiler implementation contracts."
+  },
+  {
     "file": "packages/compiler/src/codegen/__tests__/std-array-smoke.test.ts",
     "owner": "compiler-implementation",
     "reviewed": "2026-07-10",

--- a/docs/testing/test-inventory.json
+++ b/docs/testing/test-inventory.json
@@ -280,6 +280,14 @@
     ]
   },
   {
+    "file": "packages/compiler/src/codegen/__tests__/array-for-fast-path.test.ts",
+    "owner": "compiler-implementation",
+    "reviewed": "2026-08-06",
+    "disposition": "compiler-local-with-portable-signal",
+    "rationale": "Emitted direct-loop shape, exact intrinsic eligibility, and general-iterator fallback are compiler-local; portable Array growth-during-iteration behavior is represented by runtime.collections.array-iteration-growth.",
+    "portableCaseIds": ["runtime.collections.array-iteration-growth"]
+  },
+  {
     "file": "packages/compiler/src/codegen/__tests__/borrowed-array-element-views.test.ts",
     "owner": "compiler-implementation",
     "reviewed": "2026-07-10",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "bench:release:v0.3.0": "node scripts/release/benchmark-v0.3.0.mjs",
     "bench:compiler-latency": "tsx --conditions=development scripts/bench-v375-compiler-latency.ts && npm run --workspace @voyd-lang/compiler bench:typing",
     "bench:memory-safety": "node --import tsx --conditions=development scripts/bench-memory-mutation-safety.ts",
+    "bench:array-for": "node --import tsx --conditions=development scripts/bench-array-for-fast-path.ts",
     "bench:v439": "node --import tsx --conditions=development scripts/bench-v439-checked-access.ts",
     "bench:web-openapi": "npm run --workspace @voyd-lang/performance-tests bench:web-openapi --",
     "test:web-compile-gate": "node scripts/testing/run-web-compile-gate.mjs",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "bench:release:v0.3.0": "node scripts/release/benchmark-v0.3.0.mjs",
     "bench:compiler-latency": "tsx --conditions=development scripts/bench-v375-compiler-latency.ts && npm run --workspace @voyd-lang/compiler bench:typing",
     "bench:memory-safety": "node --import tsx --conditions=development scripts/bench-memory-mutation-safety.ts",
+    "bench:v439": "node --import tsx --conditions=development scripts/bench-v439-checked-access.ts",
     "bench:web-openapi": "npm run --workspace @voyd-lang/performance-tests bench:web-openapi --",
     "test:web-compile-gate": "node scripts/testing/run-web-compile-gate.mjs",
     "typecheck": "turbo run typecheck --affected",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bench:memory-safety": "node --import tsx --conditions=development scripts/bench-memory-mutation-safety.ts",
     "bench:array-for": "node --import tsx --conditions=development scripts/bench-array-for-fast-path.ts",
     "bench:iterator-for": "node --import tsx --conditions=development scripts/bench-general-iterator-specialization.ts",
+    "bench:mutable-result": "node --import tsx --conditions=development scripts/bench-mutable-result-specialization.ts",
     "bench:v439": "node --import tsx --conditions=development scripts/bench-v439-checked-access.ts",
     "bench:web-openapi": "npm run --workspace @voyd-lang/performance-tests bench:web-openapi --",
     "test:web-compile-gate": "node scripts/testing/run-web-compile-gate.mjs",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bench:compiler-latency": "tsx --conditions=development scripts/bench-v375-compiler-latency.ts && npm run --workspace @voyd-lang/compiler bench:typing",
     "bench:memory-safety": "node --import tsx --conditions=development scripts/bench-memory-mutation-safety.ts",
     "bench:array-for": "node --import tsx --conditions=development scripts/bench-array-for-fast-path.ts",
+    "bench:iterator-for": "node --import tsx --conditions=development scripts/bench-general-iterator-specialization.ts",
     "bench:v439": "node --import tsx --conditions=development scripts/bench-v439-checked-access.ts",
     "bench:web-openapi": "npm run --workspace @voyd-lang/performance-tests bench:web-openapi --",
     "test:web-compile-gate": "node scripts/testing/run-web-compile-gate.mjs",

--- a/packages/compiler/src/__tests__/optimization-policy.test.ts
+++ b/packages/compiler/src/__tests__/optimization-policy.test.ts
@@ -67,12 +67,14 @@ describe("compiler optimization policy", () => {
     const balanced = specializationPolicyForOptimizationLevel("balanced");
     const release = specializationPolicyForOptimizationLevel("release");
 
-    expect(balanced).toBe(release);
+    expect(balanced).not.toBe(release);
     expect(Object.isFrozen(balanced)).toBe(true);
-    Object.values(balanced).forEach((limit) => {
+    Object.values(release).forEach((limit) => {
       expect(Number.isSafeInteger(limit)).toBe(true);
       expect(limit).toBeGreaterThan(0);
     });
+    expect(balanced.mutableScalarAggregateLanes).toBe(0);
+    expect(release.mutableScalarAggregateLanes).toBe(8);
     expect(balanced.receiverContextsPerFunction).toBe(4);
     expect(balanced.receiverExactParametersPerContext).toBe(2);
     expect(balanced.directTraitSwitchImplementations).toBe(4);

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/array_for_fast_path.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/array_for_fast_path.voyd
@@ -1,0 +1,150 @@
+use std::array::Array
+use std::optional::all
+
+trait CustomSequence<T>
+  fn iter(self) -> CustomIterator<T>
+
+trait CustomIterator<T>
+  fn next(~self) -> Option<T>
+
+fn add_to(~total: i32, value: i32) -> void
+  total = total + value
+
+macro manual_array_loop(iterable, total)
+  let iterator_id = identifier(__manual_iterator)
+  let next_id = identifier(__manual_next)
+  let value_id = identifier(__manual_value)
+
+  `
+    let ~($iterator_id) = $iterable.iter()
+    while true:
+      let $next_id = ($iterator_id).next()
+      $next_id.match
+        Some:
+          let $value_id = $next_id.value
+          add_to(~$total, $value_id)
+        None:
+          break
+
+val WideValue {
+  first: i32,
+  second: i32,
+  third: i32,
+  fourth: i32
+}
+
+obj Node {
+  value: i32
+}
+
+obj EvaluationCounter {
+  count: i32
+}
+
+obj CounterSequence {
+  end: i32
+}
+
+obj CounterIterator {
+  current: i32,
+  end: i32
+}
+
+impl CustomSequence<i32> for CounterSequence
+  fn iter(self) -> CustomIterator<i32>
+    CounterIterator { current: 0, end: self.end }
+
+impl CustomIterator<i32> for CounterIterator
+  fn next(~self) -> Option<i32>
+    if self.current >= self.end:
+      return None {}
+    let value = self.current
+    self.current = self.current + 1
+    Some<i32> { value }
+
+fn integers() -> Array<i32>
+  let ~result = Array<i32>::with_capacity(2)
+  result.push(1)
+  result.push(2)
+  result
+
+fn count_evaluation(~counter: EvaluationCounter) -> Array<i32>
+  counter.count = counter.count + 1
+  integers()
+
+fn first<T>(source: Array<T>, fallback: T) -> T
+  for value in source:
+    return value
+  fallback
+
+pub fn dynamic_growth_and_storage_replacement() -> i32
+  let ~source = Array<i32>::with_capacity(1)
+  source.push(1)
+  let alias = source
+  var total = 0
+  for value in alias:
+    total = total + value
+    if value < 4:
+      source.push(value + 1)
+  total
+
+pub fn iterable_evaluated_once() -> i32
+  let ~counter = EvaluationCounter { count: 0 }
+  var total = 0
+  for value in count_evaluation(~counter):
+    total = total + value
+  (counter.count * 100) + total
+
+pub fn replacement_does_not_retarget_iterator() -> i32
+  var source = integers()
+  var total = 0
+  for value in source:
+    total = total + value
+    if value == 1:
+      let ~replacement = Array<i32>::with_capacity(1)
+      replacement.push(9)
+      source = replacement
+  total
+
+pub fn break_and_continue() -> i32
+  let source = integers()
+  var continued = 0
+  for value in source:
+    if value == 1:
+      continue
+    continued = continued + value
+  var broken = 0
+  for value in source:
+    broken = broken + value
+    break
+  (continued * 10) + broken
+
+pub fn generic_and_wide_values() -> i32
+  let ~wide = Array<WideValue>::with_capacity(1)
+  wide.push(WideValue { first: 1, second: 2, third: 3, fourth: 4 })
+  let value = first<WideValue>(
+    wide,
+    WideValue { first: 0, second: 0, third: 0, fourth: 0 }
+  )
+  value.first + value.second + value.third + value.fourth
+
+pub fn object_elements() -> i32
+  let ~nodes = Array<Node>::with_capacity(2)
+  nodes.push(Node { value: 4 })
+  nodes.push(Node { value: 7 })
+  var total = 0
+  for node in nodes:
+    total = total + node.value
+  total
+
+pub fn custom_sequence_fallback() -> i32
+  var total = 0
+  for value in CounterSequence { end: 4 }:
+    total = total + value
+  total
+
+pub fn manual_array_iterator_fallback() -> i32
+  let source = integers()
+  var total = 0
+  manual_array_loop(source, total)
+  total

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/iterator_for_specialization.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/iterator_for_specialization.voyd
@@ -1,0 +1,206 @@
+use std::optional::all
+
+obj CountSequence {
+  end: i32
+}
+
+obj CountIterator {
+  current: i32,
+  end: i32
+}
+
+impl Sequence<i32> for CountSequence
+  fn iter(self) -> Iterator<i32>
+    CountIterator { current: 0, end: self.end }
+
+impl Iterator<i32> for CountIterator
+  fn next(~self) -> Option<i32>
+    let alias = self
+    if self.current >= alias.end:
+      return None {}
+    let value = self.current
+    self.current = self.current + 1
+    Some<i32> { value }
+
+obj FilteredSequence {
+  end: i32,
+  stride: i32
+}
+
+obj FilteredIterator {
+  current: i32,
+  end: i32,
+  stride: i32
+}
+
+impl Sequence<i32> for FilteredSequence
+  fn iter(self) -> Iterator<i32>
+    FilteredIterator {
+      current: 0,
+      end: self.end,
+      stride: self.stride
+    }
+
+impl Iterator<i32> for FilteredIterator
+  fn next(~self) -> Option<i32>
+    while self.current < self.end:
+      let candidate = self.current
+      self.current = self.current + self.stride
+      if (candidate % 3) != 0:
+        return Some<i32> { value: candidate }
+    None {}
+
+val WideValue {
+  first: i32,
+  second: i32,
+  third: i32,
+  fourth: i32
+}
+
+obj WideSequence {}
+
+obj WideIterator {
+  emitted: i32
+}
+
+impl Sequence<WideValue> for WideSequence
+  fn iter(self) -> Iterator<WideValue>
+    WideIterator { emitted: 0 }
+
+impl Iterator<WideValue> for WideIterator
+  fn next(~self) -> Option<WideValue>
+    if self.emitted != 0:
+      return None {}
+    self.emitted = 1
+    Some<WideValue> {
+      value: WideValue { first: 1, second: 2, third: 3, fourth: 4 }
+    }
+
+obj Node {
+  value: i32
+}
+
+obj NodeSequence {
+  node: Node
+}
+
+obj NodeIterator {
+  node: Node,
+  emitted: i32
+}
+
+impl Sequence<Node> for NodeSequence
+  fn iter(self) -> Iterator<Node>
+    NodeIterator { node: self.node, emitted: 0 }
+
+impl Iterator<Node> for NodeIterator
+  fn next(~self) -> Option<Node>
+    if self.emitted != 0:
+      return None {}
+    self.emitted = 1
+    Some<Node> { value: self.node }
+
+obj SingleSequence<T> {
+  value: T
+}
+
+obj SingleIterator<T> {
+  value: T,
+  emitted: i32
+}
+
+impl<T> Sequence<T> for SingleSequence<T>
+  fn iter(self) -> Iterator<T>
+    SingleIterator<T> { value: self.value, emitted: 0 }
+
+impl<T> Iterator<T> for SingleIterator<T>
+  fn next(~self) -> Option<T>
+    if self.emitted != 0:
+      return None {}
+    self.emitted = 1
+    Some<T> { value: self.value }
+
+obj EvaluationCounter {
+  count: i32
+}
+
+fn counted_sequence(~counter: EvaluationCounter) -> FilteredSequence
+  counter.count = counter.count + 1
+  FilteredSequence { end: 12, stride: 2 }
+
+trait CustomSequence<T>
+  fn iter(self) -> CustomIterator<T>
+
+trait CustomIterator<T>
+  fn next(~self) -> Option<T>
+
+obj CustomCounter {
+  end: i32
+}
+
+obj CustomCounterIterator {
+  current: i32,
+  end: i32
+}
+
+impl CustomSequence<i32> for CustomCounter
+  fn iter(self) -> CustomIterator<i32>
+    CustomCounterIterator { current: 0, end: self.end }
+
+impl CustomIterator<i32> for CustomCounterIterator
+  fn next(~self) -> Option<i32>
+    if self.current >= self.end:
+      return None {}
+    let value = self.current
+    self.current = self.current + 1
+    Some<i32> { value }
+
+fn sum_dynamic(sequence: Sequence<i32>) -> i32
+  var total = 0
+  for value in sequence:
+    total = total + value
+  total
+
+pub fn exact_count() -> i32
+  var total = 0
+  for value in CountSequence { end: 4 }:
+    total = total + value
+  total
+
+pub fn filtered_control_flow() -> i32
+  let ~counter = EvaluationCounter { count: 0 }
+  var total = 0
+  for value in counted_sequence(~counter):
+    if value == 2:
+      continue
+    if value >= 8:
+      break
+    total = total + value
+  (counter.count * 100) + total
+
+pub fn wide_and_object_results() -> i32
+  var wide_total = 0
+  for value in WideSequence {}:
+    wide_total = value.first + value.second + value.third + value.fourth
+  var object_total = 0
+  for node in NodeSequence { node: Node { value: 7 } }:
+    object_total = node.value
+  (wide_total * 10) + object_total
+
+pub fn generic_user_iterator() -> i32
+  var total = 0
+  for value in SingleSequence<i32> { value: 9 }:
+    total = total + value
+  total
+
+pub fn dynamic_count_fallback() -> i32
+  sum_dynamic(CountSequence { end: 4 })
+
+pub fn dynamic_filtered_fallback() -> i32
+  sum_dynamic(FilteredSequence { end: 10, stride: 2 })
+
+pub fn noncanonical_fallback() -> i32
+  var total = 0
+  for value in CustomCounter { end: 4 }:
+    total = total + value
+  total

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/range_for_fast_path.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/range_for_fast_path.voyd
@@ -1,0 +1,17 @@
+obj RenderState {
+  stable: i32,
+  changing: i32
+}
+
+fn advance(~state: RenderState) -> void
+  state.changing = state.changing + 1
+
+pub fn stable_range_sum() -> i32
+  let ~state = RenderState { stable: 3, changing: 0 }
+  let alias = state
+  var total = 0
+  for index in -2..=2:
+    total = total + alias.stable + index
+    advance(~state)
+    total = total + alias.stable
+  total + state.changing

--- a/packages/compiler/src/codegen/__tests__/__fixtures__/std_array_smoke.voyd
+++ b/packages/compiler/src/codegen/__tests__/__fixtures__/std_array_smoke.voyd
@@ -7,6 +7,9 @@ pub val Vec2 {
   y: i32
 }
 
+fn sum_vec(value: Vec2) -> i32
+  value.x + value.y
+
 pub fn entry_tail() -> i32
   let ~arr = Array<i32>::with_capacity(2)
   arr.push(1)
@@ -92,6 +95,34 @@ pub fn safe_while_cached_len_sum() -> i32
     index = index + 1
   total
 
+pub fn safe_while_get_sum() -> i32
+  let values = build_ints()
+  var index = 0
+  var total = 0
+  while index < values.len():
+    match(values.get(index))
+      Some<i32> { value }:
+        total = total + value
+      None:
+        total = total - 1
+    index = index + 1
+  total
+
+pub fn safe_while_get_value_sum() -> i32
+  let ~values = Array<Vec2>::with_capacity(2)
+  values.push(Vec2 { x: 3, y: 4 })
+  values.push(Vec2 { x: 5, y: 6 })
+  var index = 0
+  var total = 0
+  while index < values.len():
+    match(values.get(index))
+      Some<Vec2> { value }:
+        total = total + sum_vec(value)
+      None:
+        total = total - 1
+    index = index + 1
+  total
+
 pub fn safe_while_value_sum() -> i32
   let ~values = Array<Vec2>::with_capacity(2)
   values.push(Vec2 { x: 3, y: 4 })
@@ -165,6 +196,23 @@ pub fn while_helper_mutation_sum() -> i32
   while index < length:
     total = total + values.at(index)
     append_marker(values)
+    index = index + 1
+  total
+
+pub fn while_helper_mutation_get_sum() -> i32
+  let ~values = Array<i32>::with_capacity(4)
+  values.push(1)
+  values.push(2)
+  let length = values.len()
+  var index = 0
+  var total = 0
+  while index < length:
+    append_marker(values)
+    match(values.get(index))
+      Some<i32> { value }:
+        total = total + value
+      None:
+        total = total - 1
     index = index + 1
   total
 

--- a/packages/compiler/src/codegen/__tests__/array-for-fast-path.test.ts
+++ b/packages/compiler/src/codegen/__tests__/array-for-fast-path.test.ts
@@ -1,0 +1,113 @@
+import { resolve } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+import { createVoydHost } from "@voyd-lang/js-host";
+import { monomorphizeProgram } from "../../semantics/linking.js";
+import { buildProgramCodegenView } from "../../semantics/codegen-view/index.js";
+import { optimizeProgram } from "../../optimize/pipeline.js";
+import { codegenProgram } from "../index.js";
+import { compileEffectFixture } from "./support/effects-harness.js";
+
+const fixturePath = resolve(
+  import.meta.dirname,
+  "__fixtures__/array_for_fast_path.voyd",
+);
+
+const watForExport = (wat: string, exportName: string): string => {
+  const exportMatch = wat.match(
+    new RegExp(`\\(export "${exportName}" \\(func \\$([^\\s\\)]+)\\)\\)`),
+  );
+  expect(exportMatch).not.toBeNull();
+  const start = wat.indexOf(`(func $${exportMatch?.[1]} `);
+  let depth = 0;
+  for (let index = start; index < wat.length; index += 1) {
+    if (wat[index] === "(") depth += 1;
+    if (wat[index] === ")") depth -= 1;
+    if (depth === 0) return wat.slice(start, index + 1);
+  }
+  throw new Error(`unterminated function for export ${exportName}`);
+};
+
+const compileFixture = async () => {
+  const prepared = await compileEffectFixture({
+    entryPath: fixturePath,
+    codegenOptions: {
+      validate: true,
+      effectsHostBoundary: "off",
+      boundaryExports: false,
+    },
+  });
+  const modules = [...prepared.semantics.values()];
+  const monomorphized = monomorphizeProgram({
+    modules,
+    semantics: prepared.semantics,
+  });
+  const program = buildProgramCodegenView(modules, {
+    instances: monomorphized.instances,
+    moduleTyping: monomorphized.moduleTyping,
+  });
+  const optimized = optimizeProgram({
+    program,
+    modules,
+    entryModuleId: prepared.entryModuleId,
+  });
+  return codegenProgram({
+    program: optimized.program,
+    entryModuleId: prepared.entryModuleId,
+    optimization: optimized.facts,
+    options: { validate: true, boundaryExports: false },
+  });
+};
+
+describe("intrinsic Array<T> for-loop fast path", () => {
+  let compiled: Awaited<ReturnType<typeof compileFixture>>;
+  let host: Awaited<ReturnType<typeof createVoydHost>>;
+  let wat: string;
+
+  beforeAll(async () => {
+    compiled = await compileFixture();
+    host = await createVoydHost({ wasm: compiled.wasm! });
+    wat = compiled.module.emitText();
+  });
+
+  it("preserves dynamic growth, storage replacement, and evaluation-once semantics", async () => {
+    await expect(
+      host.run<number>("dynamic_growth_and_storage_replacement"),
+    ).resolves.toBe(10);
+    await expect(host.run<number>("iterable_evaluated_once")).resolves.toBe(
+      103,
+    );
+    await expect(
+      host.run<number>("replacement_does_not_retarget_iterator"),
+    ).resolves.toBe(3);
+  });
+
+  it("preserves break, continue, generic, wide-value, and object element behavior", async () => {
+    await expect(host.run<number>("break_and_continue")).resolves.toBe(21);
+    await expect(host.run<number>("generic_and_wide_values")).resolves.toBe(10);
+    await expect(host.run<number>("object_elements")).resolves.toBe(11);
+  });
+
+  it("removes iterator dispatch and Option machinery only for intrinsic Arrays", () => {
+    const intrinsic = watForExport(wat, "object_elements");
+    expect(intrinsic).toContain("array_for_loop");
+    expect(intrinsic).not.toContain("call_ref");
+    expect(intrinsic).not.toMatch(
+      /ArrayIterator|optional__Some|optional__None/,
+    );
+
+    const custom = watForExport(wat, "custom_sequence_fallback");
+    expect(custom).not.toContain("array_for_loop");
+    expect(custom).toContain("call_ref");
+  });
+
+  it("leaves non-intrinsic Sequence implementations on the general path", async () => {
+    await expect(host.run<number>("custom_sequence_fallback")).resolves.toBe(6);
+  });
+
+  it("leaves macro-generated lookalike loops with meaningful arm tails intact", () => {
+    const manual = watForExport(wat, "manual_array_iterator_fallback");
+    expect(manual).not.toContain("array_for_loop");
+    expect(manual).toContain("call_ref");
+    expect(manual).toContain("add_to");
+  });
+});

--- a/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
+++ b/packages/compiler/src/codegen/__tests__/effects-perform.test.ts
@@ -100,6 +100,7 @@ const compileEffectFixtureWithCompilerOptimization = async (
       escapeAnalysis: { origins: new Map(), parameters: new Map() },
       runtimeTypeCheckElisionFieldAccesses: new Map(),
       semanticCopyForwardingFieldAccesses: new Map(),
+      stableFieldLoadForwarding: new Map(),
       codegenPlan: {
         representations: {},
         specializationPolicy:

--- a/packages/compiler/src/codegen/__tests__/iterator-for-specialization.test.ts
+++ b/packages/compiler/src/codegen/__tests__/iterator-for-specialization.test.ts
@@ -1,0 +1,178 @@
+import { resolve } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+import { createVoydHost } from "@voyd-lang/js-host";
+import { monomorphizeProgram } from "../../semantics/linking.js";
+import { buildProgramCodegenView } from "../../semantics/codegen-view/index.js";
+import { optimizeProgram } from "../../optimize/pipeline.js";
+import { codegenProgram } from "../index.js";
+import { compileEffectFixture } from "./support/effects-harness.js";
+
+const fixturePath = resolve(
+  import.meta.dirname,
+  "__fixtures__/iterator_for_specialization.voyd",
+);
+
+const watForExport = (wat: string, exportName: string): string => {
+  const exportMatch = wat.match(
+    new RegExp(`\\(export "${exportName}" \\(func \\$([^\\s\\)]+)\\)\\)`),
+  );
+  expect(exportMatch).not.toBeNull();
+  const start = wat.indexOf(`(func $${exportMatch?.[1]} `);
+  let depth = 0;
+  for (let index = start; index < wat.length; index += 1) {
+    if (wat[index] === "(") depth += 1;
+    if (wat[index] === ")") depth -= 1;
+    if (depth === 0) return wat.slice(start, index + 1);
+  }
+  throw new Error(`unterminated function for export ${exportName}`);
+};
+
+const watForCalledFunction = (wat: string, caller: string): string => {
+  const callerWat = watForExport(wat, caller);
+  const target = callerWat.match(/\((?:return_)?call \$([^\s\)]+)/)?.[1];
+  expect(target).toBeDefined();
+  return watForFunction(wat, target!);
+};
+
+const watForFunction = (wat: string, functionName: string): string => {
+  const start = wat.indexOf(`(func $${functionName} `);
+  let depth = 0;
+  for (let index = start; index < wat.length; index += 1) {
+    if (wat[index] === "(") depth += 1;
+    if (wat[index] === ")") depth -= 1;
+    if (depth === 0) return wat.slice(start, index + 1);
+  }
+  throw new Error(`unterminated function ${functionName}`);
+};
+
+const compileFixture = async ({
+  programOptimization,
+  binaryenOptimization,
+}: {
+  programOptimization: boolean;
+  binaryenOptimization: "none" | "release";
+}) => {
+  const prepared = await compileEffectFixture({
+    entryPath: fixturePath,
+    codegenOptions: {
+      validate: true,
+      effectsHostBoundary: "off",
+      boundaryExports: false,
+    },
+  });
+  const modules = [...prepared.semantics.values()];
+  const monomorphized = monomorphizeProgram({
+    modules,
+    semantics: prepared.semantics,
+  });
+  const program = buildProgramCodegenView(modules, {
+    instances: monomorphized.instances,
+    moduleTyping: monomorphized.moduleTyping,
+  });
+  const optimization = programOptimization
+    ? optimizeProgram({
+        program,
+        modules,
+        entryModuleId: prepared.entryModuleId,
+      })
+    : undefined;
+  return codegenProgram({
+    program: optimization?.program ?? program,
+    entryModuleId: prepared.entryModuleId,
+    optimization: optimization?.facts,
+    options: {
+      validate: true,
+      boundaryExports: false,
+      optimizationLevel: binaryenOptimization,
+    },
+  });
+};
+
+describe("exact standard iterator for-loop specialization", () => {
+  let optimized: Awaited<ReturnType<typeof compileFixture>>;
+  let releaseOptimized: Awaited<ReturnType<typeof compileFixture>>;
+  let baseline: Awaited<ReturnType<typeof compileFixture>>;
+  let host: Awaited<ReturnType<typeof createVoydHost>>;
+  let wat: string;
+
+  beforeAll(async () => {
+    [optimized, releaseOptimized, baseline] = await Promise.all([
+      compileFixture({
+        programOptimization: true,
+        binaryenOptimization: "none",
+      }),
+      compileFixture({
+        programOptimization: true,
+        binaryenOptimization: "release",
+      }),
+      compileFixture({
+        programOptimization: false,
+        binaryenOptimization: "none",
+      }),
+    ]);
+    host = await createVoydHost({ wasm: optimized.wasm! });
+    wat = optimized.module.emitText();
+  });
+
+  it("preserves early-return, skipping, break, continue, alias, and evaluation-once semantics", async () => {
+    await expect(host.run<number>("exact_count")).resolves.toBe(6);
+    await expect(host.run<number>("filtered_control_flow")).resolves.toBe(104);
+  });
+
+  it("supports wide value and object yields", async () => {
+    await expect(host.run<number>("wide_and_object_results")).resolves.toBe(
+      107,
+    );
+    await expect(host.run<number>("generic_user_iterator")).resolves.toBe(9);
+  });
+
+  it("removes dispatch and iterator state traffic for exact user iterators", () => {
+    for (const exportName of [
+      "exact_count",
+      "filtered_control_flow",
+      "generic_user_iterator",
+    ]) {
+      const specialized = watForExport(wat, exportName);
+      expect(specialized).not.toContain("call_ref");
+      expect(specialized).toMatch(/next[^\s]*__receiver_/);
+    }
+
+    const exactCount = watForExport(wat, "exact_count");
+    const specializedNextName = exactCount.match(
+      /\(call \$([^\s\)]*next[^\s\)]*__receiver_[^\s\)]*)/,
+    )?.[1];
+    expect(specializedNextName).toBeDefined();
+    const specializedNext = watForFunction(wat, specializedNextName!);
+    expect(specializedNext).toContain("struct.set");
+    expect(specializedNext).not.toContain("call_ref");
+
+    const baselineCount = watForExport(
+      baseline.module.emitText(),
+      "exact_count",
+    );
+    expect(baselineCount).toContain("call_ref");
+
+    const releaseCount = watForExport(
+      releaseOptimized.module.emitText(),
+      "exact_count",
+    );
+    expect(releaseCount).not.toContain("call_ref");
+    expect(releaseCount).not.toMatch(/struct\.(?:new|get|set)\b/);
+  });
+
+  it("keeps dynamically unknown and noncanonical iterators on general dispatch", async () => {
+    await expect(host.run<number>("dynamic_count_fallback")).resolves.toBe(6);
+    await expect(host.run<number>("dynamic_filtered_fallback")).resolves.toBe(
+      14,
+    );
+    await expect(host.run<number>("noncanonical_fallback")).resolves.toBe(6);
+
+    expect(watForCalledFunction(wat, "dynamic_count_fallback")).toContain(
+      "call_ref",
+    );
+    expect(watForCalledFunction(wat, "dynamic_filtered_fallback")).toContain(
+      "call_ref",
+    );
+    expect(watForExport(wat, "noncanonical_fallback")).toContain("call_ref");
+  });
+});

--- a/packages/compiler/src/codegen/__tests__/range-for-fast-path.test.ts
+++ b/packages/compiler/src/codegen/__tests__/range-for-fast-path.test.ts
@@ -1,0 +1,93 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createVoydHost } from "@voyd-lang/js-host";
+import { monomorphizeProgram } from "../../semantics/linking.js";
+import { buildProgramCodegenView } from "../../semantics/codegen-view/index.js";
+import { optimizeProgram } from "../../optimize/pipeline.js";
+import { codegenProgram } from "../index.js";
+import { compileEffectFixture } from "./support/effects-harness.js";
+
+const fixturePath = resolve(
+  import.meta.dirname,
+  "__fixtures__/range_for_fast_path.voyd",
+);
+
+const watForExport = (wat: string, exportName: string): string => {
+  const exportMatch = wat.match(
+    new RegExp(`\\(export "${exportName}" \\(func \\$([^\\s\\)]+)\\)\\)`),
+  );
+  expect(exportMatch).not.toBeNull();
+  const start = wat.indexOf(`(func $${exportMatch?.[1]} `);
+  let depth = 0;
+  for (let index = start; index < wat.length; index += 1) {
+    if (wat[index] === "(") depth += 1;
+    if (wat[index] === ")") depth -= 1;
+    if (depth === 0) return wat.slice(start, index + 1);
+  }
+  throw new Error(`unterminated function for export ${exportName}`);
+};
+
+const compileFixture = async () => {
+  const prepared = await compileEffectFixture({
+    entryPath: fixturePath,
+    codegenOptions: {
+      validate: true,
+      effectsHostBoundary: "off",
+      boundaryExports: false,
+    },
+  });
+  const modules = [...prepared.semantics.values()];
+  const monomorphized = monomorphizeProgram({
+    modules,
+    semantics: prepared.semantics,
+  });
+  const program = buildProgramCodegenView(modules, {
+    instances: monomorphized.instances,
+    moduleTyping: monomorphized.moduleTyping,
+  });
+  const optimized = optimizeProgram({
+    program,
+    modules,
+    entryModuleId: prepared.entryModuleId,
+  });
+  const generated = codegenProgram({
+    program: optimized.program,
+    entryModuleId: prepared.entryModuleId,
+    optimization: optimized.facts,
+    options: { validate: true, boundaryExports: false },
+  });
+  const baseline = codegenProgram({
+    program: optimized.program,
+    entryModuleId: prepared.entryModuleId,
+    options: { validate: true, boundaryExports: false },
+  });
+  return { prepared, optimized, generated, baseline };
+};
+
+describe("intrinsic Range<i32> for-loop fast path", () => {
+  it("emits a direct counted loop and retains stable-field forwarding", async () => {
+    const { prepared, optimized, generated, baseline } = await compileFixture();
+    const host = await createVoydHost({ wasm: generated.wasm! });
+    await expect(host.run<number>("stable_range_sum")).resolves.toBe(35);
+
+    const forwarding = optimized.facts.stableFieldLoadForwarding.get(
+      prepared.entryModuleId,
+    );
+    expect(forwarding?.size).toBe(1);
+
+    const generatedWat = watForExport(
+      generated.module.emitText(),
+      "stable_range_sum",
+    );
+    const baselineWat = watForExport(
+      baseline.module.emitText(),
+      "stable_range_sum",
+    );
+    expect(generatedWat).toContain("range_for_loop");
+    expect(generatedWat).not.toContain("$std__range__RangeIterator");
+    expect(generatedWat).not.toContain("call_ref");
+    expect(generatedWat.match(/\(struct\.get\b/g)?.length ?? 0).toBeLessThan(
+      baselineWat.match(/\(struct\.get\b/g)?.length ?? 0,
+    );
+  });
+});

--- a/packages/compiler/src/codegen/__tests__/scalar-aggregate-replacement.test.ts
+++ b/packages/compiler/src/codegen/__tests__/scalar-aggregate-replacement.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { resolve, sep } from "node:path";
 import { getWasmInstance } from "@voyd-lang/lib/wasm.js";
 import { parse } from "../../parser/index.js";
 import { semanticsPipeline } from "../../semantics/pipeline.js";
@@ -6,9 +7,17 @@ import { monomorphizeProgram } from "../../semantics/linking.js";
 import { buildProgramCodegenView } from "../../semantics/codegen-view/index.js";
 import { optimizeProgram } from "../../optimize/pipeline.js";
 import { codegenProgram } from "../index.js";
+import { createMemoryModuleHost } from "../../modules/memory-host.js";
+import { createNodePathAdapter } from "../../modules/node-path-adapter.js";
+import { buildModuleGraph } from "../../modules/graph.js";
+import { analyzeModules } from "../../pipeline-shared.js";
 import type { ModuleGraph, ModuleNode } from "../../modules/types.js";
 
-const compileOptimized = (source: string) => {
+const compileOptimized = (
+  source: string,
+  optimizationLevel: "balanced" | "release" = "release",
+  scalarAggregateContextsPerProgram?: number,
+) => {
   const ast = parse(source, "scalar_aggregate_replacement.voyd");
   const moduleNode: ModuleNode = {
     id: "std::scalar_aggregate_replacement",
@@ -40,11 +49,29 @@ const compileOptimized = (source: string) => {
     program,
     modules: [semantics],
     entryModuleId: moduleNode.id,
+    options: { optimizationLevel },
   });
+  const optimizationFacts =
+    typeof scalarAggregateContextsPerProgram === "number"
+      ? {
+          ...optimized.facts,
+          codegenPlan: {
+            ...optimized.facts.codegenPlan,
+            specializationReservations: {
+              ...optimized.facts.codegenPlan.specializationReservations,
+              scalar_aggregate: {
+                ...optimized.facts.codegenPlan.specializationReservations
+                  .scalar_aggregate,
+                contextsPerProgram: scalarAggregateContextsPerProgram,
+              },
+            },
+          },
+        }
+      : optimized.facts;
   const optimizedCodegen = codegenProgram({
     program: optimized.program,
     entryModuleId: moduleNode.id,
-    optimization: optimized.facts,
+    optimization: optimizationFacts,
     options: { validate: false },
   });
   const baselineCodegen = codegenProgram({
@@ -69,6 +96,100 @@ const runMain = (
 };
 
 describe("scalar aggregate replacement", () => {
+  it("keeps immutable heap-object aliases materialized in balanced builds", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(
+      `
+obj State {
+  count: i32
+}
+
+pub fn main() -> i32
+  let ~state = State { count: 1 }
+  let alias = state
+  state.count = 4
+  alias.count
+`,
+      "balanced",
+    );
+
+    expect(runMain(baselineCodegen.module)()).toBe(4);
+    expect(runMain(optimizedCodegen.module)()).toBe(4);
+    expect(optimizedCodegen.module.emitText()).toMatch(
+      /\(struct\.new \$voyd_struct_shape_/,
+    );
+  });
+
+  it("promotes mutable state across an imported canonical callee", async () => {
+    const root = resolve("/proj/src");
+    const host = createMemoryModuleHost({
+      files: {
+        [`${root}${sep}main.voyd`]: `
+pub use self::writer::all
+
+pub fn main(seed: i32) -> i32
+  let ~state = State { stable: 7, count: seed }
+  increment(~state, 4)
+  state.stable * 10 + state.count
+`,
+        [`${root}${sep}main${sep}writer.voyd`]: `
+pub obj State {
+  stable: i32,
+  count: i32
+}
+
+pub fn increment(~state: State, amount: i32) -> void
+  state.count = state.count + amount
+`,
+      },
+      pathAdapter: createNodePathAdapter(),
+    });
+    const graph = await buildModuleGraph({
+      entryPath: `${root}${sep}main.voyd`,
+      roots: { src: root },
+      host,
+    });
+    const analyzed = analyzeModules({ graph });
+    expect(
+      analyzed.diagnostics.filter(
+        (diagnostic) => diagnostic.severity === "error",
+      ),
+    ).toHaveLength(0);
+    const modules = Array.from(analyzed.semantics.values());
+    const monomorphized = monomorphizeProgram({
+      modules,
+      semantics: analyzed.semantics,
+    });
+    const program = buildProgramCodegenView(modules, {
+      instances: monomorphized.instances,
+      moduleTyping: monomorphized.moduleTyping,
+    });
+    const optimized = optimizeProgram({
+      program,
+      modules,
+      entryModuleId: graph.entry,
+      options: { optimizationLevel: "release" },
+    });
+    const emitted = codegenProgram({
+      program: optimized.program,
+      entryModuleId: graph.entry,
+      optimization: optimized.facts,
+      options: { validate: false },
+    });
+    expect(
+      emitted.diagnostics.filter(
+        (diagnostic) => diagnostic.severity === "error",
+      ),
+    ).toHaveLength(0);
+    expect(
+      (
+        getWasmInstance(emitted.module).exports.main as (seed: number) => number
+      )(1),
+    ).toBe(75);
+    expect(emitted.module.emitText()).toMatch(
+      /increment[^\s]*__scalar_agg_0_mutable/,
+    );
+  });
+
   it("passes scalarized arrays to optional parameters", () => {
     const { optimizedCodegen, baselineCodegen } = compileOptimized(`
 obj Array<T> { storage: FixedArray<T>, count: i32 }
@@ -529,8 +650,100 @@ pub fn main() -> i32
     expect(runMain(optimizedCodegen.module)()).toBe(5);
   });
 
-  it("does not scalarize heap-object parameters mutated by the callee", () => {
+  it("returns updated lanes from exact mutable heap-object calls", () => {
     const { optimizedCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn set_value(~box: Box, value: i32 = 9) -> void
+  box.value = value
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  set_value(box)
+  box.value
+`);
+
+    const optimizedText = optimizedCodegen.module.emitText();
+    expect(runMain(optimizedCodegen.module)()).toBe(9);
+    expect(optimizedText).toMatch(/set_value[^\s]*__scalar_agg_0_mutable/);
+    expect(optimizedText).not.toMatch(/\(struct\.new \$voyd_struct_shape_/);
+  });
+
+  it("keeps wide mutable objects and aliases in lanes across repeated calls", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+obj State {
+  stable: i32,
+  count: i32,
+  template: i32,
+  locale: i32,
+  flags: i32,
+  nodes: i32
+}
+
+fn increment(~state: State, amount: i32) -> void
+  state.count = state.count + amount
+  state.nodes = state.nodes + 1
+
+fn next_amount(~amount: i32) -> i32
+  amount = amount + 1
+  amount
+
+pub fn main() -> i32
+  let ~state = State {
+    stable: 7,
+    count: 1,
+    template: 2,
+    locale: 3,
+    flags: 4,
+    nodes: 10
+  }
+  let alias = state
+  var amount = 1
+  var index = 0
+  while index < 2:
+    increment(~state, next_amount(~amount))
+    index = index + 1
+  alias.stable * 1000 + alias.count * 100 + alias.nodes * 10 + amount
+`);
+
+    expect(runMain(baselineCodegen.module)()).toBe(7723);
+    expect(runMain(optimizedCodegen.module)()).toBe(7723);
+    const optimizedText = optimizedCodegen.module.emitText();
+    expect(optimizedText).toMatch(/increment[^\s]*__scalar_agg_0_mutable/);
+    expect(optimizedText).not.toMatch(/\(struct\.new \$voyd_struct_shape_/);
+  });
+
+  it("materializes safely when a mutable callee cannot use the lane ABI", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn maybe_set(~box: Box, should_set: bool) -> void
+  if should_set:
+    box.value = 9
+  else:
+    return void
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  if false:
+    maybe_set(~box, true)
+  box.value
+`);
+
+    expect(runMain(baselineCodegen.module)()).toBe(1);
+    expect(runMain(optimizedCodegen.module)()).toBe(1);
+    const optimizedText = optimizedCodegen.module.emitText();
+    expect(optimizedText).not.toMatch(/maybe_set[^\s]*__scalar_agg_0_mutable/);
+    expect(optimizedText).toMatch(/\(struct\.new \$voyd_struct_shape_/);
+  });
+
+  it("declines promotion before control flow when the companion budget is exhausted", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(
+      `
 obj Box {
   value: i32
 }
@@ -540,11 +753,90 @@ fn set_value(~box: Box) -> void
 
 pub fn main() -> i32
   let ~box = Box { value: 1 }
-  set_value(box)
+  if true:
+    set_value(~box)
+  box.value
+`,
+      "release",
+      0,
+    );
+
+    expect(runMain(baselineCodegen.module)()).toBe(9);
+    expect(runMain(optimizedCodegen.module)()).toBe(9);
+    const optimizedText = optimizedCodegen.module.emitText();
+    expect(optimizedText).not.toMatch(/set_value[^\s]*__scalar_agg_0_mutable/);
+    expect(optimizedText).toMatch(/\(struct\.new \$voyd_struct_shape_/);
+  });
+
+  it("keeps non-void mutable callees on the reference ABI", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn increment(~box: Box) -> i32
+  box.value = box.value + 1
+  box.value
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  increment(~box) * 10 + box.value
+`);
+
+    expect(runMain(baselineCodegen.module)()).toBe(22);
+    expect(runMain(optimizedCodegen.module)()).toBe(22);
+    const optimizedText = optimizedCodegen.module.emitText();
+    expect(optimizedText).not.toMatch(/increment[^\s]*__scalar_agg_0_mutable/);
+    expect(optimizedText).toMatch(/\(struct\.new \$voyd_struct_shape_/);
+  });
+
+  it("keeps later argument mutations ahead of the mutable call", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn add(~box: Box, amount: i32) -> void
+  box.value = box.value + amount
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  add(~box, block
+    box.value = 10
+    2)
   box.value
 `);
 
-    expect(runMain(optimizedCodegen.module)()).toBe(9);
+    expect(runMain(baselineCodegen.module)()).toBe(12);
+    expect(runMain(optimizedCodegen.module)()).toBe(12);
+    expect(optimizedCodegen.module.emitText()).not.toMatch(
+      /add[^\s]*__scalar_agg_0_mutable/,
+    );
+  });
+
+  it("preserves a second mutable object's updates across control flow", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn mutate_both(~first: Box, ~second: Box) -> void
+  first.value = first.value + 1
+  second.value = second.value + 10
+
+pub fn main() -> i32
+  let ~first = Box { value: 1 }
+  let ~second = Box { value: 2 }
+  if true:
+    mutate_both(~first, ~second)
+  first.value * 100 + second.value
+`);
+
+    expect(runMain(baselineCodegen.module)()).toBe(212);
+    expect(runMain(optimizedCodegen.module)()).toBe(212);
+    expect(optimizedCodegen.module.emitText()).toMatch(
+      /mutate_both[^\s]*__scalar_agg_0_mutable/,
+    );
   });
 
   it("does not scalarize heap-object parameters mutated through local aliases", () => {

--- a/packages/compiler/src/codegen/__tests__/scalar-aggregate-replacement.test.ts
+++ b/packages/compiler/src/codegen/__tests__/scalar-aggregate-replacement.test.ts
@@ -768,7 +768,7 @@ pub fn main() -> i32
     expect(optimizedText).toMatch(/\(struct\.new \$voyd_struct_shape_/);
   });
 
-  it("keeps non-void mutable callees on the reference ABI", () => {
+  it("returns a logical result and mutable lanes from the same exact call", () => {
     const { optimizedCodegen, baselineCodegen } = compileOptimized(`
 obj Box {
   value: i32
@@ -780,13 +780,192 @@ fn increment(~box: Box) -> i32
 
 pub fn main() -> i32
   let ~box = Box { value: 1 }
-  increment(~box) * 10 + box.value
+  let first = increment(~box)
+  increment(~box)
+  first * 100 + box.value
+`);
+
+    expect(runMain(baselineCodegen.module)()).toBe(203);
+    expect(runMain(optimizedCodegen.module)()).toBe(203);
+    const optimizedText = optimizedCodegen.module.emitText();
+    expect(optimizedText).toMatch(/increment[^\s]*__scalar_agg_0_mutable/);
+    expect(optimizedText).not.toMatch(/\(struct\.new \$voyd_struct_shape_/);
+  });
+
+  it("writes back mutable lanes on an early non-void return", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn advance(~box: Box, stop: bool) -> i32
+  box.value = box.value + 1
+  if stop:
+    return box.value * 10
+  box.value + 2
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  advance(~box, true) + box.value
 `);
 
     expect(runMain(baselineCodegen.module)()).toBe(22);
     expect(runMain(optimizedCodegen.module)()).toBe(22);
     const optimizedText = optimizedCodegen.module.emitText();
-    expect(optimizedText).not.toMatch(/increment[^\s]*__scalar_agg_0_mutable/);
+    expect(optimizedText).toMatch(/advance[^\s]*__scalar_agg_0_mutable/);
+    expect(optimizedText).not.toMatch(/\(struct\.new \$voyd_struct_shape_/);
+    expect(optimizedText).not.toContain("(return_call");
+  });
+
+  it("preserves logical multivalue ordering ahead of mutable lanes", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+val PairResult {
+  tens: i32,
+  hundreds: i32
+}
+
+fn advance_pair(~box: Box) -> PairResult
+  box.value = box.value + 1
+  PairResult { tens: box.value * 10, hundreds: box.value * 100 }
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  let result = advance_pair(~box)
+  result.tens + result.hundreds + box.value
+`);
+
+    expect(runMain(baselineCodegen.module)()).toBe(222);
+    expect(runMain(optimizedCodegen.module)()).toBe(222);
+    const optimizedText = optimizedCodegen.module.emitText();
+    expect(optimizedText).toMatch(/advance_pair[^\s]*__scalar_agg_0_mutable/);
+    expect(optimizedText).not.toMatch(/\(struct\.new \$voyd_struct_shape_/);
+  });
+
+  it("falls back when the logical result returns receiver provenance", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn expose(~box: Box) -> Box
+  box.value = box.value + 1
+  box
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  let exposed = expose(~box)
+  exposed.value + box.value
+`);
+
+    expect(runMain(baselineCodegen.module)()).toBe(4);
+    expect(runMain(optimizedCodegen.module)()).toBe(4);
+    const optimizedText = optimizedCodegen.module.emitText();
+    expect(optimizedText).not.toMatch(/expose[^\s]*__scalar_agg_0_mutable/);
+    expect(optimizedText).toMatch(/\(struct\.new \$voyd_struct_shape_/);
+  });
+
+  it("keeps wide logical results on the ordinary out-ref ABI", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+val WideResult {
+  first: i32,
+  second: i32,
+  third: i32,
+  fourth: i32,
+  fifth: i32
+}
+
+fn advance_wide(~box: Box) -> WideResult
+  box.value = box.value + 1
+  WideResult {
+    first: box.value,
+    second: 2,
+    third: 3,
+    fourth: 4,
+    fifth: 5
+  }
+
+pub fn main() -> i32
+  let ~box = Box { value: 1 }
+  let result = advance_wide(~box)
+  result.first + result.second + result.third + result.fourth + result.fifth + box.value
+`);
+
+    expect(runMain(baselineCodegen.module)()).toBe(18);
+    expect(runMain(optimizedCodegen.module)()).toBe(18);
+    expect(optimizedCodegen.module.emitText()).not.toMatch(
+      /advance_wide[^\s]*__scalar_agg_0_mutable/,
+    );
+  });
+
+  it("keeps conditional nested receiver calls on the ordinary ABI", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn increment(~box: Box) -> i32
+  box.value = box.value + 1
+  box.value
+
+fn maybe_increment(~box: Box, apply: bool) -> i32
+  if apply:
+    return increment(~box)
+  box.value
+
+pub fn main() -> i32
+  let ~first = Box { value: 1 }
+  let ~second = Box { value: 10 }
+  maybe_increment(~first, false) * 1000 + first.value * 100 + maybe_increment(~second, true) * 10 + second.value
+`);
+
+    expect(runMain(baselineCodegen.module)()).toBe(1221);
+    expect(runMain(optimizedCodegen.module)()).toBe(1221);
+    const optimizedText = optimizedCodegen.module.emitText();
+    expect(optimizedText).not.toMatch(
+      /maybe_increment[^\s]*__scalar_agg_0_mutable/,
+    );
+    expect(optimizedText).not.toMatch(/__increment_\d+__scalar_agg_0_mutable/);
+    expect(optimizedText).toMatch(/\(struct\.new \$voyd_struct_shape_/);
+  });
+
+  it("keeps zero-iteration nested receiver loops on the ordinary ABI", () => {
+    const { optimizedCodegen, baselineCodegen } = compileOptimized(`
+obj Box {
+  value: i32
+}
+
+fn increment(~box: Box) -> i32
+  box.value = box.value + 1
+  box.value
+
+fn repeat_increment(~box: Box, iterations: i32) -> i32
+  var remaining = iterations
+  while remaining > 0:
+    increment(~box)
+    remaining = remaining - 1
+  box.value
+
+pub fn main() -> i32
+  let ~first = Box { value: 3 }
+  let ~second = Box { value: 5 }
+  repeat_increment(~first, 0) * 1000 + first.value * 100 + repeat_increment(~second, 2) * 10 + second.value
+`);
+
+    expect(runMain(baselineCodegen.module)()).toBe(3377);
+    expect(runMain(optimizedCodegen.module)()).toBe(3377);
+    const optimizedText = optimizedCodegen.module.emitText();
+    expect(optimizedText).not.toMatch(
+      /repeat_increment[^\s]*__scalar_agg_0_mutable/,
+    );
+    expect(optimizedText).not.toMatch(/__increment_\d+__scalar_agg_0_mutable/);
     expect(optimizedText).toMatch(/\(struct\.new \$voyd_struct_shape_/);
   });
 

--- a/packages/compiler/src/codegen/__tests__/specialization-policy.test.ts
+++ b/packages/compiler/src/codegen/__tests__/specialization-policy.test.ts
@@ -309,6 +309,33 @@ describe("codegen specialization admission", () => {
       }),
     ).toBe(false);
   });
+
+  it("reuses a reserved identity after the local kind budget is full", () => {
+    const { ctx, item } = createAdmissionFixture();
+    const request = {
+      ctx,
+      meta: baseMeta,
+      item,
+      kind: "scalar_aggregate" as const,
+      dimensions: {
+        scalarAggregate: { parameterIndexes: [0], result: false },
+      },
+      maxKindVariants: 1,
+    };
+
+    expect(
+      tryAdmitFunctionSpecialization({
+        ...request,
+        existingKindVariants: 0,
+      }),
+    ).toBe(true);
+    expect(
+      tryAdmitFunctionSpecialization({
+        ...request,
+        existingKindVariants: 1,
+      }),
+    ).toBe(true);
+  });
 });
 
 const createAdmissionFixture = (

--- a/packages/compiler/src/codegen/__tests__/stable-field-load-forwarding.test.ts
+++ b/packages/compiler/src/codegen/__tests__/stable-field-load-forwarding.test.ts
@@ -147,6 +147,11 @@ impl Mutator for Increment
   fn bump(self, ~value: Record) -> void
     value.changing = value.changing + 1
 
+obj Reset {}
+impl Mutator for Reset
+  fn bump(self, ~value: Record) -> void
+    value.stable = 0
+
 fn run(mutator: Mutator) -> i32
   let ~value = Record { stable: 3, changing: 0 }
   let alias = value
@@ -159,8 +164,9 @@ fn run(mutator: Mutator) -> i32
     iteration = iteration + 1
   total
 
-pub fn main() -> i32
-  run(Increment {})
+pub fn main(flag: i32) -> i32
+  let mutator: Mutator = if flag == 0 then: Increment {} else: Reset {}
+  run(mutator)
 `);
     expect(
       optimized.facts.stableFieldLoadForwarding.get(moduleId)?.size ?? 0,

--- a/packages/compiler/src/codegen/__tests__/stable-field-load-forwarding.test.ts
+++ b/packages/compiler/src/codegen/__tests__/stable-field-load-forwarding.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import { getWasmInstance } from "@voyd-lang/lib/wasm.js";
+import { parse } from "../../parser/index.js";
+import { semanticsPipeline } from "../../semantics/pipeline.js";
+import { monomorphizeProgram } from "../../semantics/linking.js";
+import { buildProgramCodegenView } from "../../semantics/codegen-view/index.js";
+import { optimizeProgram } from "../../optimize/pipeline.js";
+import { codegenProgram } from "../index.js";
+import type { ModuleGraph, ModuleNode } from "../../modules/types.js";
+
+const compile = (source: string) => {
+  const ast = parse(source, "stable_field_load_forwarding.voyd");
+  const moduleNode: ModuleNode = {
+    id: "std::stable_field_load_forwarding",
+    path: { namespace: "std", segments: ["stable_field_load_forwarding"] },
+    origin: { kind: "file", filePath: "stable_field_load_forwarding.voyd" },
+    ast,
+    source,
+    dependencies: [],
+  };
+  const graph: ModuleGraph = {
+    entry: moduleNode.id,
+    modules: new Map([[moduleNode.id, moduleNode]]),
+    diagnostics: [],
+  };
+  const semantics = semanticsPipeline({ module: moduleNode, graph });
+  const semanticsByModule = new Map([[moduleNode.id, semantics]]);
+  const monomorphized = monomorphizeProgram({
+    modules: [semantics],
+    semantics: semanticsByModule,
+  });
+  const program = buildProgramCodegenView([semantics], {
+    instances: monomorphized.instances,
+    moduleTyping: monomorphized.moduleTyping,
+  });
+  const optimized = optimizeProgram({
+    program,
+    modules: [semantics],
+    entryModuleId: moduleNode.id,
+  });
+  const generated = codegenProgram({
+    program: optimized.program,
+    entryModuleId: moduleNode.id,
+    optimization: optimized.facts,
+    options: { validate: true },
+  });
+  const baseline = codegenProgram({
+    program: optimized.program,
+    entryModuleId: moduleNode.id,
+    options: { validate: true },
+  });
+  if (generated.diagnostics.length > 0) {
+    throw new Error(JSON.stringify(generated.diagnostics, null, 2));
+  }
+  return { optimized, generated, baseline, moduleId: moduleNode.id };
+};
+
+const source = ({ mutation }: { mutation: "sibling" | "same" | "root" }) => `
+obj Record { stable: i32, changing: i32 }
+
+fn bump(~value: Record) -> void
+  ${
+    mutation === "sibling"
+      ? "value.changing = value.changing + 1"
+      : mutation === "same"
+        ? "value.stable = value.stable + 1"
+        : "value = Record { stable: 9, changing: 0 }"
+  }
+
+pub fn main() -> i32
+  let ~value = Record { stable: 3, changing: 0 }
+  let alias = value
+  var iteration = 0
+  var total = 0
+  while iteration < 10:
+    total = total + alias.stable
+    bump(~value)
+    total = total + alias.stable
+    iteration = iteration + 1
+  total + value.changing
+`;
+
+describe("stable field load forwarding", () => {
+  it("forwards a fixed field load across a resolved disjoint call", () => {
+    const { optimized, generated, baseline, moduleId } = compile(
+      source({ mutation: "sibling" }),
+    );
+    const instance = getWasmInstance(generated.module);
+    expect((instance.exports.main as () => number)()).toBe(70);
+    expect(optimized.facts.stableFieldLoadForwarding.get(moduleId)?.size).toBe(
+      1,
+    );
+    const structGets = (text: string) =>
+      Array.from(text.matchAll(/\(struct\.get\b/g)).length;
+    expect(structGets(generated.module.emitText())).toBeLessThan(
+      structGets(baseline.module.emitText()),
+    );
+  });
+
+  it.each(["same", "root"] as const)(
+    "does not forward across a %s write",
+    (mutation) => {
+      const { optimized, moduleId } = compile(source({ mutation }));
+      expect(
+        optimized.facts.stableFieldLoadForwarding.get(moduleId)?.size ?? 0,
+      ).toBe(0);
+    },
+  );
+
+  it("bails out when a prior call returns provenance from the candidate root", () => {
+    const { optimized, moduleId } = compile(`
+obj Record { stable: i32, changing: i32 }
+obj Saved { value: Record }
+
+fn save(value: Record) -> Saved
+  Saved { value }
+
+fn bump(~value: Record) -> void
+  value.changing = value.changing + 1
+
+pub fn main() -> i32
+  let ~value = Record { stable: 3, changing: 0 }
+  let alias = value
+  let saved = save(value)
+  var iteration = 0
+  var total = 0
+  while iteration < 10:
+    total = total + alias.stable
+    bump(~value)
+    total = total + alias.stable
+    iteration = iteration + 1
+  total + saved.value.changing
+`);
+    expect(
+      optimized.facts.stableFieldLoadForwarding.get(moduleId)?.size ?? 0,
+    ).toBe(0);
+  });
+
+  it("bails out for dynamic method dispatch", () => {
+    const { optimized, moduleId } = compile(`
+obj Record { stable: i32, changing: i32 }
+trait Mutator
+  fn bump(self, ~value: Record) -> void
+
+obj Increment {}
+impl Mutator for Increment
+  fn bump(self, ~value: Record) -> void
+    value.changing = value.changing + 1
+
+fn run(mutator: Mutator) -> i32
+  let ~value = Record { stable: 3, changing: 0 }
+  let alias = value
+  var iteration = 0
+  var total = 0
+  while iteration < 10:
+    total = total + alias.stable
+    mutator.bump(~value)
+    total = total + alias.stable
+    iteration = iteration + 1
+  total
+
+pub fn main() -> i32
+  run(Increment {})
+`);
+    expect(
+      optimized.facts.stableFieldLoadForwarding.get(moduleId)?.size ?? 0,
+    ).toBe(0);
+  });
+
+  it("bails out for an unresolved function-value call", () => {
+    const { optimized, moduleId } = compile(`
+obj Record { stable: i32, changing: i32 }
+
+fn run(callback: fn(~Record) : () -> void) -> i32
+  let ~value = Record { stable: 3, changing: 0 }
+  let alias = value
+  var iteration = 0
+  var total = 0
+  while iteration < 10:
+    total = total + alias.stable
+    callback(~value)
+    total = total + alias.stable
+    iteration = iteration + 1
+  total
+
+pub fn main() -> i32
+  run((~value) => value.changing = value.changing + 1)
+`);
+    expect(
+      optimized.facts.stableFieldLoadForwarding.get(moduleId)?.size ?? 0,
+    ).toBe(0);
+  });
+
+  it("does not plan forwarding for indexed field paths", () => {
+    const { optimized, moduleId } = compile(`
+obj Record { stable: i32, changing: i32 }
+
+fn new_array_unchecked<T>({ from source: FixedArray<T> }) -> FixedArray<T>
+  source
+
+pub fn main() -> i32
+  let values = [Record { stable: 3, changing: 0 }]
+  var iteration = 0
+  var total = 0
+  while iteration < 10:
+    total = total + __array_get(values, 0).stable
+    total = total + __array_get(values, 0).stable
+    iteration = iteration + 1
+  total
+`);
+    expect(
+      optimized.facts.stableFieldLoadForwarding.get(moduleId)?.size ?? 0,
+    ).toBe(0);
+  });
+});

--- a/packages/compiler/src/codegen/__tests__/std-array-smoke.test.ts
+++ b/packages/compiler/src/codegen/__tests__/std-array-smoke.test.ts
@@ -61,6 +61,10 @@ describe("std::array compile smoke", () => {
     await expect(host.run<number>("direct_at_index_side_effect")).resolves.toBe(20);
     await expect(host.run<number>("safe_while_sum")).resolves.toBe(10);
     await expect(host.run<number>("safe_while_cached_len_sum")).resolves.toBe(10);
+    await expect(host.run<number>("safe_while_get_sum")).resolves.toBe(10);
+    await expect(host.run<number>("safe_while_get_value_sum")).resolves.toBe(
+      18,
+    );
     await expect(host.run<number>("safe_while_value_sum")).resolves.toBe(18);
     await expect(host.run<number>("safe_for_sum")).resolves.toBe(10);
     await expect(host.run<number>("while_non_zero_start_sum")).resolves.toBe(9);
@@ -98,7 +102,7 @@ describe("std::array compile smoke", () => {
     expect(functionWat).not.toContain("call_ref");
   });
 
-  it("elides loop-proven Array.at checks in safe counted loops", async () => {
+  it("elides loop-proven Array.at and Array.get dispatch in safe counted loops", async () => {
     const result = await compileStdArrayFixture({
       boundaryExports: false,
     });
@@ -115,6 +119,17 @@ describe("std::array compile smoke", () => {
       expect(functionWat).not.toContain("unreachable");
       expect(functionWat).not.toContain("call_ref");
       expect(functionWat).not.toContain("call_indirect");
+    }
+
+    for (const exportName of [
+      "safe_while_get_sum",
+      "safe_while_get_value_sum",
+    ]) {
+      const getWat = watForExport(wat, exportName);
+      expect(getWat).toContain("array.get");
+      expect(getWat).not.toContain("$std__array__get");
+      expect(getWat).not.toContain("call_ref");
+      expect(getWat).not.toContain("call_indirect");
     }
   });
 
@@ -138,5 +153,8 @@ describe("std::array compile smoke", () => {
       expect(functionWat).toContain("array.get");
       expect(functionWat).toContain("unreachable");
     }
+
+    const mutationGetWat = watForExport(wat, "while_helper_mutation_get_sum");
+    expect(mutationGetWat).toContain("$std__array__get");
   });
 });

--- a/packages/compiler/src/codegen/call-shape-specialization.ts
+++ b/packages/compiler/src/codegen/call-shape-specialization.ts
@@ -277,7 +277,8 @@ export const getOrCreateCallShapeSpecialization = ({
     userResultType:
       meta.resultAbiKind === "out_ref"
         ? binaryen.none
-        : meta.scalarAggregateResult
+        : meta.scalarAggregateResult ||
+            typeof meta.scalarAggregateMutableParamIndex === "number"
           ? meta.resultType
           : getSignatureWasmType(meta.resultTypeId, ctx),
   });

--- a/packages/compiler/src/codegen/context.ts
+++ b/packages/compiler/src/codegen/context.ts
@@ -129,6 +129,8 @@ export interface FunctionMetadata {
   specialization?: FunctionSpecializationDimensions;
   scalarAggregateParamIndexes?: readonly number[];
   scalarAggregateResult?: boolean;
+  /** Scalarized mutable parameter whose updated lanes are the specialized result. */
+  scalarAggregateMutableParamIndex?: number;
   callShape?: Readonly<{
     keyTokens: readonly string[];
     parameterStates: readonly CallShapeParameterState[];
@@ -428,6 +430,7 @@ export interface CompileCallOptions {
   typeInstanceId?: ProgramFunctionInstanceId;
   outResultStorageRef?: binaryen.ExpressionRef;
   scalarAggregateResultTypeId?: TypeId;
+  mutableScalarAggregateResultBinding?: LocalBindingScalarAggregate;
 }
 
 export interface ExpressionCompilerParams {

--- a/packages/compiler/src/codegen/context.ts
+++ b/packages/compiler/src/codegen/context.ts
@@ -401,6 +401,7 @@ export interface FunctionContext {
   loopStack?: LoopScope[];
   safeArrayLoopScopes?: readonly SafeArrayLoopScope[];
   safeArrayLengthSymbols?: ReadonlyMap<SymbolId, SymbolId>;
+  stableFieldLoadBindings?: ReadonlyMap<HirExprId, LocalBindingLocal>;
   runtimePlaceIdentities?: Map<HirExprId, RuntimePlaceIdentity>;
   runtimePlaceIdentityRequests?: Set<HirExprId>;
   continuations?: Map<SymbolId, ContinuationBinding>;

--- a/packages/compiler/src/codegen/context.ts
+++ b/packages/compiler/src/codegen/context.ts
@@ -25,6 +25,7 @@ import type {
   HirItemId,
   HirStmtId,
   ProgramFunctionInstanceId,
+  ProgramSymbolId,
   SymbolId,
   TypeId,
   TypeParamId,
@@ -48,7 +49,6 @@ import type { SerializerMetadata } from "../semantics/symbol-index.js";
 import type { Diagnostic, DiagnosticEmitter } from "../diagnostics/index.js";
 import type { ProgramHelperRegistry } from "./program-helpers.js";
 import type { ProgramOptimizationFacts } from "../optimize/ir.js";
-import type { ProgramSymbolId } from "../semantics/ids.js";
 import type {
   OptimizationLevel,
   SpecializationPolicy,
@@ -410,6 +410,8 @@ export interface FunctionContext {
   suppressTailResumptionExitChecks?: boolean;
   staticEffectContext?: StaticEffectHandlerContext;
   exactParameterTypes?: ReadonlyMap<SymbolId, TypeId>;
+  exactTraitDispatchTargets?: ReadonlyMap<HirExprId, ProgramSymbolId>;
+  exactCallReceiverTypes?: ReadonlyMap<HirExprId, TypeId>;
   continuation?: {
     cfg: GroupContinuationCfg;
     startedLocal: LocalBindingLocal;

--- a/packages/compiler/src/codegen/context.ts
+++ b/packages/compiler/src/codegen/context.ts
@@ -131,6 +131,11 @@ export interface FunctionMetadata {
   scalarAggregateResult?: boolean;
   /** Scalarized mutable parameter whose updated lanes are the specialized result. */
   scalarAggregateMutableParamIndex?: number;
+  /** Ordered combined-result ABI: logical lanes first, mutable writeback lanes last. */
+  scalarAggregateMutableCombinedResult?: Readonly<{
+    logicalAbiTypes: readonly binaryen.Type[];
+    writebackAbiTypes: readonly binaryen.Type[];
+  }>;
   callShape?: Readonly<{
     keyTokens: readonly string[];
     parameterStates: readonly CallShapeParameterState[];
@@ -412,6 +417,10 @@ export interface FunctionContext {
   exactParameterTypes?: ReadonlyMap<SymbolId, TypeId>;
   exactTraitDispatchTargets?: ReadonlyMap<HirExprId, ProgramSymbolId>;
   exactCallReceiverTypes?: ReadonlyMap<HirExprId, TypeId>;
+  scalarAggregateMutableReturn?: Readonly<{
+    binding: LocalBindingScalarAggregate;
+    logicalResultAbiTypes: readonly binaryen.Type[];
+  }>;
   continuation?: {
     cfg: GroupContinuationCfg;
     startedLocal: LocalBindingLocal;

--- a/packages/compiler/src/codegen/expressions/blocks.ts
+++ b/packages/compiler/src/codegen/expressions/blocks.ts
@@ -31,7 +31,7 @@ import { tailResumptionExitChecks } from "../effects/tail-resumptions.js";
 import { boxSignatureSpillValue } from "../signature-spill.js";
 import {
   arrayLengthBindingForStatement,
-  tryCompileArraySafeForStatement,
+  tryCompileRangeForStatement,
   tryCompileArraySafeWhileStatement,
 } from "../optimization/array-fast-paths.js";
 
@@ -122,7 +122,7 @@ export const compileBlockExpr = (
             fnCtx,
             compileExpr,
           }) ??
-            tryCompileArraySafeForStatement({
+            tryCompileRangeForStatement({
               block: expr,
               statementIndex,
               ctx,

--- a/packages/compiler/src/codegen/expressions/blocks.ts
+++ b/packages/compiler/src/codegen/expressions/blocks.ts
@@ -36,6 +36,7 @@ import {
   tryCompileArraySafeWhileStatement,
 } from "../optimization/array-fast-paths.js";
 import { withExactIteratorForCallTargets } from "../optimization/iterator-fast-paths.js";
+import { packMutableScalarAggregateResult } from "../optimization/mutable-scalar-aggregate-results.js";
 
 const expressionUsesExpectedResultType = ({
   exprId,
@@ -270,6 +271,59 @@ export const compileStatement = (
         fnCtx,
       );
     case "return":
+      if (fnCtx.scalarAggregateMutableReturn) {
+        if (typeof stmt.value !== "number") {
+          throw new Error(
+            "non-void mutable scalar aggregate specialization requires a return value",
+          );
+        }
+        const valueExpr = compileExpr({
+          exprId: stmt.value,
+          ctx,
+          fnCtx,
+          tailPosition: false,
+          expectedResultTypeId: fnCtx.returnTypeId,
+        }).expr;
+        const requiredActualType = getRequiredExprType(
+          stmt.value,
+          ctx,
+          typeInstanceId,
+        );
+        const actualTypeId =
+          expressionUsesExpectedResultType({ exprId: stmt.value, ctx }) &&
+          binaryen.getExpressionType(valueExpr) ===
+            wasmTypeFor(fnCtx.returnTypeId, ctx)
+            ? fnCtx.returnTypeId
+            : requiredActualType;
+        const logicalValue = coerceValueToType({
+          value: valueExpr,
+          actualType: actualTypeId,
+          targetType: fnCtx.returnTypeId,
+          ctx,
+          fnCtx,
+        });
+        const packed = packMutableScalarAggregateResult({
+          logicalValue,
+          logicalResultTypeId: fnCtx.returnTypeId,
+          logicalResultAbiTypes:
+            fnCtx.scalarAggregateMutableReturn.logicalResultAbiTypes,
+          binding: fnCtx.scalarAggregateMutableReturn.binding,
+          ctx,
+          fnCtx,
+        });
+        if (binaryen.getExpressionType(packed) === binaryen.unreachable) {
+          return packed;
+        }
+        return ctx.mod.block(
+          null,
+          [
+            ...tailResumptionExitChecks({ ctx, fnCtx }),
+            ...handlerCleanupOps({ ctx, fnCtx }),
+            ctx.mod.return(packed),
+          ],
+          binaryen.none,
+        );
+      }
       if (typeof stmt.value === "number") {
         const returnOutResultStorageRef =
           fnCtx.returnAbiKind === "out_ref" && fnCtx.returnOutPointer

--- a/packages/compiler/src/codegen/expressions/blocks.ts
+++ b/packages/compiler/src/codegen/expressions/blocks.ts
@@ -35,6 +35,7 @@ import {
   tryCompileRangeForStatement,
   tryCompileArraySafeWhileStatement,
 } from "../optimization/array-fast-paths.js";
+import { withExactIteratorForCallTargets } from "../optimization/iterator-fast-paths.js";
 
 const expressionUsesExpectedResultType = ({
   exprId,
@@ -140,6 +141,13 @@ export const compileBlockExpr = (
               compileExpr,
               compileStatement: (nestedStmtId) =>
                 compileStatement(nestedStmtId, ctx, fnCtx, compileExpr),
+            }) ??
+            withExactIteratorForCallTargets({
+              block: expr,
+              statementIndex,
+              ctx,
+              fnCtx,
+              compile: () => compileStatement(stmtId, ctx, fnCtx, compileExpr),
             }) ??
             compileStatement(stmtId, ctx, fnCtx, compileExpr),
         );

--- a/packages/compiler/src/codegen/expressions/blocks.ts
+++ b/packages/compiler/src/codegen/expressions/blocks.ts
@@ -31,6 +31,7 @@ import { tailResumptionExitChecks } from "../effects/tail-resumptions.js";
 import { boxSignatureSpillValue } from "../signature-spill.js";
 import {
   arrayLengthBindingForStatement,
+  tryCompileArrayForStatement,
   tryCompileRangeForStatement,
   tryCompileArraySafeWhileStatement,
 } from "../optimization/array-fast-paths.js";
@@ -122,6 +123,15 @@ export const compileBlockExpr = (
             fnCtx,
             compileExpr,
           }) ??
+            tryCompileArrayForStatement({
+              block: expr,
+              statementIndex,
+              ctx,
+              fnCtx,
+              compileExpr,
+              compileStatement: (nestedStmtId) =>
+                compileStatement(nestedStmtId, ctx, fnCtx, compileExpr),
+            }) ??
             tryCompileRangeForStatement({
               block: expr,
               statementIndex,

--- a/packages/compiler/src/codegen/expressions/call/arguments.ts
+++ b/packages/compiler/src/codegen/expressions/call/arguments.ts
@@ -160,6 +160,7 @@ export const compileCallArgumentsWithMetadata = ({
   args: binaryen.ExpressionRef[];
   writebacks: binaryen.ExpressionRef[];
   meta: FunctionMetadata;
+  mutableScalarAggregateResultBinding?: LocalBindingScalarAggregate;
 } => {
   const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
   const typedPlan = resolveTypedCallArgumentPlan({
@@ -185,6 +186,8 @@ export const compileCallArgumentsWithMetadata = ({
     args: compiled.args,
     writebacks: compiled.writebacks,
     meta: compiled.meta ?? meta,
+    mutableScalarAggregateResultBinding:
+      compiled.mutableScalarAggregateResultBinding,
   };
 };
 
@@ -280,8 +283,11 @@ export const compileCallArgumentsForParamsWithDetails = ({
       );
     }),
   );
+  const hasRuntimeIdentityGuards =
+    ctx.program.calls.getCallInfo(ctx.moduleId, call.id).identityGuards.length >
+    0;
   const resolvedMeta =
-    meta && eligibleScalarAggregateArgs.size > 0
+    meta && eligibleScalarAggregateArgs.size > 0 && !hasRuntimeIdentityGuards
       ? (getOrCreateScalarAggregateCallSpecialization({
           ctx,
           meta,
@@ -331,6 +337,18 @@ export const compileCallArgumentsForParamsWithDetails = ({
     }
   });
   const scalarOverrideArgIndexes = new Set(selectedScalarArgsByArgIndex.keys());
+  const mutableScalarAggregateResultBinding = (() => {
+    const paramIndex = activeMeta?.scalarAggregateMutableParamIndex;
+    const arg =
+      typeof paramIndex === "number"
+        ? selectedScalarArgs.get(paramIndex)
+        : undefined;
+    if (arg?.kind !== "binding") {
+      return undefined;
+    }
+    const binding = fnCtx.bindings.get(arg.symbol);
+    return binding?.kind === "scalar-aggregate" ? binding : undefined;
+  })();
 
   const consumedArgs = call.args.slice(0, planned.consumedArgCount);
   const preservedArgIndexes = collectPreservedStorageRefArgIndexes({
@@ -412,6 +430,7 @@ export const compileCallArgumentsForParamsWithDetails = ({
     writebacks,
     consumedArgCount: planned.consumedArgCount,
     meta: activeMeta ?? meta,
+    mutableScalarAggregateResultBinding,
   };
 };
 
@@ -433,7 +452,8 @@ const collectScalarAggregateCallArgs = ({
     if (
       entry.kind !== "direct" ||
       entry.argIndex !== 0 ||
-      meta.paramAbiKinds[paramIndex] !== "direct" ||
+      (meta.paramAbiKinds[paramIndex] !== "direct" &&
+        meta.paramAbiKinds[paramIndex] !== "mutable_ref") ||
       !scalarAggregateParameterCanUseSpecializedAbi({ meta, paramIndex, ctx })
     ) {
       return;
@@ -443,15 +463,19 @@ const collectScalarAggregateCallArgs = ({
     if (!argExpr) {
       return;
     }
-    if (argExpr.exprKind === "identifier") {
-      const binding = fnCtx.bindings.get(argExpr.symbol);
+    const addressableSymbol = resolveAddressableIdentifierSymbol({
+      exprId: argExprId,
+      ctx,
+    });
+    if (typeof addressableSymbol === "number") {
+      const binding = fnCtx.bindings.get(addressableSymbol);
       if (
         binding?.kind === "scalar-aggregate" &&
         binding.typeId === meta.paramTypeIds[paramIndex]
       ) {
         bindings.set(paramIndex, {
           kind: "binding",
-          symbol: argExpr.symbol,
+          symbol: addressableSymbol,
           typeId: meta.paramTypeIds[paramIndex]!,
         });
       }

--- a/packages/compiler/src/codegen/expressions/call/entrypoints.ts
+++ b/packages/compiler/src/codegen/expressions/call/entrypoints.ts
@@ -499,12 +499,18 @@ export const compileMethodCallExpr = (
   );
   const callView = toMethodCallView(expr);
   const concreteTraitTarget = callInfo.traitDispatch
-    ? resolveConcreteTraitMethodTarget({
-        expr: callView,
-        selectedMethod: targetFunctionId as ProgramSymbolId,
-        ctx,
-        typeInstanceId,
-      })
+    ? (() => {
+        const forcedTarget = fnCtx.exactTraitDispatchTargets?.get(expr.id);
+        if (typeof forcedTarget === "number") {
+          return ctx.program.symbols.refOf(forcedTarget);
+        }
+        return resolveConcreteTraitMethodTarget({
+          expr: callView,
+          selectedMethod: targetFunctionId as ProgramSymbolId,
+          ctx,
+          typeInstanceId,
+        });
+      })()
     : undefined;
   if (concreteTraitTarget) {
     return compileResolvedSymbolCall({

--- a/packages/compiler/src/codegen/expressions/call/entrypoints.ts
+++ b/packages/compiler/src/codegen/expressions/call/entrypoints.ts
@@ -33,7 +33,7 @@ import { getFunctionMetadataForCall } from "./metadata.js";
 import { emitResolvedCall } from "./resolved-call.js";
 import { compileTraitDispatchCall } from "./trait-dispatch.js";
 import { compileCallArgExpressionsWithTemps } from "./shared.js";
-import { getOrCreateReceiverSpecialization } from "../../receiver-specialization.js";
+import { receiverSpecializedMetaForCall } from "../../receiver-specialization.js";
 import { getOrCreateScalarAggregateCallSpecialization } from "../../optimization/scalar-aggregate-calls.js";
 import { allocateTempLocal } from "../../locals.js";
 import { captureMultivalueLanes } from "../../multivalue.js";
@@ -299,7 +299,7 @@ export const compileCallExpr = (
     });
     if (meta) {
       const resolvedMeta = receiverSpecializedMetaForCall({
-        expr,
+        callId: expr.id,
         meta,
         ctx,
         fnCtx,
@@ -318,7 +318,10 @@ export const compileCallExpr = (
       });
       const compiledCall = compileWithContractCallScope({
         calleeId,
-        tailPosition: compiledArgs.writebacks.length === 0 && tailPosition,
+        tailPosition:
+          compiledArgs.writebacks.length === 0 &&
+          !compiledArgs.mutableScalarAggregateResultBinding &&
+          tailPosition,
         ctx,
         fnCtx,
         compile: (scopedTailPosition) =>
@@ -333,6 +336,8 @@ export const compileCallExpr = (
               expectedResultTypeId,
               typeInstanceId,
               outResultStorageRef,
+              mutableScalarAggregateResultBinding:
+                compiledArgs.mutableScalarAggregateResultBinding,
             },
           }),
       });
@@ -565,7 +570,7 @@ export const compileMethodCallExpr = (
     );
   }
   const resolvedMeta = receiverSpecializedMetaForCall({
-    expr: callView,
+    callId: callView.id,
     meta,
     ctx,
     fnCtx,
@@ -588,7 +593,10 @@ export const compileMethodCallExpr = (
       targetRef.moduleId,
       targetRef.symbol,
     ),
-    tailPosition: compiledArgs.writebacks.length === 0 && tailPosition,
+    tailPosition:
+      compiledArgs.writebacks.length === 0 &&
+      !compiledArgs.mutableScalarAggregateResultBinding &&
+      tailPosition,
     ctx,
     fnCtx,
     compile: (scopedTailPosition) =>
@@ -603,6 +611,8 @@ export const compileMethodCallExpr = (
           expectedResultTypeId,
           typeInstanceId,
           outResultStorageRef,
+          mutableScalarAggregateResultBinding:
+            compiledArgs.mutableScalarAggregateResultBinding,
         },
       }),
   });
@@ -700,67 +710,6 @@ const toMethodCallView = (expr: HirMethodCallExpr): HirCallExpr => ({
   args: [{ expr: expr.target }, ...expr.args],
   typeArguments: expr.typeArguments,
 });
-
-const receiverSpecializationCallSiteKey = ({
-  moduleId,
-  exprId,
-}: {
-  moduleId: string;
-  exprId: number;
-}): string => `${moduleId}:${exprId}`;
-
-const receiverSpecializationContextKey = ({
-  instanceId,
-  exactParameterTypes,
-}: {
-  instanceId: ProgramFunctionInstanceId;
-  exactParameterTypes: ReadonlyMap<SymbolId, TypeId> | undefined;
-}): string => {
-  const serializedFacts = Array.from(exactParameterTypes?.entries() ?? [])
-    .sort(([left], [right]) => left - right)
-    .map(([symbol, type]) => `${symbol}=${type}`)
-    .join(",");
-  return `${instanceId}:${serializedFacts}`;
-};
-
-const receiverSpecializedMetaForCall = ({
-  expr,
-  meta,
-  ctx,
-  fnCtx,
-}: {
-  expr: HirCallExpr;
-  meta: FunctionMetadata;
-  ctx: CodegenContext;
-  fnCtx: FunctionContext;
-}): FunctionMetadata => {
-  if (!ctx.optimization || typeof fnCtx.instanceId !== "number") {
-    return meta;
-  }
-
-  const callSiteKey = receiverSpecializationCallSiteKey({
-    moduleId: ctx.moduleId,
-    exprId: expr.id,
-  });
-  const callerContextKey = receiverSpecializationContextKey({
-    instanceId: fnCtx.instanceId,
-    exactParameterTypes: fnCtx.exactParameterTypes,
-  });
-  const exactParameterTypes = ctx.optimization.receiverSpecializationRequests
-    .get(callSiteKey)
-    ?.get(callerContextKey);
-  if (!exactParameterTypes || exactParameterTypes.size === 0) {
-    return meta;
-  }
-
-  return (
-    getOrCreateReceiverSpecialization({
-      ctx,
-      meta,
-      exactParameterTypes,
-    }) ?? meta
-  );
-};
 
 const compileResolvedSymbolCall = ({
   expr,
@@ -904,7 +853,7 @@ const compileResolvedSymbolCall = ({
     );
   }
   const resolvedMeta = receiverSpecializedMetaForCall({
-    expr,
+    callId: expr.id,
     meta: targetMeta,
     ctx,
     fnCtx,
@@ -924,7 +873,10 @@ const compileResolvedSymbolCall = ({
   });
   const compiledCall = compileWithContractCallScope({
     calleeId,
-    tailPosition: compiledArgs.writebacks.length === 0 && tailPosition,
+    tailPosition:
+      compiledArgs.writebacks.length === 0 &&
+      !compiledArgs.mutableScalarAggregateResultBinding &&
+      tailPosition,
     ctx,
     fnCtx,
     compile: (scopedTailPosition) =>
@@ -939,6 +891,8 @@ const compileResolvedSymbolCall = ({
           expectedResultTypeId,
           typeInstanceId,
           outResultStorageRef,
+          mutableScalarAggregateResultBinding:
+            compiledArgs.mutableScalarAggregateResultBinding,
         },
       }),
   });

--- a/packages/compiler/src/codegen/expressions/call/resolved-call.ts
+++ b/packages/compiler/src/codegen/expressions/call/resolved-call.ts
@@ -35,6 +35,7 @@ import {
   boxSignatureSpillValue,
   unboxSignatureSpillValue,
 } from "../../signature-spill.js";
+import { storeScalarAggregateBindingAbiValue } from "../../optimization/scalar-aggregates.js";
 import { getOrCreateStaticEffectSpecialization } from "../../effects/static-specialization.js";
 import {
   compileRuntimeIdentityConflict,
@@ -495,6 +496,22 @@ export const emitResolvedCall = ({
     callArgs as number[],
     resolvedMeta.resultType,
   );
+  if (typeof resolvedMeta.scalarAggregateMutableParamIndex === "number") {
+    const binding = options.mutableScalarAggregateResultBinding;
+    if (!binding) {
+      throw new Error("mutable scalar aggregate call is missing its writeback");
+    }
+    const stores = storeScalarAggregateBindingAbiValue({
+      binding,
+      value: rawCall,
+      ctx,
+      fnCtx,
+    });
+    return {
+      expr: ctx.mod.block(null, [...preCallOps, ...stores], binaryen.none),
+      usedReturnCall: false,
+    };
+  }
   if (usingProvidedWideResultStorage) {
     const ops = preCallOps.length === 0 ? [rawCall] : [...preCallOps, rawCall];
     return {

--- a/packages/compiler/src/codegen/expressions/call/resolved-call.ts
+++ b/packages/compiler/src/codegen/expressions/call/resolved-call.ts
@@ -501,14 +501,87 @@ export const emitResolvedCall = ({
     if (!binding) {
       throw new Error("mutable scalar aggregate call is missing its writeback");
     }
-    const stores = storeScalarAggregateBindingAbiValue({
-      binding,
+    const combinedResult = resolvedMeta.scalarAggregateMutableCombinedResult;
+    if (!combinedResult) {
+      throw new Error(
+        "mutable scalar aggregate call is missing combined-result ABI metadata",
+      );
+    }
+    const combinedAbiTypes = [
+      ...combinedResult.logicalAbiTypes,
+      ...combinedResult.writebackAbiTypes,
+    ];
+    const captured = captureMultivalueLanes({
       value: rawCall,
+      abiTypes: combinedAbiTypes,
       ctx,
       fnCtx,
     });
+    const logicalLanes = captured.lanes.slice(
+      0,
+      combinedResult.logicalAbiTypes.length,
+    );
+    const writebackLanes = captured.lanes.slice(
+      combinedResult.logicalAbiTypes.length,
+    );
+    const writebackValue =
+      writebackLanes.length === 1
+        ? writebackLanes[0]!
+        : ctx.mod.tuple.make(writebackLanes as binaryen.ExpressionRef[]);
+    const stores = storeScalarAggregateBindingAbiValue({
+      binding,
+      value: writebackValue,
+      ctx,
+      fnCtx,
+    });
+    if (logicalLanes.length === 0) {
+      return {
+        expr: ctx.mod.block(
+          null,
+          [...preCallOps, ...captured.setup, ...stores],
+          binaryen.none,
+        ),
+        usedReturnCall: false,
+      };
+    }
+    const logicalValue =
+      logicalLanes.length === 1
+        ? logicalLanes[0]!
+        : ctx.mod.tuple.make(logicalLanes as binaryen.ExpressionRef[]);
+    const decodedLogicalValue =
+      getSignatureSpillBoxType({ typeId: resolvedMeta.resultTypeId, ctx }) ===
+      combinedResult.logicalAbiTypes[0]
+        ? unboxSignatureSpillValue({
+            value: logicalValue,
+            typeId: resolvedMeta.resultTypeId,
+            ctx,
+          })
+        : logicalValue;
+    const coercedLogicalValue =
+      resolvedMeta.resultTypeId === expectedTypeId
+        ? decodedLogicalValue
+        : coerceValueToType({
+            value: decodedLogicalValue,
+            actualType: resolvedMeta.resultTypeId,
+            targetType: expectedTypeId,
+            ctx,
+            fnCtx,
+          });
     return {
-      expr: ctx.mod.block(null, [...preCallOps, ...stores], binaryen.none),
+      expr: ctx.mod.block(
+        null,
+        [
+          ...preCallOps,
+          ...captured.setup,
+          ...stores,
+          coerceExprToWasmType({
+            expr: coercedLogicalValue,
+            targetType: callResultWasmType,
+            ctx,
+          }),
+        ],
+        callResultWasmType,
+      ),
       usedReturnCall: false,
     };
   }

--- a/packages/compiler/src/codegen/expressions/call/types.ts
+++ b/packages/compiler/src/codegen/expressions/call/types.ts
@@ -3,6 +3,7 @@ import type {
   HirCallExpr,
   HirExprId,
   FunctionMetadata,
+  LocalBindingScalarAggregate,
   TypeId,
 } from "../../context.js";
 import type { ProgramFunctionInstanceId } from "../../../semantics/ids.js";
@@ -31,6 +32,7 @@ export type CompiledCallArgumentsForParams = {
   writebacks: binaryen.ExpressionRef[];
   consumedArgCount: number;
   meta?: FunctionMetadata;
+  mutableScalarAggregateResultBinding?: LocalBindingScalarAggregate;
 };
 
 export type PlannedCallArguments = {

--- a/packages/compiler/src/codegen/expressions/control-flow.ts
+++ b/packages/compiler/src/codegen/expressions/control-flow.ts
@@ -1100,11 +1100,53 @@ export const compileWhileExpr = (
     ctx.mod.br(breakLabel),
   );
 
+  const { setup: forwardingStores, value: body } =
+    withStableFieldLoadForwarding({
+      loopExprId: expr.id,
+      ctx,
+      fnCtx,
+      compileExpr,
+      run: () =>
+        withLoopScope(
+          fnCtx,
+          { breakLabel, continueLabel: loopLabel },
+          () => compileExpr({ exprId: expr.body, ctx, fnCtx }).expr,
+        ),
+    });
+  const loopBody = ctx.mod.block(
+    null,
+    [conditionCheck, body, ctx.mod.br(loopLabel)],
+    binaryen.none,
+  );
+
+  return {
+    expr: ctx.mod.block(
+      breakLabel,
+      [...forwardingStores, ctx.mod.loop(loopLabel, loopBody)],
+      binaryen.none,
+    ),
+    usedReturnCall: false,
+  };
+};
+
+export const withStableFieldLoadForwarding = <T>({
+  loopExprId,
+  ctx,
+  fnCtx,
+  compileExpr,
+  run,
+}: {
+  loopExprId: number;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+  run: () => T;
+}): { setup: binaryen.ExpressionRef[]; value: T } => {
   const forwardingGroups =
     ctx.optimization?.stableFieldLoadForwarding
       .get(ctx.moduleId)
-      ?.get(expr.id) ?? [];
-  const forwardingStores: binaryen.ExpressionRef[] = [];
+      ?.get(loopExprId) ?? [];
+  const setup: binaryen.ExpressionRef[] = [];
   const forwardedBindings = new Map(fnCtx.stableFieldLoadBindings);
   forwardingGroups.forEach((group) => {
     const representative = group.accessExprIds[0];
@@ -1125,7 +1167,7 @@ export const compileWhileExpr = (
       ),
       ctx,
     );
-    forwardingStores.push(
+    setup.push(
       storeLocalValue({
         binding,
         value: compileExpr({ exprId: representative, ctx, fnCtx }).expr,
@@ -1139,26 +1181,11 @@ export const compileWhileExpr = (
   });
   const previousForwardedBindings = fnCtx.stableFieldLoadBindings;
   fnCtx.stableFieldLoadBindings = forwardedBindings;
-  const body = withLoopScope(
-    fnCtx,
-    { breakLabel, continueLabel: loopLabel },
-    () => compileExpr({ exprId: expr.body, ctx, fnCtx }).expr,
-  );
-  fnCtx.stableFieldLoadBindings = previousForwardedBindings;
-  const loopBody = ctx.mod.block(
-    null,
-    [conditionCheck, body, ctx.mod.br(loopLabel)],
-    binaryen.none,
-  );
-
-  return {
-    expr: ctx.mod.block(
-      breakLabel,
-      [...forwardingStores, ctx.mod.loop(loopLabel, loopBody)],
-      binaryen.none,
-    ),
-    usedReturnCall: false,
-  };
+  try {
+    return { setup, value: run() };
+  } finally {
+    fnCtx.stableFieldLoadBindings = previousForwardedBindings;
+  }
 };
 
 export const compileLoopExpr = (

--- a/packages/compiler/src/codegen/expressions/control-flow.ts
+++ b/packages/compiler/src/codegen/expressions/control-flow.ts
@@ -29,6 +29,7 @@ import {
 import { RTT_METADATA_SLOTS } from "../rtt/index.js";
 import {
   getInlineUnionLayout,
+  getExprBinaryenType,
   getOptionalLayoutInfo,
   getRequiredExprType,
   getStructuralTypeInfo,
@@ -1099,11 +1100,51 @@ export const compileWhileExpr = (
     ctx.mod.br(breakLabel),
   );
 
+  const forwardingGroups =
+    ctx.optimization?.stableFieldLoadForwarding
+      .get(ctx.moduleId)
+      ?.get(expr.id) ?? [];
+  const forwardingStores: binaryen.ExpressionRef[] = [];
+  const forwardedBindings = new Map(fnCtx.stableFieldLoadBindings);
+  forwardingGroups.forEach((group) => {
+    const representative = group.accessExprIds[0];
+    if (typeof representative !== "number") {
+      return;
+    }
+    const binding = allocateTempLocal(
+      getExprBinaryenType(
+        representative,
+        ctx,
+        fnCtx.typeInstanceId ?? fnCtx.instanceId,
+      ),
+      fnCtx,
+      getRequiredExprType(
+        representative,
+        ctx,
+        fnCtx.typeInstanceId ?? fnCtx.instanceId,
+      ),
+      ctx,
+    );
+    forwardingStores.push(
+      storeLocalValue({
+        binding,
+        value: compileExpr({ exprId: representative, ctx, fnCtx }).expr,
+        ctx,
+        fnCtx,
+      }),
+    );
+    group.accessExprIds.forEach((accessExprId) =>
+      forwardedBindings.set(accessExprId, binding),
+    );
+  });
+  const previousForwardedBindings = fnCtx.stableFieldLoadBindings;
+  fnCtx.stableFieldLoadBindings = forwardedBindings;
   const body = withLoopScope(
     fnCtx,
     { breakLabel, continueLabel: loopLabel },
     () => compileExpr({ exprId: expr.body, ctx, fnCtx }).expr,
   );
+  fnCtx.stableFieldLoadBindings = previousForwardedBindings;
   const loopBody = ctx.mod.block(
     null,
     [conditionCheck, body, ctx.mod.br(loopLabel)],
@@ -1113,7 +1154,7 @@ export const compileWhileExpr = (
   return {
     expr: ctx.mod.block(
       breakLabel,
-      [ctx.mod.loop(loopLabel, loopBody)],
+      [...forwardingStores, ctx.mod.loop(loopLabel, loopBody)],
       binaryen.none,
     ),
     usedReturnCall: false,

--- a/packages/compiler/src/codegen/expressions/mutations.ts
+++ b/packages/compiler/src/codegen/expressions/mutations.ts
@@ -41,6 +41,7 @@ import {
   wasmTypeFor,
 } from "../types.js";
 import type { ProgramFunctionInstanceId } from "../../semantics/ids.js";
+import { exactNominalForType } from "../optimization/runtime-type-checks.js";
 
 const storeIntoBinding = ({
   binding,
@@ -239,6 +240,16 @@ export const compileFieldAssignment = ({
     rootExpr?.exprKind === "identifier"
       ? fnCtx.bindings.get(rootExpr.symbol)
       : undefined;
+  const exactRootNominalTypeId = (() => {
+    if (rootExpr?.exprKind !== "identifier") {
+      return undefined;
+    }
+    const exactTypeId = fnCtx.exactParameterTypes?.get(rootExpr.symbol);
+    if (typeof exactTypeId !== "number") {
+      return undefined;
+    }
+    return exactNominalForType({ typeId: exactTypeId, ctx });
+  })();
   if (rootBinding?.kind === "scalar-aggregate" && segments.length === 1) {
     const field = rootBinding.structInfo.fieldMap.get(targetExpr.field);
     if (!field) {
@@ -366,6 +377,7 @@ export const compileFieldAssignment = ({
             ctx,
             fnCtx,
           }),
+          exactNominalTypeId: index === 0 ? exactRootNominalTypeId : undefined,
           ctx,
           fnCtx,
         }),

--- a/packages/compiler/src/codegen/expressions/objects.ts
+++ b/packages/compiler/src/codegen/expressions/objects.ts
@@ -572,6 +572,13 @@ export const compileFieldAccessExpr = (
   fnCtx: FunctionContext,
   compileExpr: ExpressionCompiler
 ): CompiledExpression => {
+  const forwardedBinding = fnCtx.stableFieldLoadBindings?.get(expr.id);
+  if (forwardedBinding) {
+    return {
+      expr: loadLocalValue(forwardedBinding, ctx),
+      usedReturnCall: false,
+    };
+  }
   const projected = tryCompileProjectedFieldAccess({
     expr,
     ctx,

--- a/packages/compiler/src/codegen/functions.ts
+++ b/packages/compiler/src/codegen/functions.ts
@@ -85,6 +85,7 @@ import {
   tryBindScalarAggregateParameter,
   tryStoreScalarAggregateExpression,
 } from "./optimization/scalar-aggregates.js";
+import { packMutableScalarAggregateResult } from "./optimization/mutable-scalar-aggregate-results.js";
 import {
   markScalarAggregateCallSpecializationCompiled,
   takePendingScalarAggregateCallSpecializations,
@@ -2148,17 +2149,34 @@ const compileMutableScalarAggregateParameterResult = ({
   if (binding?.kind !== "scalar-aggregate" || !binding.mutable) {
     throw new Error("mutable scalar aggregate parameter was not scalarized");
   }
+  const combinedResult = meta.scalarAggregateMutableCombinedResult;
+  if (!combinedResult) {
+    throw new Error(
+      "mutable scalar aggregate call is missing combined-result ABI metadata",
+    );
+  }
+  fnCtx.scalarAggregateMutableReturn = {
+    binding,
+    logicalResultAbiTypes: combinedResult.logicalAbiTypes,
+  };
   const body = compileExpression({
     exprId: fn.body,
     ctx,
     fnCtx,
     tailPosition: false,
-    expectedResultTypeId: ctx.program.primitives.void,
+    expectedResultTypeId: meta.resultTypeId,
   }).expr;
-  const result = loadScalarAggregateBindingAbiValue({ binding, ctx });
+  const result = packMutableScalarAggregateResult({
+    logicalValue: body,
+    logicalResultTypeId: meta.resultTypeId,
+    logicalResultAbiTypes: combinedResult.logicalAbiTypes,
+    binding,
+    ctx,
+    fnCtx,
+  });
   return ctx.mod.block(
     null,
-    [...paramInitOps, ...defaultInitOps, body, result],
+    [...paramInitOps, ...defaultInitOps, result],
     meta.resultType,
   );
 };

--- a/packages/compiler/src/codegen/functions.ts
+++ b/packages/compiler/src/codegen/functions.ts
@@ -526,7 +526,10 @@ const bindRawFunctionParameters = ({
         const scalarized = tryBindScalarAggregateParameter({
           symbol: param.symbol,
           typeId,
-          mutable: param.mutable,
+          mutable:
+            meta.scalarAggregateMutableParamIndex === index ||
+            param.mutable === true ||
+            param.pattern.bindingKind === "mutable-ref",
           abiValues,
           scalarAggregateAbi:
             meta.scalarAggregateParamIndexes?.includes(index) ?? false,
@@ -1988,6 +1991,24 @@ const compileFunctionItem = (
     ctx,
     fnCtx,
   });
+  const mutableScalarResultBody = compileMutableScalarAggregateParameterResult({
+    fn,
+    meta,
+    ctx,
+    fnCtx,
+    paramInitOps,
+    defaultInitOps,
+  });
+  if (mutableScalarResultBody) {
+    ctx.mod.addFunction(
+      meta.wasmName,
+      binaryen.createType(meta.paramTypes as number[]),
+      meta.resultType,
+      fnCtx.locals,
+      mutableScalarResultBody,
+    );
+    return;
+  }
   const scalarResultBody = compileScalarAggregateFunctionResult({
     fn,
     meta,
@@ -2097,6 +2118,48 @@ const compileFunctionItem = (
     meta.resultType,
     fnCtx.locals,
     functionBody,
+  );
+};
+
+const compileMutableScalarAggregateParameterResult = ({
+  fn,
+  meta,
+  ctx,
+  fnCtx,
+  paramInitOps,
+  defaultInitOps,
+}: {
+  fn: HirFunction;
+  meta: FunctionMetadata;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  paramInitOps: readonly binaryen.ExpressionRef[];
+  defaultInitOps: readonly binaryen.ExpressionRef[];
+}): binaryen.ExpressionRef | undefined => {
+  const paramIndex = meta.scalarAggregateMutableParamIndex;
+  if (typeof paramIndex !== "number") {
+    return undefined;
+  }
+  const param = fn.parameters[paramIndex];
+  const binding =
+    param && typeof param.symbol === "number"
+      ? fnCtx.bindings.get(param.symbol)
+      : undefined;
+  if (binding?.kind !== "scalar-aggregate" || !binding.mutable) {
+    throw new Error("mutable scalar aggregate parameter was not scalarized");
+  }
+  const body = compileExpression({
+    exprId: fn.body,
+    ctx,
+    fnCtx,
+    tailPosition: false,
+    expectedResultTypeId: ctx.program.primitives.void,
+  }).expr;
+  const result = loadScalarAggregateBindingAbiValue({ binding, ctx });
+  return ctx.mod.block(
+    null,
+    [...paramInitOps, ...defaultInitOps, body, result],
+    meta.resultType,
   );
 };
 

--- a/packages/compiler/src/codegen/locals.ts
+++ b/packages/compiler/src/codegen/locals.ts
@@ -443,15 +443,35 @@ export const materializeOwnedBinding = ({
     return { binding: existing, setup: [] };
   }
   if (existing.kind === "scalar-aggregate") {
+    const sharedBindings = Array.from(fnCtx.bindings.entries()).filter(
+      (
+        entry,
+      ): entry is [
+        SymbolId,
+        Extract<LocalBinding, { kind: "scalar-aggregate" }>,
+      ] =>
+        entry[1].kind === "scalar-aggregate" &&
+        entry[1].fields === existing.fields,
+    );
+    const needsMutableStorage = sharedBindings.some(
+      ([, candidate]) => candidate.mutable,
+    );
     const owned =
-      typeof existing.typeId === "number" &&
-      typeof getInlineHeapBoxType({ typeId: existing.typeId, ctx }) === "number"
-        ? allocateAddressableLocal({
+      typeof existing.typeId === "number" && needsMutableStorage
+        ? allocateMutableRefLocal({
             typeId: existing.typeId,
             ctx,
             fnCtx,
           })
-        : allocateTempLocal(existing.type, fnCtx, existing.typeId, ctx);
+        : typeof existing.typeId === "number" &&
+            typeof getInlineHeapBoxType({ typeId: existing.typeId, ctx }) ===
+              "number"
+          ? allocateAddressableLocal({
+              typeId: existing.typeId,
+              ctx,
+              fnCtx,
+            })
+          : allocateTempLocal(existing.type, fnCtx, existing.typeId, ctx);
     const setup = [
       storeLocalValue({
         binding: owned,
@@ -460,11 +480,14 @@ export const materializeOwnedBinding = ({
         fnCtx,
       }),
     ];
-    fnCtx.bindings.set(symbol, {
+    const materializedBinding: LocalBindingLocal = {
       ...owned,
       kind: "local",
       typeId: existing.typeId,
-    });
+    };
+    sharedBindings.forEach(([candidateSymbol]) =>
+      fnCtx.bindings.set(candidateSymbol, materializedBinding),
+    );
     return { binding: owned, setup };
   }
   if (existing.kind === "capture") {

--- a/packages/compiler/src/codegen/optimization/array-fast-paths.ts
+++ b/packages/compiler/src/codegen/optimization/array-fast-paths.ts
@@ -350,7 +350,10 @@ const isSafeArrayLoopRead = ({
   if (expr.method === "len" && expr.args.length === 0) {
     return true;
   }
-  if (expr.method !== "at" || expr.args.length !== 1) {
+  if (
+    (expr.method !== "at" && expr.method !== "get") ||
+    expr.args.length !== 1
+  ) {
     return false;
   }
   return expressionSymbol({ exprId: expr.args[0]!.expr, ctx }) === indexSymbol;
@@ -410,6 +413,51 @@ const isSafeLoopIntrinsicCall = ({
       }),
     )
   );
+};
+
+const isSafeLoopResolvedCall = ({
+  expr,
+  ctx,
+}: {
+  expr: HirCallExpr;
+  ctx: CodegenContext;
+}): boolean => {
+  const callInfo = ctx.program.calls.getCallInfo(ctx.moduleId, expr.id);
+  if (callInfo.traitDispatch || callInfo.identityGuards.length > 0) {
+    return false;
+  }
+  const targets = [...(callInfo.targets?.values() ?? [])];
+  if (targets.length === 0) {
+    const callee = ctx.module.hir.expressions.get(expr.callee);
+    const target =
+      callee?.exprKind === "identifier"
+        ? ctx.program.functions.getFunctionId({
+            moduleId: ctx.moduleId,
+            symbol: callee.symbol,
+          })
+        : undefined;
+    if (typeof target !== "number") {
+      return false;
+    }
+    targets.push(target);
+  }
+  return targets.every((target) => {
+    const footprint = ctx.program.callableAccesses.getFootprint(target);
+    return (
+      footprint !== undefined &&
+      !footprint.maySuspend &&
+      !footprint.externalRead &&
+      !footprint.externalWrite &&
+      footprint.parameters.every(
+        (parameter) =>
+          parameter.writePaths.length === 0 &&
+          !parameter.runtimeCheckedWrites &&
+          !parameter.retained &&
+          !parameter.returned &&
+          !parameter.returnedProvenance,
+      )
+    );
+  });
 };
 
 const isSafeLoopPrimitiveType = ({
@@ -557,7 +605,10 @@ const bodyPreservesArrayLoopProof = ({
           return "stop";
         }
         if (expr.exprKind === "call") {
-          if (!isSafeLoopIntrinsicCall({ expr, ctx, fnCtx })) {
+          if (
+            !isSafeLoopIntrinsicCall({ expr, ctx, fnCtx }) &&
+            !isSafeLoopResolvedCall({ expr, ctx })
+          ) {
             valid = false;
             return "stop";
           }
@@ -1673,6 +1724,108 @@ const compileArrayAtFastPath = ({
   };
 };
 
+const compileArrayGetFastPath = ({
+  expr,
+  info,
+  expectedResultTypeId,
+  ctx,
+  fnCtx,
+  compileExpr,
+}: {
+  expr: HirMethodCallExpr;
+  info: ArrayMethodInfo;
+  expectedResultTypeId?: TypeId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+}): CompiledExpression | undefined => {
+  if (expr.args.length !== 1) {
+    return undefined;
+  }
+
+  const safeLoopScope = activeSafeArrayLoopScope({ expr, fnCtx, ctx });
+  if (!safeLoopScope) {
+    return undefined;
+  }
+
+  const storageDesc = ctx.program.types.getTypeDesc(info.storageField.typeId);
+  if (storageDesc.kind !== "fixed-array") {
+    return undefined;
+  }
+
+  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+  const returnTypeId = getRequiredExprType(expr.id, ctx, typeInstanceId);
+  const resultTypeId = expectedResultTypeId ?? returnTypeId;
+  const resultWasmType = getExprBinaryenType(expr.id, ctx, typeInstanceId);
+  const storageLocal = allocateTempLocal(
+    wasmTypeFor(info.storageField.typeId, ctx),
+    fnCtx,
+    info.storageField.typeId,
+    ctx,
+  );
+  const indexLocal = allocateTempLocal(binaryen.i32, fnCtx);
+  const { setup: setupTarget, target } = compileArrayTarget({
+    expr,
+    info,
+    ctx,
+    fnCtx,
+    compileExpr,
+  });
+  const storage = () => loadLocalValue(storageLocal, ctx);
+  const index = () => ctx.mod.local.get(indexLocal.index, binaryen.i32);
+  const value = liftFixedArrayElementValue({
+    value: arrayGet(
+      ctx.mod,
+      storage(),
+      index(),
+      fixedArrayStorageElementType({ typeId: storageDesc.element, ctx }),
+      false,
+    ),
+    typeId: storageDesc.element,
+    ctx,
+    fnCtx,
+  });
+  const some = coerceValueToType({
+    value,
+    actualType: storageDesc.element,
+    targetType: resultTypeId,
+    ctx,
+    fnCtx,
+  });
+
+  return {
+    expr: ctx.mod.block(
+      null,
+      [
+        setupTarget,
+        ctx.mod.local.set(
+          indexLocal.index,
+          compileExpr({
+            exprId: expr.args[0]!.expr,
+            ctx,
+            fnCtx,
+            expectedResultTypeId: ctx.program.primitives.i32,
+          }).expr,
+        ),
+        storeLocalValue({
+          binding: storageLocal,
+          value: directArrayFieldLoad({
+            target,
+            structInfo: info.structInfo,
+            field: info.storageField,
+            ctx,
+          }),
+          ctx,
+          fnCtx,
+        }),
+        coerceExprToWasmType({ expr: some, targetType: resultWasmType, ctx }),
+      ],
+      resultWasmType,
+    ),
+    usedReturnCall: false,
+  };
+};
+
 export const tryCompileArrayMethodFastPath = ({
   expr,
   expectedResultTypeId,
@@ -1686,7 +1839,7 @@ export const tryCompileArrayMethodFastPath = ({
   fnCtx: FunctionContext;
   compileExpr: ExpressionCompiler;
 }): CompiledExpression | undefined => {
-  if (expr.method !== "len" && expr.method !== "at") {
+  if (expr.method !== "len" && expr.method !== "at" && expr.method !== "get") {
     return undefined;
   }
   const info = arrayMethodInfo({ expr, ctx, fnCtx });
@@ -1695,6 +1848,16 @@ export const tryCompileArrayMethodFastPath = ({
   }
   if (expr.method === "len") {
     return compileArrayLenFastPath({ expr, info, ctx, fnCtx, compileExpr });
+  }
+  if (expr.method === "get") {
+    return compileArrayGetFastPath({
+      expr,
+      info,
+      expectedResultTypeId,
+      ctx,
+      fnCtx,
+      compileExpr,
+    });
   }
   return compileArrayAtFastPath({
     expr,

--- a/packages/compiler/src/codegen/optimization/array-fast-paths.ts
+++ b/packages/compiler/src/codegen/optimization/array-fast-paths.ts
@@ -1077,15 +1077,17 @@ const isVoidLiteral = ({
   return expr?.exprKind === "literal" && expr.literalKind === "void";
 };
 
-const isCanonicalStdTraitMethodCall = ({
+export const isCanonicalStdTraitMethodCall = ({
   expr,
   traitName,
   methodName,
+  allowExternalImplementations = false,
   ctx,
 }: {
   expr: HirMethodCallExpr;
   traitName: "Sequence" | "Iterator";
   methodName: "iter" | "next";
+  allowExternalImplementations?: boolean;
   ctx: CodegenContext;
 }): boolean => {
   if (
@@ -1106,8 +1108,9 @@ const isCanonicalStdTraitMethodCall = ({
   return [...targets].every((target) => {
     const traitMethod = ctx.program.traits.getTraitMethodImpl(target);
     return (
-      ctx.program.symbols.getPackageId(target) === "std" &&
-      ctx.program.symbols.getName(target) === methodName &&
+      (allowExternalImplementations ||
+        (ctx.program.symbols.getPackageId(target) === "std" &&
+          ctx.program.symbols.getName(target) === methodName)) &&
       traitMethod !== undefined &&
       ctx.program.symbols.getPackageId(traitMethod.traitSymbol) === "std" &&
       ctx.program.symbols.getName(traitMethod.traitSymbol) === traitName &&
@@ -1174,18 +1177,21 @@ const parseArrayForIterator = ({
   };
 };
 
-const parseArrayForBody = ({
+export const parseCanonicalStdForBody = ({
   whileExpr,
   iteratorSymbol,
+  allowExternalImplementations = false,
   ctx,
 }: {
   whileExpr: HirWhileExpr;
   iteratorSymbol: SymbolId;
+  allowExternalImplementations?: boolean;
   ctx: CodegenContext;
 }):
   | {
       elementPattern: HirPattern;
       userStatements: readonly number[];
+      nextCall: HirMethodCallExpr;
     }
   | undefined => {
   if (!isLiteralBoolean({ exprId: whileExpr.condition, value: "true", ctx })) {
@@ -1212,6 +1218,7 @@ const parseArrayForBody = ({
       expr: nextCall,
       traitName: "Iterator",
       methodName: "next",
+      allowExternalImplementations,
       ctx,
     })
   ) {
@@ -1297,6 +1304,7 @@ const parseArrayForBody = ({
   return {
     elementPattern: elementStmt.pattern,
     userStatements: someBlock.statements.slice(1),
+    nextCall,
   };
 };
 
@@ -1341,7 +1349,7 @@ const tryAnalyzeArrayForLoop = ({
   if (!iterator || whileExpr?.exprKind !== "while") {
     return undefined;
   }
-  const body = parseArrayForBody({
+  const body = parseCanonicalStdForBody({
     whileExpr,
     iteratorSymbol: iteratorStmt.pattern.symbol,
     ctx,

--- a/packages/compiler/src/codegen/optimization/array-fast-paths.ts
+++ b/packages/compiler/src/codegen/optimization/array-fast-paths.ts
@@ -37,10 +37,12 @@ import {
 } from "../structural.js";
 import {
   getExprBinaryenType,
+  getMatchPatternTypeId,
   getRequiredExprType,
   getStructuralTypeInfo,
   wasmTypeFor,
 } from "../types.js";
+import { compilePatternInitializationFromValue } from "../patterns.js";
 import { coerceExprToWasmType } from "../wasm-type-coercions.js";
 import {
   isStdIntrinsicNominalType,
@@ -70,6 +72,16 @@ type RangeForLoopAnalysis = {
   userBodyExpr: HirExprId;
   userStatements: readonly number[];
   safeArrayScope?: SafeArrayLoopScope;
+};
+
+type ArrayForLoopAnalysis = {
+  whileExpr: HirWhileExpr;
+  arrayExpr: HirExprId;
+  arrayTypeId: TypeId;
+  arrayInfo: ArrayMethodInfo;
+  elementTypeId: TypeId;
+  elementPattern: HirPattern;
+  userStatements: readonly number[];
 };
 
 type StatementCompiler = (stmtId: number) => binaryen.ExpressionRef;
@@ -1034,6 +1046,498 @@ const patternTypeName = (pattern: HirPattern): string | undefined => {
     return undefined;
   }
   return pattern.type.path.at(-1);
+};
+
+const isStdIntrinsicTypePattern = ({
+  pattern,
+  intrinsicType,
+  ctx,
+}: {
+  pattern: HirPattern;
+  intrinsicType:
+    | typeof STD_INTRINSIC_TYPE.optionalSome
+    | typeof STD_INTRINSIC_TYPE.optionalNone;
+  ctx: CodegenContext;
+}): boolean =>
+  pattern.kind === "type" &&
+  isStdIntrinsicNominalType({
+    program: ctx.program,
+    typeId: getMatchPatternTypeId(pattern, ctx),
+    intrinsicType,
+  });
+
+const isVoidLiteral = ({
+  exprId,
+  ctx,
+}: {
+  exprId: HirExprId;
+  ctx: CodegenContext;
+}): boolean => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  return expr?.exprKind === "literal" && expr.literalKind === "void";
+};
+
+const isCanonicalStdTraitMethodCall = ({
+  expr,
+  traitName,
+  methodName,
+  ctx,
+}: {
+  expr: HirMethodCallExpr;
+  traitName: "Sequence" | "Iterator";
+  methodName: "iter" | "next";
+  ctx: CodegenContext;
+}): boolean => {
+  if (
+    expr.method !== methodName ||
+    expr.args.length !== 0 ||
+    ctx.program.calls.getCallInfo(ctx.moduleId, expr.id).identityGuards.length >
+      0
+  ) {
+    return false;
+  }
+  const targets = new Set(
+    ctx.program.calls.getCallInfo(ctx.moduleId, expr.id).targets?.values() ??
+      [],
+  );
+  if (targets.size !== 1) {
+    return false;
+  }
+  return [...targets].every((target) => {
+    const traitMethod = ctx.program.traits.getTraitMethodImpl(target);
+    return (
+      ctx.program.symbols.getPackageId(target) === "std" &&
+      ctx.program.symbols.getName(target) === methodName &&
+      traitMethod !== undefined &&
+      ctx.program.symbols.getPackageId(traitMethod.traitSymbol) === "std" &&
+      ctx.program.symbols.getName(traitMethod.traitSymbol) === traitName &&
+      ctx.program.symbols.getPackageId(traitMethod.traitMethodSymbol) ===
+        "std" &&
+      ctx.program.symbols.getName(traitMethod.traitMethodSymbol) === methodName
+    );
+  });
+};
+
+const parseArrayForIterator = ({
+  initializer,
+  ctx,
+  fnCtx,
+}: {
+  initializer: HirExprId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}):
+  | {
+      arrayExpr: HirExprId;
+      arrayTypeId: TypeId;
+      arrayInfo: ArrayMethodInfo;
+      elementTypeId: TypeId;
+    }
+  | undefined => {
+  const iterCall = ctx.module.hir.expressions.get(initializer);
+  if (
+    iterCall?.exprKind !== "method-call" ||
+    !isCanonicalStdTraitMethodCall({
+      expr: iterCall,
+      traitName: "Sequence",
+      methodName: "iter",
+      ctx,
+    })
+  ) {
+    return undefined;
+  }
+  const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
+  const arrayTypeId = getRequiredExprType(iterCall.target, ctx, typeInstanceId);
+  if (!isStdArrayType({ typeId: arrayTypeId, ctx })) {
+    return undefined;
+  }
+  const structInfo = getStructuralTypeInfo(arrayTypeId, ctx);
+  const storageField = structInfo?.fieldMap.get("storage");
+  const countField = structInfo?.fieldMap.get("count");
+  if (!structInfo || !storageField || !countField) {
+    return undefined;
+  }
+  const storageDesc = ctx.program.types.getTypeDesc(storageField.typeId);
+  if (storageDesc.kind !== "fixed-array") {
+    return undefined;
+  }
+  return {
+    arrayExpr: iterCall.target,
+    arrayTypeId,
+    arrayInfo: {
+      targetTypeId: arrayTypeId,
+      structInfo,
+      storageField,
+      countField,
+    },
+    elementTypeId: storageDesc.element,
+  };
+};
+
+const parseArrayForBody = ({
+  whileExpr,
+  iteratorSymbol,
+  ctx,
+}: {
+  whileExpr: HirWhileExpr;
+  iteratorSymbol: SymbolId;
+  ctx: CodegenContext;
+}):
+  | {
+      elementPattern: HirPattern;
+      userStatements: readonly number[];
+    }
+  | undefined => {
+  if (!isLiteralBoolean({ exprId: whileExpr.condition, value: "true", ctx })) {
+    return undefined;
+  }
+  const body = ctx.module.hir.expressions.get(whileExpr.body);
+  if (body?.exprKind !== "block" || body.statements.length !== 1) {
+    return undefined;
+  }
+  const nextStmt = ctx.module.hir.statements.get(body.statements[0]!);
+  if (
+    nextStmt?.kind !== "let" ||
+    nextStmt.mutable ||
+    nextStmt.pattern.kind !== "identifier"
+  ) {
+    return undefined;
+  }
+  const nextValueSymbol = nextStmt.pattern.symbol;
+  const nextCall = ctx.module.hir.expressions.get(nextStmt.initializer);
+  if (
+    nextCall?.exprKind !== "method-call" ||
+    expressionSymbol({ exprId: nextCall.target, ctx }) !== iteratorSymbol ||
+    !isCanonicalStdTraitMethodCall({
+      expr: nextCall,
+      traitName: "Iterator",
+      methodName: "next",
+      ctx,
+    })
+  ) {
+    return undefined;
+  }
+  const match =
+    typeof body.value === "number"
+      ? ctx.module.hir.expressions.get(body.value)
+      : undefined;
+  if (
+    match?.exprKind !== "match" ||
+    match.arms.length !== 2 ||
+    expressionSymbol({ exprId: match.discriminant, ctx }) !== nextValueSymbol
+  ) {
+    return undefined;
+  }
+  const [someArm, noneArm] = match.arms;
+  if (
+    !someArm ||
+    !noneArm ||
+    someArm.guard !== undefined ||
+    noneArm.guard !== undefined ||
+    someArm.pattern.kind !== "type" ||
+    someArm.pattern.binding !== undefined ||
+    !isStdIntrinsicTypePattern({
+      pattern: someArm.pattern,
+      intrinsicType: STD_INTRINSIC_TYPE.optionalSome,
+      ctx,
+    }) ||
+    noneArm.pattern.kind !== "type" ||
+    noneArm.pattern.binding !== undefined ||
+    !isStdIntrinsicTypePattern({
+      pattern: noneArm.pattern,
+      intrinsicType: STD_INTRINSIC_TYPE.optionalNone,
+      ctx,
+    }) ||
+    !isBreakBlock({ exprId: noneArm.value, ctx })
+  ) {
+    return undefined;
+  }
+  const someBlock = ctx.module.hir.expressions.get(someArm.value);
+  if (
+    someBlock?.exprKind !== "block" ||
+    someBlock.statements.length === 0 ||
+    typeof someBlock.value !== "number" ||
+    !isVoidLiteral({ exprId: someBlock.value, ctx })
+  ) {
+    return undefined;
+  }
+  const elementStmt = ctx.module.hir.statements.get(someBlock.statements[0]!);
+  if (elementStmt?.kind !== "let" || elementStmt.mutable) {
+    return undefined;
+  }
+  const payload = ctx.module.hir.expressions.get(elementStmt.initializer);
+  if (
+    payload?.exprKind !== "field-access" ||
+    payload.field !== "value" ||
+    expressionSymbol({ exprId: payload.target, ctx }) !== nextValueSymbol
+  ) {
+    return undefined;
+  }
+  let usesMacroTemporary = false;
+  walkHirExpression({
+    exprId: someArm.value,
+    ctx,
+    visitor: {
+      onExpr: (exprId, expr) => {
+        if (
+          expr.exprKind !== "identifier" ||
+          (expr.symbol !== iteratorSymbol &&
+            (expr.symbol !== nextValueSymbol || exprId === payload.target))
+        ) {
+          return;
+        }
+        usesMacroTemporary = true;
+        return "stop";
+      },
+    },
+  });
+  if (usesMacroTemporary) {
+    return undefined;
+  }
+  return {
+    elementPattern: elementStmt.pattern,
+    userStatements: someBlock.statements.slice(1),
+  };
+};
+
+const tryAnalyzeArrayForLoop = ({
+  block,
+  statementIndex,
+  ctx,
+  fnCtx,
+}: {
+  block: HirBlockExpr;
+  statementIndex: number;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): ArrayForLoopAnalysis | undefined => {
+  const currentStmt = ctx.module.hir.statements.get(
+    block.statements[statementIndex]!,
+  );
+  if (currentStmt?.kind !== "expr-stmt") {
+    return undefined;
+  }
+  const wrapper = ctx.module.hir.expressions.get(currentStmt.expr);
+  if (wrapper?.exprKind !== "block" || wrapper.statements.length !== 1) {
+    return undefined;
+  }
+  const iteratorStmt = ctx.module.hir.statements.get(wrapper.statements[0]!);
+  if (
+    iteratorStmt?.kind !== "let" ||
+    iteratorStmt.mutable ||
+    iteratorStmt.pattern.kind !== "identifier"
+  ) {
+    return undefined;
+  }
+  const iterator = parseArrayForIterator({
+    initializer: iteratorStmt.initializer,
+    ctx,
+    fnCtx,
+  });
+  const whileExpr =
+    typeof wrapper.value === "number"
+      ? ctx.module.hir.expressions.get(wrapper.value)
+      : undefined;
+  if (!iterator || whileExpr?.exprKind !== "while") {
+    return undefined;
+  }
+  const body = parseArrayForBody({
+    whileExpr,
+    iteratorSymbol: iteratorStmt.pattern.symbol,
+    ctx,
+  });
+  return body
+    ? {
+        whileExpr,
+        ...iterator,
+        ...body,
+      }
+    : undefined;
+};
+
+const compileArrayForLoop = ({
+  analysis,
+  ctx,
+  fnCtx,
+  compileExpr,
+  compileStatement,
+}: {
+  analysis: ArrayForLoopAnalysis;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+  compileStatement: StatementCompiler;
+}): binaryen.ExpressionRef => {
+  const { loopLabel, breakLabel } = allocateLoopLabels({
+    fnCtx,
+    prefix: "array_for_loop",
+  });
+  const arrayLocal = allocateTempLocal(
+    wasmTypeFor(analysis.arrayTypeId, ctx),
+    fnCtx,
+    analysis.arrayTypeId,
+    ctx,
+  );
+  const storageLocal = allocateTempLocal(
+    wasmTypeFor(analysis.arrayInfo.storageField.typeId, ctx),
+    fnCtx,
+    analysis.arrayInfo.storageField.typeId,
+    ctx,
+  );
+  const cursorLocal = allocateTempLocal(
+    binaryen.i32,
+    fnCtx,
+    ctx.program.primitives.i32,
+    ctx,
+  );
+  const array = () => loadLocalValue(arrayLocal, ctx);
+  const storage = () => loadLocalValue(storageLocal, ctx);
+  const cursor = () => ctx.mod.local.get(cursorLocal.index, binaryen.i32);
+  const previousBindings = new Map(fnCtx.bindings);
+  const { setup: forwardingStores, value: body } = (() => {
+    try {
+      return withStableFieldLoadForwarding({
+        loopExprId: analysis.whileExpr.id,
+        ctx,
+        fnCtx,
+        compileExpr,
+        run: () => {
+          const itemOps: binaryen.ExpressionRef[] = [];
+          const item = liftFixedArrayElementValue({
+            value: arrayGet(
+              ctx.mod,
+              storage(),
+              cursor(),
+              fixedArrayStorageElementType({
+                typeId: analysis.elementTypeId,
+                ctx,
+              }),
+              false,
+            ),
+            typeId: analysis.elementTypeId,
+            ctx,
+            fnCtx,
+          });
+          compilePatternInitializationFromValue({
+            pattern: analysis.elementPattern,
+            value: item,
+            valueTypeId: analysis.elementTypeId,
+            ctx,
+            fnCtx,
+            ops: itemOps,
+            options: { declare: true },
+          });
+          const userBody = withLoopScope(
+            fnCtx,
+            { breakLabel, continueLabel: loopLabel },
+            () =>
+              ctx.mod.block(
+                null,
+                analysis.userStatements.map((stmtId) =>
+                  compileStatement(stmtId),
+                ),
+                binaryen.none,
+              ),
+          );
+          return ctx.mod.block(
+            null,
+            [
+              ...itemOps,
+              ctx.mod.local.set(
+                cursorLocal.index,
+                ctx.mod.i32.add(cursor(), ctx.mod.i32.const(1)),
+              ),
+              userBody,
+            ],
+            binaryen.none,
+          );
+        },
+      });
+    } finally {
+      fnCtx.bindings = previousBindings;
+    }
+  })();
+  const count = directArrayFieldLoad({
+    target: array,
+    structInfo: analysis.arrayInfo.structInfo,
+    field: analysis.arrayInfo.countField,
+    ctx,
+  });
+  const conditionCheck = ctx.mod.if(
+    ctx.mod.i32.ge_s(cursor(), count),
+    ctx.mod.br(breakLabel),
+  );
+  const loadStorage = storeLocalValue({
+    binding: storageLocal,
+    value: directArrayFieldLoad({
+      target: array,
+      structInfo: analysis.arrayInfo.structInfo,
+      field: analysis.arrayInfo.storageField,
+      ctx,
+    }),
+    ctx,
+    fnCtx,
+  });
+  const loopBody = ctx.mod.block(
+    null,
+    [conditionCheck, loadStorage, body, ctx.mod.br(loopLabel)],
+    binaryen.none,
+  );
+  return ctx.mod.block(
+    breakLabel,
+    [
+      storeLocalValue({
+        binding: arrayLocal,
+        value: compileExpr({
+          exprId: analysis.arrayExpr,
+          ctx,
+          fnCtx,
+          expectedResultTypeId: analysis.arrayTypeId,
+        }).expr,
+        ctx,
+        fnCtx,
+      }),
+      ctx.mod.local.set(cursorLocal.index, ctx.mod.i32.const(0)),
+      ...forwardingStores,
+      ctx.mod.loop(loopLabel, loopBody),
+    ],
+    binaryen.none,
+  );
+};
+
+export const tryCompileArrayForStatement = ({
+  block,
+  statementIndex,
+  ctx,
+  fnCtx,
+  compileExpr,
+  compileStatement,
+}: {
+  block: HirBlockExpr;
+  statementIndex: number;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compileExpr: ExpressionCompiler;
+  compileStatement: StatementCompiler;
+}): binaryen.ExpressionRef | undefined => {
+  if (fnCtx.effectful) {
+    return undefined;
+  }
+  const analysis = tryAnalyzeArrayForLoop({
+    block,
+    statementIndex,
+    ctx,
+    fnCtx,
+  });
+  return analysis
+    ? compileArrayForLoop({
+        analysis,
+        ctx,
+        fnCtx,
+        compileExpr,
+        compileStatement,
+      })
+    : undefined;
 };
 
 const somePayloadExpr = ({

--- a/packages/compiler/src/codegen/optimization/array-fast-paths.ts
+++ b/packages/compiler/src/codegen/optimization/array-fast-paths.ts
@@ -22,6 +22,7 @@ import type {
   TypeId,
 } from "../context.js";
 import { allocateLoopLabels, withLoopScope } from "../control-flow-stack.js";
+import { withStableFieldLoadForwarding } from "../expressions/control-flow.js";
 import { walkHirExpression } from "../hir-walk.js";
 import {
   allocateTempLocal,
@@ -43,6 +44,7 @@ import {
 import { coerceExprToWasmType } from "../wasm-type-coercions.js";
 import {
   isStdIntrinsicNominalType,
+  isStdIntrinsicNominalTypeInstantiation,
   STD_INTRINSIC_TYPE,
 } from "../../compiler-contracts/types.js";
 
@@ -59,10 +61,15 @@ type SafeArrayWhileLoopAnalysis = {
   cachedLengthExpr?: HirExprId;
 };
 
-type SafeArrayForLoopAnalysis = {
-  scope: SafeArrayLoopScope;
-  lengthExpr: HirExprId;
+type RangeForLoopAnalysis = {
+  whileExpr: HirWhileExpr;
+  startExpr: HirExprId;
+  endExpr: HirExprId;
+  includeEnd: boolean;
+  indexSymbol: SymbolId;
+  userBodyExpr: HirExprId;
   userStatements: readonly number[];
+  safeArrayScope?: SafeArrayLoopScope;
 };
 
 type StatementCompiler = (stmtId: number) => binaryen.ExpressionRef;
@@ -889,9 +896,7 @@ const loadI32Local = ({
     return undefined;
   }
   const value = loadLocalValue(binding, ctx);
-  return binaryen.getExpressionType(value) === binaryen.i32
-    ? value
-    : undefined;
+  return binaryen.getExpressionType(value) === binaryen.i32 ? value : undefined;
 };
 
 const withSafeArrayLoopScope = <T>({
@@ -1058,7 +1063,14 @@ const parseRangeForIterator = ({
   initializer: HirExprId;
   ctx: CodegenContext;
   fnCtx: FunctionContext;
-}): { arraySymbol: SymbolId; lengthExpr: HirExprId } | undefined => {
+}):
+  | {
+      startExpr: HirExprId;
+      endExpr: HirExprId;
+      includeEnd: boolean;
+      safeArray?: { arraySymbol: SymbolId };
+    }
+  | undefined => {
   const iterCall = ctx.module.hir.expressions.get(initializer);
   if (
     iterCall?.exprKind !== "method-call" ||
@@ -1074,10 +1086,11 @@ const parseRangeForIterator = ({
   const typeInstanceId = fnCtx.typeInstanceId ?? fnCtx.instanceId;
   const rangeTypeId = getRequiredExprType(iterCall.target, ctx, typeInstanceId);
   if (
-    !isStdIntrinsicNominalType({
+    !isStdIntrinsicNominalTypeInstantiation({
       program: ctx.program,
       typeId: rangeTypeId,
       intrinsicType: STD_INTRINSIC_TYPE.range,
+      typeArgs: [ctx.program.primitives.i32],
     })
   ) {
     return undefined;
@@ -1094,19 +1107,25 @@ const parseRangeForIterator = ({
   if (!start || start.kind !== "field" || !end || end.kind !== "field") {
     return undefined;
   }
-  if (
-    !includeEnd ||
-    includeEnd.kind !== "field" ||
-    !isLiteralBoolean({ exprId: includeEnd.value, value: "false", ctx })
-  ) {
+  if (!includeEnd || includeEnd.kind !== "field") {
     return undefined;
   }
   const startValue = somePayloadExpr({ exprId: start.value, ctx });
   const endValue = somePayloadExpr({ exprId: end.value, ctx });
+  const isInclusive = isLiteralBoolean({
+    exprId: includeEnd.value,
+    value: "true",
+    ctx,
+  });
+  const isHalfOpen = isLiteralBoolean({
+    exprId: includeEnd.value,
+    value: "false",
+    ctx,
+  });
   if (
     typeof startValue !== "number" ||
-    !isLiteralI32({ exprId: startValue, value: "0", ctx }) ||
-    typeof endValue !== "number"
+    typeof endValue !== "number" ||
+    (!isInclusive && !isHalfOpen)
   ) {
     return undefined;
   }
@@ -1115,12 +1134,18 @@ const parseRangeForIterator = ({
     ctx,
     fnCtx,
   });
-  return length
-    ? {
-        arraySymbol: length.arraySymbol,
-        lengthExpr: endValue,
-      }
-    : undefined;
+  const safeArray =
+    isHalfOpen &&
+    isLiteralI32({ exprId: startValue, value: "0", ctx }) &&
+    length
+      ? { arraySymbol: length.arraySymbol }
+      : undefined;
+  return {
+    startExpr: startValue,
+    endExpr: endValue,
+    includeEnd: isInclusive,
+    safeArray,
+  };
 };
 
 const isLiteralBoolean = ({
@@ -1162,17 +1187,17 @@ const isBreakBlock = ({
 const parseRangeForBody = ({
   whileExpr,
   iteratorSymbol,
-  arraySymbol,
   ctx,
-  fnCtx,
 }: {
   whileExpr: HirWhileExpr;
   iteratorSymbol: SymbolId;
-  arraySymbol: SymbolId;
   ctx: CodegenContext;
-  fnCtx: FunctionContext;
 }):
-  | { indexSymbol: SymbolId; userStatements: readonly number[] }
+  | {
+      indexSymbol: SymbolId;
+      userBodyExpr: HirExprId;
+      userStatements: readonly number[];
+    }
   | undefined => {
   if (!isLiteralBoolean({ exprId: whileExpr.condition, value: "true", ctx })) {
     return undefined;
@@ -1194,6 +1219,7 @@ const parseRangeForBody = ({
   if (
     nextCall?.exprKind !== "method-call" ||
     nextCall.method !== "next" ||
+    nextCall.args.length !== 0 ||
     expressionSymbol({ exprId: nextCall.target, ctx }) !== iteratorSymbol
   ) {
     return undefined;
@@ -1204,6 +1230,7 @@ const parseRangeForBody = ({
       : undefined;
   if (
     match?.exprKind !== "match" ||
+    match.arms.length !== 2 ||
     expressionSymbol({ exprId: match.discriminant, ctx }) !== nextValueSymbol
   ) {
     return undefined;
@@ -1238,25 +1265,14 @@ const parseRangeForBody = ({
     return undefined;
   }
   const indexSymbol = indexStmt.pattern.symbol;
-  if (
-    !bodyPreservesArrayLoopProof({
-      bodyExprId: someArm.value,
-      indexSymbol,
-      arraySymbol,
-      indexUpdate: "none",
-      ctx,
-      fnCtx,
-    })
-  ) {
-    return undefined;
-  }
   return {
     indexSymbol,
+    userBodyExpr: someArm.value,
     userStatements: someBlock.statements.slice(1),
   };
 };
 
-const tryAnalyzeSafeArrayForLoop = ({
+const tryAnalyzeRangeForLoop = ({
   block,
   statementIndex,
   ctx,
@@ -1266,7 +1282,7 @@ const tryAnalyzeSafeArrayForLoop = ({
   statementIndex: number;
   ctx: CodegenContext;
   fnCtx: FunctionContext;
-}): SafeArrayForLoopAnalysis | undefined => {
+}): RangeForLoopAnalysis | undefined => {
   const currentStmt = ctx.module.hir.statements.get(
     block.statements[statementIndex]!,
   );
@@ -1300,31 +1316,45 @@ const tryAnalyzeSafeArrayForLoop = ({
   const body = parseRangeForBody({
     whileExpr,
     iteratorSymbol: iteratorStmt.pattern.symbol,
-    arraySymbol: iterator.arraySymbol,
     ctx,
-    fnCtx,
   });
   if (!body) {
     return undefined;
   }
   return {
-    scope: {
-      arraySymbol: iterator.arraySymbol,
-      indexSymbol: body.indexSymbol,
-    },
-    lengthExpr: iterator.lengthExpr,
+    whileExpr,
+    startExpr: iterator.startExpr,
+    endExpr: iterator.endExpr,
+    includeEnd: iterator.includeEnd,
+    indexSymbol: body.indexSymbol,
+    userBodyExpr: body.userBodyExpr,
     userStatements: body.userStatements,
+    safeArrayScope:
+      iterator.safeArray &&
+      bodyPreservesArrayLoopProof({
+        bodyExprId: body.userBodyExpr,
+        indexSymbol: body.indexSymbol,
+        arraySymbol: iterator.safeArray.arraySymbol,
+        indexUpdate: "none",
+        ctx,
+        fnCtx,
+      })
+        ? {
+            arraySymbol: iterator.safeArray.arraySymbol,
+            indexSymbol: body.indexSymbol,
+          }
+        : undefined,
   };
 };
 
-const compileSafeArrayForLoop = ({
+const compileRangeForLoop = ({
   analysis,
   ctx,
   fnCtx,
   compileExpr,
   compileStatement,
 }: {
-  analysis: SafeArrayForLoopAnalysis;
+  analysis: RangeForLoopAnalysis;
   ctx: CodegenContext;
   fnCtx: FunctionContext;
   compileExpr: ExpressionCompiler;
@@ -1332,65 +1362,97 @@ const compileSafeArrayForLoop = ({
 }): binaryen.ExpressionRef => {
   const { loopLabel, breakLabel } = allocateLoopLabels({
     fnCtx,
-    prefix: "array_safe_for_loop",
+    prefix: "range_for_loop",
   });
-  const lengthLocal = allocateTempLocal(binaryen.i32, fnCtx);
+  const cursorLocal = allocateTempLocal(
+    binaryen.i32,
+    fnCtx,
+    ctx.program.primitives.i32,
+    ctx,
+  );
+  const endLocal = allocateTempLocal(binaryen.i32, fnCtx);
   const indexLocal = allocateTempLocal(
     binaryen.i32,
     fnCtx,
     ctx.program.primitives.i32,
     ctx,
   );
-  const previousIndexBinding = fnCtx.bindings.get(analysis.scope.indexSymbol);
-  fnCtx.bindings.set(analysis.scope.indexSymbol, {
+  const doneLocal = analysis.includeEnd
+    ? allocateTempLocal(binaryen.i32, fnCtx)
+    : undefined;
+  const previousIndexBinding = fnCtx.bindings.get(analysis.indexSymbol);
+  fnCtx.bindings.set(analysis.indexSymbol, {
     ...indexLocal,
     kind: "local",
     typeId: ctx.program.primitives.i32,
   });
-  const body = (() => {
+  const { setup: forwardingStores, value: body } = (() => {
     try {
-      return withSafeArrayLoopScope({
-        scope: analysis.scope,
+      return withStableFieldLoadForwarding({
+        loopExprId: analysis.whileExpr.id,
+        ctx,
         fnCtx,
-        run: () =>
-          withLoopScope(fnCtx, { breakLabel, continueLabel: loopLabel }, () =>
-            ctx.mod.block(
-              null,
-              analysis.userStatements.map((stmtId) => compileStatement(stmtId)),
-              binaryen.none,
-            ),
-          ),
+        compileExpr,
+        run: () => {
+          const compileBody = () =>
+            withLoopScope(fnCtx, { breakLabel, continueLabel: loopLabel }, () =>
+              ctx.mod.block(
+                null,
+                analysis.userStatements.map((stmtId) =>
+                  compileStatement(stmtId),
+                ),
+                binaryen.none,
+              ),
+            );
+          return analysis.safeArrayScope
+            ? withSafeArrayLoopScope({
+                scope: analysis.safeArrayScope,
+                fnCtx,
+                run: compileBody,
+              })
+            : compileBody();
+        },
       });
     } finally {
       if (previousIndexBinding) {
-        fnCtx.bindings.set(analysis.scope.indexSymbol, previousIndexBinding);
+        fnCtx.bindings.set(analysis.indexSymbol, previousIndexBinding);
       } else {
-        fnCtx.bindings.delete(analysis.scope.indexSymbol);
+        fnCtx.bindings.delete(analysis.indexSymbol);
       }
     }
   })();
 
+  const cursor = () => ctx.mod.local.get(cursorLocal.index, binaryen.i32);
+  const end = () => ctx.mod.local.get(endLocal.index, binaryen.i32);
   const conditionCheck = ctx.mod.if(
-    ctx.mod.i32.eqz(
-      ctx.mod.i32.lt_s(
-        ctx.mod.local.get(indexLocal.index, binaryen.i32),
-        ctx.mod.local.get(lengthLocal.index, binaryen.i32),
-      ),
-    ),
+    analysis.includeEnd
+      ? ctx.mod.i32.or(
+          ctx.mod.local.get(doneLocal!.index, binaryen.i32),
+          ctx.mod.i32.gt_s(cursor(), end()),
+        )
+      : ctx.mod.i32.ge_s(cursor(), end()),
     ctx.mod.br(breakLabel),
   );
+  const advance = analysis.includeEnd
+    ? ctx.mod.if(
+        ctx.mod.i32.eq(cursor(), end()),
+        ctx.mod.local.set(doneLocal!.index, ctx.mod.i32.const(1)),
+        ctx.mod.local.set(
+          cursorLocal.index,
+          ctx.mod.i32.add(cursor(), ctx.mod.i32.const(1)),
+        ),
+      )
+    : ctx.mod.local.set(
+        cursorLocal.index,
+        ctx.mod.i32.add(cursor(), ctx.mod.i32.const(1)),
+      );
   const loopBody = ctx.mod.block(
     null,
     [
       conditionCheck,
+      ctx.mod.local.set(indexLocal.index, cursor()),
+      advance,
       body,
-      ctx.mod.local.set(
-        indexLocal.index,
-        ctx.mod.i32.add(
-          ctx.mod.local.get(indexLocal.index, binaryen.i32),
-          ctx.mod.i32.const(1),
-        ),
-      ),
       ctx.mod.br(loopLabel),
     ],
     binaryen.none,
@@ -1399,22 +1461,34 @@ const compileSafeArrayForLoop = ({
     breakLabel,
     [
       ctx.mod.local.set(
-        lengthLocal.index,
+        cursorLocal.index,
         compileExpr({
-          exprId: analysis.lengthExpr,
+          exprId: analysis.startExpr,
           ctx,
           fnCtx,
           expectedResultTypeId: ctx.program.primitives.i32,
         }).expr,
       ),
-      ctx.mod.local.set(indexLocal.index, ctx.mod.i32.const(0)),
+      ctx.mod.local.set(
+        endLocal.index,
+        compileExpr({
+          exprId: analysis.endExpr,
+          ctx,
+          fnCtx,
+          expectedResultTypeId: ctx.program.primitives.i32,
+        }).expr,
+      ),
+      ...(doneLocal
+        ? [ctx.mod.local.set(doneLocal.index, ctx.mod.i32.const(0))]
+        : []),
+      ...forwardingStores,
       ctx.mod.loop(loopLabel, loopBody),
     ],
     binaryen.none,
   );
 };
 
-export const tryCompileArraySafeForStatement = ({
+export const tryCompileRangeForStatement = ({
   block,
   statementIndex,
   ctx,
@@ -1429,14 +1503,17 @@ export const tryCompileArraySafeForStatement = ({
   compileExpr: ExpressionCompiler;
   compileStatement: StatementCompiler;
 }): binaryen.ExpressionRef | undefined => {
-  const analysis = tryAnalyzeSafeArrayForLoop({
+  if (fnCtx.effectful) {
+    return undefined;
+  }
+  const analysis = tryAnalyzeRangeForLoop({
     block,
     statementIndex,
     ctx,
     fnCtx,
   });
   return analysis
-    ? compileSafeArrayForLoop({
+    ? compileRangeForLoop({
         analysis,
         ctx,
         fnCtx,

--- a/packages/compiler/src/codegen/optimization/iterator-fast-paths.ts
+++ b/packages/compiler/src/codegen/optimization/iterator-fast-paths.ts
@@ -1,0 +1,271 @@
+import type {
+  CodegenContext,
+  FunctionContext,
+  HirBlockExpr,
+  HirExprId,
+  HirMethodCallExpr,
+  TypeId,
+} from "../context.js";
+import type { ProgramSymbolId } from "../../semantics/ids.js";
+import { getRequiredExprType } from "../types.js";
+import {
+  isCanonicalStdTraitMethodCall,
+  parseCanonicalStdForBody,
+} from "./array-fast-paths.js";
+import { getFunctionMetadataForCall } from "../expressions/call/metadata.js";
+
+export const withExactIteratorForCallTargets = <T>({
+  block,
+  statementIndex,
+  ctx,
+  fnCtx,
+  compile,
+}: {
+  block: HirBlockExpr;
+  statementIndex: number;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+  compile: () => T;
+}): T | undefined => {
+  if (!ctx.optimization) {
+    return undefined;
+  }
+  const currentStmt = ctx.module.hir.statements.get(
+    block.statements[statementIndex]!,
+  );
+  const wrapper =
+    currentStmt?.kind === "expr-stmt"
+      ? ctx.module.hir.expressions.get(currentStmt.expr)
+      : undefined;
+  const iteratorStmt =
+    wrapper?.exprKind === "block" && wrapper.statements.length === 1
+      ? ctx.module.hir.statements.get(wrapper.statements[0]!)
+      : undefined;
+  const iterCall =
+    iteratorStmt?.kind === "let"
+      ? ctx.module.hir.expressions.get(iteratorStmt.initializer)
+      : undefined;
+  const whileExpr =
+    wrapper?.exprKind === "block" && typeof wrapper.value === "number"
+      ? ctx.module.hir.expressions.get(wrapper.value)
+      : undefined;
+  if (
+    iteratorStmt?.kind !== "let" ||
+    iteratorStmt.mutable ||
+    iteratorStmt.pattern.kind !== "identifier" ||
+    iterCall?.exprKind !== "method-call" ||
+    !isCanonicalStdTraitMethodCall({
+      expr: iterCall,
+      traitName: "Sequence",
+      methodName: "iter",
+      allowExternalImplementations: true,
+      ctx,
+    }) ||
+    whileExpr?.exprKind !== "while"
+  ) {
+    return undefined;
+  }
+  const body = parseCanonicalStdForBody({
+    whileExpr,
+    iteratorSymbol: iteratorStmt.pattern.symbol,
+    allowExternalImplementations: true,
+    ctx,
+  });
+  if (!body) {
+    return undefined;
+  }
+  const exactNext = exactIteratorNextTargetFor({
+    iterCall,
+    nextCall: body.nextCall,
+    ctx,
+    fnCtx,
+  });
+  if (!exactNext) {
+    return undefined;
+  }
+  const previousTargets = fnCtx.exactTraitDispatchTargets;
+  const previousReceiverTypes = fnCtx.exactCallReceiverTypes;
+  fnCtx.exactTraitDispatchTargets = new Map([
+    ...(previousTargets?.entries() ?? []),
+    [body.nextCall.id, exactNext.target],
+  ]);
+  fnCtx.exactCallReceiverTypes = new Map([
+    ...(previousReceiverTypes?.entries() ?? []),
+    [body.nextCall.id, exactNext.iteratorTypeId],
+  ]);
+  try {
+    return compile();
+  } finally {
+    fnCtx.exactTraitDispatchTargets = previousTargets;
+    fnCtx.exactCallReceiverTypes = previousReceiverTypes;
+  }
+};
+
+const exactIteratorNextTargetFor = ({
+  iterCall,
+  nextCall,
+  ctx,
+  fnCtx,
+}: {
+  iterCall: HirMethodCallExpr;
+  nextCall: HirMethodCallExpr;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): { target: ProgramSymbolId; iteratorTypeId: TypeId } | undefined => {
+  if (!exactNominalExpressionType({ exprId: iterCall.target, ctx, fnCtx })) {
+    return undefined;
+  }
+  const iterTarget = callTargetForContext({ callId: iterCall.id, ctx, fnCtx });
+  if (typeof iterTarget !== "number") {
+    return undefined;
+  }
+  const iterRef = ctx.program.symbols.refOf(iterTarget);
+  const iterMeta = getFunctionMetadataForCall({
+    symbol: iterRef.symbol,
+    moduleId: iterRef.moduleId,
+    callId: iterCall.id,
+    ctx,
+    typeInstanceId: fnCtx.typeInstanceId ?? fnCtx.instanceId,
+  });
+  if (!iterMeta) {
+    return undefined;
+  }
+  const targetCtx = ctx.moduleContexts.get(iterRef.moduleId);
+  const iterItem = targetCtx
+    ? [...targetCtx.module.hir.items.values()].find(
+        (item) => item.kind === "function" && item.symbol === iterRef.symbol,
+      )
+    : undefined;
+  if (!targetCtx || iterItem?.kind !== "function") {
+    return undefined;
+  }
+  const iteratorTypeId = freshExactNominalResultType({
+    exprId: iterItem.body,
+    ctx: targetCtx,
+    instanceId: iterMeta.instanceId,
+  });
+  if (typeof iteratorTypeId !== "number") {
+    return undefined;
+  }
+
+  const selectedNext = callTargetForContext({
+    callId: nextCall.id,
+    ctx,
+    fnCtx,
+  });
+  const mapping =
+    typeof selectedNext === "number"
+      ? ctx.program.traits.getTraitMethodImpl(selectedNext)
+      : undefined;
+  if (!mapping) {
+    return undefined;
+  }
+  const matches = ctx.program.traits
+    .getImplsByNominal(iteratorTypeId)
+    .filter((impl) => impl.traitSymbol === mapping.traitSymbol)
+    .flatMap((impl) =>
+      impl.methods
+        .filter((method) => method.traitMethod === mapping.traitMethodSymbol)
+        .map((method) => method.implMethod),
+    );
+  const unique = [...new Set(matches)];
+  return unique.length === 1
+    ? { target: unique[0]!, iteratorTypeId }
+    : undefined;
+};
+
+const exactNominalExpressionType = ({
+  exprId,
+  ctx,
+  fnCtx,
+}: {
+  exprId: HirExprId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): TypeId | undefined => {
+  const typeId = getRequiredExprType(
+    exprId,
+    ctx,
+    fnCtx.typeInstanceId ?? fnCtx.instanceId,
+  );
+  const desc = ctx.program.types.getTypeDesc(typeId);
+  if (desc.kind === "nominal-object" || desc.kind === "value-object") {
+    return typeId;
+  }
+  return desc.kind === "intersection" ? desc.nominal : undefined;
+};
+
+const callTargetForContext = ({
+  callId,
+  ctx,
+  fnCtx,
+}: {
+  callId: HirExprId;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): ProgramSymbolId | undefined => {
+  const targets = ctx.program.calls.getCallInfo(ctx.moduleId, callId).targets;
+  for (const instanceId of [fnCtx.instanceId, fnCtx.typeInstanceId]) {
+    if (typeof instanceId !== "number") {
+      continue;
+    }
+    const target = targets?.get(instanceId);
+    if (typeof target === "number") {
+      return target;
+    }
+  }
+  return targets?.size === 1 ? targets.values().next().value : undefined;
+};
+
+const freshExactNominalResultType = ({
+  exprId,
+  ctx,
+  instanceId,
+}: {
+  exprId: HirExprId;
+  ctx: CodegenContext;
+  instanceId: import("../../semantics/ids.js").ProgramFunctionInstanceId;
+}): TypeId | undefined => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  if (!expr) {
+    return undefined;
+  }
+  if (expr.exprKind === "object-literal") {
+    const typeId = getRequiredExprType(exprId, ctx, instanceId);
+    const desc = ctx.program.types.getTypeDesc(typeId);
+    if (desc.kind === "nominal-object" || desc.kind === "value-object") {
+      return typeId;
+    }
+    return desc.kind === "intersection" ? desc.nominal : undefined;
+  }
+  if (expr.exprKind === "block") {
+    return expr.statements.length === 0 && typeof expr.value === "number"
+      ? freshExactNominalResultType({ exprId: expr.value, ctx, instanceId })
+      : undefined;
+  }
+  if (expr.exprKind !== "if" && expr.exprKind !== "cond") {
+    return undefined;
+  }
+  if (typeof expr.defaultBranch !== "number") {
+    return undefined;
+  }
+  const resultTypes = [
+    ...expr.branches.map((branch) =>
+      freshExactNominalResultType({
+        exprId: branch.value,
+        ctx,
+        instanceId,
+      }),
+    ),
+    freshExactNominalResultType({
+      exprId: expr.defaultBranch,
+      ctx,
+      instanceId,
+    }),
+  ];
+  const first = resultTypes[0];
+  return typeof first === "number" &&
+    resultTypes.every((type) => type === first)
+    ? first
+    : undefined;
+};

--- a/packages/compiler/src/codegen/optimization/mutable-scalar-aggregate-calls.ts
+++ b/packages/compiler/src/codegen/optimization/mutable-scalar-aggregate-calls.ts
@@ -1,0 +1,204 @@
+import type {
+  CodegenContext,
+  FunctionMetadata,
+  StructuralTypeInfo,
+} from "../context.js";
+import type { HirFunction } from "../../semantics/hir/index.js";
+import type { HirExprId, SymbolId } from "../../semantics/ids.js";
+import { getStructuralTypeInfo } from "../types.js";
+import { walkHirExpression } from "../hir-walk.js";
+import {
+  composeSpecializationDimensions,
+  tryAdmitFunctionSpecialization,
+  type FunctionSpecializationDimensions,
+} from "../specialization-policy.js";
+
+export const mutableScalarAggregateCalleeCanUseLaneAbi = ({
+  meta,
+  paramIndex,
+  ctx,
+}: {
+  meta: FunctionMetadata;
+  paramIndex: number;
+  ctx: CodegenContext;
+}): boolean => {
+  const typeId = meta.paramTypeIds[paramIndex];
+  const item = functionItemFor({ ctx, meta });
+  const signature = ctx.program.functions.getSignature(
+    meta.moduleId,
+    meta.symbol,
+  );
+  const parameter = signature?.parameters[paramIndex];
+  const hirParameter = item?.parameters[paramIndex];
+  const targetCtx = ctx.moduleContexts.get(meta.moduleId);
+  const structInfo =
+    typeof typeId === "number" && targetCtx
+      ? getStructuralTypeInfo(typeId, targetCtx)
+      : undefined;
+  const functionId = ctx.program.functions.getFunctionId({
+    moduleId: meta.moduleId,
+    symbol: meta.symbol,
+  });
+  const footprint =
+    typeof functionId === "number"
+      ? ctx.program.callableAccesses.getFootprint(functionId)
+      : undefined;
+  const access = footprint?.parameters[paramIndex];
+
+  if (
+    !item ||
+    !targetCtx ||
+    !structInfo ||
+    structInfo.layoutKind !== "heap-object" ||
+    !hirParameter ||
+    typeof hirParameter.symbol !== "number" ||
+    !signature ||
+    signature.returnType !== ctx.program.primitives.void ||
+    !ctx.program.effects.isEmpty(signature.effectRow) ||
+    meta.resultTypeId !== ctx.program.primitives.void ||
+    meta.effectful ||
+    meta.paramAbiKinds[paramIndex] !== "mutable_ref" ||
+    parameter?.bindingKind !== "mutable-ref" ||
+    parameter.optional ||
+    parameter.defaulted ||
+    parameter.typeId !== typeId ||
+    !footprint ||
+    !access ||
+    footprint.maySuspend ||
+    footprint.externalRead ||
+    footprint.externalWrite ||
+    access.runtimeCheckedWrites ||
+    access.retained ||
+    access.returned ||
+    access.returnedProvenance ||
+    access.writePaths.length === 0 ||
+    !parameterUsesOnlyDirectFields({
+      item,
+      symbol: hirParameter.symbol,
+      ctx: targetCtx,
+    })
+  ) {
+    return false;
+  }
+
+  return (
+    access.readPaths.every((path) => directFieldPath(path, structInfo)) &&
+    access.writePaths.every((path) => directFieldPath(path, structInfo))
+  );
+};
+
+export const mutableScalarAggregateSpecializationDimensions = ({
+  meta,
+  paramIndex,
+}: {
+  meta: FunctionMetadata;
+  paramIndex: number;
+}): FunctionSpecializationDimensions =>
+  composeSpecializationDimensions({
+    meta,
+    next: {
+      scalarAggregate: {
+        parameterIndexes: [paramIndex],
+        result: false,
+      },
+    },
+  });
+
+export const tryReserveMutableScalarAggregateSpecialization = ({
+  meta,
+  paramIndex,
+  existingKindVariants,
+  ctx,
+}: {
+  meta: FunctionMetadata;
+  paramIndex: number;
+  existingKindVariants: number;
+  ctx: CodegenContext;
+}): boolean => {
+  const item = functionItemFor({ ctx, meta });
+  if (!item) {
+    return false;
+  }
+  return tryAdmitFunctionSpecialization({
+    ctx,
+    meta,
+    item,
+    kind: "scalar_aggregate",
+    dimensions: mutableScalarAggregateSpecializationDimensions({
+      meta,
+      paramIndex,
+    }),
+    existingKindVariants,
+    maxKindVariants:
+      ctx.specializationPolicy.scalarAggregateCallContextsPerFunction,
+  });
+};
+
+const functionItemFor = ({
+  ctx,
+  meta,
+}: {
+  ctx: CodegenContext;
+  meta: FunctionMetadata;
+}): HirFunction | undefined => {
+  const targetCtx = ctx.moduleContexts.get(meta.moduleId);
+  const targetModule =
+    targetCtx?.module ?? ctx.program.modules.get(meta.moduleId);
+  return Array.from(targetModule?.hir.items.values() ?? []).find(
+    (item): item is HirFunction =>
+      item.kind === "function" && item.symbol === meta.symbol,
+  );
+};
+
+const parameterUsesOnlyDirectFields = ({
+  item,
+  symbol,
+  ctx,
+}: {
+  item: HirFunction;
+  symbol: SymbolId;
+  ctx: CodegenContext;
+}): boolean => {
+  const allowedIdentifiers = new Set<HirExprId>();
+  let safe = true;
+  walkHirExpression({
+    exprId: item.body,
+    ctx,
+    visitor: {
+      onStmt: (_stmtId, stmt) => {
+        if (stmt.kind === "return") {
+          safe = false;
+          return "stop";
+        }
+        return undefined;
+      },
+      onExpr: (exprId, expr) => {
+        if (expr.exprKind === "field-access") {
+          const target = ctx.module.hir.expressions.get(expr.target);
+          if (target?.exprKind === "identifier" && target.symbol === symbol) {
+            allowedIdentifiers.add(target.id);
+          }
+          return undefined;
+        }
+        if (
+          expr.exprKind === "identifier" &&
+          expr.symbol === symbol &&
+          !allowedIdentifiers.has(exprId)
+        ) {
+          safe = false;
+          return "stop";
+        }
+        return undefined;
+      },
+    },
+  });
+  return safe;
+};
+
+const directFieldPath = (
+  path: readonly import("../../semantics/codegen-view/index.js").CodegenPlaceProjection[],
+  structInfo: StructuralTypeInfo,
+): boolean =>
+  path.length === 1 &&
+  path[0]?.kind === "field" &&
+  structInfo.fieldMap.has(path[0].name);

--- a/packages/compiler/src/codegen/optimization/mutable-scalar-aggregate-calls.ts
+++ b/packages/compiler/src/codegen/optimization/mutable-scalar-aggregate-calls.ts
@@ -5,7 +5,7 @@ import type {
 } from "../context.js";
 import type { HirFunction } from "../../semantics/hir/index.js";
 import type { HirExprId, SymbolId } from "../../semantics/ids.js";
-import { getStructuralTypeInfo } from "../types.js";
+import { getOptimizedResultAbiKind, getStructuralTypeInfo } from "../types.js";
 import { walkHirExpression } from "../hir-walk.js";
 import {
   composeSpecializationDimensions,
@@ -53,9 +53,11 @@ export const mutableScalarAggregateCalleeCanUseLaneAbi = ({
     !hirParameter ||
     typeof hirParameter.symbol !== "number" ||
     !signature ||
-    signature.returnType !== ctx.program.primitives.void ||
     !ctx.program.effects.isEmpty(signature.effectRow) ||
-    meta.resultTypeId !== ctx.program.primitives.void ||
+    meta.resultTypeId !== signature.returnType ||
+    meta.resultAbiKind !== "direct" ||
+    getOptimizedResultAbiKind({ typeId: meta.resultTypeId, ctx: targetCtx }) !==
+      "direct" ||
     meta.effectful ||
     meta.paramAbiKinds[paramIndex] !== "mutable_ref" ||
     parameter?.bindingKind !== "mutable-ref" ||
@@ -75,6 +77,7 @@ export const mutableScalarAggregateCalleeCanUseLaneAbi = ({
     !parameterUsesOnlyDirectFields({
       item,
       symbol: hirParameter.symbol,
+      allowReturns: meta.resultTypeId !== ctx.program.primitives.void,
       ctx: targetCtx,
     })
   ) {
@@ -153,10 +156,12 @@ const functionItemFor = ({
 const parameterUsesOnlyDirectFields = ({
   item,
   symbol,
+  allowReturns,
   ctx,
 }: {
   item: HirFunction;
   symbol: SymbolId;
+  allowReturns: boolean;
   ctx: CodegenContext;
 }): boolean => {
   const allowedIdentifiers = new Set<HirExprId>();
@@ -166,7 +171,7 @@ const parameterUsesOnlyDirectFields = ({
     ctx,
     visitor: {
       onStmt: (_stmtId, stmt) => {
-        if (stmt.kind === "return") {
+        if (stmt.kind === "return" && !allowReturns) {
           safe = false;
           return "stop";
         }

--- a/packages/compiler/src/codegen/optimization/mutable-scalar-aggregate-results.ts
+++ b/packages/compiler/src/codegen/optimization/mutable-scalar-aggregate-results.ts
@@ -1,0 +1,66 @@
+import binaryen from "binaryen";
+import type {
+  CodegenContext,
+  FunctionContext,
+  LocalBindingScalarAggregate,
+  TypeId,
+} from "../context.js";
+import { captureMultivalueLanes } from "../multivalue.js";
+import { boxSignatureSpillValue } from "../signature-spill.js";
+import { abiTypeFor } from "../types.js";
+import { loadScalarAggregateBindingAbiLanes } from "./scalar-aggregates.js";
+
+export const packMutableScalarAggregateResult = ({
+  logicalValue,
+  logicalResultTypeId,
+  logicalResultAbiTypes,
+  binding,
+  ctx,
+  fnCtx,
+}: {
+  logicalValue: binaryen.ExpressionRef;
+  logicalResultTypeId: TypeId;
+  logicalResultAbiTypes: readonly binaryen.Type[];
+  binding: LocalBindingScalarAggregate;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): binaryen.ExpressionRef => {
+  if (binaryen.getExpressionType(logicalValue) === binaryen.unreachable) {
+    return logicalValue;
+  }
+
+  const boxedLogicalValue =
+    logicalResultAbiTypes.length === 0
+      ? logicalValue
+      : boxSignatureSpillValue({
+          value: logicalValue,
+          typeId: logicalResultTypeId,
+          ctx,
+          fnCtx,
+        });
+  const logical = captureMultivalueLanes({
+    value: boxedLogicalValue,
+    abiTypes: logicalResultAbiTypes,
+    ctx,
+    fnCtx,
+  });
+  const resultLanes = [
+    ...logical.lanes,
+    ...loadScalarAggregateBindingAbiLanes({ binding, ctx }),
+  ];
+  const result =
+    resultLanes.length === 1
+      ? resultLanes[0]!
+      : ctx.mod.tuple.make(resultLanes as binaryen.ExpressionRef[]);
+  const setup =
+    logicalResultAbiTypes.length === 0
+      ? [logicalValue, ...logical.setup]
+      : logical.setup;
+  return setup.length === 0
+    ? result
+    : ctx.mod.block(
+        null,
+        [...setup, result],
+        abiTypeFor(resultLanes.map((lane) => binaryen.getExpressionType(lane))),
+      );
+};

--- a/packages/compiler/src/codegen/optimization/scalar-aggregate-calls.ts
+++ b/packages/compiler/src/codegen/optimization/scalar-aggregate-calls.ts
@@ -5,6 +5,7 @@ import type { HirExprId, SymbolId, TypeId } from "../../semantics/ids.js";
 import { abiTypeFor, getStructuralTypeInfo } from "../types.js";
 import {
   canStoreScalarAggregateExpression,
+  mutableScalarAggregateAbiTypesForType,
   scalarAggregateAbiTypesForType,
 } from "./scalar-aggregates.js";
 import { walkHirExpression } from "../hir-walk.js";
@@ -13,6 +14,11 @@ import {
   functionSpecializationIdentity,
   tryAdmitFunctionSpecialization,
 } from "../specialization-policy.js";
+import {
+  mutableScalarAggregateCalleeCanUseLaneAbi,
+  mutableScalarAggregateSpecializationDimensions,
+  tryReserveMutableScalarAggregateSpecialization,
+} from "./mutable-scalar-aggregate-calls.js";
 
 export interface ScalarAggregateCallSpecialization {
   base: FunctionMetadata;
@@ -44,6 +50,11 @@ const stateOf = (ctx: CodegenContext): ScalarAggregateCallSpecializationState =>
 
 const sanitize = (value: string): string =>
   value.replace(/[^a-zA-Z0-9_]/g, "_");
+
+const parameterIsMutable = (
+  param: HirFunction["parameters"][number] | undefined,
+): boolean =>
+  param?.mutable === true || param?.pattern.bindingKind === "mutable-ref";
 
 const functionItemFor = ({
   ctx,
@@ -208,6 +219,32 @@ const parameterHasFieldAssignment = ({
   return hasAssignment;
 };
 
+const mutableScalarAggregateParameterCanUseSpecializedAbi = ({
+  meta,
+  paramIndex,
+  item,
+  ctx,
+}: {
+  meta: FunctionMetadata;
+  paramIndex: number;
+  item: HirFunction;
+  ctx: CodegenContext;
+}): boolean => {
+  const param = meta.parameters[paramIndex];
+  if (
+    !param ||
+    typeof param.symbol !== "number" ||
+    item.parameters[paramIndex]?.symbol !== param.symbol
+  ) {
+    return false;
+  }
+  return mutableScalarAggregateCalleeCanUseLaneAbi({
+    meta,
+    paramIndex,
+    ctx,
+  });
+};
+
 export const scalarAggregateParameterCanUseSpecializedAbi = ({
   meta,
   paramIndex,
@@ -228,18 +265,34 @@ export const scalarAggregateParameterCanUseSpecializedAbi = ({
   if (!structInfo || structInfo.layoutKind !== "heap-object") {
     return false;
   }
-  const abiTypes = scalarAggregateAbiTypesForType({
-    typeId: param.typeId,
-    ctx,
-  });
+  const item = functionItemFor({ ctx, meta });
+  const targetCtx = ctx.moduleContexts.get(meta.moduleId) ?? ctx;
+  const mutable =
+    meta.paramAbiKinds[paramIndex] === "mutable_ref" ||
+    parameterIsMutable(item?.parameters[paramIndex]);
+  const abiTypes = mutable
+    ? mutableScalarAggregateAbiTypesForType({
+        typeId: param.typeId,
+        ctx,
+      })
+    : scalarAggregateAbiTypesForType({
+        typeId: param.typeId,
+        ctx,
+      });
   if (!abiTypes || abiTypes.length === 0) {
     return false;
   }
-  const item = functionItemFor({ ctx, meta });
-  if (item?.parameters[paramIndex]?.mutable) {
-    return false;
+  if (mutable) {
+    return Boolean(
+      item &&
+      mutableScalarAggregateParameterCanUseSpecializedAbi({
+        meta,
+        paramIndex,
+        item,
+        ctx: targetCtx,
+      }),
+    );
   }
-  const targetCtx = ctx.moduleContexts.get(meta.moduleId) ?? ctx;
   if (
     item &&
     parameterHasFieldAssignment({
@@ -381,11 +434,27 @@ export const getOrCreateScalarAggregateCallSpecialization = ({
   if (!ctx.optimization || (paramIndexes.size === 0 && !scalarResult)) {
     return undefined;
   }
-  const selectedIndexes = Array.from(paramIndexes)
+  const eligibleIndexes = Array.from(paramIndexes)
     .filter((paramIndex) =>
       scalarAggregateParameterCanUseSpecializedAbi({ meta, paramIndex, ctx }),
     )
     .sort((left, right) => left - right);
+  const mutableIndexes = eligibleIndexes.filter(
+    (paramIndex) =>
+      meta.paramAbiKinds[paramIndex] === "mutable_ref" ||
+      parameterIsMutable(item?.parameters[paramIndex]),
+  );
+  if (
+    mutableIndexes.length > 1 ||
+    (mutableIndexes.length > 0 && scalarResult)
+  ) {
+    return undefined;
+  }
+  const mutableParamIndex = mutableIndexes[0];
+  const selectedIndexes =
+    typeof mutableParamIndex === "number"
+      ? [mutableParamIndex]
+      : eligibleIndexes;
   if (selectedIndexes.length === 0 && !scalarResult) {
     return undefined;
   }
@@ -393,15 +462,21 @@ export const getOrCreateScalarAggregateCallSpecialization = ({
     return undefined;
   }
 
-  const specializationDimensions = composeSpecializationDimensions({
-    meta,
-    next: {
-      scalarAggregate: {
-        parameterIndexes: selectedIndexes,
-        result: scalarResult,
-      },
-    },
-  });
+  const specializationDimensions =
+    typeof mutableParamIndex === "number"
+      ? mutableScalarAggregateSpecializationDimensions({
+          meta,
+          paramIndex: mutableParamIndex,
+        })
+      : composeSpecializationDimensions({
+          meta,
+          next: {
+            scalarAggregate: {
+              parameterIndexes: selectedIndexes,
+              result: scalarResult,
+            },
+          },
+        });
   const key = functionSpecializationIdentity({
     meta,
     dimensions: specializationDimensions,
@@ -416,65 +491,96 @@ export const getOrCreateScalarAggregateCallSpecialization = ({
       specialization.base.moduleId === meta.moduleId &&
       specialization.base.instanceId === meta.instanceId,
   );
-  if (
-    !tryAdmitFunctionSpecialization({
-      ctx,
-      meta,
-      item,
-      kind: "scalar_aggregate",
-      dimensions: specializationDimensions,
-      existingKindVariants: existingForFunction.length,
-      maxKindVariants:
-        ctx.specializationPolicy.scalarAggregateCallContextsPerFunction,
-    })
-  ) {
+  const admitted =
+    typeof mutableParamIndex === "number"
+      ? tryReserveMutableScalarAggregateSpecialization({
+          ctx,
+          meta,
+          paramIndex: mutableParamIndex,
+          existingKindVariants: existingForFunction.length,
+        })
+      : tryAdmitFunctionSpecialization({
+          ctx,
+          meta,
+          item,
+          kind: "scalar_aggregate",
+          dimensions: specializationDimensions,
+          existingKindVariants: existingForFunction.length,
+          maxKindVariants:
+            ctx.specializationPolicy.scalarAggregateCallContextsPerFunction,
+        });
+  if (!admitted) {
     return undefined;
   }
 
   const paramAbiTypes = meta.paramAbiTypes.map((abiTypes, index) =>
     selectedIndexes.includes(index) &&
     typeof meta.paramTypeIds[index] === "number"
-      ? (scalarAggregateAbiTypesForType({
-          typeId: meta.paramTypeIds[index]!,
-          ctx,
-        }) ?? abiTypes)
+      ? ((meta.paramAbiKinds[index] === "mutable_ref" ||
+        parameterIsMutable(item.parameters[index])
+          ? mutableScalarAggregateAbiTypesForType({
+              typeId: meta.paramTypeIds[index]!,
+              ctx,
+            })
+          : scalarAggregateAbiTypesForType({
+              typeId: meta.paramTypeIds[index]!,
+              ctx,
+            })) ?? abiTypes)
       : abiTypes,
   );
+  const paramAbiKinds = meta.paramAbiKinds.map((kind, index) =>
+    index === mutableParamIndex ? "direct" : kind,
+  );
   const userParamTypes = paramAbiTypes.flat();
+  const mutableResultAbiTypes =
+    typeof mutableParamIndex === "number"
+      ? mutableScalarAggregateAbiTypesForType({
+          typeId: meta.paramTypeIds[mutableParamIndex]!,
+          ctx,
+        })
+      : undefined;
   const widened = ctx.effectsBackend.abi.widenSignature({
     ctx,
     effectful: meta.effectful,
     userParamTypes: meta.outParamType
       ? [meta.outParamType, ...userParamTypes]
       : userParamTypes,
-    userResultType: scalarResult
-      ? abiTypeFor(
-          scalarAggregateAbiTypesForType({
-            typeId: meta.resultTypeId,
-            ctx,
-          }) ?? [meta.resultType],
-        )
-      : meta.resultAbiKind === "out_ref"
-        ? binaryen.none
-        : meta.resultType,
+    userResultType: mutableResultAbiTypes
+      ? abiTypeFor(mutableResultAbiTypes)
+      : scalarResult
+        ? abiTypeFor(
+            scalarAggregateAbiTypesForType({
+              typeId: meta.resultTypeId,
+              ctx,
+            }) ?? [meta.resultType],
+          )
+        : meta.resultAbiKind === "out_ref"
+          ? binaryen.none
+          : meta.resultType,
   });
-  const resultAbiTypes = scalarResult
-    ? (scalarAggregateAbiTypesForType({ typeId: meta.resultTypeId, ctx }) ??
-      meta.resultAbiTypes)
-    : meta.resultAbiTypes;
+  const resultAbiTypes =
+    mutableResultAbiTypes ??
+    (scalarResult
+      ? (scalarAggregateAbiTypesForType({ typeId: meta.resultTypeId, ctx }) ??
+        meta.resultAbiTypes)
+      : meta.resultAbiTypes);
   const specializedMeta: FunctionMetadata = {
     ...meta,
     wasmName: `${meta.wasmName}__scalar_agg_${sanitize(
-      `${selectedIndexes.join("_")}${scalarResult ? "_result" : ""}`,
+      `${selectedIndexes.join("_")}${
+        typeof mutableParamIndex === "number" ? "_mutable" : ""
+      }${scalarResult ? "_result" : ""}`,
     )}`,
     paramTypes: widened.paramTypes,
     paramAbiTypes,
+    paramAbiKinds,
     userParamOffset: widened.userParamOffset,
     firstUserParamIndex: widened.userParamOffset + (meta.outParamType ? 1 : 0),
     resultType: widened.resultType,
     resultAbiTypes,
     scalarAggregateParamIndexes: selectedIndexes,
     scalarAggregateResult: scalarResult,
+    scalarAggregateMutableParamIndex: mutableParamIndex,
     specialization: specializationDimensions,
   };
   const specialization: ScalarAggregateCallSpecialization = {

--- a/packages/compiler/src/codegen/optimization/scalar-aggregate-calls.ts
+++ b/packages/compiler/src/codegen/optimization/scalar-aggregate-calls.ts
@@ -539,14 +539,17 @@ export const getOrCreateScalarAggregateCallSpecialization = ({
           ctx,
         })
       : undefined;
+  const combinedMutableResultAbiTypes = mutableResultAbiTypes
+    ? [...meta.resultAbiTypes, ...mutableResultAbiTypes]
+    : undefined;
   const widened = ctx.effectsBackend.abi.widenSignature({
     ctx,
     effectful: meta.effectful,
     userParamTypes: meta.outParamType
       ? [meta.outParamType, ...userParamTypes]
       : userParamTypes,
-    userResultType: mutableResultAbiTypes
-      ? abiTypeFor(mutableResultAbiTypes)
+    userResultType: combinedMutableResultAbiTypes
+      ? abiTypeFor(combinedMutableResultAbiTypes)
       : scalarResult
         ? abiTypeFor(
             scalarAggregateAbiTypesForType({
@@ -559,7 +562,7 @@ export const getOrCreateScalarAggregateCallSpecialization = ({
           : meta.resultType,
   });
   const resultAbiTypes =
-    mutableResultAbiTypes ??
+    combinedMutableResultAbiTypes ??
     (scalarResult
       ? (scalarAggregateAbiTypesForType({ typeId: meta.resultTypeId, ctx }) ??
         meta.resultAbiTypes)
@@ -581,6 +584,13 @@ export const getOrCreateScalarAggregateCallSpecialization = ({
     scalarAggregateParamIndexes: selectedIndexes,
     scalarAggregateResult: scalarResult,
     scalarAggregateMutableParamIndex: mutableParamIndex,
+    scalarAggregateMutableCombinedResult:
+      mutableResultAbiTypes && combinedMutableResultAbiTypes
+        ? {
+            logicalAbiTypes: meta.resultAbiTypes,
+            writebackAbiTypes: mutableResultAbiTypes,
+          }
+        : undefined,
     specialization: specializationDimensions,
   };
   const specialization: ScalarAggregateCallSpecialization = {

--- a/packages/compiler/src/codegen/optimization/scalar-aggregates.ts
+++ b/packages/compiler/src/codegen/optimization/scalar-aggregates.ts
@@ -3,6 +3,7 @@ import type {
   CodegenContext,
   ExpressionCompiler,
   FunctionContext,
+  FunctionMetadata,
   HirExprId,
   HirBlockExpr,
   HirCondExpr,
@@ -31,10 +32,24 @@ import {
 } from "../types.js";
 import { compileCallArgExpressionsWithTemps } from "../expressions/call/shared.js";
 import { incrementCompilerPerfCounter } from "../../perf.js";
+import { walkHirExpression } from "../hir-walk.js";
+import { getFunctionMetadataForCall } from "../expressions/call/metadata.js";
+import { receiverSpecializedMetaForCall } from "../receiver-specialization.js";
+import {
+  mutableScalarAggregateCalleeCanUseLaneAbi,
+  tryReserveMutableScalarAggregateSpecialization,
+} from "./mutable-scalar-aggregate-calls.js";
 
 const SCALAR_AGGREGATE_MATERIALIZATION_BOUNDARY_REASONS = new Set([
   "assignment",
   "return",
+]);
+
+const MUTABLE_SCALAR_AGGREGATE_BOUNDARY_REASONS = new Set([
+  "assignment",
+  "call-boundary",
+  "mutable-call-argument",
+  "unknown",
 ]);
 
 const recordScalarAggregateDecision = (
@@ -57,14 +72,16 @@ const aggregateLaneCount = (structInfo: StructuralTypeInfo): number =>
 
 const isSmallScalarAggregate = ({
   structInfo,
+  maxLanes,
   ctx,
 }: {
   structInfo: StructuralTypeInfo;
+  maxLanes?: number;
   ctx: CodegenContext;
 }): boolean =>
   structInfo.fields.length > 0 &&
   aggregateLaneCount(structInfo) <=
-    ctx.specializationPolicy.scalarAggregateLanes;
+    (maxLanes ?? ctx.specializationPolicy.scalarAggregateLanes);
 
 const symbolIsUsedAsMethodReceiver = ({
   symbol,
@@ -178,6 +195,281 @@ const heapObjectSymbolNeedsStableIdentity = ({
   ctx: CodegenContext;
 }): boolean => symbolIsUsedAsMutableAliasInitializer({ symbol, ctx });
 
+const owningFunctionBody = ({
+  ctx,
+  fnCtx,
+}: {
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): HirExprId | undefined => {
+  const instanceId = fnCtx.instanceId ?? fnCtx.typeInstanceId;
+  const meta =
+    typeof instanceId === "number"
+      ? ctx.functionInstances.get(instanceId)
+      : undefined;
+  if (!meta || meta.moduleId !== ctx.moduleId) {
+    return undefined;
+  }
+  const item = Array.from(ctx.module.hir.items.values()).find(
+    (candidate) =>
+      candidate.kind === "function" && candidate.symbol === meta.symbol,
+  );
+  return item?.kind === "function" ? item.body : undefined;
+};
+
+const expressionUsesAlias = ({
+  exprId,
+  aliases,
+  ctx,
+}: {
+  exprId: HirExprId;
+  aliases: ReadonlySet<SymbolId>;
+  ctx: CodegenContext;
+}): boolean => {
+  let found = false;
+  walkHirExpression({
+    exprId,
+    ctx,
+    visitor: {
+      onExpr: (_candidateId, expr) => {
+        if (expr.exprKind === "identifier" && aliases.has(expr.symbol)) {
+          found = true;
+          return "stop";
+        }
+        return undefined;
+      },
+    },
+  });
+  return found;
+};
+
+const mutableAggregateUsesCanPromote = ({
+  symbol,
+  initializer,
+  structInfo,
+  ctx,
+  fnCtx,
+}: {
+  symbol: SymbolId;
+  initializer: HirExprId;
+  structInfo: StructuralTypeInfo;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): boolean => {
+  const origin = ctx.optimization?.escapeAnalysis.origins
+    .get(ctx.moduleId)
+    ?.get(initializer);
+  if (!origin || !origin.directLocalSymbols.includes(symbol)) {
+    return false;
+  }
+  const body = owningFunctionBody({ ctx, fnCtx });
+  if (typeof body !== "number") {
+    return false;
+  }
+  const aliases = new Set(origin.directLocalSymbols);
+  const allowedIdentifiers = new Set<HirExprId>();
+  const requiredSpecializations: {
+    meta: FunctionMetadata;
+    paramIndex: number;
+  }[] = [];
+  let safe = true;
+
+  walkHirExpression({
+    exprId: body,
+    ctx,
+    visitor: {
+      onStmt: (_stmtId, stmt) => {
+        if (
+          stmt.kind !== "let" ||
+          stmt.mutable ||
+          stmt.pattern.kind !== "identifier" ||
+          !aliases.has(stmt.pattern.symbol)
+        ) {
+          return undefined;
+        }
+        const value = ctx.module.hir.expressions.get(stmt.initializer);
+        if (value?.exprKind === "identifier" && aliases.has(value.symbol)) {
+          allowedIdentifiers.add(value.id);
+        }
+        return undefined;
+      },
+      onExpr: (_exprId, expr) => {
+        if (!safe) {
+          return "stop";
+        }
+        if (expr.exprKind === "field-access") {
+          const target = ctx.module.hir.expressions.get(expr.target);
+          if (target?.exprKind === "identifier" && aliases.has(target.symbol)) {
+            allowedIdentifiers.add(target.id);
+          }
+          return undefined;
+        }
+        if (expr.exprKind === "identifier") {
+          if (aliases.has(expr.symbol) && !allowedIdentifiers.has(expr.id)) {
+            safe = false;
+            return "stop";
+          }
+          return undefined;
+        }
+        if (expr.exprKind !== "call") {
+          return undefined;
+        }
+        const callee = ctx.module.hir.expressions.get(expr.callee);
+        const calleeId =
+          callee?.exprKind === "identifier"
+            ? ctx.program.symbols.canonicalIdOf(ctx.moduleId, callee.symbol)
+            : undefined;
+        if (
+          typeof calleeId === "number" &&
+          (ctx.program.symbols.getIntrinsicName(calleeId) === "~" ||
+            ctx.program.symbols.getName(calleeId) === "~")
+        ) {
+          return undefined;
+        }
+        const groupArgs = expr.args.flatMap((arg, argumentIndex) => {
+          const root = scalarMutableArgumentRoot({
+            exprId: arg.expr,
+            aliases,
+            ctx,
+          });
+          return root ? [{ ...root, argumentIndex }] : [];
+        });
+        if (groupArgs.length === 0) {
+          return undefined;
+        }
+        const callInfo = ctx.program.calls.getCallInfo(ctx.moduleId, expr.id);
+        const directTarget =
+          typeof calleeId === "number"
+            ? ctx.program.functions.getFunctionId(
+                ctx.program.symbols.refOf(calleeId),
+              )
+            : undefined;
+        const targetIds = [
+          ...new Set([
+            ...(callInfo.targets?.values() ?? []),
+            ...(typeof directTarget === "number" ? [directTarget] : []),
+          ]),
+        ];
+        const targetRef =
+          targetIds.length === 1
+            ? ctx.program.functions.getFunctionRef(targetIds[0]!)
+            : undefined;
+        if (
+          groupArgs.length !== 1 ||
+          groupArgs[0]!.argumentIndex !== 0 ||
+          callInfo.traitDispatch ||
+          callInfo.identityGuards.length > 0 ||
+          callee?.exprKind !== "identifier" ||
+          !targetRef ||
+          expr.args
+            .slice(1)
+            .some((arg) =>
+              expressionUsesAlias({ exprId: arg.expr, aliases, ctx }),
+            ) ||
+          (ctx.effectLowering.callArgTemps.get(expr.id) ?? []).some(
+            (entry) => entry.argIndex === 0,
+          )
+        ) {
+          safe = false;
+          return "stop";
+        }
+        const callerInstanceId = fnCtx.instanceId ?? fnCtx.typeInstanceId;
+        const plan =
+          typeof callerInstanceId === "number"
+            ? callInfo.argPlans?.get(callerInstanceId)
+            : undefined;
+        const parameterIndex = plan
+          ? plan.findIndex(
+              (entry) =>
+                entry.kind === "direct" &&
+                entry.argIndex === groupArgs[0]!.argumentIndex,
+            )
+          : groupArgs[0]!.argumentIndex;
+        const baseMeta = getFunctionMetadataForCall({
+          symbol: targetRef.symbol,
+          moduleId: targetRef.moduleId,
+          callId: expr.id,
+          ctx,
+          typeInstanceId: callerInstanceId,
+        });
+        const meta = baseMeta
+          ? receiverSpecializedMetaForCall({
+              callId: expr.id,
+              meta: baseMeta,
+              ctx,
+              fnCtx,
+            })
+          : undefined;
+        if (
+          parameterIndex < 0 ||
+          !meta ||
+          meta.paramTypeIds[parameterIndex] !== structInfo.typeId ||
+          !mutableScalarAggregateCalleeCanUseLaneAbi({
+            meta,
+            paramIndex: parameterIndex,
+            ctx,
+          })
+        ) {
+          safe = false;
+          return "stop";
+        }
+        requiredSpecializations.push({ meta, paramIndex: parameterIndex });
+        allowedIdentifiers.add(groupArgs[0]!.identifierExprId);
+        return undefined;
+      },
+    },
+  });
+  return (
+    safe &&
+    requiredSpecializations.length > 0 &&
+    requiredSpecializations.every(({ meta, paramIndex }) =>
+      tryReserveMutableScalarAggregateSpecialization({
+        meta,
+        paramIndex,
+        existingKindVariants: 0,
+        ctx,
+      }),
+    )
+  );
+};
+
+const scalarMutableArgumentRoot = ({
+  exprId,
+  aliases,
+  ctx,
+}: {
+  exprId: HirExprId;
+  aliases: ReadonlySet<SymbolId>;
+  ctx: CodegenContext;
+}): { symbol: SymbolId; identifierExprId: HirExprId } | undefined => {
+  const expr = ctx.module.hir.expressions.get(exprId);
+  if (expr?.exprKind === "identifier" && aliases.has(expr.symbol)) {
+    return { symbol: expr.symbol, identifierExprId: expr.id };
+  }
+  if (expr?.exprKind !== "call" || expr.args.length !== 1) {
+    return undefined;
+  }
+  const callee = ctx.module.hir.expressions.get(expr.callee);
+  if (callee?.exprKind !== "identifier") {
+    return undefined;
+  }
+  const calleeId = ctx.program.symbols.canonicalIdOf(
+    ctx.moduleId,
+    callee.symbol,
+  );
+  if (
+    ctx.program.symbols.getIntrinsicName(calleeId) !== "~" &&
+    ctx.program.symbols.getName(calleeId) !== "~"
+  ) {
+    return undefined;
+  }
+  return scalarMutableArgumentRoot({
+    exprId: expr.args[0]!.expr,
+    aliases,
+    ctx,
+  });
+};
+
 export const scalarAggregateAbiTypesForType = ({
   typeId,
   ctx,
@@ -194,15 +486,40 @@ export const scalarAggregateAbiTypesForType = ({
   ]);
 };
 
+export const mutableScalarAggregateAbiTypesForType = ({
+  typeId,
+  ctx,
+}: {
+  typeId: TypeId;
+  ctx: CodegenContext;
+}): readonly binaryen.Type[] | undefined => {
+  const structInfo = getStructuralTypeInfo(typeId, ctx);
+  if (
+    !structInfo ||
+    !isSmallScalarAggregate({
+      structInfo,
+      maxLanes: ctx.specializationPolicy.mutableScalarAggregateLanes,
+      ctx,
+    })
+  ) {
+    return undefined;
+  }
+  return structInfo.fields.flatMap((field) => [
+    ...binaryen.expandType(field.wasmType),
+  ]);
+};
+
 const nonEscapingOriginFactAllowsScalarization = ({
   symbol,
   exprId,
   typeId,
+  allowMutableCallBoundary = false,
   ctx,
 }: {
   symbol: SymbolId;
   exprId: HirExprId;
   typeId: TypeId;
+  allowMutableCallBoundary?: boolean;
   ctx: CodegenContext;
 }): boolean => {
   const fact = ctx.optimization?.escapeAnalysis.origins
@@ -215,9 +532,11 @@ const nonEscapingOriginFactAllowsScalarization = ({
     fact.typeId === typeId &&
     (!fact.escapes ||
       fact.escapeReasons.every((reason) =>
-        reason === "assignment"
-          ? structInfo?.layoutKind === "value-object"
-          : SCALAR_AGGREGATE_MATERIALIZATION_BOUNDARY_REASONS.has(reason),
+        allowMutableCallBoundary
+          ? MUTABLE_SCALAR_AGGREGATE_BOUNDARY_REASONS.has(reason)
+          : reason === "assignment"
+            ? structInfo?.layoutKind === "value-object"
+            : SCALAR_AGGREGATE_MATERIALIZATION_BOUNDARY_REASONS.has(reason),
       )) &&
     fact.directLocalSymbols.includes(symbol),
   );
@@ -481,6 +800,7 @@ const exprCanScalarizeAggregateAssignment = ({
   targetTypeId,
   structInfo,
   requireOriginFact,
+  allowMutableCallBoundary = false,
   allowBlockStatements,
   ctx,
 }: {
@@ -489,6 +809,7 @@ const exprCanScalarizeAggregateAssignment = ({
   targetTypeId: TypeId;
   structInfo: StructuralTypeInfo;
   requireOriginFact: boolean;
+  allowMutableCallBoundary?: boolean;
   allowBlockStatements: boolean;
   ctx: CodegenContext;
 }): boolean => {
@@ -505,6 +826,7 @@ const exprCanScalarizeAggregateAssignment = ({
             symbol,
             exprId,
             typeId: targetTypeId,
+            allowMutableCallBoundary,
             ctx,
           }))) &&
       objectLiteralCanScalarize(expr, structInfo)
@@ -519,6 +841,7 @@ const exprCanScalarizeAggregateAssignment = ({
             symbol,
             exprId,
             typeId: targetTypeId,
+            allowMutableCallBoundary,
             ctx,
           }))) &&
       structInfo.fields.length === expr.elements.length
@@ -535,6 +858,7 @@ const exprCanScalarizeAggregateAssignment = ({
         targetTypeId,
         structInfo,
         requireOriginFact,
+        allowMutableCallBoundary,
         allowBlockStatements,
         ctx,
       })
@@ -551,6 +875,7 @@ const exprCanScalarizeAggregateAssignment = ({
           targetTypeId,
           structInfo,
           requireOriginFact,
+          allowMutableCallBoundary,
           allowBlockStatements,
           ctx,
         }),
@@ -561,6 +886,7 @@ const exprCanScalarizeAggregateAssignment = ({
         targetTypeId,
         structInfo,
         requireOriginFact,
+        allowMutableCallBoundary,
         allowBlockStatements,
         ctx,
       })
@@ -874,23 +1200,43 @@ export const tryScalarizeAggregateInitializer = ({
     recordScalarAggregateDecision("initializer", "bailout.effectful");
     return undefined;
   }
-  if (ctx.module.mutableStorageSymbols.has(symbol)) {
-    recordScalarAggregateDecision("initializer", "bailout.address_taken");
-    return undefined;
-  }
   const structInfo = getStructuralTypeInfo(targetTypeId, ctx);
   if (!structInfo) {
     recordScalarAggregateDecision("initializer", "bailout.no_layout");
     return undefined;
   }
-  if (!isSmallScalarAggregate({ structInfo, ctx })) {
+  const addressTaken = ctx.module.mutableStorageSymbols.has(symbol);
+  const promoteAcrossMutableCalls =
+    mutable &&
+    addressTaken &&
+    mutableAggregateUsesCanPromote({
+      symbol,
+      initializer,
+      structInfo,
+      ctx,
+      fnCtx,
+    });
+  if (addressTaken && !promoteAcrossMutableCalls) {
+    recordScalarAggregateDecision("initializer", "bailout.address_taken");
+    return undefined;
+  }
+  if (
+    !isSmallScalarAggregate({
+      structInfo,
+      maxLanes: promoteAcrossMutableCalls
+        ? ctx.specializationPolicy.mutableScalarAggregateLanes
+        : undefined,
+      ctx,
+    })
+  ) {
     recordScalarAggregateDecision("initializer", "bailout.too_wide");
     return undefined;
   }
   if (
     mutable &&
     (symbolIsUsedAsMethodReceiver({ symbol, ctx }) ||
-      symbolIsUsedAsCallArgument({ symbol, ctx }))
+      (!promoteAcrossMutableCalls &&
+        symbolIsUsedAsCallArgument({ symbol, ctx })))
   ) {
     recordScalarAggregateDecision("initializer", "bailout.mutable_dynamic_use");
     return undefined;
@@ -918,6 +1264,7 @@ export const tryScalarizeAggregateInitializer = ({
       exprId: initializer,
       targetTypeId,
       requireOriginFact: true,
+      allowMutableCallBoundary: promoteAcrossMutableCalls,
       allowBlockStatements: Boolean(
         compileStatement && compileBlockInitializer,
       ),
@@ -1117,11 +1464,14 @@ export const tryBindScalarAggregateParameter = ({
     recordScalarAggregateDecision("parameter", "bailout.effectful");
     return undefined;
   }
-  if (mutable) {
+  if (mutable && scalarAggregateAbi !== true) {
     recordScalarAggregateDecision("parameter", "bailout.mutable");
     return undefined;
   }
-  if (!nonEscapingParameterFactAllowsScalarization({ symbol, fnCtx, ctx })) {
+  if (
+    !mutable &&
+    !nonEscapingParameterFactAllowsScalarization({ symbol, fnCtx, ctx })
+  ) {
     recordScalarAggregateDecision("parameter", "bailout.escapes");
     return undefined;
   }
@@ -1134,7 +1484,15 @@ export const tryBindScalarAggregateParameter = ({
     recordScalarAggregateDecision("parameter", "bailout.incompatible_abi");
     return undefined;
   }
-  if (!isSmallScalarAggregate({ structInfo, ctx })) {
+  if (
+    !isSmallScalarAggregate({
+      structInfo,
+      maxLanes: mutable
+        ? ctx.specializationPolicy.mutableScalarAggregateLanes
+        : undefined,
+      ctx,
+    })
+  ) {
     recordScalarAggregateDecision("parameter", "bailout.too_wide");
     return undefined;
   }
@@ -1146,7 +1504,7 @@ export const tryBindScalarAggregateParameter = ({
   const binding = createScalarAggregateBinding({
     symbol,
     typeId,
-    mutable: false,
+    mutable,
     structInfo,
     ctx,
     fnCtx,

--- a/packages/compiler/src/codegen/optimization/scalar-aggregates.ts
+++ b/packages/compiler/src/codegen/optimization/scalar-aggregates.ts
@@ -1427,7 +1427,20 @@ export const loadScalarAggregateBindingAbiValue = ({
   binding: LocalBindingScalarAggregate;
   ctx: CodegenContext;
 }): binaryen.ExpressionRef => {
-  const lanes = binding.structInfo.fields.flatMap((field) => {
+  const lanes = loadScalarAggregateBindingAbiLanes({ binding, ctx });
+  return lanes.length === 1
+    ? lanes[0]!
+    : ctx.mod.tuple.make(lanes as binaryen.ExpressionRef[]);
+};
+
+export const loadScalarAggregateBindingAbiLanes = ({
+  binding,
+  ctx,
+}: {
+  binding: LocalBindingScalarAggregate;
+  ctx: CodegenContext;
+}): readonly binaryen.ExpressionRef[] =>
+  binding.structInfo.fields.flatMap((field) => {
     const fieldBinding = binding.fields.get(field.name);
     if (!fieldBinding) {
       throw new Error(`scalar aggregate missing field ${field.name}`);
@@ -1438,10 +1451,6 @@ export const loadScalarAggregateBindingAbiValue = ({
       ? [value]
       : fieldAbiTypes.map((_, index) => ctx.mod.tuple.extract(value, index));
   });
-  return lanes.length === 1
-    ? lanes[0]!
-    : ctx.mod.tuple.make(lanes as binaryen.ExpressionRef[]);
-};
 
 export const tryBindScalarAggregateParameter = ({
   symbol,

--- a/packages/compiler/src/codegen/patterns.ts
+++ b/packages/compiler/src/codegen/patterns.ts
@@ -498,6 +498,27 @@ export const compilePatternInitialization = ({
     return;
   }
 
+  const immutableAliasSource = ctx.module.hir.expressions.get(initializer);
+  const immutableAliasBinding =
+    options.declare &&
+    !mutableBinding &&
+    immutableAliasSource?.exprKind === "identifier"
+      ? fnCtx.bindings.get(immutableAliasSource.symbol)
+      : undefined;
+  if (
+    immutableAliasBinding?.kind === "scalar-aggregate" &&
+    immutableAliasBinding.mutable &&
+    ctx.specializationPolicy.mutableScalarAggregateLanes > 0 &&
+    immutableAliasBinding.structInfo.layoutKind === "heap-object" &&
+    immutableAliasBinding.typeId === targetTypeId
+  ) {
+    fnCtx.bindings.set(pattern.symbol, {
+      ...immutableAliasBinding,
+      mutable: false,
+    });
+    return;
+  }
+
   ops.push(
     ...materializeScalarHeapInitializerAlias({
       initializer,

--- a/packages/compiler/src/codegen/receiver-specialization.ts
+++ b/packages/compiler/src/codegen/receiver-specialization.ts
@@ -156,6 +156,20 @@ export const receiverSpecializedMetaForCall = ({
   ctx: CodegenContext;
   fnCtx: FunctionContext;
 }): FunctionMetadata => {
+  const exactReceiverType = fnCtx.exactCallReceiverTypes?.get(callId);
+  const receiverSymbol = meta.parameters[0]?.symbol;
+  if (
+    typeof exactReceiverType === "number" &&
+    typeof receiverSymbol === "number"
+  ) {
+    return (
+      getOrCreateReceiverSpecialization({
+        ctx,
+        meta,
+        exactParameterTypes: new Map([[receiverSymbol, exactReceiverType]]),
+      }) ?? meta
+    );
+  }
   if (!ctx.optimization || typeof fnCtx.instanceId !== "number") {
     return meta;
   }

--- a/packages/compiler/src/codegen/receiver-specialization.ts
+++ b/packages/compiler/src/codegen/receiver-specialization.ts
@@ -1,4 +1,8 @@
-import type { CodegenContext, FunctionMetadata } from "./context.js";
+import type {
+  CodegenContext,
+  FunctionContext,
+  FunctionMetadata,
+} from "./context.js";
 import type { HirFunction } from "../semantics/hir/index.js";
 import type { SymbolId, TypeId } from "../semantics/ids.js";
 import {
@@ -139,6 +143,43 @@ export const getOrCreateReceiverSpecialization = ({
   state.byKey.set(key, specialization);
   state.pending.push(specialization);
   return specializedMeta;
+};
+
+export const receiverSpecializedMetaForCall = ({
+  callId,
+  meta,
+  ctx,
+  fnCtx,
+}: {
+  callId: number;
+  meta: FunctionMetadata;
+  ctx: CodegenContext;
+  fnCtx: FunctionContext;
+}): FunctionMetadata => {
+  if (!ctx.optimization || typeof fnCtx.instanceId !== "number") {
+    return meta;
+  }
+
+  const callSiteKey = `${ctx.moduleId}:${callId}`;
+  const serializedFacts = Array.from(fnCtx.exactParameterTypes?.entries() ?? [])
+    .sort(([left], [right]) => left - right)
+    .map(([symbol, type]) => `${symbol}=${type}`)
+    .join(",");
+  const callerContextKey = `${fnCtx.instanceId}:${serializedFacts}`;
+  const exactParameterTypes = ctx.optimization.receiverSpecializationRequests
+    .get(callSiteKey)
+    ?.get(callerContextKey);
+  if (!exactParameterTypes || exactParameterTypes.size === 0) {
+    return meta;
+  }
+
+  return (
+    getOrCreateReceiverSpecialization({
+      ctx,
+      meta,
+      exactParameterTypes,
+    }) ?? meta
+  );
 };
 
 export const takePendingReceiverSpecializations = (

--- a/packages/compiler/src/codegen/specialization-policy.ts
+++ b/packages/compiler/src/codegen/specialization-policy.ts
@@ -84,16 +84,15 @@ export const decideFunctionSpecializationAdmission = ({
 }): SpecializationAdmissionDecision => {
   const metricPrefix = `codegen.specialization.${kind}`;
   incrementCompilerPerfCounter(`${metricPrefix}.requested`);
-  if (existingKindVariants >= maxKindVariants) {
-    incrementCompilerPerfCounter(`${metricPrefix}.rejected.kind_budget`);
-    return { stage: "admission", outcome: "rejected", reason: "kind_budget" };
-  }
-
   const state = stateOf(ctx);
   const identity = functionSpecializationIdentity({ meta, dimensions });
   if (state.identities.has(identity)) {
     incrementCompilerPerfCounter(`${metricPrefix}.reused`);
     return { stage: "admission", outcome: "reused" };
+  }
+  if (existingKindVariants >= maxKindVariants) {
+    incrementCompilerPerfCounter(`${metricPrefix}.rejected.kind_budget`);
+    return { stage: "admission", outcome: "rejected", reason: "kind_budget" };
   }
 
   const reservation = ctx.specializationReservations[kind];

--- a/packages/compiler/src/codegen/structural.ts
+++ b/packages/compiler/src/codegen/structural.ts
@@ -2749,6 +2749,7 @@ export const storeStructuralField = ({
   field,
   pointer,
   value,
+  exactNominalTypeId,
   ctx,
   fnCtx,
 }: {
@@ -2756,6 +2757,7 @@ export const storeStructuralField = ({
   field: StructuralFieldInfo;
   pointer: () => binaryen.ExpressionRef;
   value: binaryen.ExpressionRef;
+  exactNominalTypeId?: TypeId;
   ctx: CodegenContext;
   fnCtx: FunctionContext;
 }): binaryen.ExpressionRef => {
@@ -2763,6 +2765,23 @@ export const storeStructuralField = ({
     throw new Error(
       "storing directly into inline value-object fields is not supported",
     );
+  }
+  if (
+    typeof exactNominalTypeId === "number" &&
+    exactNominalTypeId === structInfo.nominalId
+  ) {
+    return structSetFieldValue({
+      mod: ctx.mod,
+      fieldIndex: field.runtimeIndex,
+      ref: refCast(ctx.mod, pointer(), structInfo.runtimeType),
+      value: lowerValueForHeapField({
+        value,
+        typeId: field.typeId,
+        targetType: field.heapWasmType,
+        ctx,
+        fnCtx,
+      }),
+    });
   }
   if (!field.setterType) {
     throw new Error(`missing setter for structural field ${field.name}`);

--- a/packages/compiler/src/compiler-contracts/__tests__/types.test.ts
+++ b/packages/compiler/src/compiler-contracts/__tests__/types.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { ProgramCodegenView } from "../../semantics/codegen-view/index.js";
 import {
   isStdIntrinsicNominalType,
+  isStdIntrinsicNominalTypeInstantiation,
   STD_INTRINSIC_TYPE,
   type StdIntrinsicTypeContractId,
 } from "../types.js";
@@ -91,6 +92,33 @@ describe("std intrinsic nominal type contracts", () => {
       }),
     ).toBe(true);
   });
+
+  it("requires exact generic arguments for an intrinsic instantiation", () => {
+    const program = programWithNominal({
+      name: "Range",
+      packageId: "std",
+      intrinsicType: STD_INTRINSIC_TYPE.range,
+      validatedContractId: STD_INTRINSIC_TYPE.range,
+      typeArgs: [21],
+    });
+
+    expect(
+      isStdIntrinsicNominalTypeInstantiation({
+        program,
+        typeId: 11,
+        intrinsicType: STD_INTRINSIC_TYPE.range,
+        typeArgs: [21],
+      }),
+    ).toBe(true);
+    expect(
+      isStdIntrinsicNominalTypeInstantiation({
+        program,
+        typeId: 11,
+        intrinsicType: STD_INTRINSIC_TYPE.range,
+        typeArgs: [22],
+      }),
+    ).toBe(false);
+  });
 });
 
 const programWithNominal = ({
@@ -98,11 +126,13 @@ const programWithNominal = ({
   packageId,
   intrinsicType,
   validatedContractId,
+  typeArgs = [],
 }: {
   name: string;
   packageId: string;
   intrinsicType: string | undefined;
   validatedContractId: StdIntrinsicTypeContractId | undefined;
+  typeArgs?: readonly number[];
 }): ProgramCodegenView =>
   ({
     types: {
@@ -110,7 +140,7 @@ const programWithNominal = ({
         kind: "nominal-object",
         name,
         owner: 3,
-        typeArgs: [],
+        typeArgs,
       }),
     },
     symbols: {

--- a/packages/compiler/src/compiler-contracts/types.ts
+++ b/packages/compiler/src/compiler-contracts/types.ts
@@ -14,9 +14,7 @@ export const STD_INTRINSIC_TYPE = {
 export type StdIntrinsicTypeId =
   (typeof STD_INTRINSIC_TYPE)[keyof typeof STD_INTRINSIC_TYPE];
 
-export type StdIntrinsicTypeProviderKind =
-  | "nominal-object"
-  | "value-object";
+export type StdIntrinsicTypeProviderKind = "nominal-object" | "value-object";
 
 const NOMINAL_PROVIDER_KINDS = [
   "nominal-object",
@@ -118,6 +116,37 @@ export const isStdIntrinsicNominalType = ({
   }
   return (
     program.symbols.getPackageId(desc.owner) === "std" &&
-    program.symbols.getStdIntrinsicTypeContract(desc.owner)?.id === intrinsicType
+    program.symbols.getStdIntrinsicTypeContract(desc.owner)?.id ===
+      intrinsicType
+  );
+};
+
+export const isStdIntrinsicNominalTypeInstantiation = ({
+  program,
+  typeId,
+  intrinsicType,
+  typeArgs,
+}: {
+  program: ProgramCodegenView;
+  typeId: TypeId;
+  intrinsicType: StdIntrinsicTypeId;
+  typeArgs: readonly TypeId[];
+}): boolean => {
+  if (!isStdIntrinsicNominalType({ program, typeId, intrinsicType })) {
+    return false;
+  }
+  const desc = program.types.getTypeDesc(typeId);
+  if (desc.kind === "intersection" && typeof desc.nominal === "number") {
+    return isStdIntrinsicNominalTypeInstantiation({
+      program,
+      typeId: desc.nominal,
+      intrinsicType,
+      typeArgs,
+    });
+  }
+  return (
+    (desc.kind === "nominal-object" || desc.kind === "value-object") &&
+    desc.typeArgs.length === typeArgs.length &&
+    desc.typeArgs.every((arg, index) => arg === typeArgs[index])
   );
 };

--- a/packages/compiler/src/optimization-policy.ts
+++ b/packages/compiler/src/optimization-policy.ts
@@ -23,6 +23,7 @@ export type SpecializationPolicy = Readonly<{
   receiverExactParametersPerContext: number;
   directTraitSwitchImplementations: number;
   scalarAggregateLanes: number;
+  mutableScalarAggregateLanes: number;
   scalarAggregateCallContextsPerFunction: number;
   staticEffectContextsPerFunction: number;
   callShapeContextsPerFunction: number;
@@ -36,6 +37,7 @@ const DEFAULT_SPECIALIZATION_POLICY: SpecializationPolicy = Object.freeze({
   receiverExactParametersPerContext: 2,
   directTraitSwitchImplementations: 4,
   scalarAggregateLanes: 4,
+  mutableScalarAggregateLanes: 8,
   scalarAggregateCallContextsPerFunction: 8,
   staticEffectContextsPerFunction: 8,
   callShapeContextsPerFunction: 4,
@@ -44,10 +46,17 @@ const DEFAULT_SPECIALIZATION_POLICY: SpecializationPolicy = Object.freeze({
   totalEstimatedBodyNodes: 100_000,
 });
 
-/** Public levels currently share semantic specialization limits. */
+const BALANCED_SPECIALIZATION_POLICY: SpecializationPolicy = Object.freeze({
+  ...DEFAULT_SPECIALIZATION_POLICY,
+  mutableScalarAggregateLanes: 0,
+});
+
 export const specializationPolicyForOptimizationLevel = (
-  _level: OptimizationLevel,
-): SpecializationPolicy => DEFAULT_SPECIALIZATION_POLICY;
+  level: OptimizationLevel,
+): SpecializationPolicy =>
+  level === "release"
+    ? DEFAULT_SPECIALIZATION_POLICY
+    : BALANCED_SPECIALIZATION_POLICY;
 
 export const resolveOptimizationPolicy = (
   input: OptimizationPolicyInput = {},

--- a/packages/compiler/src/optimize/__tests__/schedule.test.ts
+++ b/packages/compiler/src/optimize/__tests__/schedule.test.ts
@@ -21,6 +21,7 @@ describe("optimizer schedule", () => {
       handlerEnvironmentShrinking: pass("handler-captures"),
       runtimeTypeCheckElimination: pass("runtime-types"),
       semanticCopyForwarding: pass("copy-forwarding"),
+      stableFieldLoadForwarding: pass("stable-field-loads"),
       escapeAnalysis: pass("escape"),
       callShapeSpecialization: pass("call-shape"),
     });
@@ -46,6 +47,7 @@ describe("optimizer schedule", () => {
       "handler-captures",
       "runtime-types",
       "copy-forwarding",
+      "stable-field-loads",
       "escape",
     ]);
     expect(schedule.minimumFixedPointIterations).toBeGreaterThan(3);

--- a/packages/compiler/src/optimize/ir.ts
+++ b/packages/compiler/src/optimize/ir.ts
@@ -143,6 +143,15 @@ export type ProgramOptimizationFacts = {
     string,
     ReadonlySet<HirExprId>
   >;
+  stableFieldLoadForwarding: ReadonlyMap<
+    string,
+    ReadonlyMap<
+      HirExprId,
+      readonly {
+        accessExprIds: readonly HirExprId[];
+      }[]
+    >
+  >;
   codegenPlan: ProgramCodegenOptimizationPlan;
 };
 

--- a/packages/compiler/src/optimize/passes/stable-field-loads.ts
+++ b/packages/compiler/src/optimize/passes/stable-field-loads.ts
@@ -255,7 +255,15 @@ const loopPreservesCandidate = ({
           return;
         }
         if (expr.exprKind === "method-call") {
-          safe = false;
+          safe = callIsDisjoint({
+            exprId,
+            expr,
+            candidate,
+            aliases,
+            callInfo: calls.get(exprId),
+            moduleView,
+            program,
+          });
           return;
         }
         if (
@@ -388,15 +396,18 @@ const loopPreservesCandidate = ({
         safe = false;
         return;
       }
-      if (expr.exprKind !== "call") {
+      if (expr.exprKind !== "call" && expr.exprKind !== "method-call") {
         return;
       }
-      if (isBorrowMarker({ expr, moduleView, program })) {
+      if (
+        expr.exprKind === "call" &&
+        isBorrowMarker({ expr, moduleView, program })
+      ) {
         return;
       }
-      const aliasesRoot = expr.args.some((argument) => {
+      const aliasesRoot = callArgumentExprIds(expr).some((argumentExprId) => {
         const symbol = argumentRootSymbol({
-          exprId: argument.expr,
+          exprId: argumentExprId,
           moduleView,
           program,
         });
@@ -482,14 +493,13 @@ const isBorrowMarker = ({
   if (callee?.exprKind !== "identifier") {
     return false;
   }
-  return (
-    program.symbols.getName(
-      program.symbols.idOf({
-        moduleId: moduleView.moduleId,
-        symbol: callee.symbol,
-      }),
-    ) === "~"
+  const name = program.symbols.getName(
+    program.symbols.idOf({
+      moduleId: moduleView.moduleId,
+      symbol: callee.symbol,
+    }),
   );
+  return name === "~";
 };
 
 const callHasNoEscape = ({
@@ -499,7 +509,7 @@ const callHasNoEscape = ({
   program,
 }: {
   callInfo: OptimizedCallInfo | undefined;
-  expr: Extract<HirExpression, { exprKind: "call" }>;
+  expr: Extract<HirExpression, { exprKind: "call" | "method-call" }>;
   moduleView: ReadonlyOptimizedModuleView;
   program: ProgramCodegenView;
 }): boolean => {
@@ -531,19 +541,30 @@ const callIsDisjoint = ({
   program,
 }: {
   exprId: HirExprId;
-  expr: Extract<HirExpression, { exprKind: "call" }>;
+  expr: Extract<HirExpression, { exprKind: "call" | "method-call" }>;
   candidate: Candidate;
   aliases: AliasGroups;
   callInfo: OptimizedCallInfo | undefined;
   moduleView: ReadonlyOptimizedModuleView;
   program: ProgramCodegenView;
 }): boolean => {
-  if (isBorrowMarker({ expr, moduleView, program })) {
+  if (
+    expr.exprKind === "call" &&
+    isBorrowMarker({ expr, moduleView, program })
+  ) {
     return true;
   }
-  const passesRoot = expr.args.some((argument) => {
+  if (
+    expr.exprKind === "method-call" &&
+    callInfo?.traitDispatch &&
+    expr.args.length > 0
+  ) {
+    return false;
+  }
+  const argumentExprIds = callArgumentExprIds(expr);
+  const passesRoot = argumentExprIds.some((argumentExprId) => {
     const symbol = argumentRootSymbol({
-      exprId: argument.expr,
+      exprId: argumentExprId,
       moduleView,
       program,
     });
@@ -593,10 +614,11 @@ const callIsDisjoint = ({
       if (typeof argumentIndex !== "number") {
         return parameter.writePaths.length === 0;
       }
-      const argument = expr.args[argumentIndex];
-      const argumentSymbol = argument
-        ? argumentRootSymbol({ exprId: argument.expr, moduleView, program })
-        : undefined;
+      const argumentExprId = argumentExprIds[argumentIndex];
+      const argumentSymbol =
+        typeof argumentExprId === "number"
+          ? argumentRootSymbol({ exprId: argumentExprId, moduleView, program })
+          : undefined;
       if (
         typeof argumentSymbol !== "number" ||
         !aliases.aliases(argumentSymbol, candidate.root)
@@ -648,7 +670,7 @@ const resolvedFootprints = ({
   program,
 }: {
   callInfo: OptimizedCallInfo | undefined;
-  expr: Extract<HirExpression, { exprKind: "call" }>;
+  expr: Extract<HirExpression, { exprKind: "call" | "method-call" }>;
   moduleView: ReadonlyOptimizedModuleView;
   program: ProgramCodegenView;
 }): readonly CodegenCallableAccessFootprint[] => {
@@ -683,7 +705,7 @@ const resolvedTargetEntries = ({
   program,
 }: {
   callInfo: OptimizedCallInfo;
-  expr: Extract<HirExpression, { exprKind: "call" }>;
+  expr: Extract<HirExpression, { exprKind: "call" | "method-call" }>;
   moduleView: ReadonlyOptimizedModuleView;
   program: ProgramCodegenView;
 }): readonly [ProgramFunctionInstanceId, ProgramFunctionId][] => {
@@ -694,7 +716,10 @@ const resolvedTargetEntries = ({
   // Monomorphic direct calls intentionally omit the per-instance target map;
   // the callee's declaration symbol plus its callable footprint is their
   // resolution proof. Function-value locals have no footprint and bail out.
-  const callee = moduleView.hir.expressions.get(expr.callee);
+  const callee =
+    expr.exprKind === "call"
+      ? moduleView.hir.expressions.get(expr.callee)
+      : undefined;
   const target =
     callee?.exprKind === "identifier"
       ? program.functions.getFunctionId({
@@ -710,3 +735,10 @@ const resolvedTargetEntries = ({
     ? callerInstances.map((caller) => [caller, target] as const)
     : [[-1 as ProgramFunctionInstanceId, target]];
 };
+
+const callArgumentExprIds = (
+  expr: Extract<HirExpression, { exprKind: "call" | "method-call" }>,
+): readonly HirExprId[] =>
+  expr.exprKind === "method-call"
+    ? [expr.target, ...expr.args.map((argument) => argument.expr)]
+    : expr.args.map((argument) => argument.expr);

--- a/packages/compiler/src/optimize/passes/stable-field-loads.ts
+++ b/packages/compiler/src/optimize/passes/stable-field-loads.ts
@@ -1,0 +1,712 @@
+import { walkExpression } from "../../semantics/hir/index.js";
+import type { HirExpression, HirFunction } from "../../semantics/hir/index.js";
+import type {
+  HirExprId,
+  ProgramFunctionId,
+  ProgramFunctionInstanceId,
+  SymbolId,
+} from "../../semantics/ids.js";
+import type {
+  CodegenCallableAccessFootprint,
+  ProgramCodegenView,
+} from "../../semantics/codegen-view/index.js";
+import type { ProgramOptimizationPass } from "../pass.js";
+import type { OptimizedCallInfo, ReadonlyOptimizedModuleView } from "../ir.js";
+import { exactNominalForType, exprTypeFor } from "./shared.js";
+
+type AliasGroups = {
+  rootOf(symbol: SymbolId): SymbolId;
+  aliases(left: SymbolId, right: SymbolId): boolean;
+  isFresh(symbol: SymbolId): boolean;
+};
+
+type Candidate = {
+  root: SymbolId;
+  field: string;
+  accessExprIds: HirExprId[];
+};
+
+export const stableFieldLoadForwardingPass: ProgramOptimizationPass = {
+  name: "stable-field-load-forwarding",
+  run(ctx) {
+    const byModule = new Map<
+      string,
+      Map<HirExprId, readonly { accessExprIds: readonly HirExprId[] }[]>
+    >();
+    let forwardedLoads = 0;
+
+    ctx.ir.modules.forEach((moduleView, moduleId) => {
+      const loops = new Map<
+        HirExprId,
+        readonly { accessExprIds: readonly HirExprId[] }[]
+      >();
+      const calls = ctx.ir.calls.get(moduleId) ?? new Map();
+
+      moduleView.hir.items.forEach((item) => {
+        if (item.kind !== "function") {
+          return;
+        }
+        const aliases = collectAliases(item, moduleView);
+        walkExpression({
+          exprId: item.body,
+          hir: moduleView.hir,
+          onEnterExpression: (exprId, expr) => {
+            if (expr.exprKind !== "while") {
+              return;
+            }
+            const rawCandidates = collectCandidates({
+              body: expr.body,
+              aliases,
+              moduleView,
+              program: ctx.ir.baseProgram,
+            });
+            const candidates = rawCandidates.filter(
+              (candidate) =>
+                candidate.accessExprIds.length > 1 &&
+                loopPreservesCandidate({
+                  body: expr.body,
+                  condition: expr.condition,
+                  functionBody: item.body,
+                  candidate,
+                  aliases,
+                  calls,
+                  moduleView,
+                  program: ctx.ir.baseProgram,
+                }),
+            );
+            if (candidates.length === 0) {
+              return;
+            }
+            loops.set(
+              exprId,
+              candidates.map(({ accessExprIds }) => ({ accessExprIds })),
+            );
+            forwardedLoads += candidates.reduce(
+              (total, candidate) => total + candidate.accessExprIds.length - 1,
+              0,
+            );
+          },
+        });
+      });
+
+      if (loops.size > 0) {
+        byModule.set(moduleId, loops);
+      }
+    });
+
+    ctx.mutateProducedFacts((mutation) =>
+      mutation.setFact("stableFieldLoadForwarding", byModule),
+    );
+    return {
+      changed: forwardedLoads > 0,
+      metrics: { forwarded_loads: forwardedLoads },
+    };
+  },
+};
+
+const collectAliases = (
+  fn: HirFunction,
+  moduleView: ReadonlyOptimizedModuleView,
+): AliasGroups => {
+  const parents = new Map<SymbolId, SymbolId>();
+  const freshSymbols = new Set<SymbolId>();
+  const assignedSymbols = new Set<SymbolId>();
+  const rootOf = (symbol: SymbolId): SymbolId => {
+    const parent = parents.get(symbol);
+    if (typeof parent !== "number" || parent === symbol) {
+      return symbol;
+    }
+    const root = rootOf(parent);
+    parents.set(symbol, root);
+    return root;
+  };
+  const union = (left: SymbolId, right: SymbolId): void => {
+    const leftRoot = rootOf(left);
+    const rightRoot = rootOf(right);
+    if (leftRoot !== rightRoot) {
+      parents.set(rightRoot, leftRoot);
+    }
+  };
+
+  walkExpression({
+    exprId: fn.body,
+    hir: moduleView.hir,
+    onEnterStatement: (_stmtId, statement) => {
+      if (statement.kind !== "let" || statement.pattern.kind !== "identifier") {
+        return;
+      }
+      const initializer = moduleView.hir.expressions.get(statement.initializer);
+      if (initializer?.exprKind === "identifier") {
+        union(statement.pattern.symbol, initializer.symbol);
+      } else if (initializer?.exprKind === "object-literal") {
+        freshSymbols.add(statement.pattern.symbol);
+      }
+    },
+    onEnterExpression: (_exprId, expression) => {
+      if (
+        expression.exprKind !== "assign" ||
+        typeof expression.target !== "number"
+      ) {
+        return;
+      }
+      const target = moduleView.hir.expressions.get(expression.target);
+      if (target?.exprKind === "identifier") {
+        assignedSymbols.add(target.symbol);
+      }
+    },
+  });
+  return {
+    rootOf,
+    aliases: (left, right) => rootOf(left) === rootOf(right),
+    isFresh: (symbol) =>
+      [...freshSymbols].some((fresh) => rootOf(fresh) === rootOf(symbol)) &&
+      ![...assignedSymbols].some(
+        (assigned) => rootOf(assigned) === rootOf(symbol),
+      ),
+  };
+};
+
+const collectCandidates = ({
+  body,
+  aliases,
+  moduleView,
+  program,
+}: {
+  body: HirExprId;
+  aliases: AliasGroups;
+  moduleView: ReadonlyOptimizedModuleView;
+  program: ProgramCodegenView;
+}): Candidate[] => {
+  const candidates = new Map<string, Candidate>();
+  walkExpression({
+    exprId: body,
+    hir: moduleView.hir,
+    onEnterExpression: (exprId, expr) => {
+      if (expr.exprKind !== "field-access") {
+        return;
+      }
+      const target = moduleView.hir.expressions.get(expr.target);
+      const targetType = exprTypeFor({ moduleView, exprId: expr.target });
+      const nominal = exactNominalForType({ typeId: targetType, program });
+      if (
+        target?.exprKind !== "identifier" ||
+        typeof nominal !== "number" ||
+        program.types.getTypeDesc(nominal).kind !== "nominal-object"
+      ) {
+        return;
+      }
+      const root = aliases.rootOf(target.symbol);
+      if (!aliases.isFresh(root)) {
+        return;
+      }
+      const key = `${root}:${expr.field}`;
+      const candidate = candidates.get(key) ?? {
+        root,
+        field: expr.field,
+        accessExprIds: [],
+      };
+      candidate.accessExprIds.push(exprId);
+      candidates.set(key, candidate);
+    },
+  });
+  return [...candidates.values()];
+};
+
+const loopPreservesCandidate = ({
+  body,
+  condition,
+  functionBody,
+  candidate,
+  aliases,
+  calls,
+  moduleView,
+  program,
+}: {
+  body: HirExprId;
+  condition: HirExprId;
+  functionBody: HirExprId;
+  candidate: Candidate;
+  aliases: AliasGroups;
+  calls: ReadonlyMap<HirExprId, OptimizedCallInfo>;
+  moduleView: ReadonlyOptimizedModuleView;
+  program: ProgramCodegenView;
+}): boolean => {
+  let safe = true;
+  const inspectLoopExpression = (root: HirExprId): void =>
+    walkExpression({
+      exprId: root,
+      hir: moduleView.hir,
+      onEnterExpression: (exprId, expr) => {
+        if (!safe) {
+          return { stop: true };
+        }
+        if (expr.exprKind === "assign") {
+          const valueSymbol = argumentRootSymbol({
+            exprId: expr.value,
+            moduleView,
+            program,
+          });
+          safe =
+            assignmentIsDisjoint({ expr, candidate, aliases, moduleView }) &&
+            !(
+              typeof valueSymbol === "number" &&
+              aliases.aliases(valueSymbol, candidate.root)
+            );
+          return;
+        }
+        if (expr.exprKind === "method-call") {
+          safe = false;
+          return;
+        }
+        if (
+          expr.exprKind === "lambda" &&
+          expr.captures?.some((capture) =>
+            aliases.aliases(capture.symbol, candidate.root),
+          )
+        ) {
+          safe = false;
+          return;
+        }
+        if (
+          expr.exprKind === "object-literal" &&
+          expr.entries.some((entry) => {
+            const symbol = argumentRootSymbol({
+              exprId: entry.value,
+              moduleView,
+              program,
+            });
+            return (
+              typeof symbol === "number" &&
+              aliases.aliases(symbol, candidate.root)
+            );
+          })
+        ) {
+          safe = false;
+          return;
+        }
+        if (
+          expr.exprKind === "tuple" &&
+          expr.elements.some((element) => {
+            const symbol = argumentRootSymbol({
+              exprId: element,
+              moduleView,
+              program,
+            });
+            return (
+              typeof symbol === "number" &&
+              aliases.aliases(symbol, candidate.root)
+            );
+          })
+        ) {
+          safe = false;
+          return;
+        }
+        if (expr.exprKind === "call") {
+          safe = callIsDisjoint({
+            exprId,
+            expr,
+            candidate,
+            aliases,
+            callInfo: calls.get(exprId),
+            moduleView,
+            program,
+          });
+        }
+      },
+    });
+  inspectLoopExpression(condition);
+  if (safe) {
+    inspectLoopExpression(body);
+  }
+  if (!safe) {
+    return false;
+  }
+
+  // A prior call that retains or returns an alias can make a later otherwise
+  // unrelated call mutate it. Exclude such roots across the whole callable.
+  walkExpression({
+    exprId: functionBody,
+    hir: moduleView.hir,
+    onEnterExpression: (exprId, expr) => {
+      if (!safe) {
+        return;
+      }
+      if (
+        expr.exprKind === "lambda" &&
+        expr.captures?.some((capture) =>
+          aliases.aliases(capture.symbol, candidate.root),
+        )
+      ) {
+        safe = false;
+        return;
+      }
+      if (
+        expr.exprKind === "object-literal" &&
+        expr.entries.some((entry) => {
+          const symbol = argumentRootSymbol({
+            exprId: entry.value,
+            moduleView,
+            program,
+          });
+          return (
+            typeof symbol === "number" &&
+            aliases.aliases(symbol, candidate.root)
+          );
+        })
+      ) {
+        safe = false;
+        return;
+      }
+      if (expr.exprKind === "assign") {
+        const symbol = argumentRootSymbol({
+          exprId: expr.value,
+          moduleView,
+          program,
+        });
+        if (
+          typeof symbol === "number" &&
+          aliases.aliases(symbol, candidate.root)
+        ) {
+          safe = false;
+          return;
+        }
+      }
+      if (
+        expr.exprKind === "tuple" &&
+        expr.elements.some((element) => {
+          const symbol = argumentRootSymbol({
+            exprId: element,
+            moduleView,
+            program,
+          });
+          return (
+            typeof symbol === "number" &&
+            aliases.aliases(symbol, candidate.root)
+          );
+        })
+      ) {
+        safe = false;
+        return;
+      }
+      if (expr.exprKind !== "call") {
+        return;
+      }
+      if (isBorrowMarker({ expr, moduleView, program })) {
+        return;
+      }
+      const aliasesRoot = expr.args.some((argument) => {
+        const symbol = argumentRootSymbol({
+          exprId: argument.expr,
+          moduleView,
+          program,
+        });
+        return (
+          typeof symbol === "number" && aliases.aliases(symbol, candidate.root)
+        );
+      });
+      if (!aliasesRoot) {
+        return;
+      }
+      safe = callHasNoEscape({
+        callInfo: calls.get(exprId),
+        expr,
+        moduleView,
+        program,
+      });
+    },
+    onEnterStatement: (_statementId, statement) => {
+      if (
+        !safe ||
+        statement.kind !== "return" ||
+        typeof statement.value !== "number"
+      ) {
+        return;
+      }
+      const symbol = argumentRootSymbol({
+        exprId: statement.value,
+        moduleView,
+        program,
+      });
+      if (
+        typeof symbol === "number" &&
+        aliases.aliases(symbol, candidate.root)
+      ) {
+        safe = false;
+      }
+    },
+  });
+  return safe;
+};
+
+const assignmentIsDisjoint = ({
+  expr,
+  candidate,
+  aliases,
+  moduleView,
+}: {
+  expr: Extract<HirExpression, { exprKind: "assign" }>;
+  candidate: Candidate;
+  aliases: AliasGroups;
+  moduleView: ReadonlyOptimizedModuleView;
+}): boolean => {
+  if (typeof expr.target !== "number") {
+    return false;
+  }
+  const target = moduleView.hir.expressions.get(expr.target);
+  if (target?.exprKind === "identifier") {
+    return !aliases.aliases(target.symbol, candidate.root);
+  }
+  if (target?.exprKind !== "field-access") {
+    return false;
+  }
+  const root = moduleView.hir.expressions.get(target.target);
+  if (
+    root?.exprKind !== "identifier" ||
+    !aliases.aliases(root.symbol, candidate.root)
+  ) {
+    return true;
+  }
+  return target.field !== candidate.field;
+};
+
+const isBorrowMarker = ({
+  expr,
+  moduleView,
+  program,
+}: {
+  expr: Extract<HirExpression, { exprKind: "call" }>;
+  moduleView: ReadonlyOptimizedModuleView;
+  program: ProgramCodegenView;
+}): boolean => {
+  const callee = moduleView.hir.expressions.get(expr.callee);
+  if (callee?.exprKind !== "identifier") {
+    return false;
+  }
+  return (
+    program.symbols.getName(
+      program.symbols.idOf({
+        moduleId: moduleView.moduleId,
+        symbol: callee.symbol,
+      }),
+    ) === "~"
+  );
+};
+
+const callHasNoEscape = ({
+  callInfo,
+  expr,
+  moduleView,
+  program,
+}: {
+  callInfo: OptimizedCallInfo | undefined;
+  expr: Extract<HirExpression, { exprKind: "call" }>;
+  moduleView: ReadonlyOptimizedModuleView;
+  program: ProgramCodegenView;
+}): boolean => {
+  const footprints = resolvedFootprints({
+    callInfo,
+    expr,
+    moduleView,
+    program,
+  });
+  return (
+    footprints.length > 0 &&
+    footprints.every((footprint) =>
+      footprint.parameters.every(
+        (parameter) =>
+          !parameter.retained &&
+          !parameter.returned &&
+          !parameter.returnedProvenance,
+      ),
+    )
+  );
+};
+
+const callIsDisjoint = ({
+  expr,
+  candidate,
+  aliases,
+  callInfo,
+  moduleView,
+  program,
+}: {
+  exprId: HirExprId;
+  expr: Extract<HirExpression, { exprKind: "call" }>;
+  candidate: Candidate;
+  aliases: AliasGroups;
+  callInfo: OptimizedCallInfo | undefined;
+  moduleView: ReadonlyOptimizedModuleView;
+  program: ProgramCodegenView;
+}): boolean => {
+  if (isBorrowMarker({ expr, moduleView, program })) {
+    return true;
+  }
+  const passesRoot = expr.args.some((argument) => {
+    const symbol = argumentRootSymbol({
+      exprId: argument.expr,
+      moduleView,
+      program,
+    });
+    return (
+      typeof symbol === "number" && aliases.aliases(symbol, candidate.root)
+    );
+  });
+  if (!passesRoot) {
+    return true;
+  }
+  if (
+    !callInfo ||
+    callInfo.traitDispatch ||
+    callInfo.identityGuards.length > 0 ||
+    !callHasNoEscape({ callInfo, expr, moduleView, program })
+  ) {
+    return false;
+  }
+  const targets = resolvedTargetEntries({
+    callInfo,
+    expr,
+    moduleView,
+    program,
+  });
+  if (targets.length === 0) {
+    return false;
+  }
+  return targets.every(([callerInstance, target]) => {
+    const footprint = program.callableAccesses.getFootprint(target);
+    const plan = callInfo.argPlans?.get(callerInstance);
+    if (
+      !footprint ||
+      footprint.maySuspend ||
+      footprint.externalRead ||
+      footprint.externalWrite
+    ) {
+      return false;
+    }
+    return footprint.parameters.every((parameter, parameterIndex) => {
+      const planned = plan?.[parameterIndex];
+      const argumentIndex =
+        planned?.kind === "direct"
+          ? planned.argIndex
+          : plan
+            ? undefined
+            : parameterIndex;
+      if (typeof argumentIndex !== "number") {
+        return parameter.writePaths.length === 0;
+      }
+      const argument = expr.args[argumentIndex];
+      const argumentSymbol = argument
+        ? argumentRootSymbol({ exprId: argument.expr, moduleView, program })
+        : undefined;
+      if (
+        typeof argumentSymbol !== "number" ||
+        !aliases.aliases(argumentSymbol, candidate.root)
+      ) {
+        return true;
+      }
+      return (
+        !parameter.runtimeCheckedWrites &&
+        parameter.writePaths.every(
+          (path) =>
+            path.length > 0 &&
+            path[0]?.kind === "field" &&
+            path[0].name !== candidate.field,
+        )
+      );
+    });
+  });
+};
+
+const argumentRootSymbol = ({
+  exprId,
+  moduleView,
+  program,
+}: {
+  exprId: HirExprId;
+  moduleView: ReadonlyOptimizedModuleView;
+  program: ProgramCodegenView;
+}): SymbolId | undefined => {
+  const expr = moduleView.hir.expressions.get(exprId);
+  if (expr?.exprKind === "identifier") {
+    return expr.symbol;
+  }
+  if (
+    expr?.exprKind !== "call" ||
+    !isBorrowMarker({ expr, moduleView, program })
+  ) {
+    return undefined;
+  }
+  const argument = expr.args[0];
+  return argument
+    ? argumentRootSymbol({ exprId: argument.expr, moduleView, program })
+    : undefined;
+};
+
+const resolvedFootprints = ({
+  callInfo,
+  expr,
+  moduleView,
+  program,
+}: {
+  callInfo: OptimizedCallInfo | undefined;
+  expr: Extract<HirExpression, { exprKind: "call" }>;
+  moduleView: ReadonlyOptimizedModuleView;
+  program: ProgramCodegenView;
+}): readonly CodegenCallableAccessFootprint[] => {
+  if (
+    !callInfo ||
+    callInfo.traitDispatch ||
+    callInfo.identityGuards.length > 0
+  ) {
+    return [];
+  }
+  const targets = [
+    ...new Set(
+      resolvedTargetEntries({ callInfo, expr, moduleView, program }).map(
+        ([, target]) => target,
+      ),
+    ),
+  ];
+  if (targets.length === 0) {
+    return [];
+  }
+  const footprints = targets.flatMap((target) => {
+    const footprint = program.callableAccesses.getFootprint(target);
+    return footprint ? [footprint] : [];
+  });
+  return footprints.length === targets.length ? footprints : [];
+};
+
+const resolvedTargetEntries = ({
+  callInfo,
+  expr,
+  moduleView,
+  program,
+}: {
+  callInfo: OptimizedCallInfo;
+  expr: Extract<HirExpression, { exprKind: "call" }>;
+  moduleView: ReadonlyOptimizedModuleView;
+  program: ProgramCodegenView;
+}): readonly [ProgramFunctionInstanceId, ProgramFunctionId][] => {
+  const resolved = [...(callInfo.targets?.entries() ?? [])];
+  if (resolved.length > 0) {
+    return resolved;
+  }
+  // Monomorphic direct calls intentionally omit the per-instance target map;
+  // the callee's declaration symbol plus its callable footprint is their
+  // resolution proof. Function-value locals have no footprint and bail out.
+  const callee = moduleView.hir.expressions.get(expr.callee);
+  const target =
+    callee?.exprKind === "identifier"
+      ? program.functions.getFunctionId({
+          moduleId: moduleView.moduleId,
+          symbol: callee.symbol,
+        })
+      : undefined;
+  if (typeof target !== "number") {
+    return [];
+  }
+  const callerInstances = [...(callInfo.argPlans?.keys() ?? [])];
+  return callerInstances.length > 0
+    ? callerInstances.map((caller) => [caller, target] as const)
+    : [[-1 as ProgramFunctionInstanceId, target]];
+};

--- a/packages/compiler/src/optimize/pipeline.ts
+++ b/packages/compiler/src/optimize/pipeline.ts
@@ -33,6 +33,7 @@ import {
 import { wholeProgramSpecializationPruningPass } from "./passes/reachability.js";
 import { escapeAnalysisPass } from "./passes/escape-analysis.js";
 import { callShapeSpecializationPlanningPass } from "./passes/call-shape-planning.js";
+import { stableFieldLoadForwardingPass } from "./passes/stable-field-loads.js";
 
 const OPTIMIZATION_SCHEDULE = createOptimizationSchedule({
   pureCompileTimeEvaluation: pureCompileTimeEvaluationPass,
@@ -46,6 +47,7 @@ const OPTIMIZATION_SCHEDULE = createOptimizationSchedule({
   handlerEnvironmentShrinking: continuationAndHandlerEnvironmentShrinkingPass,
   runtimeTypeCheckElimination: redundantRuntimeTypeCheckEliminationPass,
   semanticCopyForwarding: semanticCopyForwardingPass,
+  stableFieldLoadForwarding: stableFieldLoadForwardingPass,
   escapeAnalysis: escapeAnalysisPass,
   callShapeSpecialization: callShapeSpecializationPlanningPass,
 });

--- a/packages/compiler/src/optimize/schedule.ts
+++ b/packages/compiler/src/optimize/schedule.ts
@@ -13,6 +13,7 @@ export type OptimizationPassRegistry = {
   handlerEnvironmentShrinking: ProgramOptimizationPass;
   runtimeTypeCheckElimination: ProgramOptimizationPass;
   semanticCopyForwarding: ProgramOptimizationPass;
+  stableFieldLoadForwarding: ProgramOptimizationPass;
   escapeAnalysis: ProgramOptimizationPass;
   callShapeSpecialization: ProgramOptimizationPass;
 };
@@ -52,6 +53,7 @@ export const createOptimizationSchedule = (
     passes.handlerEnvironmentShrinking,
     passes.runtimeTypeCheckElimination,
     passes.semanticCopyForwarding,
+    passes.stableFieldLoadForwarding,
     passes.escapeAnalysis,
   ],
   minimumFixedPointIterations: 32,

--- a/packages/compiler/src/optimize/state.ts
+++ b/packages/compiler/src/optimize/state.ts
@@ -79,6 +79,10 @@ export type MutableOptimizationIr = {
     };
     runtimeTypeCheckElisionFieldAccesses: Map<string, Set<HirExprId>>;
     semanticCopyForwardingFieldAccesses: Map<string, Set<HirExprId>>;
+    stableFieldLoadForwarding: Map<
+      string,
+      Map<HirExprId, readonly { accessExprIds: readonly HirExprId[] }[]>
+    >;
     codegenPlan: ProgramCodegenOptimizationPlan;
   };
 };
@@ -199,6 +203,7 @@ export const buildOptimizationIr = ({
       },
       runtimeTypeCheckElisionFieldAccesses: new Map(),
       semanticCopyForwardingFieldAccesses: new Map(),
+      stableFieldLoadForwarding: new Map(),
       codegenPlan: {
         representations: {},
         specializationPolicy,

--- a/packages/compiler/src/semantics/codegen-view/index.ts
+++ b/packages/compiler/src/semantics/codegen-view/index.ts
@@ -370,6 +370,26 @@ export type CallLoweringIndex = {
   }[];
 };
 
+export type CodegenCallableAccessFootprint = {
+  parameters: readonly {
+    readPaths: readonly (readonly CodegenPlaceProjection[])[];
+    writePaths: readonly (readonly CodegenPlaceProjection[])[];
+    runtimeCheckedWrites: boolean;
+    retained: boolean;
+    returned: boolean;
+    returnedProvenance: boolean;
+  }[];
+  maySuspend: boolean;
+  externalRead: boolean;
+  externalWrite: boolean;
+};
+
+export type CallableAccessIndex = {
+  getFootprint(
+    target: ProgramFunctionId,
+  ): CodegenCallableAccessFootprint | undefined;
+};
+
 export type MonomorphizedInstanceIndex = {
   getAll(): readonly MonomorphizedInstanceInfo[];
   getById(
@@ -481,6 +501,7 @@ export type ProgramCodegenView = {
   objects: ObjectLayoutIndex;
   traits: TraitDispatchIndex;
   calls: CallLoweringIndex;
+  callableAccesses: CallableAccessIndex;
   instances: MonomorphizedInstanceIndex;
   imports: ImportWiringIndex;
   modules: ReadonlyMap<string, ModuleCodegenView>;
@@ -2465,6 +2486,41 @@ export const buildProgramCodegenView = (
       defaultIdentityGuardDiagnosticsByTarget.get(target) ?? [],
   };
 
+  const callableAccesses: CallableAccessIndex = {
+    getFootprint: (target) => {
+      const ref = symbols.refOf(target);
+      const contract = modulesById
+        .get(ref.moduleId)
+        ?.borrowing.callables.get(ref.symbol);
+      if (!contract) {
+        return undefined;
+      }
+      return {
+        parameters: contract.parameters.map((parameter) => ({
+          readPaths: copyAccessPaths(parameter.readPaths),
+          writePaths: copyAccessPaths(parameter.writePaths),
+          runtimeCheckedWrites: parameter.runtimeCheckedWrites === true,
+          retained:
+            parameter.retained === true ||
+            parameter.retainedUnlessBorrowed === true ||
+            (parameter.retainedPaths?.length ?? 0) > 0 ||
+            (parameter.externalRetainedPaths?.length ?? 0) > 0 ||
+            (parameter.borrowedRetainedPaths?.length ?? 0) > 0,
+          returned: parameter.returned === true,
+          returnedProvenance:
+            parameter.returnedAggregate === true ||
+            (parameter.returnedPaths?.length ?? 0) > 0 ||
+            (parameter.returnedOrigins?.length ?? 0) > 0 ||
+            (parameter.returnedSharedOrigins?.length ?? 0) > 0 ||
+            (parameter.returnedTypeMatchingOrigins?.length ?? 0) > 0,
+        })),
+        maySuspend: contract.maySuspend,
+        externalRead: contract.externalRead === true,
+        externalWrite: contract.externalWrite === true,
+      };
+    },
+  };
+
   const functions: FunctionLoweringIndex = {
     getSignature: (moduleId, symbol) => {
       const mod = modulesById.get(moduleId);
@@ -2666,6 +2722,7 @@ export const buildProgramCodegenView = (
     objects,
     traits,
     calls,
+    callableAccesses,
     instances,
     imports,
     modules: moduleViews,

--- a/scripts/bench-array-for-fast-path.ts
+++ b/scripts/bench-array-for-fast-path.ts
@@ -1,0 +1,136 @@
+import { gzipSync } from "node:zlib";
+import { performance } from "node:perf_hooks";
+import { resolve } from "node:path";
+import { createSdk, type CompileResult } from "@voyd-lang/sdk";
+import { createVoydHost } from "@voyd-lang/sdk/js-host";
+
+const valueAfter = (name: string): string | undefined => {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+};
+
+const positiveInt = (name: string, fallback: number): number => {
+  const raw = valueAfter(name);
+  const value = raw === undefined ? fallback : Number.parseInt(raw, 10);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+};
+
+const median = (values: readonly number[]): number => {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1]! + sorted[middle]!) / 2
+    : sorted[middle]!;
+};
+
+const expectCompileSuccess = (
+  result: CompileResult,
+): Extract<CompileResult, { success: true }> => {
+  if (!result.success) {
+    throw new Error(
+      result.diagnostics.map((diagnostic) => diagnostic.message).join("\n"),
+    );
+  }
+  return result;
+};
+
+const count = (source: string, pattern: RegExp): number =>
+  Array.from(source.matchAll(pattern)).length;
+
+const compileSamples = positiveInt("--compile-samples", 5);
+const runtimeSamples = positiveInt("--runtime-samples", 21);
+const label = valueAfter("--label") ?? "local";
+const entryPath = resolve(
+  "tests/performance/fixtures/array-for-fast-path.voyd",
+);
+const sdk = createSdk({ compilerCache: "none" });
+const compileDurationsMs: number[] = [];
+let compiled: Extract<CompileResult, { success: true }> | undefined;
+
+for (let sample = 0; sample < compileSamples; sample += 1) {
+  const startedAt = performance.now();
+  compiled = expectCompileSuccess(
+    await sdk.compile({ entryPath, optimize: true, emitWasmText: true }),
+  );
+  compileDurationsMs.push(performance.now() - startedAt);
+}
+
+if (!compiled) {
+  throw new Error("benchmark did not compile a program");
+}
+
+const host = await createVoydHost({ wasm: compiled.wasm });
+const entries = [
+  "light_for_benchmark",
+  "light_indexed_control",
+  "render_for_benchmark",
+  "render_indexed_control",
+] as const;
+const checksums = new Map<string, number>();
+const runtimes: Record<string, { medianMs: number; samplesMs: number[] }> = {};
+
+for (const entry of entries) {
+  const checksum = await host.runPure<number>(entry);
+  checksums.set(entry, checksum);
+  const samplesMs: number[] = [];
+  for (let sample = 0; sample < runtimeSamples; sample += 1) {
+    const startedAt = performance.now();
+    const value = await host.runPure<number>(entry);
+    if (value !== checksum) {
+      throw new Error(`${entry} returned a non-deterministic checksum`);
+    }
+    samplesMs.push(performance.now() - startedAt);
+  }
+  runtimes[entry] = { medianMs: median(samplesMs), samplesMs };
+}
+
+if (
+  checksums.get("light_for_benchmark") !==
+    checksums.get("light_indexed_control") ||
+  checksums.get("render_for_benchmark") !==
+    checksums.get("render_indexed_control")
+) {
+  throw new Error("for-loop and indexed controls produced different checksums");
+}
+
+const wasmText = compiled.wasmText ?? "";
+console.log(
+  JSON.stringify(
+    {
+      benchmark: "intrinsic-array-for-fast-path",
+      label,
+      methodology: {
+        compileSamples,
+        runtimeSamples,
+        optimize: true,
+        compilerCache: "none",
+        runtimeHost: "one warmed host; one untimed warmup per entry",
+      },
+      compile: {
+        medianMs: median(compileDurationsMs),
+        samplesMs: compileDurationsMs,
+      },
+      artifact: {
+        wasmBytes: compiled.wasm.byteLength,
+        gzipBytes: gzipSync(compiled.wasm).byteLength,
+        callRefSites: count(wasmText, /\bcall_ref\b/g),
+        allocationSites: count(
+          wasmText,
+          /\((?:array|struct)\.new(?:_fixed|_default)?\b/g,
+        ),
+      },
+      checksums: Object.fromEntries(checksums),
+      runtimes,
+      environment: {
+        node: process.version,
+        platform: process.platform,
+        arch: process.arch,
+      },
+    },
+    null,
+    2,
+  ),
+);

--- a/scripts/bench-general-iterator-specialization.ts
+++ b/scripts/bench-general-iterator-specialization.ts
@@ -1,0 +1,145 @@
+import { gzipSync } from "node:zlib";
+import { performance } from "node:perf_hooks";
+import { resolve } from "node:path";
+import { cpus } from "node:os";
+import { createSdk, type CompileResult } from "@voyd-lang/sdk";
+import { createVoydHost } from "@voyd-lang/sdk/js-host";
+
+const valueAfter = (name: string): string | undefined => {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+};
+
+const positiveInt = (name: string, fallback: number): number => {
+  const raw = valueAfter(name);
+  const value = raw === undefined ? fallback : Number.parseInt(raw, 10);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+};
+
+const median = (values: readonly number[]): number => {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1]! + sorted[middle]!) / 2
+    : sorted[middle]!;
+};
+
+const expectCompileSuccess = (
+  result: CompileResult,
+): Extract<CompileResult, { success: true }> => {
+  if (!result.success) {
+    throw new Error(
+      result.diagnostics.map((diagnostic) => diagnostic.message).join("\n"),
+    );
+  }
+  return result;
+};
+
+const count = (source: string, pattern: RegExp): number =>
+  Array.from(source.matchAll(pattern)).length;
+
+const compileSamples = positiveInt("--compile-samples", 5);
+const runtimeSamples = positiveInt("--runtime-samples", 21);
+const label = valueAfter("--label") ?? "local";
+const entryPath = resolve(
+  "tests/performance/fixtures/general-iterator-specialization.voyd",
+);
+const sdk = createSdk({ compilerCache: "none" });
+const compileDurationsMs: number[] = [];
+let compiled: Extract<CompileResult, { success: true }> | undefined;
+
+for (let sample = 0; sample < compileSamples; sample += 1) {
+  const startedAt = performance.now();
+  compiled = expectCompileSuccess(
+    await sdk.compile({ entryPath, optimize: true, emitWasmText: true }),
+  );
+  compileDurationsMs.push(performance.now() - startedAt);
+}
+
+if (!compiled) {
+  throw new Error("benchmark did not compile a program");
+}
+
+const host = await createVoydHost({ wasm: compiled.wasm });
+const entries = [
+  "light_for_benchmark",
+  "light_manual_control",
+  "filtered_for_benchmark",
+  "filtered_manual_control",
+] as const;
+const checksums = new Map<string, number>();
+const runtimes: Record<string, { medianMs: number; samplesMs: number[] }> = {};
+
+for (const entry of entries) {
+  const checksum = await host.runPure<number>(entry);
+  checksums.set(entry, checksum);
+  const samplesMs: number[] = [];
+  for (let sample = 0; sample < runtimeSamples; sample += 1) {
+    const startedAt = performance.now();
+    const value = await host.runPure<number>(entry);
+    if (value !== checksum) {
+      throw new Error(`${entry} returned a non-deterministic checksum`);
+    }
+    samplesMs.push(performance.now() - startedAt);
+  }
+  runtimes[entry] = { medianMs: median(samplesMs), samplesMs };
+}
+
+if (
+  checksums.get("light_for_benchmark") !==
+    checksums.get("light_manual_control") ||
+  checksums.get("filtered_for_benchmark") !==
+    checksums.get("filtered_manual_control")
+) {
+  throw new Error("for-loop and manual controls produced different checksums");
+}
+
+const wasmText = compiled.wasmText ?? "";
+console.log(
+  JSON.stringify(
+    {
+      benchmark: "general-iterator-specialization",
+      label,
+      methodology: {
+        compileSamples,
+        runtimeSamples,
+        optimize: true,
+        compilerCache: "none",
+        runtimeHost: "one warmed host; one untimed warmup per entry",
+      },
+      compile: {
+        medianMs: median(compileDurationsMs),
+        samplesMs: compileDurationsMs,
+      },
+      artifact: {
+        wasmBytes: compiled.wasm.byteLength,
+        gzipBytes: gzipSync(compiled.wasm).byteLength,
+        callRefSites: count(wasmText, /\bcall_ref\b/g),
+        directCallSites: count(wasmText, /\(call \$/g),
+        allocationSites: count(
+          wasmText,
+          /\((?:array|struct)\.new(?:_fixed|_default)?\b/g,
+        ),
+        optionAllocationSites: count(
+          wasmText,
+          /\(struct\.new \$std__optional__(?:Some|None)/g,
+        ),
+        structGetSites: count(wasmText, /\(struct\.get\b/g),
+        structSetSites: count(wasmText, /\(struct\.set\b/g),
+      },
+      checksums: Object.fromEntries(checksums),
+      runtimes,
+      environment: {
+        node: process.version,
+        platform: process.platform,
+        arch: process.arch,
+        cpu: cpus()[0]?.model ?? "unknown",
+      },
+    },
+    null,
+    2,
+  ),
+);

--- a/scripts/bench-mutable-result-specialization.ts
+++ b/scripts/bench-mutable-result-specialization.ts
@@ -1,0 +1,151 @@
+import { gzipSync } from "node:zlib";
+import { performance } from "node:perf_hooks";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { cpus } from "node:os";
+import type { CompileResult } from "@voyd-lang/sdk";
+
+const valueAfter = (name: string): string | undefined => {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+};
+
+const positiveInt = (name: string, fallback: number): number => {
+  const raw = valueAfter(name);
+  const value = raw === undefined ? fallback : Number.parseInt(raw, 10);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+};
+
+const median = (values: readonly number[]): number => {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1]! + sorted[middle]!) / 2
+    : sorted[middle]!;
+};
+
+const expectCompileSuccess = (
+  result: CompileResult,
+): Extract<CompileResult, { success: true }> => {
+  if (!result.success) {
+    throw new Error(
+      result.diagnostics.map((diagnostic) => diagnostic.message).join("\n"),
+    );
+  }
+  return result;
+};
+
+const count = (source: string, pattern: RegExp): number =>
+  Array.from(source.matchAll(pattern)).length;
+
+const compileSamples = positiveInt("--compile-samples", 7);
+const runtimeSamples = positiveInt("--runtime-samples", 31);
+const label = valueAfter("--label") ?? "local";
+const sdkRoot = valueAfter("--sdk-root");
+const sdkModule = sdkRoot
+  ? pathToFileURL(resolve(sdkRoot, "packages/sdk/src/index.ts")).href
+  : "@voyd-lang/sdk";
+const sdkHostModule = sdkRoot
+  ? pathToFileURL(resolve(sdkRoot, "packages/sdk/src/js-host.ts")).href
+  : "@voyd-lang/sdk/js-host";
+const { createSdk } = (await import(
+  sdkModule
+)) as typeof import("@voyd-lang/sdk");
+const { createVoydHost } = (await import(
+  sdkHostModule
+)) as typeof import("@voyd-lang/sdk/js-host");
+const entryPath = resolve(
+  "tests/performance/fixtures/mutable-result-specialization.voyd",
+);
+const sdk = createSdk({ compilerCache: "none" });
+const compileDurationsMs: number[] = [];
+let compiled: Extract<CompileResult, { success: true }> | undefined;
+
+for (let sample = 0; sample < compileSamples; sample += 1) {
+  const startedAt = performance.now();
+  compiled = expectCompileSuccess(
+    await sdk.compile({ entryPath, optimize: true, emitWasmText: true }),
+  );
+  compileDurationsMs.push(performance.now() - startedAt);
+}
+
+if (!compiled) {
+  throw new Error("benchmark did not compile a program");
+}
+
+const host = await createVoydHost({ wasm: compiled.wasm });
+const entries = [
+  "direct_result_workload",
+  "discarded_result_workload",
+  "manual_control",
+] as const;
+const checksums = new Map<string, number>();
+const runtimes: Record<string, { medianMs: number; samplesMs: number[] }> = {};
+
+for (const entry of entries) {
+  const checksum = await host.runPure<number>(entry);
+  checksums.set(entry, checksum);
+  const samplesMs: number[] = [];
+  for (let sample = 0; sample < runtimeSamples; sample += 1) {
+    const startedAt = performance.now();
+    const value = await host.runPure<number>(entry);
+    if (value !== checksum) {
+      throw new Error(`${entry} returned a non-deterministic checksum`);
+    }
+    samplesMs.push(performance.now() - startedAt);
+  }
+  runtimes[entry] = { medianMs: median(samplesMs), samplesMs };
+}
+
+if (
+  checksums.get("direct_result_workload") !== checksums.get("manual_control")
+) {
+  throw new Error("specialized workloads and manual control disagree");
+}
+
+const wasmText = compiled.wasmText ?? "";
+console.log(
+  JSON.stringify(
+    {
+      benchmark: "mutable-result-specialization",
+      label,
+      methodology: {
+        compileSamples,
+        runtimeSamples,
+        optimize: true,
+        compilerCache: "none",
+        sdkRoot: sdkRoot ?? "current checkout",
+        runtimeHost: "one warmed host; one untimed warmup per entry",
+      },
+      compile: {
+        medianMs: median(compileDurationsMs),
+        samplesMs: compileDurationsMs,
+      },
+      artifact: {
+        wasmBytes: compiled.wasm.byteLength,
+        gzipBytes: gzipSync(compiled.wasm).byteLength,
+        callRefSites: count(wasmText, /\bcall_ref\b/g),
+        directCallSites: count(wasmText, /\(call \$/g),
+        allocationSites: count(
+          wasmText,
+          /\((?:array|struct)\.new(?:_fixed|_default)?\b/g,
+        ),
+        structGetSites: count(wasmText, /\(struct\.get\b/g),
+        structSetSites: count(wasmText, /\(struct\.set\b/g),
+      },
+      checksums: Object.fromEntries(checksums),
+      runtimes,
+      environment: {
+        node: process.version,
+        platform: process.platform,
+        arch: process.arch,
+        cpu: cpus()[0]?.model ?? "unknown",
+      },
+    },
+    null,
+    2,
+  ),
+);

--- a/scripts/bench-v439-checked-access.ts
+++ b/scripts/bench-v439-checked-access.ts
@@ -1,0 +1,308 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { cpus, totalmem } from "node:os";
+import { performance } from "node:perf_hooks";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
+import { createSdk, type CompileResult } from "@voyd-lang/sdk";
+import { createVoydHost } from "@voyd-lang/sdk/js-host";
+
+type Entrypoint = {
+  name: string;
+  expected: unknown;
+};
+
+type Scenario = {
+  name: string;
+  entryPath: string;
+  entrypoints: readonly Entrypoint[];
+};
+
+type CompileSuccess = Extract<CompileResult, { success: true }>;
+
+const valueAfter = (name: string): string | undefined => {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+};
+
+const sampleCount = Number.parseInt(valueAfter("--samples") ?? "7", 10);
+const runtimeSampleCount = Number.parseInt(
+  valueAfter("--runtime-samples") ?? "31",
+  10,
+);
+const label = valueAfter("--label") ?? "worktree";
+const scenarioFilter = valueAfter("--scenario");
+if (sampleCount < 3 || runtimeSampleCount < 3) {
+  throw new Error(
+    "benchmark requires at least three compile and runtime samples",
+  );
+}
+
+const repository = path.resolve(import.meta.dirname, "..");
+const performanceFixtures = path.join(
+  repository,
+  "tests",
+  "performance",
+  "fixtures",
+);
+const scenarios: readonly Scenario[] = [
+  {
+    name: "representative-vtrace",
+    entryPath: path.join(performanceFixtures, "vtrace-compute-benchmark.voyd"),
+    entrypoints: [{ name: "main", expected: 3_825_271 }],
+  },
+  {
+    name: "focused-checked-access",
+    entryPath: path.join(performanceFixtures, "checked-access-optimizer.voyd"),
+    entrypoints: [
+      { name: "checked_access_memory_traffic", expected: 2_200_000 },
+      { name: "memory_traffic_control", expected: 2_200_000 },
+      { name: "hoisted_memory_traffic_control", expected: 2_200_000 },
+      { name: "ordinary_mutation_control", expected: 100_003 },
+      { name: "shared_cell_runtime_checks", expected: 100_003 },
+      { name: "checked_array_loop", expected: 3_400_000 },
+      { name: "optional_array_loop", expected: 3_400_000 },
+    ],
+  },
+  {
+    name: "representative-scalar-aggregate",
+    entryPath: path.join(
+      performanceFixtures,
+      "scalar-aggregate-representative.voyd",
+    ),
+    entrypoints: [{ name: "main", expected: 1_100_340_000 }],
+  },
+];
+
+if (!scenarioFilter) {
+  const script = fileURLToPath(import.meta.url);
+  const documents = scenarios.map(
+    (scenario) =>
+      JSON.parse(
+        execFileSync(
+          process.execPath,
+          [
+            "--import",
+            "tsx",
+            "--conditions=development",
+            script,
+            "--label",
+            label,
+            "--samples",
+            sampleCount.toString(),
+            "--runtime-samples",
+            runtimeSampleCount.toString(),
+            "--scenario",
+            scenario.name,
+          ],
+          {
+            cwd: repository,
+            encoding: "utf8",
+            maxBuffer: 100 * 1024 * 1024,
+            stdio: ["ignore", "pipe", "inherit"],
+          },
+        ),
+      ) as {
+        schemaVersion: number;
+        label: string;
+        methodology: unknown;
+        environment: unknown;
+        results: unknown[];
+      },
+  );
+  const first = documents[0];
+  if (!first) {
+    throw new Error("benchmark has no scenarios");
+  }
+  console.log(
+    JSON.stringify(
+      {
+        schemaVersion: first.schemaVersion,
+        label: first.label,
+        methodology: first.methodology,
+        environment: first.environment,
+        results: documents.flatMap((document) => document.results),
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(0);
+}
+
+const selectedScenarios = scenarioFilter
+  ? scenarios.filter((scenario) => scenario.name === scenarioFilter)
+  : scenarios;
+if (selectedScenarios.length === 0) {
+  throw new Error(`unknown benchmark scenario ${scenarioFilter}`);
+}
+
+const median = (values: readonly number[]): number => {
+  const ordered = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(ordered.length / 2);
+  return ordered.length % 2 === 0
+    ? (ordered[middle - 1]! + ordered[middle]!) / 2
+    : ordered[middle]!;
+};
+
+const expectCompileSuccess = (
+  result: CompileResult,
+  scenario: string,
+): CompileSuccess => {
+  if (result.success) {
+    return result;
+  }
+  throw new Error(
+    `${scenario} failed to compile:\n${result.diagnostics
+      .map((diagnostic) => diagnostic.message)
+      .join("\n")}`,
+  );
+};
+
+const assertResult = ({
+  scenario,
+  entrypoint,
+  actual,
+}: {
+  scenario: string;
+  entrypoint: Entrypoint;
+  actual: unknown;
+}): void => {
+  if (Object.is(actual, entrypoint.expected)) {
+    return;
+  }
+  throw new Error(
+    `${scenario}.${entrypoint.name} returned ${String(actual)}, expected ${String(
+      entrypoint.expected,
+    )}`,
+  );
+};
+
+const count = (source: string, pattern: RegExp): number =>
+  Array.from(source.matchAll(pattern)).length;
+
+const codeShape = (wasmText: string) => ({
+  allocationSites: count(
+    wasmText,
+    /\((?:array|struct)\.new(?:_fixed|_default)?\b/g,
+  ),
+  structGets: count(wasmText, /\(struct\.get\b/g),
+  structSets: count(wasmText, /\(struct\.set\b/g),
+  arrayGets: count(wasmText, /\(array\.get(?:_[su])?\b/g),
+  arraySets: count(wasmText, /\(array\.set\b/g),
+  arrayLengths: count(wasmText, /\(array\.len\b/g),
+  identityComparisons: count(wasmText, /\(ref\.eq\b/g),
+  directCalls: count(wasmText, /\(call\s+\$/g),
+  indirectCalls: count(wasmText, /\(call_ref\b/g),
+});
+
+const measureScenario = async ({
+  scenario,
+  optimize,
+}: {
+  scenario: Scenario;
+  optimize: boolean;
+}) => {
+  const compileMs: number[] = [];
+  let compiled: CompileSuccess | undefined;
+  for (let sample = 0; sample < sampleCount; sample += 1) {
+    const startedAt = performance.now();
+    compiled = expectCompileSuccess(
+      await createSdk().compile({
+        entryPath: scenario.entryPath,
+        optimize,
+        emitWasmText: true,
+      }),
+      scenario.name,
+    );
+    compileMs.push(performance.now() - startedAt);
+  }
+  if (!compiled) {
+    throw new Error(`${scenario.name} did not produce a compiled module`);
+  }
+
+  const host = await createVoydHost({ wasm: compiled.wasm });
+  for (let warmup = 0; warmup < 3; warmup += 1) {
+    for (const entrypoint of scenario.entrypoints) {
+      assertResult({
+        scenario: scenario.name,
+        entrypoint,
+        actual: await host.run<unknown>(entrypoint.name),
+      });
+    }
+  }
+
+  const memory = host.instance.exports.memory;
+  const beforeBytes =
+    memory instanceof WebAssembly.Memory ? memory.buffer.byteLength : 0;
+  const runtimeEntries: Array<
+    readonly [string, { samplesMs: number[]; medianMs: number }]
+  > = [];
+  for (const entrypoint of scenario.entrypoints) {
+    const samplesMs: number[] = [];
+    for (let sample = 0; sample < runtimeSampleCount; sample += 1) {
+      const startedAt = performance.now();
+      const actual = await host.run<unknown>(entrypoint.name);
+      samplesMs.push(performance.now() - startedAt);
+      assertResult({ scenario: scenario.name, entrypoint, actual });
+    }
+    runtimeEntries.push([
+      entrypoint.name,
+      { samplesMs, medianMs: median(samplesMs) },
+    ]);
+  }
+  const runtime = Object.fromEntries(runtimeEntries);
+  const afterBytes =
+    memory instanceof WebAssembly.Memory ? memory.buffer.byteLength : 0;
+  const wasmText = compiled.wasmText ?? "";
+
+  return {
+    optimize,
+    compile: { samplesMs: compileMs, medianMs: median(compileMs) },
+    runtime,
+    linearMemoryGrowthBytes: afterBytes - beforeBytes,
+    wasmBytes: compiled.wasm.byteLength,
+    gzipBytes: gzipSync(compiled.wasm).byteLength,
+    wasmTextBytes: new TextEncoder().encode(wasmText).byteLength,
+    wasmSha256: createHash("sha256").update(compiled.wasm).digest("hex"),
+    codeShape: codeShape(wasmText),
+  };
+};
+
+const results = [];
+for (const scenario of selectedScenarios) {
+  const none = await measureScenario({ scenario, optimize: false });
+  const release = await measureScenario({ scenario, optimize: true });
+  results.push({ scenario: scenario.name, modes: { none, release } });
+}
+
+const cpu = cpus();
+console.log(
+  JSON.stringify(
+    {
+      schemaVersion: 1,
+      label,
+      methodology: {
+        compileSamples: sampleCount,
+        freshSdkPerCompile: true,
+        runtimeWarmups: 3,
+        runtimeSamples: runtimeSampleCount,
+        modes: ["none", "release"],
+        codeShape:
+          "Static instruction-site counts from the emitted WAT for each complete module",
+      },
+      environment: {
+        platform: process.platform,
+        arch: process.arch,
+        node: process.version,
+        cpu: cpu[0]?.model ?? "unknown",
+        logicalCpus: cpu.length,
+        totalMemoryBytes: totalmem(),
+      },
+      results,
+    },
+    null,
+    2,
+  ),
+);

--- a/scripts/bench-v439-checked-access.ts
+++ b/scripts/bench-v439-checked-access.ts
@@ -3,10 +3,9 @@ import { execFileSync } from "node:child_process";
 import { cpus, totalmem } from "node:os";
 import { performance } from "node:perf_hooks";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { gzipSync } from "node:zlib";
-import { createSdk, type CompileResult } from "@voyd-lang/sdk";
-import { createVoydHost } from "@voyd-lang/sdk/js-host";
+import type { CompileResult } from "@voyd-lang/sdk";
 
 type Entrypoint = {
   name: string;
@@ -33,6 +32,7 @@ const runtimeSampleCount = Number.parseInt(
 );
 const label = valueAfter("--label") ?? "worktree";
 const scenarioFilter = valueAfter("--scenario");
+const sdkRoot = valueAfter("--sdk-root");
 if (sampleCount < 3 || runtimeSampleCount < 3) {
   throw new Error(
     "benchmark requires at least three compile and runtime samples",
@@ -40,6 +40,19 @@ if (sampleCount < 3 || runtimeSampleCount < 3) {
 }
 
 const repository = path.resolve(import.meta.dirname, "..");
+const sdkModule = sdkRoot
+  ? pathToFileURL(path.join(sdkRoot, "packages", "sdk", "src", "index.ts")).href
+  : "@voyd-lang/sdk";
+const sdkHostModule = sdkRoot
+  ? pathToFileURL(path.join(sdkRoot, "packages", "sdk", "src", "js-host.ts"))
+      .href
+  : "@voyd-lang/sdk/js-host";
+const { createSdk } = (await import(
+  sdkModule
+)) as typeof import("@voyd-lang/sdk");
+const { createVoydHost } = (await import(
+  sdkHostModule
+)) as typeof import("@voyd-lang/sdk/js-host");
 const performanceFixtures = path.join(
   repository,
   "tests",
@@ -73,6 +86,15 @@ const scenarios: readonly Scenario[] = [
     ),
     entrypoints: [{ name: "main", expected: 1_100_340_000 }],
   },
+  {
+    name: "representative-web-app-request",
+    entryPath: path.join(performanceFixtures, "web-app-request-pipeline.voyd"),
+    entrypoints: [
+      { name: "main", expected: 708_207_620 },
+      { name: "request_lookup_stage", expected: 302_557_517 },
+      { name: "response_serialization_stage", expected: 600_952_779 },
+    ],
+  },
 ];
 
 if (!scenarioFilter) {
@@ -95,6 +117,7 @@ if (!scenarioFilter) {
             runtimeSampleCount.toString(),
             "--scenario",
             scenario.name,
+            ...(sdkRoot ? ["--sdk-root", sdkRoot] : []),
           ],
           {
             cwd: repository,
@@ -222,24 +245,22 @@ const measureScenario = async ({
     throw new Error(`${scenario.name} did not produce a compiled module`);
   }
 
-  const host = await createVoydHost({ wasm: compiled.wasm });
-  for (let warmup = 0; warmup < 3; warmup += 1) {
-    for (const entrypoint of scenario.entrypoints) {
+  let maxLinearMemoryGrowthBytes = 0;
+  const runtimeEntries: Array<
+    readonly [string, { samplesMs: number[]; medianMs: number }]
+  > = [];
+  for (const entrypoint of scenario.entrypoints) {
+    const host = await createVoydHost({ wasm: compiled.wasm });
+    for (let warmup = 0; warmup < 3; warmup += 1) {
       assertResult({
         scenario: scenario.name,
         entrypoint,
         actual: await host.run<unknown>(entrypoint.name),
       });
     }
-  }
-
-  const memory = host.instance.exports.memory;
-  const beforeBytes =
-    memory instanceof WebAssembly.Memory ? memory.buffer.byteLength : 0;
-  const runtimeEntries: Array<
-    readonly [string, { samplesMs: number[]; medianMs: number }]
-  > = [];
-  for (const entrypoint of scenario.entrypoints) {
+    const memory = host.instance.exports.memory;
+    const beforeBytes =
+      memory instanceof WebAssembly.Memory ? memory.buffer.byteLength : 0;
     const samplesMs: number[] = [];
     for (let sample = 0; sample < runtimeSampleCount; sample += 1) {
       const startedAt = performance.now();
@@ -251,17 +272,21 @@ const measureScenario = async ({
       entrypoint.name,
       { samplesMs, medianMs: median(samplesMs) },
     ]);
+    const afterBytes =
+      memory instanceof WebAssembly.Memory ? memory.buffer.byteLength : 0;
+    maxLinearMemoryGrowthBytes = Math.max(
+      maxLinearMemoryGrowthBytes,
+      afterBytes - beforeBytes,
+    );
   }
   const runtime = Object.fromEntries(runtimeEntries);
-  const afterBytes =
-    memory instanceof WebAssembly.Memory ? memory.buffer.byteLength : 0;
   const wasmText = compiled.wasmText ?? "";
 
   return {
     optimize,
     compile: { samplesMs: compileMs, medianMs: median(compileMs) },
     runtime,
-    linearMemoryGrowthBytes: afterBytes - beforeBytes,
+    linearMemoryGrowthBytes: maxLinearMemoryGrowthBytes,
     wasmBytes: compiled.wasm.byteLength,
     gzipBytes: gzipSync(compiled.wasm).byteLength,
     wasmTextBytes: new TextEncoder().encode(wasmText).byteLength,
@@ -288,7 +313,9 @@ console.log(
         freshSdkPerCompile: true,
         runtimeWarmups: 3,
         runtimeSamples: runtimeSampleCount,
+        freshHostPerEntrypoint: true,
         modes: ["none", "release"],
+        sdkRoot: sdkRoot ? path.resolve(sdkRoot) : repository,
         codeShape:
           "Static instruction-site counts from the emitted WAT for each complete module",
       },

--- a/tests/conformance/cases/runtime/collections.voyd
+++ b/tests/conformance/cases/runtime/collections.voyd
@@ -17,6 +17,15 @@ pub fn write_index() -> i32
   arr[1] = 99
   optional_i32_or(arr[1], -1)
 
+pub fn array_iteration_observes_growth() -> i32
+  let ~arr = [1]
+  var total = 0
+  for value in arr:
+    total = total + value
+    if value < 3:
+      arr.push(value + 1)
+  total
+
 pub fn slice_exclusive() -> i32
   let arr = [1, 2, 3, 4]
   let slice = arr[1..3]

--- a/tests/conformance/cases/runtime/range-for.voyd
+++ b/tests/conformance/cases/runtime/range-for.voyd
@@ -19,6 +19,51 @@ pub fn range_for_nested() -> i32
       total = total + (x + y)
   total
 
+pub fn range_for_nonzero_negative_and_empty() -> i32
+  var total = 0
+  for value in -2..2:
+    total = total * 10 + value
+  for value in 5..2:
+    total = total + value * 1000
+  for value in 3..3:
+    total = total + value * 1000
+  total
+
+pub fn range_for_break_and_continue() -> i32
+  var total = 0
+  for value in 0..10:
+    if value == 2:
+      continue
+    if value == 5:
+      break
+    total = total + value
+  total
+
+pub fn range_for_inclusive_i32_max_stops() -> i32
+  var count = 0
+  var last = 0
+  for value in 2147483647..=2147483647:
+    count = count + 1
+    last = value
+  if count == 1 and last == 2147483647 then: 1 else: 0
+
+obj BoundProbe {
+  order: i32,
+  evaluations: i32
+}
+
+fn record_bound(~probe: BoundProbe, label: i32, value: i32) -> i32
+  probe.order = probe.order * 10 + label
+  probe.evaluations = probe.evaluations + 1
+  value
+
+pub fn range_for_evaluates_bounds_once_in_order() -> i32
+  let ~probe = BoundProbe { order: 0, evaluations: 0 }
+  var total = 0
+  for value in record_bound(~probe, 1, -2)..record_bound(~probe, 2, 2):
+    total = total + value
+  probe.order * 100 + probe.evaluations * 10 + total
+
 pub fn range_iterator_inclusive_i32_max_stops() -> i32
   let ~iter = (2147483647..=2147483647).iter()
 

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -701,6 +701,30 @@
           "expect": { "kind": "equals", "value": 18 }
         },
         {
+          "id": "runtime.range-for.nonzero-negative-empty",
+          "title": "handles nonzero, negative, descending, and empty bounds",
+          "entryName": "range_for_nonzero_negative_and_empty",
+          "expect": { "kind": "equals", "value": -2099 }
+        },
+        {
+          "id": "runtime.range-for.break-continue",
+          "title": "advances correctly across break and continue",
+          "entryName": "range_for_break_and_continue",
+          "expect": { "kind": "equals", "value": 8 }
+        },
+        {
+          "id": "runtime.range-for.fast-i32-max",
+          "title": "stops direct inclusive iteration at i32 max",
+          "entryName": "range_for_inclusive_i32_max_stops",
+          "expect": { "kind": "equals", "value": 1 }
+        },
+        {
+          "id": "runtime.range-for.bound-evaluation",
+          "title": "evaluates bounds once in source order",
+          "entryName": "range_for_evaluates_bounds_once_in_order",
+          "expect": { "kind": "equals", "value": 1218 }
+        },
+        {
           "id": "runtime.range-for.i32-max",
           "title": "stops inclusive iteration at i32 max",
           "entryName": "range_iterator_inclusive_i32_max_stops",

--- a/tests/conformance/manifest.json
+++ b/tests/conformance/manifest.json
@@ -1230,6 +1230,12 @@
           "expect": { "kind": "equals", "value": 99 }
         },
         {
+          "id": "runtime.collections.array-iteration-growth",
+          "title": "observes Array growth while iterating",
+          "entryName": "array_iteration_observes_growth",
+          "expect": { "kind": "equals", "value": 6 }
+        },
+        {
           "id": "runtime.collections.slice-exclusive",
           "title": "creates exclusive slices",
           "entryName": "slice_exclusive",

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -3,6 +3,22 @@
 Performance tests and large regression workloads are opt-in. They do not run
 as part of the default test suite.
 
+## Intrinsic Array `for` benchmark
+
+Measure intrinsic Array iteration against equivalent indexed-loop controls:
+
+```sh
+npm run bench:array-for -- \
+  --label <label> \
+  --compile-samples 5 \
+  --runtime-samples 21
+```
+
+The light-body case makes iterator overhead visible. The render case traverses
+view-model records and computes representative serialization work. Output is
+JSON with raw and median compile/runtime samples, checksums, Wasm/gzip sizes,
+and code-shape counts.
+
 ## Checked-access application benchmark
 
 Run the complete checked-access benchmark suite from the repository root:

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -101,6 +101,25 @@ artifact hashes, static instruction-site counts, host details, and memory
 growth. The committed V-439 results and methodology are in
 `docs/notes/v439-checked-access-optimization-results.md`.
 
+### Idiomatic Vtrace renderer
+
+Measure only the compute-bound path tracer with:
+
+```sh
+npm run bench:v439 -- \
+  --label <label> \
+  --samples 7 \
+  --runtime-samples 31 \
+  --scenario representative-vtrace
+```
+
+The fixture deliberately uses normal application source: mutable data is
+modeled with `obj`, counted work uses range-based `for`, and the scene is
+traversed with `for object in self.objects`. It avoids manual indexed-loop and
+value-layout controls so the result includes the cost of Voyd's standard
+abstractions. Use `--sdk-root` as shown above to compile this same source with a
+different compiler checkout.
+
 ## Web OpenAPI package-scale compile
 
 Run the dependency-heavy Web OpenAPI compile in a fresh Node process:

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -3,6 +3,46 @@
 Performance tests and large regression workloads are opt-in. They do not run
 as part of the default test suite.
 
+## Checked-access application benchmark
+
+Run the complete checked-access benchmark suite from the repository root:
+
+```sh
+npm run bench:v439 -- --label <label> --samples 7 --runtime-samples 31
+```
+
+To measure only the representative server-rendered web-app request pipeline:
+
+```sh
+npm run bench:v439 -- \
+  --label <label> \
+  --samples 7 \
+  --runtime-samples 31 \
+  --scenario representative-web-app-request
+```
+
+The web-app scenario runs 10,000 route, catalog/view-model, and response
+serialization operations per sample. It reports the integrated handler plus
+separate lookup and serialization stages. Each entrypoint uses a fresh warmed
+host instance.
+
+Compare another local compiler revision without copying the fixture by passing
+the other checkout's repository root:
+
+```sh
+npm run bench:v439 -- \
+  --label before \
+  --samples 7 \
+  --runtime-samples 31 \
+  --scenario representative-web-app-request \
+  --sdk-root /path/to/voyd-checkout
+```
+
+The JSON output includes all raw samples, medians, emitted Wasm and gzip sizes,
+artifact hashes, static instruction-site counts, host details, and memory
+growth. The committed V-439 results and methodology are in
+`docs/notes/v439-checked-access-optimization-results.md`.
+
 ## Web OpenAPI package-scale compile
 
 Run the dependency-heavy Web OpenAPI compile in a fresh Node process:

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -19,6 +19,23 @@ view-model records and computes representative serialization work. Output is
 JSON with raw and median compile/runtime samples, checksums, Wasm/gzip sizes,
 and code-shape counts.
 
+## General iterator `for` benchmark
+
+Measure exact non-intrinsic user iterators against equivalent manual state
+machines:
+
+```sh
+npm run bench:iterator-for -- \
+  --label <label> \
+  --compile-samples 7 \
+  --runtime-samples 31
+```
+
+The focused case uses a light-body counter. The application-shaped case uses
+a filtered, strided iterator with variable internal work and early returns.
+Output includes raw samples, medians, checksums, compile time, Wasm/gzip size,
+and dispatch, allocation, Option, and structural-access site counts.
+
 ## Checked-access application benchmark
 
 Run the complete checked-access benchmark suite from the repository root:

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -36,6 +36,30 @@ a filtered, strided iterator with variable internal work and early returns.
 Output includes raw samples, medians, checksums, compile time, Wasm/gzip size,
 and dispatch, allocation, Option, and structural-access site counts.
 
+## Mutable-result specialization benchmark
+
+Measure mutable scalar-aggregate calls that both update request-local state and
+return a value:
+
+```sh
+npm run bench:mutable-result -- \
+  --label <label> \
+  --compile-samples 7 \
+  --runtime-samples 31
+```
+
+The fixture models the hot inner loop of a server-rendered response encoder. A
+writer accumulates response bytes, emitted-node counts, escape events, and a
+checksum while each helper returns the number of bytes it wrote. The benchmark
+separately measures a caller that uses the result and one that discards it. A
+manually expanded implementation provides a checksum-equivalence control.
+
+Output is JSON with every raw and median compile/runtime sample, result
+checksums, Wasm/gzip sizes, and static call, allocation, and structural-access
+site counts. To compare another compiler checkout against the current fixture,
+add `--sdk-root /path/to/voyd-checkout`. Run once with that flag and once
+without it, then compare the reported medians and code-shape counts.
+
 ## Checked-access application benchmark
 
 Run the complete checked-access benchmark suite from the repository root:

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -24,7 +24,9 @@ npm run bench:v439 -- \
 The web-app scenario runs 10,000 route, catalog/view-model, and response
 serialization operations per sample. It reports the integrated handler plus
 separate lookup and serialization stages. Each entrypoint uses a fresh warmed
-host instance.
+host instance. Counted setup and request-driver loops use range-based `for`
+syntax; the hot response-node inner loop remains `while` to isolate stable-load
+forwarding from the general range iterator's cost.
 
 Compare another local compiler revision without copying the fixture by passing
 the other checkout's repository root:

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -24,9 +24,8 @@ npm run bench:v439 -- \
 The web-app scenario runs 10,000 route, catalog/view-model, and response
 serialization operations per sample. It reports the integrated handler plus
 separate lookup and serialization stages. Each entrypoint uses a fresh warmed
-host instance. Counted setup and request-driver loops use range-based `for`
-syntax; the hot response-node inner loop remains `while` to isolate stable-load
-forwarding from the general range iterator's cost.
+host instance. Every counted setup, request-driver, array, and response-node
+loop uses idiomatic range-based `for` syntax.
 
 Compare another local compiler revision without copying the fixture by passing
 the other checkout's repository root:

--- a/tests/performance/fixtures/array-for-fast-path.voyd
+++ b/tests/performance/fixtures/array-for-fast-path.voyd
@@ -1,0 +1,75 @@
+use std::array::Array
+
+val ViewNode {
+  kind: i32,
+  text_length: i32,
+  attribute_count: i32,
+  child_count: i32
+}
+
+fn nodes() -> Array<ViewNode>
+  let ~result = Array<ViewNode>::with_capacity(48)
+  var index = 0
+  while index < 48:
+    result.push(ViewNode {
+      kind: (index % 5) + 1,
+      text_length: (index * 3) + 7,
+      attribute_count: index % 4,
+      child_count: index % 6
+    })
+    index = index + 1
+  result
+
+fn serialized_size(node: ViewNode) -> i32
+  let tag_bytes = (node.kind * 2) + 3
+  let attribute_bytes = node.attribute_count * 9
+  let child_markers = node.child_count * 4
+  tag_bytes + attribute_bytes + child_markers + node.text_length
+
+pub fn light_for_benchmark() -> i32
+  let source = nodes()
+  var pass = 0
+  var total = 0
+  while pass < 8000:
+    for node in source:
+      total = total + node.kind
+    pass = pass + 1
+  total
+
+pub fn light_indexed_control() -> i32
+  let source = nodes()
+  var pass = 0
+  var total = 0
+  while pass < 8000:
+    var index = 0
+    while index < source.len():
+      total = total + source.at(index).kind
+      index = index + 1
+    pass = pass + 1
+  total
+
+pub fn render_for_benchmark() -> i32
+  let source = nodes()
+  var request = 0
+  var total = 0
+  while request < 4000:
+    for node in source:
+      total = total + serialized_size(node) + (request % 7)
+    request = request + 1
+  total
+
+pub fn render_indexed_control() -> i32
+  let source = nodes()
+  var request = 0
+  var total = 0
+  while request < 4000:
+    var index = 0
+    while index < source.len():
+      let node = source.at(index)
+      total = total + serialized_size(node) + (request % 7)
+      index = index + 1
+    request = request + 1
+  total
+
+pub fn main() -> i32
+  render_for_benchmark()

--- a/tests/performance/fixtures/checked-access-optimizer.voyd
+++ b/tests/performance/fixtures/checked-access-optimizer.voyd
@@ -1,0 +1,130 @@
+use std::array::Array
+use std::optional::all
+use std::shared_cell::SharedCell
+
+obj AccessRecord {
+  stable: i32,
+  changing: i32
+}
+
+val WideElement {
+  first: i32,
+  second: i32,
+  third: i32,
+  fourth: i32
+}
+
+fn bump_changing(~value: AccessRecord) -> void
+  value.changing = value.changing + 1
+
+fn access_records() -> Array<AccessRecord>
+  let ~result = Array<AccessRecord>::with_capacity(2)
+  result.push(AccessRecord { stable: 3, changing: 0 })
+  result.push(AccessRecord { stable: 7, changing: 0 })
+  result
+
+fn wide_elements() -> Array<WideElement>
+  let ~result = Array<WideElement>::with_capacity(4)
+  result.push(WideElement { first: 1, second: 2, third: 3, fourth: 4 })
+  result.push(WideElement { first: 5, second: 6, third: 7, fourth: 8 })
+  result.push(WideElement { first: 9, second: 10, third: 11, fourth: 12 })
+  result.push(WideElement { first: 13, second: 14, third: 15, fourth: 16 })
+  result
+
+fn sum(value: WideElement) -> i32
+  value.first + value.second + value.third + value.fourth
+
+pub fn checked_access_memory_traffic() -> i32
+  let ~records = access_records()
+  let first_alias = records.at(0)
+  let second_alias = records.at(1)
+  var iteration = 0
+  var total = 0
+  while iteration < 100000:
+    total = total + first_alias.stable + second_alias.stable
+    bump_changing(~records.at(0))
+    bump_changing(~records.at(1))
+    total = total + first_alias.stable + second_alias.stable
+    iteration = iteration + 1
+  total + first_alias.changing + second_alias.changing
+
+pub fn memory_traffic_control() -> i32
+  let ~first = AccessRecord { stable: 3, changing: 0 }
+  let ~second = AccessRecord { stable: 7, changing: 0 }
+  let first_alias = first
+  let second_alias = second
+  var iteration = 0
+  var total = 0
+  while iteration < 100000:
+    total = total + first_alias.stable + second_alias.stable
+    bump_changing(~first)
+    bump_changing(~second)
+    total = total + first_alias.stable + second_alias.stable
+    iteration = iteration + 1
+  total + first_alias.changing + second_alias.changing
+
+pub fn hoisted_memory_traffic_control() -> i32
+  let ~first = AccessRecord { stable: 3, changing: 0 }
+  let ~second = AccessRecord { stable: 7, changing: 0 }
+  let first_alias = first
+  let second_alias = second
+  let first_stable = first_alias.stable
+  let second_stable = second_alias.stable
+  var iteration = 0
+  var total = 0
+  while iteration < 100000:
+    total = total + first_stable + second_stable
+    bump_changing(~first)
+    bump_changing(~second)
+    total = total + first_stable + second_stable
+    iteration = iteration + 1
+  total + first_alias.changing + second_alias.changing
+
+pub fn ordinary_mutation_control() -> i32
+  let ~value = AccessRecord { stable: 3, changing: 0 }
+  var iteration = 0
+  while iteration < 100000:
+    value.changing = value.changing + 1
+    iteration = iteration + 1
+  value.stable + value.changing
+
+pub fn shared_cell_runtime_checks() -> i32
+  let value = SharedCell(AccessRecord { stable: 3, changing: 0 })
+  var iteration = 0
+  while iteration < 100000:
+    value.with_mut((~current) =>
+      current.changing = current.changing + 1
+    )
+    iteration = iteration + 1
+  value.with((current) => current.stable + current.changing)
+
+pub fn checked_array_loop() -> i32
+  let values = wide_elements()
+  var iteration = 0
+  var total = 0
+  while iteration < 25000:
+    var index = 0
+    while index < values.len():
+      total = total + sum(values.at(index))
+      index = index + 1
+    iteration = iteration + 1
+  total
+
+pub fn optional_array_loop() -> i32
+  let values = wide_elements()
+  var iteration = 0
+  var total = 0
+  while iteration < 25000:
+    var index = 0
+    while index < values.len():
+      match(values.get(index))
+        Some<WideElement> { value }:
+          total = total + sum(value)
+        None:
+          total = total - 1
+      index = index + 1
+    iteration = iteration + 1
+  total
+
+pub fn main() -> i32
+  checked_access_memory_traffic()

--- a/tests/performance/fixtures/general-iterator-specialization.voyd
+++ b/tests/performance/fixtures/general-iterator-specialization.voyd
@@ -1,0 +1,98 @@
+use std::optional::all
+
+obj CountSequence {
+  end: i32
+}
+
+obj CountIterator {
+  current: i32,
+  end: i32
+}
+
+impl Sequence<i32> for CountSequence
+  fn iter(self) -> Iterator<i32>
+    CountIterator { current: 0, end: self.end }
+
+impl Iterator<i32> for CountIterator
+  fn next(~self) -> Option<i32>
+    if self.current >= self.end:
+      return None {}
+    let value = self.current
+    self.current = self.current + 1
+    Some<i32> { value }
+
+obj FilteredSequence {
+  end: i32,
+  stride: i32
+}
+
+obj FilteredIterator {
+  current: i32,
+  end: i32,
+  stride: i32
+}
+
+impl Sequence<i32> for FilteredSequence
+  fn iter(self) -> Iterator<i32>
+    FilteredIterator {
+      current: 0,
+      end: self.end,
+      stride: self.stride
+    }
+
+impl Iterator<i32> for FilteredIterator
+  fn next(~self) -> Option<i32>
+    while self.current < self.end:
+      let candidate = self.current
+      self.current = self.current + self.stride
+      if (candidate % 3) != 0:
+        return Some<i32> { value: candidate }
+    None {}
+
+fn score(value: i32, request: i32) -> i32
+  ((value * 5) + (request % 11)) % 997
+
+pub fn light_for_benchmark() -> i32
+  var pass = 0
+  var total = 0
+  while pass < 20000:
+    for value in CountSequence { end: 64 }:
+      total = total + value
+    pass = pass + 1
+  total
+
+pub fn light_manual_control() -> i32
+  var pass = 0
+  var total = 0
+  while pass < 20000:
+    var current = 0
+    while current < 64:
+      total = total + current
+      current = current + 1
+    pass = pass + 1
+  total
+
+pub fn filtered_for_benchmark() -> i32
+  var request = 0
+  var total = 0
+  while request < 10000:
+    for value in FilteredSequence { end: 96, stride: 2 }:
+      total = total + score(value, request)
+    request = request + 1
+  total
+
+pub fn filtered_manual_control() -> i32
+  var request = 0
+  var total = 0
+  while request < 10000:
+    var current = 0
+    while current < 96:
+      let candidate = current
+      current = current + 2
+      if (candidate % 3) != 0:
+        total = total + score(candidate, request)
+    request = request + 1
+  total
+
+pub fn main() -> i32
+  filtered_for_benchmark()

--- a/tests/performance/fixtures/mutable-result-specialization.voyd
+++ b/tests/performance/fixtures/mutable-result-specialization.voyd
@@ -1,0 +1,122 @@
+// Models the hot inner loop of an SSR response encoder. Each helper mutates
+// request-local writer state and returns the number of bytes emitted so the
+// caller can update a response budget.
+
+obj ResponseWriter {
+  template_seed: i32,
+  escape_seed: i32,
+  response_bytes: i32,
+  emitted_nodes: i32,
+  escape_events: i32,
+  checksum: i32
+}
+
+fn write_dynamic_text(~writer: ResponseWriter, value: i32) -> i32
+  if value < 0:
+    writer.escape_events = writer.escape_events + 1
+    writer.checksum = (writer.checksum + writer.template_seed * 3) % 1000003
+    writer.checksum = (writer.checksum + writer.escape_seed * 5) % 1000003
+    writer.checksum = (writer.checksum + writer.response_bytes * 7) % 1000003
+    writer.response_bytes = writer.response_bytes + 12
+    writer.emitted_nodes = writer.emitted_nodes + 1
+    return 12
+  if value > 1000000000:
+    writer.escape_events = writer.escape_events + 1
+    writer.checksum = (writer.checksum + value * 11) % 1000003
+    writer.checksum = (writer.checksum + writer.template_seed * 13) % 1000003
+    writer.checksum = (writer.checksum + writer.escape_seed * 17) % 1000003
+    writer.response_bytes = writer.response_bytes + 16
+    writer.emitted_nodes = writer.emitted_nodes + 1
+    return 16
+  let bytes = 8 + ((value + writer.escape_seed) % 23)
+  writer.response_bytes = writer.response_bytes + bytes
+  writer.emitted_nodes = writer.emitted_nodes + 1
+  writer.checksum = (writer.checksum + value * 7 + writer.template_seed) % 1000003
+  if (value % 11) == 0:
+    writer.escape_events = writer.escape_events + 1
+    return bytes + 2
+  bytes
+
+pub fn direct_result_workload() -> i32
+  let ~writer = ResponseWriter {
+    template_seed: 19,
+    escape_seed: 29,
+    response_bytes: 0,
+    emitted_nodes: 0,
+    escape_events: 0,
+    checksum: 0
+  }
+  let writer_alias = writer
+  var budget = 0
+  for request in 0..10000:
+    for node in 0..64:
+      budget = budget + writer_alias.template_seed + writer_alias.escape_seed
+      budget = budget + write_dynamic_text(~writer, request * 64 + node)
+      budget = budget + writer_alias.template_seed + writer_alias.escape_seed
+  budget + writer.response_bytes + writer.emitted_nodes + writer.escape_events + writer.checksum
+
+pub fn discarded_result_workload() -> i32
+  let ~writer = ResponseWriter {
+    template_seed: 19,
+    escape_seed: 29,
+    response_bytes: 0,
+    emitted_nodes: 0,
+    escape_events: 0,
+    checksum: 0
+  }
+  let writer_alias = writer
+  var observer = 0
+  for request in 0..10000:
+    for node in 0..64:
+      observer = observer + writer_alias.template_seed + writer_alias.escape_seed
+      write_dynamic_text(~writer, request * 64 + node)
+      observer = observer + writer_alias.template_seed + writer_alias.escape_seed
+  observer + writer.response_bytes + writer.emitted_nodes + writer.escape_events + writer.checksum
+
+pub fn manual_control() -> i32
+  let ~writer = ResponseWriter {
+    template_seed: 19,
+    escape_seed: 29,
+    response_bytes: 0,
+    emitted_nodes: 0,
+    escape_events: 0,
+    checksum: 0
+  }
+  let writer_alias = writer
+  var budget = 0
+  for request in 0..10000:
+    for node in 0..64:
+      let value = request * 64 + node
+      budget = budget + writer_alias.template_seed + writer_alias.escape_seed
+      if value < 0:
+        writer.escape_events = writer.escape_events + 1
+        writer.checksum = (writer.checksum + writer.template_seed * 3) % 1000003
+        writer.checksum = (writer.checksum + writer.escape_seed * 5) % 1000003
+        writer.checksum = (writer.checksum + writer.response_bytes * 7) % 1000003
+        writer.response_bytes = writer.response_bytes + 12
+        writer.emitted_nodes = writer.emitted_nodes + 1
+        budget = budget + 12
+      else:
+        if value > 1000000000:
+          writer.escape_events = writer.escape_events + 1
+          writer.checksum = (writer.checksum + value * 11) % 1000003
+          writer.checksum = (writer.checksum + writer.template_seed * 13) % 1000003
+          writer.checksum = (writer.checksum + writer.escape_seed * 17) % 1000003
+          writer.response_bytes = writer.response_bytes + 16
+          writer.emitted_nodes = writer.emitted_nodes + 1
+          budget = budget + 16
+        else:
+          let bytes = 8 + ((value + writer.escape_seed) % 23)
+          writer.response_bytes = writer.response_bytes + bytes
+          writer.emitted_nodes = writer.emitted_nodes + 1
+          writer.checksum = (writer.checksum + value * 7 + writer.template_seed) % 1000003
+          if (value % 11) == 0:
+            writer.escape_events = writer.escape_events + 1
+            budget = budget + bytes + 2
+          else:
+            budget = budget + bytes
+      budget = budget + writer_alias.template_seed + writer_alias.escape_seed
+  budget + writer.response_bytes + writer.emitted_nodes + writer.escape_events + writer.checksum
+
+pub fn main() -> i32
+  direct_result_workload()

--- a/tests/performance/fixtures/vtrace-compute-benchmark.voyd
+++ b/tests/performance/fixtures/vtrace-compute-benchmark.voyd
@@ -1,3 +1,5 @@
+// Keep this renderer source-idiomatic. It intentionally uses ordinary objects,
+// range-based loops, and direct Array iteration instead of hand-lowered controls.
 use std::math::{ INFINITY }
 use std::number::all
 use std::number::cast::to_i64
@@ -153,12 +155,7 @@ impl Vec3
   fn init(x: f64, y: f64, z: f64) -> Vec3
     Vec3 { x, y, z }
 
-  fn apply(~self, vec: Vec3) -> void
-    self.x = vec.x
-    self.y = vec.y
-    self.z = vec.z
-
-  fn '+='(~self, other: Vec3) -> void
+  fn add_assign(~self, other: Vec3) -> void
     self.x = self.x + other.x
     self.y = self.y + other.y
     self.z = self.z + other.z
@@ -258,13 +255,6 @@ impl Ray
   fn at(self, t: f64) -> Vec3
     self.origin + self.direction * t
 
-  fn apply(~self, ray: Ray) -> void
-    self.origin = ray.origin
-    self.direction = ray.direction
-
-  fn empty() -> Ray
-    Ray { origin: Vec3::empty(), direction: Vec3::empty() }
-
 obj Interval {
   min: f64,
   max: f64
@@ -283,7 +273,7 @@ impl Interval
   fn surrounds(self, x: f64) -> bool
     self.min < x and x < self.max
 
-val ScatterResult {
+obj ScatterResult {
   attenuation: Color,
   scattered: Ray
 }
@@ -319,8 +309,8 @@ impl Material for Metal
     Metal { albedo: albedo ?? Color(0.0, 0.0, 0.0), fuzz: fuzz ?? 0.0 }
 
   fn scatter(self, { r_in: Ray, rec: HitRecord }) -> ScatterResult
-    var reflected = r_in.direction.reflect(rec.normal)
-    reflected = reflected.unit_vector() + (Vec3::random_unit_vector() * self.fuzz)
+    let reflected = r_in.direction.reflect(rec.normal).unit_vector()
+      + (Vec3::random_unit_vector() * self.fuzz)
     ScatterResult {
       attenuation: self.albedo,
       scattered: Ray { origin: rec.p, direction: reflected }
@@ -352,8 +342,8 @@ impl Material for Dielectric
     }
 
   fn reflectance(self, cosine: f64) -> f64
-    var r0 = (1.0 - self.refraction_index) / (1.0 + self.refraction_index)
-    r0 = r0 * r0
+    let base = (1.0 - self.refraction_index) / (1.0 + self.refraction_index)
+    let r0 = base * base
     r0 + (1.0 - r0) * math::pow((1.0 - cosine), 5.0)
 
 obj HitRecord {
@@ -402,13 +392,11 @@ impl HittableList
 
 impl Hittable for HittableList
   fn hit(self, { ray: Ray, ray_t: Interval, ~rec: HitRecord }) -> bool
-    var ~temp_rec = HitRecord()
+    let ~temp_rec = HitRecord()
     var hit_anything = false
     var closest_so_far = ray_t.max
-    var index = 0
 
-    while index < self.objects.len():
-      let object = self.objects.at(index)
+    for object in self.objects:
       if object.hit({
         ray,
         ray_t: Interval(ray_t.min, closest_so_far),
@@ -417,7 +405,6 @@ impl Hittable for HittableList
         hit_anything = true
         closest_so_far = temp_rec.t
         rec.apply(temp_rec)
-      index = index + 1
 
     hit_anything
 
@@ -563,7 +550,7 @@ impl Camera
         let ~color = Color(1.0, 1.0, 1.0)
         for sample in 0..self.samples_per_pixel:
           let r = self.get_ray(i_f, j_f)
-          color.apply(color + ray_color(r, self.max_depth, world))
+          color.add_assign(ray_color(r, self.max_depth, world))
 
         checksum = checksum + checksum_color(color * self.pixel_samples_scale)
 

--- a/tests/performance/fixtures/web-app-request-pipeline.voyd
+++ b/tests/performance/fixtures/web-app-request-pipeline.voyd
@@ -1,0 +1,169 @@
+use std::array::Array
+use std::optional::all
+
+// Models the CPU-bound handler work after request I/O and database access:
+// route selection, product view-model construction, and SSR serialization.
+
+val Route {
+  path_hash: i32,
+  auth_cost: i32,
+  layout_id: i32
+}
+
+val ProductCard {
+  id: i32,
+  price_cents: i32,
+  inventory: i32,
+  personalization: i32
+}
+
+val RequestContext {
+  request_id: i32,
+  tenant_id: i32,
+  user_segment: i32,
+  route_hash: i32
+}
+
+obj ResponseRenderState {
+  template_seed: i32,
+  locale_bias: i32,
+  escaping_seed: i32,
+  hydration_seed: i32,
+  emitted_nodes: i32,
+  response_bytes: i32
+}
+
+fn routes() -> Array<Route>
+  let ~result = Array<Route>::with_capacity(12)
+  var index = 0
+  while index < 12:
+    result.push(Route {
+      path_hash: 1000 + index * 37,
+      auth_cost: 3 + index % 5,
+      layout_id: 11 + index % 4
+    })
+    index = index + 1
+  result
+
+fn catalog() -> Array<ProductCard>
+  let ~result = Array<ProductCard>::with_capacity(48)
+  var index = 0
+  while index < 48:
+    result.push(ProductCard {
+      id: index + 1,
+      price_cents: 499 + index * 73,
+      inventory: 5 + index % 17,
+      personalization: 7 + index % 9
+    })
+    index = index + 1
+  result
+
+fn route_score(route: Route, request: RequestContext) -> i32
+  let distance = (route.path_hash - request.route_hash) % 97
+  distance * distance + route.auth_cost * request.user_segment + route.layout_id
+
+fn product_card_score(card: ProductCard, request: RequestContext) -> i32
+  let tenant_price = card.price_cents + request.tenant_id * 13
+  tenant_price % 997 + card.inventory * 5 + card.personalization * request.user_segment + request.request_id % 11
+
+fn select_route(route_table: Array<Route>, request: RequestContext) -> i32
+  var index = 0
+  var score = 1000000
+  while index < route_table.len():
+    match(route_table.get(index))
+      Some<Route> { value }:
+        let candidate = route_score(value, request)
+        if candidate < score:
+          score = candidate
+      None:
+        score = -100000
+    index = index + 1
+  score
+
+fn build_product_view(cards: Array<ProductCard>, request: RequestContext) -> i32
+  var index = 0
+  var checksum = 0
+  while index < cards.len():
+    match(cards.get(index))
+      Some<ProductCard> { value }:
+        checksum = checksum + product_card_score(value, request)
+      None:
+        checksum = checksum - 100000
+    index = index + 1
+  checksum
+
+fn record_response_chunk(~state: ResponseRenderState, bytes: i32) -> void
+  state.emitted_nodes = state.emitted_nodes + 1
+  state.response_bytes = state.response_bytes + bytes
+
+fn render_response(route: i32, products: i32, request: RequestContext) -> i32
+  let ~state = ResponseRenderState {
+    template_seed: 19 + request.tenant_id + request.request_id % 3,
+    locale_bias: 23 + request.user_segment,
+    escaping_seed: 29 + request.tenant_id % 3,
+    hydration_seed: 31 + request.user_segment % 2,
+    emitted_nodes: 0,
+    response_bytes: 0
+  }
+  let state_alias = state
+  var node = 0
+  var checksum = route + products
+  while node < 128:
+    checksum = checksum + state_alias.template_seed + state_alias.locale_bias + state_alias.escaping_seed + state_alias.hydration_seed
+    record_response_chunk(~state, 80 + (products + node) % 31)
+    checksum = checksum + state_alias.template_seed + state_alias.locale_bias + state_alias.escaping_seed + state_alias.hydration_seed
+    node = node + 1
+  checksum + state_alias.emitted_nodes + state_alias.response_bytes
+
+fn request_context(request_id: i32) -> RequestContext
+  RequestContext {
+    request_id: request_id,
+    tenant_id: request_id % 7,
+    user_segment: 1 + request_id % 5,
+    route_hash: 1000 + request_id % 12 * 37
+  }
+
+fn handle_request(
+  route_table: Array<Route>,
+  cards: Array<ProductCard>,
+  request: RequestContext
+) -> i32
+  let selected_route = select_route(route_table, request)
+  let product_view = build_product_view(cards, request)
+  render_response(selected_route, product_view, request)
+
+pub fn main() -> i32
+  let route_table = routes()
+  let cards = catalog()
+  var request_id = 0
+  var checksum = 0
+  while request_id < 10000:
+    let request = request_context(request_id)
+    checksum = checksum + handle_request(route_table, cards, request)
+    request_id = request_id + 1
+  checksum
+
+pub fn request_lookup_stage() -> i32
+  let route_table = routes()
+  let cards = catalog()
+  var request_id = 0
+  var checksum = 0
+  while request_id < 10000:
+    let request = request_context(request_id)
+    checksum = checksum + select_route(route_table, request)
+    checksum = checksum + build_product_view(cards, request)
+    request_id = request_id + 1
+  checksum
+
+pub fn response_serialization_stage() -> i32
+  var request_id = 0
+  var checksum = 0
+  while request_id < 10000:
+    let request = request_context(request_id)
+    checksum = checksum + render_response(
+      31 + request_id % 7,
+      19000 + request_id % 997,
+      request
+    )
+    request_id = request_id + 1
+  checksum

--- a/tests/performance/fixtures/web-app-request-pipeline.voyd
+++ b/tests/performance/fixtures/web-app-request-pipeline.voyd
@@ -35,27 +35,23 @@ obj ResponseRenderState {
 
 fn routes() -> Array<Route>
   let ~result = Array<Route>::with_capacity(12)
-  var index = 0
-  while index < 12:
+  for index in 0..12:
     result.push(Route {
       path_hash: 1000 + index * 37,
       auth_cost: 3 + index % 5,
       layout_id: 11 + index % 4
     })
-    index = index + 1
   result
 
 fn catalog() -> Array<ProductCard>
   let ~result = Array<ProductCard>::with_capacity(48)
-  var index = 0
-  while index < 48:
+  for index in 0..48:
     result.push(ProductCard {
       id: index + 1,
       price_cents: 499 + index * 73,
       inventory: 5 + index % 17,
       personalization: 7 + index % 9
     })
-    index = index + 1
   result
 
 fn route_score(route: Route, request: RequestContext) -> i32
@@ -67,9 +63,8 @@ fn product_card_score(card: ProductCard, request: RequestContext) -> i32
   tenant_price % 997 + card.inventory * 5 + card.personalization * request.user_segment + request.request_id % 11
 
 fn select_route(route_table: Array<Route>, request: RequestContext) -> i32
-  var index = 0
   var score = 1000000
-  while index < route_table.len():
+  for index in 0..route_table.len():
     match(route_table.get(index))
       Some<Route> { value }:
         let candidate = route_score(value, request)
@@ -77,19 +72,16 @@ fn select_route(route_table: Array<Route>, request: RequestContext) -> i32
           score = candidate
       None:
         score = -100000
-    index = index + 1
   score
 
 fn build_product_view(cards: Array<ProductCard>, request: RequestContext) -> i32
-  var index = 0
   var checksum = 0
-  while index < cards.len():
+  for index in 0..cards.len():
     match(cards.get(index))
       Some<ProductCard> { value }:
         checksum = checksum + product_card_score(value, request)
       None:
         checksum = checksum - 100000
-    index = index + 1
   checksum
 
 fn record_response_chunk(~state: ResponseRenderState, bytes: i32) -> void
@@ -106,6 +98,8 @@ fn render_response(route: i32, products: i32, request: RequestContext) -> i32
     response_bytes: 0
   }
   let state_alias = state
+  // Keep this hot inner loop explicit so V-475 is measured independently from
+  // the general Range iterator used by the outer request loop.
   var node = 0
   var checksum = route + products
   while node < 128:
@@ -135,35 +129,29 @@ fn handle_request(
 pub fn main() -> i32
   let route_table = routes()
   let cards = catalog()
-  var request_id = 0
   var checksum = 0
-  while request_id < 10000:
+  for request_id in 0..10000:
     let request = request_context(request_id)
     checksum = checksum + handle_request(route_table, cards, request)
-    request_id = request_id + 1
   checksum
 
 pub fn request_lookup_stage() -> i32
   let route_table = routes()
   let cards = catalog()
-  var request_id = 0
   var checksum = 0
-  while request_id < 10000:
+  for request_id in 0..10000:
     let request = request_context(request_id)
     checksum = checksum + select_route(route_table, request)
     checksum = checksum + build_product_view(cards, request)
-    request_id = request_id + 1
   checksum
 
 pub fn response_serialization_stage() -> i32
-  var request_id = 0
   var checksum = 0
-  while request_id < 10000:
+  for request_id in 0..10000:
     let request = request_context(request_id)
     checksum = checksum + render_response(
       31 + request_id % 7,
       19000 + request_id % 997,
       request
     )
-    request_id = request_id + 1
   checksum

--- a/tests/performance/fixtures/web-app-request-pipeline.voyd
+++ b/tests/performance/fixtures/web-app-request-pipeline.voyd
@@ -98,15 +98,11 @@ fn render_response(route: i32, products: i32, request: RequestContext) -> i32
     response_bytes: 0
   }
   let state_alias = state
-  // Keep this hot inner loop explicit so V-475 is measured independently from
-  // the general Range iterator used by the outer request loop.
-  var node = 0
   var checksum = route + products
-  while node < 128:
+  for node in 0..128:
     checksum = checksum + state_alias.template_seed + state_alias.locale_bias + state_alias.escaping_seed + state_alias.hydration_seed
     record_response_chunk(~state, 80 + (products + node) % 31)
     checksum = checksum + state_alias.template_seed + state_alias.locale_bias + state_alias.escaping_seed + state_alias.hydration_seed
-    node = node + 1
   checksum + state_alias.emitted_nodes + state_alias.response_bytes
 
 fn request_context(request_id: i32) -> RequestContext


### PR DESCRIPTION
## Why this PR exists

Voyd's compiler already proves useful facts about memory safety: whether an object can escape, which fields a known function may read or write, whether an array remains stable through a loop, and whether a value's identity can be observed. Before this work, code generation often stopped using those facts after proving the program safe. The generated Wasm could still allocate objects, repeat field loads, construct and match `Option` values, and drive general-purpose iterators in places where the compiler already knew that work could not affect the result.

This PR adds a repeatable benchmark for those costs and six proof-gated optimizations. The common idea is straightforward: when the compiler has already proved that a runtime representation or check cannot affect program behavior, optimized code should not keep paying for it.

## What changed

### V-440: add measurement and regression controls

The new `npm run bench:v439` harness measures both optimized and nonoptimized builds. It records runtime samples, compile time, emitted and gzipped Wasm size, artifact hashes, allocation and access instruction sites, call sites, and linear-memory growth.

The harness contains three representative programs plus a focused checked-access fixture. This distinction matters: the representative programs tell us whether the PR changes broader application-shaped code, while the focused fixture explains which individual mechanisms are responsible.

### V-475: forward stable field loads across calls

A loop may repeatedly read the same object field while calling other functions. If every possible call target is known and its access summary proves it cannot write that field, the release optimizer now loads the field once and reuses the value.

Unknown calls, escaping aliases, observable identity, external access, suspension, and overlapping writes retain the existing behavior.

### V-476: remove proven `Array.get` `Option` traffic

`Array.get` normally returns an `Option` because an arbitrary index may be out of bounds. Inside the compiler's existing proof for a zero-based, unit-step loop bounded by the same stable array length, success is already guaranteed. Codegen now loads the element directly instead of rebuilding and matching the normal checked-access machinery on every iteration.

Calls outside that proven loop shape continue to use the ordinary safe `Array.get` path.

### V-477: lower intrinsic `Range<i32>` `for` loops directly

Idiomatic Voyd uses loops such as `for i in 0..10000`. Previously, that syntax allocated a range iterator and matched an `Option` returned from `.next()` on every iteration. The iterator call could also hide other optimization opportunities.

The compiler now recognizes its validated `Range<i32>` and exact standard `for` expansion and emits a direct counted Wasm loop. Bounds are evaluated once in source order, `continue` behavior is preserved, and inclusive `i32::MAX` is handled without overflow. Arbitrary iterators, open-ended ranges, other range types, and effectful functions keep the general iterator path.

This lets application code remain idiomatic without requiring hand-written `while` loops for performance.

### V-479: keep eligible mutable objects in scalar values across exact calls

A fresh mutable object previously had to remain a heap object as soon as it was passed by mutable borrow, even when escape analysis and the exact callee's access summary proved that only a few direct scalar fields could be read or changed.

For eligible calls, the compiler keeps those fields in Wasm scalar values and passes them to a specialized exact callee. The original form covered procedures returning `void`: the specialized result consisted only of the updated object fields. The generalized form now supports ordinary direct return values as well, using an internal multivalue result ordered as `(logical result lanes..., updated object lanes...)`. The caller evaluates the call once, writes the object lanes back, and then exposes or discards the original logical result.

Explicit non-`void` early returns package the result and current state the same way as fallthrough. Wide/out-pointer results, effects, returned receiver provenance, aliases, identity guards, and unsupported shapes keep the normal heap-object ABI. A helper that passes the mutable receiver to another helper also remains on the ordinary ABI; the review loop deliberately narrowed that boundary rather than introducing graph-wide specialization and path-sensitive materialization state.

This optimization depends directly on Voyd's memory-safety facts. Escape analysis proves where object identity can be observed, and callable access summaries prove that the exact callee cannot hide, retain, or mutate storage beyond the listed fields. If any part of that proof is missing, the compiler materializes the normal object.

[The checked-in V-479 walkthrough](https://github.com/voyd-lang/voyd/blob/f3145a3af99426cd6fe8fad96a8a44c5574fba51/docs/notes/v439-checked-access-optimization-results.md#how-v-479-transforms-voyd) now shows both the original `void` ABI and generalized value-result ABI, early returns, the conservative nested-helper boundary, realistic Voyd, and the benchmark methodology.

### Intrinsic Array `for` loops

`Array<T>` is already a compiler-owned intrinsic. The compiler now recognizes the exact standard expansion of `for node in nodes`, evaluates the Array once, and traverses its count and current backing storage directly. It reloads count and storage each iteration, so growing the Array or replacing its storage through an alias retains the existing `ArrayIterator` semantics. Custom and non-intrinsic sequences are never matched by this path.

### Exact standard user iterators

For non-intrinsic user types implementing the standard `Sequence` and `Iterator` traits, the release compiler can now prove a fresh concrete iterator returned by the exact `iter` implementation, resolve that type's exact `next` implementation, and remove dynamic dispatch from the macro-generated call. The iterator keeps its normal object and `Option<T>` ABI. Existing exact receiver specialization plus Binaryen escape analysis then removes the state object and Option traffic when they are unobservable.

The proof supports contextual generic iterator instances. Dynamic, ambiguous, noncanonical, and non-fresh iterator paths retain ordinary trait dispatch. To make mutable `next` specialization effective, exact receiver facts now permit direct field stores under the same nominal proof already used for direct field loads; that shared improvement also removes checked-store plumbing in other exact receiver-specialized calls.

## What the benchmark suite contains

The V-439 harness has three representative programs:

- **Vtrace** is an object- and effect-heavy renderer written in ordinary application style. It uses `obj` records, range-based loops, and `for object in self.objects`, so it measures the cost of standard language abstractions instead of hiding that cost behind a manual indexed loop.
- **Scalar aggregate** repeatedly creates and mutates a small particle-like object. It represents the compiler's existing scalar-replacement strengths and catches regressions in code that was already well optimized before this PR.
- **Web request pipeline** models the CPU-bound part of rendering a product page after network and database I/O completes. It performs route lookup, view-model construction, checked array access, and response serialization while updating writer state.

The suite also contains a **focused checked-access fixture**. Its individual entrypoints isolate stable field reads, mutable objects, checked array loops, `SharedCell`, and controls. Those numbers explain why an optimization works; they are not substitutes for the representative programs.

Three follow-up benchmarks cover the newly optimized forms:

- **Intrinsic Array iteration** compares realistic `for node in nodes` traversal with equivalent indexed controls, including a view-model serialization workload.
- **General iterator specialization** compares non-intrinsic user iterators with equivalent manual state machines, including a filtered, strided iterator whose `next` performs variable work and returns early.
- **Mutable value-result specialization** models an SSR response writer whose helper mutates request-local state and returns bytes written. It separately measures callers that use and discard the logical result, plus a manual checksum control.

## Why we added the web request pipeline

The initial focused benchmark showed large wins in carefully isolated loops, but our existing representative programs did not exercise the same combinations of access patterns. That left an important question unanswered: would these optimizations remove meaningful work from code shaped like a full-stack application?

The web fixture fills that gap. Each modeled request performs work commonly found after application I/O has completed:

- indexed route selection over a stable route table;
- product-card view-model construction over a stable catalog;
- checked `Array.get` handling;
- serialization of a 128-node response using stable template, locale, escaping, and hydration configuration; and
- mutation of writer counters while the response is assembled.

Each sample repeats the request 10,000 times to make small CPU costs measurable. This does not mean a real application performs 10,000 requests inside one user request; the batch amplifies the same routing, data-shaping, and serialization work that affects server throughput.

Every counted loop uses idiomatic range-based `for` syntax. Lookup and serialization are also exported separately, so we can attribute changes instead of relying only on one integrated number.

The fixture exposed an important interaction between the optimizations. V-475 could not see through the old generated range iterator. V-476 removed the array-heavy lookup cost. V-477 removed the iterator plumbing and allowed V-475 to work in idiomatic code. V-479 then removed the remaining mutable writer-object traffic.

The web percentages below apply to this CPU-bound workload. They are not a claim that total page latency, including databases and networks, becomes 80% faster.

## What each optimization contributes

The table below measures each optimization against the immediately preceding accepted compiler stage, rather than comparing every row with the original baseline. These percentages therefore describe the additional value of that optimization in the code it targets; they should not be added together to reconstruct the final 80% result.

| Optimization | Target niche | Most representative incremental result | Wider effect |
| --- | --- | ---: | --- |
| V-475: stable field forwarding | Repeated reads of a fixed field around exact calls that cannot write it | Focused stable-field loop: 0.3035 → 0.2433 ms (**-19.8%**) | Reaches the manually hoisted control; the all-`for` web fixture needs V-477 before this proof becomes visible |
| V-476: proven `Array.get` | `Array.get` inside a stable `0..array.len()` loop | Web lookup stage: 3.261 → 0.691 ms (**-78.8%**) | Integrated web pipeline: 14.192 → 9.171 ms (**-35.4%**) |
| V-477: intrinsic range lowering | Standard `Range<i32>` used by idiomatic `for` loops | Web integrated pipeline: 9.171 → 5.103 ms (**-44.4%**) | Serialization: 11.789 → 7.059 ms (**-40.1%**); restores all-`for` code to hand-written-`while` parity |
| V-479: mutable scalar lanes | Fresh mutable objects passed to exact, pure mutable-borrow callees | Web serialization for the original `void` form: 7.047 → 2.154 ms (**-69.4%**) | Integrated web pipeline: **-44.1%**; generalized discarded-result helper: **-7.0% to -7.6%**; used-result timing is inconclusive |
| Intrinsic Array iteration | Standard `for element in array` over compiler-owned `Array<T>` | View-model serialization: 1.708 → 0.150 ms (**-91.2%**) | Light element loop: 3.264 → 0.143 ms (**-95.6%**); idiomatic Vtrace: 165.317 → 77.689 ms (**-53.0%**); reaches indexed-loop parity |
| Exact user iterators and receivers | Fresh concrete iterators returned by exact standard `Sequence.iter` implementations | Filtered/strided traversal: 0.992 → 0.440 ms (**-55.7%**) | Light user iterator: 2.472 → 0.385 ms (**-84.4%**); iterator allocation, indirect calls, and field traffic fall to zero |

### V-475: remove repeated stable-field reads

The focused case is the cleanest isolated measurement: forwarding the load improves the target loop by 19.8% and brings it to the cost of the manually hoisted source control.

V-475 initially has no measurable effect on the all-`for` web fixture because the macro-generated range iterator's `.next()` call sits between the loop and the access proof. That is a useful limitation rather than a failed result. Once V-477 removes the iterator plumbing, compiler telemetry reports four V-475 field loads forwarded in the serialization loop. The V-477 stage numbers include both direct range lowering and that newly exposed forwarding, so there is no honest way to assign part of the combined 40.1% serialization improvement to V-475 alone.

### V-476: make already-proven `Array.get` cheap

The focused matched `Array.get` loop improves from 0.2553 to 0.0708 ms (**-72.3%**) and reaches the existing direct `Array.at` control.

In the web fixture, the route and view-model lookup stage is dominated by exactly this pattern and improves by 78.8%. That reduces the complete request pipeline by 35.4%, while serialization remains effectively unchanged (+0.6%), which is expected because serialization is not array-lookup-heavy. At this stage the web module also shrinks from 6,262 to 5,489 bytes (-12.3%).

### V-477: remove general iterator overhead from ordinary counted loops

Starting from the V-476 stage, direct range lowering improves the integrated web pipeline by 44.4% and serialization by 40.1%. Lookup improves another 6.8%.

The important source-level result is that idiomatic range-based `for` loops no longer require a performance tradeoff. Before V-477, the all-`for` pipeline was 79.3% slower than its hand-written `while` control. After V-477, integrated runtime is within 0.7% of that control and serialization is within 0.2%. The web module shrinks from 5,489 to 4,579 bytes (-16.6%).

### V-479: avoid materializing eligible mutable writer objects

Starting from the V-477 stage, mutable scalar lanes improve response serialization by 69.4% and the integrated request pipeline by 44.1%. Lookup is unchanged, which is expected because it does not use the mutable writer pattern.

The isolated exact-object case improves from 0.2689 to 0.0269 ms (**-90.0%**) and reaches approximately the ordinary scalar-mutation control's cost. The web module shrinks another 7.9%, from 4,579 to 4,219 bytes, while removing eight allocation sites, fourteen `struct.get` sites, and six `struct.set` sites.

#### Generalized non-`void` results

The follow-up benchmark performs 640,000 SSR-style writer calls per sample. Three counterbalanced, isolated A/B pairs reproduce a **7.0% to 7.6%** improvement when the caller discards the helper's byte-count result. Used-result timing ranges from +0.1% to -7.4% and is inconclusive, so this PR does not claim that value-returning mutable calls are generally faster.

The focused module shrinks from 3,861 to 3,334 bytes (**-13.6%**), while allocation sites fall 33→27, `struct.get` sites 121→41, and `struct.set` sites 26→10. Gzip moves from 1,541 to 1,559 bytes (+1.2%), so there is no compressed-size win. Compile timing is noisy. Nested receiver helpers intentionally remain on the ordinary ABI.

Together, the original stages explain the representative PR result: V-476 removes checked array overhead, V-477 removes counted-iterator overhead and exposes V-475's field proof, and the original V-479 form removes the remaining mutable writer-object traffic. The generalized form adds a narrower independently measured capability without changing the existing representative modules.

### Intrinsic Array iteration: make `for node in nodes` as cheap as indexing

The intrinsic Array benchmark's light loop improves from 3.264 to 0.143 ms (-95.6%), while its indexed control is 0.145 ms. The application-shaped view-model serialization case improves from 1.708 to 0.150 ms (-91.2%), compared with a 0.154 ms indexed control.

The module shrinks from 4,078 to 3,018 bytes (-26.0%) and from 1,956 to 1,482 bytes after gzip (-24.2%). Indirect-call sites fall from 23 to 12 and allocation sites from 31 to 18. The combined final branch retains runtime parity and further reduces this fixture to 2,880 bytes, or 1,413 bytes after gzip.

The idiomatic Vtrace fixture provides a larger application-shaped confirmation. On the exact same source, the compiler stage immediately before intrinsic Array lowering takes 165.317 ms; the Array path takes 77.689 ms (**-53.0%**). The final compiler measures 78.101 ms, within noise of the former manually indexed fixture's 78.448 ms. In practical terms, `for object in objects` now reaches the performance that previously required rewriting the renderer as an indexed `while` loop.

### Exact user iterators: expose ordinary state machines to scalar replacement

The light non-intrinsic iterator improves from 2.472 to 0.385 ms (-84.4%). The filtered/strided application case improves from 0.992 to 0.440 ms (-55.7%). Their manual controls measure 0.309 and 0.398 ms respectively.

The module shrinks from 2,221 to 1,654 bytes (-25.5%) and from 1,088 to 781 bytes after gzip (-28.2%). Indirect calls fall from four to zero; allocation sites from fifteen to zero; and iterator structural gets/sets from 13/7 to zero. A parent rerun reproduced the zero-traffic code shape and measured 0.354 and 0.423 ms.

The exact receiver store proof also applies outside iteration. The previously unmatched projected-field workload improves from 0.3635 to 0.1064 ms (-70.7%). After intrinsic Array lowering removes Vtrace's runtime bottleneck, this follow-up makes the final Vtrace and web modules smaller without a measurable additional runtime change.

## Before and after: all representative programs

These measurements compare the PR merge base, `29ad6f0a`, with the final PR commit, `f3145a3a`. Both revisions compile the same final fixtures with the same harness. The generalized V-479 follow-up does not match any of the three representative programs; its representative artifacts remain identical to the preceding accepted iterator commit.

### Optimized runtime

| Representative program | Before PR | After PR | Change | What happened |
| --- | ---: | ---: | ---: | --- |
| Idiomatic Vtrace renderer | 167.419 ms | 78.101 ms | **-53.4%** | Intrinsic Array iteration removes the abstraction cost of `for object in objects` and reaches the former indexed-loop performance |
| Scalar aggregate | 0.0407 ms | 0.0409 ms | +0.4% | Emitted Wasm remains byte-identical |
| Web request pipeline | 14.199 ms | 2.852 ms | **-79.9%** | The proof-gated paths match this workload |

Scalar aggregate retains an identical Wasm hash, size, and instruction counts. The idiomatic Vtrace source improves by 53.4% and finishes within noise of the former hand-shaped fixture. Its release module is 5.4% smaller and gzip is 3.4% smaller than the PR-base compiler's output for the same source.

The web pipeline's separately measured stages show where its improvement comes from:

| Web pipeline stage | Before PR | After PR | Change |
| --- | ---: | ---: | ---: |
| Route and view-model lookup | 3.245 ms | 0.645 ms | **-80.1%** |
| Response serialization | 11.715 ms | 2.152 ms | **-81.6%** |
| Integrated pipeline | 14.199 ms | 2.852 ms | **-79.9%** |

The lookup result is primarily the combination of proven `Array.get` access and direct range-loop lowering. Serialization benefits from direct range loops, stable-field forwarding, and mutable-object scalar promotion.

### Optimized compile time and artifacts

| Representative program | Compile median before → after | Wasm before → after | Gzip before → after |
| --- | ---: | ---: | ---: |
| Idiomatic Vtrace renderer | 2,881.7 → 2,908.1 ms (+0.9%) | 36,058 → 34,105 B (-5.4%) | 13,108 → 12,666 B (-3.4%) |
| Scalar aggregate | 1,510.2 → 1,477.1 ms (-2.2%) | 1,112 → 1,112 B | 677 → 677 B |
| Web request pipeline | 1,671.8 → 1,659.3 ms (-0.7%) | 6,262 → 3,878 B (**-38.1%**) | 2,884 → 1,883 B (**-34.7%**) |

Compile medians come from seven fresh SDK instances. The table reports the observed movements rather than treating small changes as wins. Vtrace's compile samples remain noisy; its final emitted release module is smaller because intrinsic Array lowering removes iterator machinery and exact receiver specialization trims additional traffic. Web and scalar-aggregate medians show no material compile-time regression.

For the web module, the smaller artifact reflects substantial removal of runtime machinery: allocation sites fall from 86 to 30, `struct.get` sites from 92 to 33, `struct.set` sites from 20 to 4, direct call sites from 103 to 47, and indirect call sites from 42 to 20. These are static sites in the complete emitted module, not estimates of dynamic execution counts.

### Nonoptimized control

The harness also compiles every representative program without the release optimizer:

| Representative program | Runtime before → after | Change | Wasm before → after |
| --- | ---: | ---: | ---: |
| Idiomatic Vtrace renderer | 521.656 → 367.473 ms | **-29.6%** | 166,793 → 166,727 B (-0.04%) |
| Scalar aggregate | 0.1686 → 0.1718 ms | +1.9% | 37,854 → 37,854 B, byte-identical |
| Web request pipeline | 61.808 → 30.676 ms | **-50.4%** | 56,626 → 53,925 B (-4.8%) |

Vtrace and the web fixture improve without release optimization because intrinsic Array iteration, proven `Array.get`, and intrinsic range lowering are safe code-generation decisions rather than speculative release-only transforms. Vtrace improves by 29.6%. In the web workload, lookup improves from 15.216 to 1.028 ms (-93.2%) and serialization from 47.065 to 30.117 ms (-36.0%). V-475's optimizer pass and V-479's mutable scalar-lane promotion remain release-only.

## Before and after: focused examples

All entries below are optimized runtime medians from the focused fixture.

| Focused example | Before PR | After PR | Change | Purpose |
| --- | ---: | ---: | ---: | --- |
| Projected fields from array elements | 0.3635 ms | 0.1050 ms | **-71.1%** | Exact receiver stores remove checked write plumbing while retaining projected-array semantics |
| Stable fields across exact calls | 0.2963 ms | 0.0262 ms | **-91.2%** | Exercises stable-load forwarding and mutable scalar lanes |
| Manually hoisted stable-field control | 0.2397 ms | 0.0268 ms | **-88.8%** | Shows the remaining object cost removed by V-479 |
| Ordinary scalar mutation control | 0.0235 ms | 0.0235 ms | +0.2% | Lower-bound control; unchanged |
| `SharedCell` runtime checks | 0.2260 ms | 0.2238 ms | -1.0% | Runtime-identity case; intentionally unchanged |
| Proven `Array.at` loop | 0.0748 ms | 0.0683 ms | -8.8% | Existing direct-access control |
| Matched `Array.get` loop | 0.2551 ms | 0.0685 ms | **-73.1%** | Exercises V-476's proven successful access |

The complete focused module shrinks from 7,528 to 6,688 bytes (-11.2%) and from 2,898 to 2,626 bytes after gzip (-9.4%). Allocation sites fall from 56 to 47, `struct.get` sites from 131 to 99, and `struct.set` sites from 15 to 8.

## Methodology

The numbers above were collected on Node 24.18.0 using an Apple M4 Pro with 14 logical CPUs. For every scenario and compiler mode, the harness:

- creates seven fresh SDK instances and reports the median compile time;
- warms each entrypoint three times;
- reports the median of 31 runtime samples;
- creates a fresh host for every entrypoint;
- runs scenarios in isolated child processes;
- verifies every returned result;
- records complete-module Wasm hashes, sizes, gzip sizes, and static instruction counts; and
- measures linear-memory growth.

All measured scenarios report zero linear-memory growth.

### Reproducing the comparison

Run these commands from a checkout of this PR. The separate worktree is important because the final benchmark harness and fixtures must remain constant while only the compiler SDK changes.

```sh
git fetch origin

V439_BASE=/private/tmp/voyd-v439-pr-base
git worktree add --detach "$V439_BASE" "$(git merge-base HEAD origin/main)"

npm ci --include=optional
(cd "$V439_BASE" && npm ci --include=optional)
```

Collect the PR-base results using the compiler from the temporary worktree:

```sh
npm run --silent bench:v439 -- \
  --label pr-base \
  --samples 7 \
  --runtime-samples 31 \
  --sdk-root "$V439_BASE" \
  > /private/tmp/v439-pr-base.json
```

Collect the final PR results using the current checkout:

```sh
npm run --silent bench:v439 -- \
  --label pr-final \
  --samples 7 \
  --runtime-samples 31 \
  > /private/tmp/v439-pr-final.json
```

Both files contain the raw samples, medians, environment details, artifact hashes, sizes, instruction counts, and memory-growth measurements. To inspect the compact optimized-build results:

```sh
jq '.results[] | {
  scenario,
  compile_median_ms: .modes.release.compile.medianMs,
  runtime: (.modes.release.runtime | map_values(.medianMs)),
  wasm_bytes: .modes.release.wasmBytes,
  gzip_bytes: .modes.release.gzipBytes,
  wasm_sha256: .modes.release.wasmSha256
}' /private/tmp/v439-pr-base.json /private/tmp/v439-pr-final.json
```

Pass one of these values with `--scenario` to rerun a single case:

- `representative-vtrace`
- `representative-scalar-aggregate`
- `representative-web-app-request`
- `focused-checked-access`

Run the three focused follow-up benchmarks independently:

```sh
npm run bench:array-for -- \
  --label final \
  --compile-samples 5 \
  --runtime-samples 21

npm run bench:iterator-for -- \
  --label final \
  --compile-samples 7 \
  --runtime-samples 31

npm run bench:mutable-result -- \
  --label final \
  --compile-samples 7 \
  --runtime-samples 31
```

The Array and iterator commands compare idiomatic `for` entrypoints with equivalent indexed or manual controls. The mutable-result command compares used and discarded logical results with a manual checksum control. All report raw samples, checksums, compile time, Wasm/gzip size, and code-shape counts. Pass `--sdk-root /path/to/checkout` to the mutable-result command to compile the final fixture with another compiler revision.

## CI follow-up

The compiler codegen suite now runs as one `compiler-codegen` job instead of a four-way matrix. The exact unsharded command passes locally with 53 files and 344 tests in 57.6 seconds. The job has a 20-minute ceiling so the next hosted run can report its real end-to-end cost, including checkout and dependency installation.

All workflow steps explicitly install Node `24.x`. JavaScript actions were also moved to Node 24-native releases: checkout v6, setup-node v6, cache v5, upload-artifact v7, paths-filter v4, and the current Node 24 Pages action majors. This removes reliance on GitHub's compatibility mode for actions that still declare the deprecated Node 20 runtime.

The final PR head passed with the merged `compiler-codegen` job completing in **11m09s** end to end, including checkout and dependency installation. All other jobs passed as well; the optimizer scorecard completed in 8m44s. This confirms that the unsharded suite fits comfortably within its 20-minute ceiling, although it is slower than the previous four-way wall-clock lane and intentionally trades latency for a simpler, lower-overhead CI shape.

## Safety, validation, and review

All six optimizations are guarded by compiler proofs and fall back to the existing general implementation when those proofs do not apply. V-475 consumes callable write footprints; V-476 consumes the stable counted-array-loop proof; V-477 relies on compiler ownership of the intrinsic range type and standard `for` expansion; V-479 combines escape facts with exact callable access summaries; intrinsic Array iteration requires the validated std Array contract and exact std `for` expansion; and general iterator specialization requires a fresh concrete result from an exact standard `Sequence.iter` implementation plus one canonical standard `Iterator.next` implementation.

Validation completed successfully:

- `npm test`
- `npm run typecheck`
- `npm run test:audit`
- focused optimizer, range, intrinsic Array, general iterator, scalar-aggregate, and specialization-policy tests
- the complete release and non-release benchmark matrix
- the GitHub optimizer scorecard and all other CI jobs

Each optimization went through a review-and-repair loop. V-479 received additional completeness, design, and correctness reviews because it crosses scalar replacement, call specialization, alias materialization, and control-flow state. The generalized V-479 review found that recursively specializing nested receiver helpers could return stale or uninitialized state after conditional and zero-iteration-loop fallback, and that its recursive proof could repeat work exponentially. The repair removed nested-helper eligibility entirely, added both fallback regressions, and passed a fresh verification review. The intrinsic Array review caught and repaired an overbroad macro-lookalike matcher. The general iterator review caught and repaired missing generic contextual instantiation and missing post-Binaryen shape coverage. Fresh verification reviews were clean.

[Detailed measurements, worked examples, methodology, and safety boundaries](https://github.com/voyd-lang/voyd/blob/f3145a3af99426cd6fe8fad96a8a44c5574fba51/docs/notes/v439-checked-access-optimization-results.md) are checked in with the branch.

Linear: V-439, V-440, V-475, V-476, V-477, V-479