### PR TITLE
Optimize compiler semantic analysis and codegen hotspots

### DIFF
--- a/packages/compiler/src/__tests__/module-imports.test.ts
+++ b/packages/compiler/src/__tests__/module-imports.test.ts
@@ -785,6 +785,12 @@ use SecondStore::{ save }
       host,
     });
 
+    const strict = analyzeModules({ graph });
+    expect(strict.semantics.has("src::b")).toBe(false);
+    expect(strict.diagnostics.some((diag) => diag.code === "TY0006")).toBe(
+      true,
+    );
+
     const { diagnostics, semantics } = analyzeModules({
       graph,
       recoverFromTypingErrors: true,

--- a/packages/compiler/src/codegen/__tests__/support/test-codegen-context.ts
+++ b/packages/compiler/src/codegen/__tests__/support/test-codegen-context.ts
@@ -145,7 +145,7 @@ export const createTestCodegenContext = (): {
         getTemplate: () => undefined,
         getInfoByNominal: () => undefined,
         getNominalOwnerRef: () => undefined,
-        getNominalInstancesByOwner: () => [],
+        getCompatibleNominalInstantiations: () => [],
       },
       traits: {
         getImplsByNominal: () => [],

--- a/packages/compiler/src/codegen/types.ts
+++ b/packages/compiler/src/codegen/types.ts
@@ -2185,11 +2185,6 @@ const makeRuntimeTypeLabel = ({
   return `${moduleLabel}__struct_${nominalPrefix}type_${typeId}_shape_${structuralId}`;
 };
 
-const isUnknownPrimitive = (typeId: TypeId, ctx: CodegenContext): boolean => {
-  const desc = ctx.program.types.getTypeDesc(typeId);
-  return desc.kind === "primitive" && desc.name === "unknown";
-};
-
 const buildRuntimeAncestors = ({
   typeId,
   structuralId,
@@ -2233,57 +2228,15 @@ const buildRuntimeAncestors = ({
   });
   add(structuralId);
 
-  const addCompatibleSuperInstantiations = (nominalId?: TypeId) => {
-    if (typeof nominalId !== "number") {
-      return;
-    }
-    const sourceDesc = ctx.program.types.getTypeDesc(nominalId);
-    if (
-      sourceDesc.kind !== "nominal-object" ||
-      sourceDesc.typeArgs.some((arg) => isUnknownPrimitive(arg, ctx))
-    ) {
-      return;
-    }
-
-    const candidates = ctx.program.objects.getNominalInstancesByOwner(
-      sourceDesc.owner,
-    );
-
-    candidates.forEach((candidateNominal) => {
-      if (candidateNominal === nominalId) {
-        return;
-      }
-      const info = ctx.program.objects.getInfoByNominal(candidateNominal);
-      if (!info || info.nominal !== candidateNominal) {
-        return;
-      }
-      const targetDesc = ctx.program.types.getTypeDesc(candidateNominal);
-      if (
-        targetDesc.kind !== "nominal-object" ||
-        targetDesc.typeArgs.length !== sourceDesc.typeArgs.length ||
-        targetDesc.typeArgs.some((arg) => isUnknownPrimitive(arg, ctx))
-      ) {
-        return;
-      }
-
-      const compatible = sourceDesc.typeArgs.every((arg, index) => {
-        const targetArg = targetDesc.typeArgs[index]!;
-        const forward = ctx.program.types.unify(arg, targetArg, {
-          location: ctx.module.hir.module.ast,
-          reason: "nominal instantiation compatibility",
-          variance: "covariant",
-        });
-        return forward.ok;
+  const nominalId = nominalAncestry[0]?.nominalId;
+  if (typeof nominalId === "number") {
+    ctx.program.objects
+      .getCompatibleNominalInstantiations(nominalId)
+      .forEach((entry) => {
+        add(entry.typeId);
+        add(entry.nominalId);
       });
-
-      if (compatible) {
-        add(info.type);
-        add(candidateNominal);
-      }
-    });
-  };
-
-  addCompatibleSuperInstantiations(nominalAncestry[0]?.nominalId);
+  }
 
   return ancestors;
 };

--- a/packages/compiler/src/modules/semantic-analysis.ts
+++ b/packages/compiler/src/modules/semantic-analysis.ts
@@ -3,6 +3,7 @@ import { diagnosticFromCode, DiagnosticError } from "../diagnostics/index.js";
 import type { ModuleGraph, ModuleNode } from "./types.js";
 import { modulePathToString } from "./path.js";
 import {
+  reanalyzeSemanticsBorrowing,
   semanticsPipeline,
   type SemanticsPipelineResult,
 } from "../semantics/pipeline.js";
@@ -25,6 +26,7 @@ import { getModuleSccGroups } from "./scc.js";
 import { collectCyclicModuleExportSurfaces } from "./cyclic-export-surfaces.js";
 import { cloneSemanticsMapForTypingState } from "./semantic-snapshot.js";
 import type { BorrowingResult } from "../semantics/borrowing/index.js";
+import { incrementCompilerPerfCounter } from "../perf.js";
 
 export type SemanticsTypingState = {
   arena: TypeArena;
@@ -525,37 +527,98 @@ const analyzeCyclicScc = ({
     stabilizationExports.set(moduleId, result.exports);
   });
 
+  const cyclicModuleIds = new Set(moduleIds);
+  const cyclicModuleIndex = new Map(
+    moduleIds.map((moduleId, index) => [moduleId, index]),
+  );
+
   moduleIds.forEach((moduleId) => {
     throwIfCancelled(isCancelled);
 
-    const result = analyzeModule({
-      moduleId,
-      includeTests,
-      recoverFromTypingErrors,
-      cycleModuleIdsByModuleId,
-      graph,
-      semantics: mergeWithOverrides({
-        base: mergeWithOverrides({
-          base: semantics,
-          overrides: stabilizationSemantics,
-        }),
-        overrides: finalPassSemantics,
+    const dependencySemantics = mergeWithOverrides({
+      base: mergeWithOverrides({
+        base: semantics,
+        overrides: stabilizationSemantics,
       }),
-      exports: mergeWithOverrides({
-        base: mergeWithOverrides({
-          base: exports,
-          overrides: stabilizationExports,
-        }),
-        overrides: finalPassExports,
-      }),
-      arena,
-      effectInterner,
-      diagnostics,
-      isCancelled,
-      reusableBorrowing,
-      previousBorrowing: previousSemantics?.get(moduleId)?.borrowing,
-      retainBorrowingIncrementalData,
+      overrides: finalPassSemantics,
     });
+    const dependencyExports = mergeWithOverrides({
+      base: mergeWithOverrides({
+        base: exports,
+        overrides: stabilizationExports,
+      }),
+      overrides: finalPassExports,
+    });
+    const stabilized = stabilizationSemantics.get(moduleId);
+    // Stabilization recovers typing errors and may have observed first-pass
+    // dependencies. Retain its typing only when strictness and every cyclic
+    // dependency's public typing contract match the final-pass inputs.
+    const canReuseRecoveredTyping =
+      recoverFromTypingErrors === true ||
+      !stabilized?.typing.diagnostics.some(
+        (diagnostic) => diagnostic.severity === "error",
+      );
+    const canReuseStabilizedTyping =
+      canReuseRecoveredTyping &&
+      graph.modules
+        .get(moduleId)
+        ?.dependencies.filter((dependency) =>
+          cyclicModuleIds.has(modulePathToString(dependency.path)),
+        )
+        .every((dependency) => {
+          const dependencyId = modulePathToString(dependency.path);
+          const dependencyIndex = cyclicModuleIndex.get(dependencyId);
+          const moduleIndex = cyclicModuleIndex.get(moduleId);
+          const exportsUsedForStabilization =
+            dependencyIndex !== undefined &&
+            moduleIndex !== undefined &&
+            dependencyIndex < moduleIndex
+              ? stabilizationExports.get(dependencyId)
+              : firstPassExports.get(dependencyId);
+          const exportsUsedForFinalization =
+            finalPassExports.get(dependencyId) ??
+            stabilizationExports.get(dependencyId);
+          return haveEquivalentPublicTypingSurfaces(
+            exportsUsedForStabilization,
+            exportsUsedForFinalization,
+          );
+        }) === true;
+    incrementCompilerPerfCounter(
+      canReuseStabilizedTyping
+        ? "semantics.cyclic_scc.stabilized_typing_reused"
+        : "semantics.cyclic_scc.full_final_pass",
+    );
+    const result =
+      canReuseStabilizedTyping && stabilized
+        ? reanalyzeBorrowing({
+            semantics: stabilized,
+            moduleId,
+            graph,
+            cycleModuleIdsByModuleId,
+            dependencies: dependencySemantics,
+            exports: dependencyExports,
+            recoverFromTypingErrors,
+            diagnostics,
+            reusableBorrowing,
+            previousBorrowing: previousSemantics?.get(moduleId)?.borrowing,
+            retainBorrowingIncrementalData,
+          })
+        : analyzeModule({
+            moduleId,
+            includeTests,
+            recoverFromTypingErrors,
+            cycleModuleIdsByModuleId,
+            graph,
+            semantics: dependencySemantics,
+            exports: dependencyExports,
+            arena,
+            effectInterner,
+            diagnostics,
+            isCancelled,
+            reusableBorrowing,
+            previousBorrowing: previousSemantics?.get(moduleId)?.borrowing,
+            retainBorrowingIncrementalData,
+          });
     if (!result) {
       return;
     }
@@ -589,6 +652,116 @@ const analyzeCyclicScc = ({
       }),
     );
   });
+};
+
+const haveEquivalentPublicTypingSurfaces = (
+  left: ModuleExportTable | undefined,
+  right: ModuleExportTable | undefined,
+): boolean => {
+  const leftInterface = left?.packageSemanticInterface;
+  const rightInterface = right?.packageSemanticInterface;
+  if (!leftInterface || !rightInterface) {
+    return false;
+  }
+
+  const publicTypingSurface = (
+    packageInterface: NonNullable<ModuleExportTable["packageSemanticInterface"]>,
+  ) => ({
+    moduleId: packageInterface.moduleId,
+    exports: packageInterface.exports.map((entry) => ({
+      name: entry.name,
+      kind: entry.kind,
+      visibility: entry.visibility,
+      declarations: entry.declarations.map(
+        ({ summaryId: _summaryId, capability: _capability, ...declaration }) =>
+          declaration,
+      ),
+      members: entry.members.map(
+        ({ summaryId: _summaryId, capability: _capability, ...member }) =>
+          member,
+      ),
+    })),
+    types: packageInterface.types,
+  });
+
+  return (
+    JSON.stringify(publicTypingSurface(leftInterface)) ===
+    JSON.stringify(publicTypingSurface(rightInterface))
+  );
+};
+
+const reanalyzeBorrowing = ({
+  semantics,
+  moduleId,
+  graph,
+  cycleModuleIdsByModuleId,
+  dependencies,
+  exports,
+  recoverFromTypingErrors,
+  diagnostics,
+  reusableBorrowing,
+  previousBorrowing,
+  retainBorrowingIncrementalData,
+}: {
+  semantics: SemanticsPipelineResult;
+  moduleId: string;
+  graph: ModuleGraph;
+  cycleModuleIdsByModuleId: ReadonlyMap<string, readonly string[]>;
+  dependencies: Map<string, SemanticsPipelineResult>;
+  exports: Map<string, ModuleExportTable>;
+  recoverFromTypingErrors: boolean | undefined;
+  diagnostics: Diagnostic[];
+  reusableBorrowing?: ReadonlyMap<string, BorrowingResult>;
+  previousBorrowing?: BorrowingResult;
+  retainBorrowingIncrementalData: boolean;
+}): SemanticsPipelineResult | undefined => {
+  const module = graph.modules.get(moduleId);
+  if (!module) {
+    return undefined;
+  }
+
+  try {
+    const result = reanalyzeSemanticsBorrowing({
+      semantics,
+      module,
+      dependencies,
+      exports,
+      recoverFromTypingErrors,
+      borrowingOverride: reusableBorrowing?.get(moduleId),
+      previousBorrowing,
+      retainBorrowingIncrementalData,
+    });
+    diagnostics.push(
+      ...augmentCycleTy0022Diagnostics({
+        diagnostics: result.diagnostics,
+        moduleId,
+        cycleModuleIdsByModuleId,
+      }),
+    );
+    return result;
+  } catch (error) {
+    if (error instanceof DiagnosticError) {
+      diagnostics.push(
+        ...augmentCycleTy0022Diagnostics({
+          diagnostics: error.diagnostics,
+          moduleId,
+          cycleModuleIdsByModuleId,
+        }),
+      );
+      return undefined;
+    }
+    diagnostics.push(
+      diagnosticFromCode({
+        code: "TY9999",
+        params: {
+          kind: "unexpected-error",
+          message: error instanceof Error ? error.message : String(error),
+        },
+        span: { file: moduleDiagnosticFilePath(module), start: 0, end: 0 },
+      }),
+    );
+    return undefined;
+  }
 };
 
 const analyzeModule = ({

--- a/packages/compiler/src/semantics/borrowing/summaries.ts
+++ b/packages/compiler/src/semantics/borrowing/summaries.ts
@@ -3393,6 +3393,7 @@ const summarizeFunction = ({
   moduleId,
   imports,
   dependencies,
+  externalBindingFlows,
   decls,
 }: {
   functionItem: HirFunction;
@@ -3405,6 +3406,7 @@ const summarizeFunction = ({
   moduleId: string;
   imports: ReadonlyMap<SymbolId, SymbolRef>;
   dependencies: ReadonlyMap<string, BorrowingDependency>;
+  externalBindingFlows: ReadonlyMap<SymbolId, Flow>;
   decls: DeclTable;
 }): CallableBorrowContract => {
   incrementCompilerPerfCounter("borrowing.summary.evaluations");
@@ -3480,8 +3482,8 @@ const summarizeFunction = ({
   invalidated.set(env, emptyFlow());
   placeEnvs.set(env, new Map());
   expressionFlows.set(env, new Map());
-  externalModuleBindingFlows(hir, typing, imports, dependencies).forEach(
-    (flow, symbol) => env.set(symbol, new Map(flow)),
+  externalBindingFlows.forEach((flow, symbol) =>
+    env.set(symbol, new Map(flow)),
   );
   functionItem.parameters.forEach((parameter, index) => {
     bindPattern(parameter.pattern, parameterFlows.get(index)!, env);
@@ -4725,6 +4727,12 @@ export const computeCallableBorrowContracts = ({
       localSummaryDependencies.set(dependent.symbol, targets);
     });
   });
+  const externalBindingFlows = externalModuleBindingFlows(
+    hir,
+    typing,
+    importMap,
+    dependencies,
+  );
   let evaluationCount = 0;
   const summarize = (node: SummarySolveNode): CallableBorrowContract => {
     evaluationCount += 1;
@@ -4740,6 +4748,7 @@ export const computeCallableBorrowContracts = ({
           moduleId,
           imports: importMap,
           dependencies,
+          externalBindingFlows,
           decls,
         })
       : summarizeLambdaBorrowing({
@@ -4752,6 +4761,7 @@ export const computeCallableBorrowContracts = ({
           moduleId,
           imports: importMap,
           dependencies,
+          externalBindingFlows,
           contracts,
           decls,
         });
@@ -5127,6 +5137,7 @@ const summarizeLambdaBorrowing = ({
   moduleId,
   imports,
   dependencies,
+  externalBindingFlows,
   contracts,
   decls,
 }: {
@@ -5139,6 +5150,7 @@ const summarizeLambdaBorrowing = ({
   moduleId: string;
   imports: ReadonlyMap<SymbolId, SymbolRef>;
   dependencies: ReadonlyMap<string, BorrowingDependency>;
+  externalBindingFlows: ReadonlyMap<SymbolId, Flow>;
   contracts: ReadonlyMap<SymbolId, CallableBorrowContract>;
   decls: DeclTable;
 }): CallableBorrowContract => {
@@ -5186,8 +5198,8 @@ const summarizeLambdaBorrowing = ({
   invalidated.set(env, emptyFlow());
   placeEnvs.set(env, new Map());
   expressionFlows.set(env, new Map());
-  externalModuleBindingFlows(hir, typing, imports, dependencies).forEach(
-    (flow, symbol) => env.set(symbol, new Map(flow)),
+  externalBindingFlows.forEach((flow, symbol) =>
+    env.set(symbol, new Map(flow)),
   );
   lambda.parameters.forEach((parameter, index) => {
     bindPattern(parameter.pattern, parameterFlows.get(index)!, env);

--- a/packages/compiler/src/semantics/borrowing/summaries.ts
+++ b/packages/compiler/src/semantics/borrowing/summaries.ts
@@ -230,11 +230,23 @@ const originKey = (origin: ParameterOrigin): string => {
     return cached;
   }
   const comparator = origin.accessTypeComparator;
+  const sourceProjectionKey = projectionPathKey(origin.sourceProjections);
+  const resultProjectionKey =
+    origin.resultProjections === origin.sourceProjections
+      ? sourceProjectionKey
+      : projectionPathKey(origin.resultProjections);
+  const comparatorProjectionKey = comparator
+    ? comparator.sourceProjections === origin.sourceProjections
+      ? sourceProjectionKey
+      : comparator.sourceProjections === origin.resultProjections
+        ? resultProjectionKey
+        : projectionPathKey(comparator.sourceProjections)
+    : "";
   const key = [
     origin.parameter,
     origin.sourceEndpointAccess,
-    projectionPathKey(origin.sourceProjections),
-    projectionPathKey(origin.resultProjections),
+    sourceProjectionKey,
+    resultProjectionKey,
     origin.resultNominal ?? "",
     origin.borrowed === true ? 1 : 0,
     origin.shared === true ? 1 : 0,
@@ -243,7 +255,7 @@ const originKey = (origin: ParameterOrigin): string => {
     origin.defaultParameter ?? "",
     origin.returnTypeConditionId ?? "",
     comparator
-      ? `${comparator.conditionId.length}:${comparator.conditionId}:${comparator.parameter}:${projectionPathKey(comparator.sourceProjections)}`
+      ? `${comparator.conditionId.length}:${comparator.conditionId}:${comparator.parameter}:${comparatorProjectionKey}`
       : "",
   ].join("|");
   originKeys.set(origin, key);

--- a/packages/compiler/src/semantics/codegen-view/index.ts
+++ b/packages/compiler/src/semantics/codegen-view/index.ts
@@ -347,7 +347,9 @@ export type ObjectLayoutIndex = {
   getTemplate(owner: ProgramSymbolId): CodegenObjectTemplate | undefined;
   getInfoByNominal(nominal: TypeId): CodegenObjectTypeInfo | undefined;
   getNominalOwnerRef(nominal: TypeId): ProgramSymbolId | undefined;
-  getNominalInstancesByOwner(owner: ProgramSymbolId): readonly TypeId[];
+  getCompatibleNominalInstantiations(
+    nominal: TypeId,
+  ): readonly { nominalId: TypeId; typeId: TypeId }[];
 };
 
 export type TraitDispatchIndex = {
@@ -745,6 +747,10 @@ export const buildProgramCodegenView = (
   const objectInfoByNominal = new Map<TypeId, CodegenObjectTypeInfo>();
   const nominalOwnerByNominal = new Map<TypeId, ProgramSymbolId>();
   const nominalsByOwner = new Map<ProgramSymbolId, TypeId[]>();
+  const compatibleNominalInstantiations = new Map<
+    TypeId,
+    readonly { nominalId: TypeId; typeId: TypeId }[]
+  >();
   const aliasSymbolsByType = new Map<TypeId, Set<ProgramSymbolId>>();
   const standaloneVariantAliasesByType = new Map<
     TypeId,
@@ -2391,11 +2397,64 @@ export const buildProgramCodegenView = (
     },
   };
 
+  const isUnknownPrimitive = (typeId: TypeId): boolean => {
+    const desc = arena.get(typeId);
+    return desc.kind === "primitive" && desc.name === "unknown";
+  };
+
   const objects: ObjectLayoutIndex = {
     getTemplate: (owner) => objectTemplateByOwner.get(owner),
     getInfoByNominal: (nominal) => objectInfoByNominal.get(nominal),
     getNominalOwnerRef: (nominal) => nominalOwnerByNominal.get(nominal),
-    getNominalInstancesByOwner: (owner) => nominalsByOwner.get(owner) ?? [],
+    getCompatibleNominalInstantiations: (nominal) => {
+      const cached = compatibleNominalInstantiations.get(nominal);
+      if (cached) {
+        return cached;
+      }
+
+      const sourceDesc = arena.get(nominal);
+      if (
+        sourceDesc.kind !== "nominal-object" ||
+        sourceDesc.typeArgs.some(isUnknownPrimitive)
+      ) {
+        compatibleNominalInstantiations.set(nominal, []);
+        return [];
+      }
+
+      const compatible = (
+        nominalsByOwner.get(
+          symbols.idOf(canonicalSymbolRef(sourceDesc.owner)),
+        ) ?? []
+      ).flatMap((candidateNominal) => {
+        if (candidateNominal === nominal) {
+          return [];
+        }
+        const info = objectInfoByNominal.get(candidateNominal);
+        const targetDesc = arena.get(candidateNominal);
+        if (
+          !info ||
+          info.nominal !== candidateNominal ||
+          targetDesc.kind !== "nominal-object" ||
+          targetDesc.typeArgs.length !== sourceDesc.typeArgs.length ||
+          targetDesc.typeArgs.some(isUnknownPrimitive)
+        ) {
+          return [];
+        }
+        const isCompatible = sourceDesc.typeArgs.every(
+          (typeArg, index) =>
+            arena.unify(typeArg, targetDesc.typeArgs[index]!, {
+              location: first.hir.module.ast,
+              reason: "nominal instantiation compatibility",
+              variance: "covariant",
+            }).ok,
+        );
+        return isCompatible
+          ? [{ nominalId: candidateNominal, typeId: info.type }]
+          : [];
+      });
+      compatibleNominalInstantiations.set(nominal, compatible);
+      return compatible;
+    },
   };
 
   const traits: TraitDispatchIndex = {

--- a/packages/compiler/src/semantics/effects/__tests__/effect-table.test.ts
+++ b/packages/compiler/src/semantics/effects/__tests__/effect-table.test.ts
@@ -126,6 +126,34 @@ describe("EffectTable", () => {
     expect(() => effects.setFunctionEffect(2, scheme, effects.emptyRow)).toThrow();
   });
 
+  it("rolls back nested expression effect scopes", () => {
+    const effects = createEffectTable();
+    const initial = effects.internRow({
+      operations: [{ name: "Async.await" }],
+    });
+    const outer = effects.internRow({ operations: [{ name: "Log.write" }] });
+    const inner = effects.internRow({ operations: [{ name: "State.get" }] });
+    effects.setExprEffect(1, initial);
+
+    effects.pushExprEffectScope();
+    effects.setExprEffect(1, outer);
+    effects.setExprEffect(2, outer);
+    const outerComposed = effects.getExprEffect(1);
+
+    effects.pushExprEffectScope();
+    effects.setExprEffect(1, inner);
+    effects.setExprEffect(3, inner);
+    effects.popExprEffectScope();
+
+    expect(effects.getExprEffect(1)).toBe(outerComposed);
+    expect(effects.getExprEffect(2)).toBe(outer);
+    expect(effects.getExprEffect(3)).toBeUndefined();
+
+    effects.popExprEffectScope();
+    expect(effects.getExprEffect(1)).toBe(initial);
+    expect(effects.getExprEffect(2)).toBeUndefined();
+  });
+
   it("exposes empty vs open rows", () => {
     const effects = createEffectTable();
     expect(effects.isEmpty(effects.emptyRow)).toBe(true);

--- a/packages/compiler/src/semantics/effects/effect-table.ts
+++ b/packages/compiler/src/semantics/effects/effect-table.ts
@@ -76,6 +76,8 @@ export interface EffectTable {
   cloneInterner(): EffectInterner;
   setExprEffect(expr: HirExprId, row: EffectRowId): void;
   getExprEffect(expr: HirExprId): EffectRowId | undefined;
+  pushExprEffectScope(): void;
+  popExprEffectScope(): void;
   snapshotExprEffects(): ReadonlyMap<HirExprId, EffectRowId>;
   restoreExprEffects(snapshot: ReadonlyMap<HirExprId, EffectRowId>): void;
   setFunctionEffect(symbol: SymbolId, scheme: TypeSchemeId, row: EffectRowId): void;
@@ -87,6 +89,8 @@ export type EffectInterner = Omit<
   EffectTable,
   | "setExprEffect"
   | "getExprEffect"
+  | "pushExprEffectScope"
+  | "popExprEffectScope"
   | "snapshotExprEffects"
   | "restoreExprEffects"
   | "setFunctionEffect"
@@ -330,6 +334,7 @@ export const createEffectTable = ({
       { scheme: effect.scheme, row: effect.row },
     ]) ?? [],
   );
+  const exprEffectScopes: Map<HirExprId, EffectRowId | undefined>[] = [];
 
   const setExprEffect = (expr: HirExprId, row: EffectRowId): void => {
     const existing = exprEffects.get(expr);
@@ -339,11 +344,33 @@ export const createEffectTable = ({
       }
       row = shared.compose(existing, row);
     }
+    const activeScope = exprEffectScopes.at(-1);
+    if (activeScope && !activeScope.has(expr)) {
+      activeScope.set(expr, existing);
+    }
     exprEffects.set(expr, row);
   };
 
   const getExprEffect = (expr: HirExprId): EffectRowId | undefined =>
     exprEffects.get(expr);
+
+  const pushExprEffectScope = (): void => {
+    exprEffectScopes.push(new Map());
+  };
+
+  const popExprEffectScope = (): void => {
+    const scope = exprEffectScopes.pop();
+    if (!scope) {
+      throw new Error("cannot pop expression effect scope: no scope is active");
+    }
+    scope.forEach((row, expr) => {
+      if (typeof row === "number") {
+        exprEffects.set(expr, row);
+      } else {
+        exprEffects.delete(expr);
+      }
+    });
+  };
 
   const snapshotExprEffects = (): ReadonlyMap<HirExprId, EffectRowId> =>
     new Map(exprEffects);
@@ -386,6 +413,8 @@ export const createEffectTable = ({
     ...shared,
     setExprEffect,
     getExprEffect,
+    pushExprEffectScope,
+    popExprEffectScope,
     snapshotExprEffects,
     restoreExprEffects,
     setFunctionEffect,

--- a/packages/compiler/src/semantics/pipeline.ts
+++ b/packages/compiler/src/semantics/pipeline.ts
@@ -110,6 +110,17 @@ export interface SemanticsPipelineOptions {
   retainBorrowingIncrementalData?: boolean;
 }
 
+export interface ReanalyzeSemanticsBorrowingOptions {
+  semantics: SemanticsPipelineResult;
+  module: ModuleNode;
+  exports?: Map<string, ModuleExportTable>;
+  dependencies?: Map<string, SemanticsPipelineResult>;
+  recoverFromTypingErrors?: boolean;
+  borrowingOverride?: BorrowingResult;
+  previousBorrowing?: BorrowingResult;
+  retainBorrowingIncrementalData?: boolean;
+}
+
 type SemanticsPipelineInput = SemanticsPipelineOptions | Form;
 
 export const semanticsPipeline = (
@@ -225,6 +236,86 @@ export const semanticsPipeline = (
     moduleId: module.id,
     imports: binding.imports,
   });
+  return finalizeSemanticsPipeline({
+    module,
+    binding,
+    symbolTable,
+    hir,
+    typing,
+    exports,
+    dependencies,
+    recoverFromTypingErrors,
+    checkBorrowBodies,
+    borrowingOverride,
+    previousBorrowing,
+    retainBorrowingIncrementalData,
+  });
+};
+
+/**
+ * Reuses stabilized binding, lowering, and typing state while recomputing the
+ * dependency-sensitive borrowing and export contracts for a cyclic module.
+ */
+export const reanalyzeSemanticsBorrowing = ({
+  semantics,
+  module,
+  exports,
+  dependencies,
+  recoverFromTypingErrors,
+  borrowingOverride,
+  previousBorrowing,
+  retainBorrowingIncrementalData,
+}: ReanalyzeSemanticsBorrowingOptions): SemanticsPipelineResult => {
+  const symbolTable = (
+    semantics as SemanticsPipelineResult & { symbolTable?: SymbolTable }
+  ).symbolTable;
+  if (!symbolTable) {
+    throw new Error("semantics result is missing its internal symbol table");
+  }
+
+  return finalizeSemanticsPipeline({
+    module,
+    binding: semantics.binding,
+    symbolTable,
+    hir: semantics.hir,
+    typing: semantics.typing,
+    exports,
+    dependencies,
+    recoverFromTypingErrors,
+    checkBorrowBodies: true,
+    borrowingOverride,
+    previousBorrowing,
+    retainBorrowingIncrementalData,
+  });
+};
+
+const finalizeSemanticsPipeline = ({
+  module,
+  binding,
+  symbolTable,
+  hir,
+  typing,
+  exports,
+  dependencies,
+  recoverFromTypingErrors,
+  checkBorrowBodies,
+  borrowingOverride,
+  previousBorrowing,
+  retainBorrowingIncrementalData,
+}: {
+  module: ModuleNode;
+  binding: BindingResult;
+  symbolTable: SymbolTable;
+  hir: HirGraph;
+  typing: TypingResult;
+  exports?: Map<string, ModuleExportTable>;
+  dependencies?: Map<string, SemanticsPipelineResult>;
+  recoverFromTypingErrors?: boolean;
+  checkBorrowBodies?: boolean;
+  borrowingOverride?: BorrowingResult;
+  previousBorrowing?: BorrowingResult;
+  retainBorrowingIncrementalData?: boolean;
+}): SemanticsPipelineResult => {
   const borrowingStartedAt = startCompilerPerfPhase();
   const borrowingDependencies = selectBorrowingDependencySemantics({
     dependencies,

--- a/packages/compiler/src/semantics/typing/expressions.ts
+++ b/packages/compiler/src/semantics/typing/expressions.ts
@@ -53,7 +53,6 @@ export const withSpeculativeExprTyping = <T>(
 ): T => {
   const previousResolved = ctx.resolvedExprTypes;
   const previousTailResumptions = ctx.tailResumptions;
-  const previousExprEffects = ctx.effects.snapshotExprEffects();
   const previousTargets = ctx.callResolution.targets;
   const previousArgumentPlans = ctx.callResolution.argumentPlans;
   const previousTypeArguments = ctx.callResolution.typeArguments;
@@ -61,6 +60,7 @@ export const withSpeculativeExprTyping = <T>(
   const previousTraitDispatches = ctx.callResolution.traitDispatches;
 
   ctx.table.pushExprTypeScope();
+  ctx.effects.pushExprEffectScope();
   ctx.resolvedExprTypes = new Map(previousResolved);
   ctx.tailResumptions = new Map(previousTailResumptions);
   ctx.callResolution.targets = cloneNestedMap(previousTargets);
@@ -72,7 +72,7 @@ export const withSpeculativeExprTyping = <T>(
   try {
     return run();
   } finally {
-    ctx.effects.restoreExprEffects(previousExprEffects);
+    ctx.effects.popExprEffectScope();
     ctx.callResolution.targets = previousTargets;
     ctx.callResolution.argumentPlans = previousArgumentPlans;
     ctx.callResolution.typeArguments = previousTypeArguments;

--- a/packages/compiler/src/semantics/typing/type-system.ts
+++ b/packages/compiler/src/semantics/typing/type-system.ts
@@ -183,73 +183,106 @@ const paramsReferencedInType = (
   type: TypeId,
   allowed: ReadonlySet<TypeParamId>,
   ctx: TypingContext,
-  seen: Set<TypeId> = new Set(),
 ): Set<TypeParamId> => {
+  const referenced = new Set<TypeParamId>();
+  collectParamsReferencedInType(type, allowed, ctx, referenced, new Set());
+  return referenced;
+};
+
+const collectParamsReferencedInType = (
+  type: TypeId,
+  allowed: ReadonlySet<TypeParamId>,
+  ctx: TypingContext,
+  referenced: Set<TypeParamId>,
+  seen: Set<TypeId>,
+): void => {
   if (seen.has(type)) {
-    return new Set();
+    return;
   }
   seen.add(type);
 
   const desc = ctx.arena.get(type);
   switch (desc.kind) {
     case "borrowed":
-      return paramsReferencedInType(desc.inner, allowed, ctx, seen);
+      collectParamsReferencedInType(desc.inner, allowed, ctx, referenced, seen);
+      return;
     case "type-param-ref":
-      return allowed.has(desc.param) ? new Set([desc.param]) : new Set();
+      if (allowed.has(desc.param)) {
+        referenced.add(desc.param);
+      }
+      return;
     case "trait":
     case "nominal-object":
-    case "value-object": {
-      return desc.typeArgs.reduce((acc, arg) => {
-        paramsReferencedInType(arg, allowed, ctx, seen).forEach((entry) =>
-          acc.add(entry),
-        );
-        return acc;
-      }, new Set<TypeParamId>());
-    }
+    case "value-object":
+      desc.typeArgs.forEach((arg) =>
+        collectParamsReferencedInType(arg, allowed, ctx, referenced, seen),
+      );
+      return;
     case "structural-object":
-      return desc.fields.reduce((acc, field) => {
-        paramsReferencedInType(field.type, allowed, ctx, seen).forEach(
-          (entry) => acc.add(entry),
-        );
-        return acc;
-      }, new Set<TypeParamId>());
-    case "function": {
-      const acc = new Set<TypeParamId>();
-      desc.parameters.forEach((param) =>
-        paramsReferencedInType(param.type, allowed, ctx, seen).forEach(
-          (entry) => acc.add(entry),
+      desc.fields.forEach((field) =>
+        collectParamsReferencedInType(
+          field.type,
+          allowed,
+          ctx,
+          referenced,
+          seen,
         ),
       );
-      paramsReferencedInType(desc.returnType, allowed, ctx, seen).forEach(
-        (entry) => acc.add(entry),
+      return;
+    case "function":
+      desc.parameters.forEach((param) =>
+        collectParamsReferencedInType(
+          param.type,
+          allowed,
+          ctx,
+          referenced,
+          seen,
+        ),
       );
-      return acc;
-    }
+      collectParamsReferencedInType(
+        desc.returnType,
+        allowed,
+        ctx,
+        referenced,
+        seen,
+      );
+      return;
     case "union":
-      return desc.members.reduce((acc, member) => {
-        paramsReferencedInType(member, allowed, ctx, seen).forEach((entry) =>
-          acc.add(entry),
-        );
-        return acc;
-      }, new Set<TypeParamId>());
-    case "intersection": {
-      const acc = new Set<TypeParamId>();
+      desc.members.forEach((member) =>
+        collectParamsReferencedInType(member, allowed, ctx, referenced, seen),
+      );
+      return;
+    case "intersection":
       if (typeof desc.nominal === "number") {
-        paramsReferencedInType(desc.nominal, allowed, ctx, seen).forEach(
-          (entry) => acc.add(entry),
+        collectParamsReferencedInType(
+          desc.nominal,
+          allowed,
+          ctx,
+          referenced,
+          seen,
         );
       }
       if (typeof desc.structural === "number") {
-        paramsReferencedInType(desc.structural, allowed, ctx, seen).forEach(
-          (entry) => acc.add(entry),
+        collectParamsReferencedInType(
+          desc.structural,
+          allowed,
+          ctx,
+          referenced,
+          seen,
         );
       }
-      return acc;
-    }
+      return;
     case "fixed-array":
-      return paramsReferencedInType(desc.element, allowed, ctx, seen);
+      collectParamsReferencedInType(
+        desc.element,
+        allowed,
+        ctx,
+        referenced,
+        seen,
+      );
+      return;
     default:
-      return new Set();
+      return;
   }
 };
 


### PR DESCRIPTION
## Summary

- reuse stabilized typing results for cyclic module SCCs while rerunning dependency-sensitive finalization
- reduce allocation and key-construction overhead in borrowing, type-parameter scans, and speculative effect typing
- lazily cache compatible nominal instantiations behind the semantic/codegen view boundary
- compute immutable external-module borrow binding flows once per contract solve instead of once per callable evaluation

## Impact

The initial five-fix package-scale OpenAPI benchmark reduced median compiler time from 43.988s to 38.610s (-12.23%). Semantic analysis improved 11.77%, codegen improved 19.76%, and process wall time improved 12.57%.

The follow-up borrow-flow hoist was measured with three fresh processes per variant against the five-fix branch:

- compiler total: 39.749s to 36.303s (-8.67%)
- borrow analysis: 18.990s to 15.319s (-19.33%)
- borrow-contract inference: 10.839s to 7.254s (-33.07%)
- process wall time: 41.478s to 37.953s (-8.50%)

A smaller scalar workload improved 5.68% overall before the follow-up borrow change.

## Validation

- `npm test` (18/18 package tasks)
- `npm run typecheck`
- `npm run test:audit`
- `npm run --workspace @voyd-lang/compiler build`
- focused borrowing and result-provenance tests (450 passed)
- focused A/B benchmarks and CPU profiles for each accepted optimization
- fresh standard review pass after each fix